### PR TITLE
Fix audience validation in jwt decoding

### DIFF
--- a/docs/server-apis/python.md
+++ b/docs/server-apis/python.md
@@ -73,15 +73,15 @@ def requires_auth(f):
     try:
         payload = jwt.decode(
             token,
-            base64.b64decode('@@account.clientSecret@@'.replace("_","/").replace("-","+"))
+            base64.b64decode('@@account.clientSecret@@'.replace("_","/").replace("-","+")),
+            audience='@@account.clientId@@'
         )
     except jwt.ExpiredSignature:
         return authenticate({'code': 'token_expired', 'description': 'token is expired'})
     except jwt.DecodeError:
         return authenticate({'code': 'token_invalid_signature', 'description': 'token signature is invalid'})
-
-    if payload['aud'] != '@@account.clientId@@':
-      return authenticate({'code': 'invalid_audience', 'description': 'the audience does not match. expected: ' + CLIENT_ID})
+    except jwt.InvalidAudienceError:
+        return authenticate({'code': 'invalid_audience', 'description': 'the audience does not match. expected: @@account.clientId@@'})
 
     _request_ctx_stack.top.current_user = user = payload
     return f(*args, **kwargs)


### PR DESCRIPTION
I added the parameter audience in the jwt.decode function. Otherwise, jwt raise the InvalidAudienceError exception.
I removed the audience control who was redundant.