### PR TITLE
Changed name of module to enable on Apache tutorial.

### DIFF
--- a/articles/server-platforms/apache.md
+++ b/articles/server-platforms/apache.md
@@ -20,7 +20,7 @@ You can get the binaries from [Github](https://github.com/pingidentity/mod_auth_
 Once you've installed it, you just need to enable it for Apache
 
 ```bash
-sudo a2enmod mod_auth_openidc
+sudo a2enmod auth_openidc
 ```
 
 ### 2. Configure the module with your Auth0 Account information


### PR DESCRIPTION
Step 1 of Apache tutorial indicated to enable mod_auth_openidc module,
but the name of the module that gets installed is auth_openidc.
