### PR TITLE
Fixes #40: fix GetAccessToken parameter names

### DIFF
--- a/articles/server-platforms/asp-classic.md
+++ b/articles/server-platforms/asp-classic.md
@@ -86,7 +86,7 @@ Function GetUserProfile(access_token)
 End Function
 
 
-Function GetAccessToken(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI, code)
+Function GetAccessToken(client_id, client_secret, redirect_uri, authorization_code)
 
   Set http = Server.CreateObject("MSXML2.ServerXMLHTTP")
 
@@ -94,7 +94,7 @@ Function GetAccessToken(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI, code)
 
   http.setRequestHeader "Content-Type", "application/x-www-form-urlencoded"
 
-  http.send "client_id=" & CLIENT_ID & "&client_secret=" & CLIENT_SECRET & "&redirect_uri=" & server.UrlEncode(REDIRECT_URI) & "&code=" & AUTHORIZATION_CODE & "&grant_type=authorization_code"
+  http.send "client_id=" & client_id & "&client_secret=" & client_secret & "&redirect_uri=" & server.UrlEncode(redirect_uri) & "&code=" & authorization_code & "&grant_type=authorization_code"
 
   result = http.responseText
 


### PR DESCRIPTION
Fixes #40

I'm actually cleaning up the other function parameters as they should be different than the more global VB "constants".  I don't have an easy way to test that this works, so I'm going to create a PR.  If someone can point me to instructions on how to test in the future, I'll gladly give it a shot.
