### PR TITLE
Add explanation of SAML roles and generic instructions for SAML configuration

### DIFF
--- a/docs/saml-configuration.md
+++ b/docs/saml-configuration.md
@@ -1,6 +1,76 @@
 # SAML
 
-Auth0 supports SAML protocol (used by apps like Salesforce, Box, etc.), WS-Federation protocol (used by apps like [SharePoint](integrations/sharepoint), CRM, etc.) and the OAuth2/OpenID Connect protocol (used by custom developed applications). This document explains how to customize the SAML Assertions and the SAML and WS-Fed protocol parameters.
+In a SAML federation there is a Service Provider and an Identity Provider.  The Service Provider agrees to trust the Identity Provider to authenticate users.  The Identity Provider authenticates users and provides to Service Providers an Authentication Assertion that indicates a user has been authenticated.
+
+Auth0 supports the SAML protocol and can serve in either a SAML Service Provider (SP) role, a SAML Identity Provider (IDP) role, or both.
+
+
+### SAML Identity Provider
+
+Some Applications, such as Salesforce, Box, Workday, can be configured to allow users to authenticate against an external Identity Provider using the SAML protocol.  Such applications can be integrated with Auth0 and in this case Auth0 will serve as the SAML IDP for the application.  
+
+Users of the application will be redirected to Auth0 to log in, and Auth0 can authenticate them using any backend authentication connection, such as an LDAP directory, a database, or even other SAML IDPs or Social Providers.  Once the user is authenticated, Auth0 will return a SAML assertion to the application indicating that the user has been successfully authenticated.
+
+![](https://cdn.auth0.com/docs/img/saml-case2.png)
+
+### SAML Service Provider
+
+Other applications, especially custom applications, may externalize authentication against an external Identity Provider using a protocol such as OpenID Connect or OAuth2.  In such cases, even though the application was written to utilize the OpenID Connect or OAuth2 protocol, it may be desirable to leverage an enterprise SAML provider for authentication.  
+
+In this situation, Auth0 will receive an authentication request from the application using the OpenID Connect or OAuth2 protocol, and Auth0 will translate the request into a SAML Authentication Request and send it on to a SAML Identity Provider.  In this case, Auth0 serves as a SAML Service Provider in the federation with the Identity Provider.
+
+![](https://cdn.auth0.com/docs/img/saml-case1.png)
+
+### SAML Service Provider and Identity Provider
+
+Auth0 can also serve as an authentication hub between applications making a SAML request and backend SAML Identity Providers.  In this case, Auth0 would serve as a SAML Identity Provider to the applications, and it would also serve as a SAML Service Provider to backend SAML Identity Providers.  This use case is advantageous when applications need to support multiple backend Identity Providers.
+
+![](https://cdn.auth0.com/docs/img/saml-case3.png)  
+
+## Configuring Auth0 as a Service Provider
+
+If Auth0 will serve as a SAML Service Provider, an Auth0 Connection is used to configure the Auth0 side (Service Provider) of each SAML federation. 
+
+There are instructions for several specific providers below: 
+
+* [ADFS](@@env.BASE_URL@@/adfs)
+* [Okta](@@env.BASE_URL@@/okta)
+* [OneLogin](@@env.BASE_URL@@/onelogin)
+* [Ping7](@@env.BASE_URL@@/ping7)
+* [SiteMinder](@@env.BASE_URL@@/siteminder)
+* [SSOCircle](@@env.BASE_URL@@/ssocircle)
+
+Auth0 can be configured as a Service Provider to any other SAML-compliant Identity Provider using the following generic instructions:
+
+* [Generic Service Provider Configuration](@@env.BASE_URL@@/saml-sp-generic)
+
+
+## Configuring Auth0 as a SAML Identity Provider
+
+Configuring Auth0 to serve as a SAML Identity Provider is done in a couple different places, depending on the type of application.
+
+For some 3rd party applications that support SAML, the Auth0 side of the configuration is done using the "Third Party Apps" link in the dashboard, and selecting the specific application.  Instructions specific to each application are provided.
+
+For any application not listed on the "Third Party Apps" page, the Auth0 side of the configuration is done using the "Apps/APIs" link and then clicking on the "Addons" tab.
+
+* Generic instructions for Auth0 as SAML Identity Provider
+
+Once Auth0 has been configured to serve as a SAML Identity Provider to client applications, it needs a way to authenticate users.  It can use any of the supported connection types for this.  Auth0 can authenticate users against ldap directories, databases, other SAML Identity Providers or even Social providers and once a user is authenticated, Auth0 can translate the authentication result into a SAML Authentication Assertion to send back to the application client.
+
+## Configuration Auth0 as both Service Provider and Identity Provider
+
+In this situation, there are two federations to configure.  The federation between the application and Auth0 will follow the instructions above for Configuring Auth0 as an Identity Provider.   The federation between Auth0 and any backend SAML Identity providers would follow the instructions for Configuring Auth0 as a Service Provider.
+
+## Some SAML-compliant Identity Providers
+
+  
+A list of [Identity Providers](@@env.BASE_URL@@/samlp-providers) that are believed to be SAML compliant.
+
+## Customizing SAML assertions (Auth0 as IDP)
+
+ 
+ 
+This section explains how to customize the SAML Assertions and the SAML and WS-Fed protocol parameters when Auth0 is configured to serve as an Identity Provider.
 
 By default, Auth0 will generate a SAML Assertion following certain conventions. However, you can customize everything by creating a [rule](rules) like this:
 
@@ -21,7 +91,7 @@ By default, Auth0 will generate a SAML Assertion following certain conventions. 
 
 ### Configuration options
 
-Below all the customizations you can do:
+Below are all the customizations you can do:
 
 * __audience (`string`):__ The audience of the SAML Assertion. Default will be the `Issuer` on `SAMLRequest`.
 * __recipient (`string`):__ The recipient of the SAML Assertion (SubjectConfirmationData). Default is `AssertionConsumerUrl` on `SAMLRequest` or Callback URL if no SAMLRequest was sent.
@@ -37,3 +107,6 @@ Below all the customizations you can do:
 * __signResponse (`bool`):__ Whether or not the SAML Response should be signed. By default the SAML Assertion will be signed, but not the SAML Response. If `true`, SAML Response will be signed instead of SAML Assertion.
 * __nameIdentifierFormat (`string`):__ Default is `urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified`.
 * __nameIdentifierProbes (`Array`):__ Auth0 will try each of the attributes of this array in order. If one of them has a value, it will use that for the Subject/NameID. The order is: `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier` (mapped from `user_id`), `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress` (mapped from `email`), `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name` (mapped from `name`).
+
+
+

--- a/docs/saml-configuration.md
+++ b/docs/saml-configuration.md
@@ -53,7 +53,7 @@ For some 3rd party applications that support SAML, the Auth0 side of the configu
 
 For any application not listed on the "Third Party Apps" page, the Auth0 side of the configuration is done using the "Apps/APIs" link and then clicking on the "Addons" tab.
 
-* Generic instructions for Auth0 as SAML Identity Provider
+* [Generic Identity Provider Configuration](@@env.BASE_URL@@/saml-idp-generic)
 
 Once Auth0 has been configured to serve as a SAML Identity Provider to client applications, it needs a way to authenticate users.  It can use any of the supported connection types for this.  Auth0 can authenticate users against ldap directories, databases, other SAML Identity Providers or even Social providers and once a user is authenticated, Auth0 can translate the authentication result into a SAML Authentication Assertion to send back to the application client.
 

--- a/docs/saml-idp-generic.md
+++ b/docs/saml-idp-generic.md
@@ -1,0 +1,96 @@
+# Auth0 as Identity Provider
+
+These instructions explain how to configure Auth0 to serve as an Identity Provider in a SAML federation.
+
+There are **5 sections**, including a troubleshooting section at the end.
+
+1. Obtain information from the Service Provider/Application
+2. Configure Auth0 as IDP
+3. Configure the Service Provider
+4. Test 
+5. Troubleshooting
+
+##1. Obtain Information from the Service Provider
+
+1. You will need to obtain from the Service Provider (application) the URL to which the SAML Authentication Assertion should be sent.  This may be called the Assertion Consumer Service URL, or the Post-back URL or the Callback URL.
+
+##2. Configure Auth0 as IDP 
+
+In this section you will configure Auth0 to serve as an Identity Provider.  You will do this by registering an application and using an AddOn.
+
+**In the Auth0 dashboard:**
+
+1. Click on **"Apps/APIs"** link at left.
+
+2. Click on the red **"+ NEW APP/API"** button on the right.
+
+3. In the **Name** field, enter a name like "MySAMLApp".
+
+4. Press the blue **"SAVE"** button.
+
+5. In the **Auth0 dashboard**, click again on the **"Apps/APIs"** link at left
+
+6. Find the row for the application you just created, and click on the **"Settings"** icon to the right of the application name. (the round gear icon)
+
+7. Scroll down and click on the **"Advanced Settings"** link.
+
+8. In the expanded window, scroll down to the **"CERTIFICATES"** section and click on the **"DOWNLOAD CERTIFICATES"** button.  In the popup which appears, select "PEM" to select a PEM-formatted certificate.  The certificate will be downloaded to a file called "@@account.tenant@@.pem".  Save this file as you will need to upload this file when configuring the Service Provider.
+
+![](https://cdn.auth0.com/docs/img/saml-idp-generic1.png)
+
+
+9. Scroll down further to the **"ENDPOINTS"** section and click on the blue **"SAML"** tab within that section.  Copy the entire contents of the **"SAML Protocol URL"** field and save it as you will need to provide it to the Service Provider.
+
+![](https://cdn.auth0.com/docs/img/saml-idp-generic2.png)
+
+10. Scroll back up and click on the "Addons" tab.  Then click on the box labeled "SAML2 WEB APP".  
+
+![](https://cdn.auth0.com/docs/img/saml-idp-generic3.png)
+ 
+
+11. In the "Application Callback URL" field, enter the URL at the Service Provider (or application) to which the SAML assertions should be sent after Auth0 has authenticated the user.  
+
+![](https://cdn.auth0.com/docs/img/saml-idp-generic4.png)
+
+12.  In the Addon SAML2 Web App popup, click on the "Usage" tab.  This tab will provide you with the information needed to configure the Service Provider application.
+
+![](https://cdn.auth0.com/docs/img/saml-idp-generic5.png)
+
+##3. Configure the Service Provider 
+
+In this section you will add some information to the Service Provider  so the Service Provider knows how to send SAML-based authentication requests to the Auth0 Identity Provider.  The instructions provided here are generic.  You will need to find the appropriate screens and fields on the Service Provider.
+
+If the Service Provider supports uploading a metadata file, you can simply provide the metadata URL obtained in the step above. (Apps/APIs -> Addons -> Usage)
+
+If the Service Provider does not support uploading a metadata file, you can configure it manually, using the information from the Auth0 Apps/APIs -> Addons -> Usage screen as follows:
+
+Identity Provider Login URL:  This is the URL to which the Service Provider should send its SAML Authentication Requests.
+
+If the Service Provider also has a field for a Logout URL, you can enter the same Identity Provider Login URL.  Both login and logout are handled by the same URL.
+
+The Service Provider will need a certificate from the Auth0 Identity Provider.  You can download this certificate from the Auth0 Apps/APIs -> Addons -> Usage screen.  This certificate will be used to validate the signature of the SAML Authentication Assertions sent from Auth0 Identity Provider to the Service Provider application.
+
+If the Service Provider asks for an Issuer, this can also be obtained from the same screen.
+
+
+##4. Test 
+
+Once you have completed the above configuration, test the login.
+
+If the Service Provider has been configured correctly, it should redirect the user browser to Auth0 for login.  After authenticating the user, Auth0 should redirect the user browser back to the application.
+
+
+
+##5. Troubleshooting.
+
+This section has a few ideas for things to check if your sample doesn't work.
+
+Note that if your application doesn't work the first time, you should clear your browser history and ideally cookies each time before you test again.  Otherwise, the browser may not be picking up the latest version of your html page or it may have stale cookies that impact execution.
+
+When troubleshooting SSO, it is often helpful to capture an HTTP trace of the interaction.  There are many tools that will capture the HTTP traffic from your browser for analysis.  Search for "HTTP Trace" to find some.  Once you have an http trace tool, capture the login sequence from start to finish and analyze the trace to see the sequence of GETs to see how far in the expected sequence you get.  You should see a redirect from the Service Provider to the Identity Provider, a post of credentials if you had to log in, and then a redirect back to the callback URL or the Service Provider application.
+
+Be sure to check to make sure cookies and javascript are enabled for your browser.
+
+
+The **[http://samltool.io](http://samltool.io)** tool can decode a SAML assertion and is a useful debugging tool.
+

--- a/docs/saml-sp-generic.md
+++ b/docs/saml-sp-generic.md
@@ -1,0 +1,155 @@
+# Auth0 as ServiceProvider 
+
+These instructions explain how to configure Auth0 to serve as a Service Provider in a SAML federation.
+
+
+There are **5 sections**, including a troubleshooting section at the end.
+
+1. Obtain information from IDP
+2. Configure Auth0 as Service Provider
+3. Add your Service Provider metadata to the Identity Provider
+4. Test the connection from Service Provider to Identity Provider
+5. Troubleshooting
+
+
+##1. Obtain information from IDP 
+
+You will need to obtain some information from the Identity Provider.  The instructions here will be generic.  You will have to locate this information in your specific Identity Provider.
+
+* SSO URL - The URL at the Identity Provider to which SAML authentication requests should be sent.  This is often called an SSO URL.
+
+* Logout URL - The URL at the Identity Provider to which SAML logout requests should be sent.  This is often called a logout URL, a global logout URL or single logout URL.
+
+* Signing certificate - The Identity Provider will digitally sign authentication assertions and the signing certificate is needed by the Service Provider to validate the signature of the signed assertions.  There should be a place to download the signing certificate from the Identity Provider.   If the certificate is not in .pem or .cer format, you should convert it to one of those formats.
+
+
+##2. Configure Auth0 as Service Provider 
+
+In this section you will configure Auth0 to serve as a SAML Service Provider.
+
+
+**In the Auth0 dashboard:**
+
+1. Click on **"Connections"** link at left.
+2. In the list of options below "Connections", click on **"Enterprise"**
+3. In the middle of the screen, click on **"SAMLP Identity Provider"**
+4. Click on the blue **"Create New Connection"** button
+
+
+In the **"Create SAMLP Identity Provider"** connection window, enter the following information into the "Configuration" tab.
+
+**Connection Name:** You can enter any name, such as "SAML-SP"
+
+**Email Domains:** In this example, we will use the Lock Widget, so in the Email Domains field enter the email domain name for the users that will log in via this connection.
+For example, if your users have an email domain of 'abc-example.com', you would enter that into this field. You can enter multiple email domains if needed.  Make sure the test user you created in section 2 has an email address with email domain that matches what you enter here.
+If you leave this field blank, users with any email domain can use the IDP.
+
+**Sign In URL:** enter the **"SAML SSO URL"** that you obtained from the Identity Provider.
+
+**Sign Out URL:** enter the **SAML Logout URL** obtained from the Identity Provider.
+
+**Certificate:**  
+Click on the red **"UPLOAD CERTIFICATE"** button and select the `.pem` file you obtained from the Identity Provider.
+
+You can ignore the rest of the fields for now.
+
+**Save:** Click on the blue **"SAVE"** button at the bottom.
+
+Here is an example of what the filled-out screen would look like: (you should have filled out the Email domains field as well with your specific test user's email domain.)
+
+![](https://cdn.auth0.com/docs/img/saml-sp-generic1.png)
+
+
+After pressing the **"SAVE"** button, A window will appear with a red **"CONTINUE"** button. (You might have to scroll up to see it) 
+
+Click on the **"CONTINUE"** button. 
+
+In the window that appears, metadata about this SAML  service provider  is displayed.  You will need to use the information from this screen to configure the Identity Provider.
+
+The first bullet is the post-back URL or Assertion Consumer Service (ACS) URL.  This is the URL to which the Identity Provider will sent Authentication Assertions after authenticating a user.  Enter this value where the Identity Provider asks for Assertion Consumer Service URL.  It may just call this a Service Provider URL.
+
+The second bullet tells you the **"Entity ID"**.  It will be of the form __urn:auth0:@@account.tenant@@:@@connectionName@@__.  
+
+Copy and save this entire Entity ID field from "urn" all the way to the end of the connection name.  Use this value if the Identity Provider asks for Entity ID or SAML Audience.
+
+The third bullet indicates the binding that will be used to send the SAML Request from Auth0 to the Identity Provider.    If the Identity Provider provides a choice, select HTTP-Redirect as shown on your metadata screen.
+
+The fourth bullet indicates that Auth0 expects the Identity Provider to respond with an HTTP POST.  e.g. the Authentication Assertion from the Identity Provider will be sent using the HTTP POST binding.  If the Identity Provider provides a choice, indicate that HTTP-POST binding should be used for Authentication Assertions.
+
+The nameid format is the format for the attribute that will be used to identify users.
+
+In that same window, near the bottom, there is a line that says, _"You can access the metadata for your connection in Auth0 here:"_.  
+
+In general, you can access the metadata for a SAML connection in Auth0 here: `https://@@account.namespace@@/samlp/metadata?connection=@@connectionName@@`.
+
+Make a note of this metadata URL as you may be able to use it to configure the Identity Provider in the next step.
+
+
+##3. Add your Service Provider metadata to the Identity Provider
+
+In this section you will add some information to the Identity Provider  so the Identity Provider knows how to receive and respond to SAML-based authentication requests from the Auth0 Service Provider.  The instructions provided here are generic.  You will need to find the appropriate screens and fields on the Identity Provider.
+
+Locate the screens in the Identity Provider that allow you to configure SAML.
+
+If the Identity Provider supports uploading a metadata file, you can simply provide the metadata URL obtained in the step above.
+
+If the Identity Provider does not support uploading a metadata file, you can configure it manually as follows:
+
+The Identity Provider will need to know where to send the SAML assertions after it has authenticated a user.  This is the Assertion Consumer Service URL in Auth0.  
+The Identity Provider may call this any of the following
+* Assertion Consumer Service URL
+* Application Callback URL
+* 
+
+If the Identity Provider has a field called "Audience" or "Entity ID", you should enter into that field the Entity ID" from Auth0.
+
+
+````
+    "audience":"urn:auth0:@@account.tenant@@:@@connectionName@@"
+````
+
+If the Identity Provider provides a choice for bindings, you should select HTTP-Redirect for Authentication Requests.
+
+If the Identity Provider provides a choice for bindings, you should select HTTP-Redirect for Authentication Requests.
+
+
+##4. Test the connection from Service Provider to Identity Provider
+
+In this section, you will test to make sure the SAML configuration between Auth0, the Service Provider, and the remote SAML Identity Provider is working.
+
+
+
+* In the **Auth0 dashboard**, navigate to:  __Connections -> Enterprise -> SAMLP Identity Provider__.
+
+* Click on the triangular **"Try"** button for the SAML connection you created earlier.  This button is to the right of the name of the connection.  You can hover your mouse over the button to have the text label appear.
+
+* You will first see a Lock login widget appear that is triggered by the Service Provider.  Enter the username.   If you entered an email domain in the SAMLP connection configuration, the username should belong to that email domain.   
+
+You will then be redirected to the login screen of the Identity Provider.  Login with the credentials for a user that exists in the Identity Provider.
+
+If the SAML configuration works, your browser will be redirected back to an Auth0 page that says __"It works!!!"__.  This page will display the contents of the SAML authentication assertion sent by the Identity Provider to Auth0 Service Provider.
+This means the SAML connection from Auth0 Service Provider to Identity Provider is working.
+
+If it didn't work, double check the above steps and then consult the **troubleshooting** section at the end of this document.
+
+> NOTE: the **Try** button only works for users logged in to the Auth0 dashboard.  You cannot send this to an anonymous user to have them try it.
+
+Here is a sample of the **"It Works"** screen:
+
+![](https://cdn.auth0.com/docs/img/saml-auth0-9.png)
+
+
+##5. Troubleshooting.
+
+This section has a few ideas for things to check if your sample doesn't work.
+
+Note that if your application doesn't work the first time, you should clear your browser history and ideally cookies each time before you test again.  Otherwise, the browser may not be picking up the latest version of your html page or it may have stale cookies that impact execution.
+
+When troubleshooting SSO, it is often helpful to capture an HTTP trace of the interaction.  There are many tools that will capture the HTTP traffic from your browser for analysis.  Search for "HTTP Trace" to find some.  Once you have an http trace tool, capture the login sequence from start to finish and analyze the trace to see the sequence of GETs to see how far in the expected sequence you get.  You should see a redirect from your original site to the Service Provider, and then to the Identity Provider, a post of credentials if you had to log in, and then a redirect back to the callback URL or the Service Provider and then finally a redirect to the callback URL specified in your application.
+
+Be sure to check to make sure cookies and javascript are enabled for your browser.
+
+Check to make sure that the callback URL specified by your application in its authentication request is listed in the **Allowed Callback URLs** field in the __""Settings""__ tab of the application registered in the Auth0 Dashboard.  (In dashboard, Click on __"Apps/APIs"__ link, then on the __"Settings"__ icon to the right of the application name.)
+
+The **[http://samltool.io](http://samltool.io)** tool can decode a SAML assertion and is a useful debugging tool.
+

--- a/docs/saml-sp-generic.md
+++ b/docs/saml-sp-generic.md
@@ -40,9 +40,8 @@ In the **"Create SAMLP Identity Provider"** connection window, enter the followi
 
 **Connection Name:** You can enter any name, such as "SAML-SP"
 
-**Email Domains:** In this example, we will use the Lock Widget, so in the Email Domains field enter the email domain name for the users that will log in via this connection.
-For example, if your users have an email domain of 'abc-example.com', you would enter that into this field. You can enter multiple email domains if needed.  Make sure the test user you created in section 2 has an email address with email domain that matches what you enter here.
-If you leave this field blank, users with any email domain can use the IDP.
+**Email Domains:** Enter the email domain name for the users that will log in via this connection.
+For example, if your users have an email domain of 'abc-example.com', you would enter that into this field. You can enter multiple email domains if needed.  If you leave this field blank, users with any email domain can use the IDP.
 
 **Sign In URL:** enter the **"SAML SSO URL"** that you obtained from the Identity Provider.
 

--- a/docs/samlp-providers.md
+++ b/docs/samlp-providers.md
@@ -1,0 +1,31 @@
+# List of SAML-P Identity Providers
+
+This is a list of Identity Provider services known to support the SAML protocol.  There may be additional services beyond what is shown below.
+
+
+
+## SAML-P
+The following providers have participated in a Kantara inter-operability test and are therefore likely to conform well to the SAML spec.
+
+  * __adAS__
+  * __ADFS__
+  * __Dot Net Workflow__
+  * __Elastic SSO Team & Enterprise__
+  * __Entrust GetAccess & IdentityGuard__  (check protocol supported)
+  * __EIC__  (check protocol supported)
+  * __Ilex Sign&go__
+  * __iWelcome__
+  * __NetIQ Access Manager__
+  * __OpenAM__
+  * __RCDevs Open SAMPL IdP__
+  * __Optimal IdM VIS Federation Services__
+  * __Oracle Access Manager__ (Oracle Identity Federation merged into this)
+  * __PingFederate__  (IDP Light)
+  * __RSA Federated Identity__  (IDP Light)
+  * __SecureAuth__
+  * __Symplified__
+  * __Tivoli Federated Identity Manager__
+  * __TrustBuilder__
+  * __Ubisecure SSO__
+  
+  


### PR DESCRIPTION
Added explanation of SAML roles to main "SAML" dashboard link.
Added instructions for configuring any generic SAML SP
Added instructions for configuring any generic SAML IDP
Added a list of known SAML-compliant Identity Providers