### PR TITLE
Fix link to other article that wasn't absolute

### DIFF
--- a/articles/connector/test-dc.md
+++ b/articles/connector/test-dc.md
@@ -1,6 +1,6 @@
 # Creating a Test Active Directory Domain Controller
 
-While Auth0's Active Directory/LDAP integration is powerful and relatively easy to set up, it does require you have access to an existing directory service and sufficient privileges to [install and configure the Connector](install.md) - which is something that is usually done by a network administrator.  But what if you'd just like to try out the Connector or maybe set up a separate dev or test environment?  The following steps will guide you in creating a minimal Active Directory Domain Controller installation on your own cloud-deployed virtual machine for just that purpose.
+While Auth0's Active Directory/LDAP integration is powerful and relatively easy to set up, it does require you have access to an existing directory service and sufficient privileges to [install and configure the Connector](/connector/install) - which is something that is usually done by a network administrator.  But what if you'd just like to try out the Connector or maybe set up a separate dev or test environment?  The following steps will guide you in creating a minimal Active Directory Domain Controller installation on your own cloud-deployed virtual machine for just that purpose.
 
 In these instructions you will:
 * [Create a new Windows Server VM on Azure](#create-a-new-windows-server-vm-on-azure)


### PR DESCRIPTION
In **Creating a Test Active Directory Domain Controller** article
