### PR TITLE
Include URL un-escaping in OnValidateIdentity

### DIFF
--- a/articles/server-apis/webapi-owin.md
+++ b/articles/server-apis/webapi-owin.md
@@ -116,8 +116,9 @@ app.UseJwtBearerAuthentication(
                 if (!string.IsNullOrEmpty(token))
                 {
                     var notPadded = token.Split('.')[1];
-                    var claimsPart = Convert.FromBase64String(
-                        notPadded.PadRight(notPadded.Length + (4 - notPadded.Length % 4) % 4, '='));
+                    var padded = notPadded.PadRight(notPadded.Length + (4 - notPadded.Length % 4) % 4, '=');
+                    var urlUnescaped = padded.Replace('-', '+').Replace('_', '/');
+                    var claimsPart = Convert.FromBase64String(urlUnescaped);
 
                     var obj = JObject.Parse(Encoding.UTF8.GetString(claimsPart, 0, claimsPart.Length));
 


### PR DESCRIPTION
Padding with `=` isn't enough as some tokens contain URL-escaped `+` and `/` characters.  We need to escape them back before attempting to convert them from base64.
