### PR TITLE
Add documentation of tabs in AD/LDAP Connector Admin Console

### DIFF
--- a/articles/connector/modify.md
+++ b/articles/connector/modify.md
@@ -26,9 +26,37 @@ For an explanation of each test, see the "Troubleshooting" section of the [AD/LD
 
 Your AD/LDAP connector will connect using the new directory parameters after changes are made that pass all the tests.  If any test fails, the changes will not be saved.
 
+## Profile Mapper
+
+To modify the mapping of profile attributes from AD/LDAP attributes to attributes in the Auth0 user profile, launch the Connector Admin Console as described above and click on **"Profile Mapper"**
+
+This displays an editor screen with a short description at the top.  The body of   the editor screen displays a javascript function which maps attributes from a source directory service, represented by the `raw_data` variable, into a variable that gets returned to populate the Auth0 User Profile.  The first part of the function instantiates a variable called "profile" and has a mapping for the core portion of the Auth0 User Profile.  Additional attributes can be set below that using syntax of the form:
+
+```
+profile['department'] = raw_data['companydept'];
+```
+
+where "department" is the name of the attribute in the Auth0 user profile and "companydept" is the name of the attribute in the source directory service, AD.
+
+## Import / Export
+
+The Import/Export feature of the Connector Admin Console can be used to export the configuration of the AD/LDAP Connector or import a previously exported configuration.  This is useful for deployments with more than one node of the AD/LDAP connector deployed for high availability.  The configuration can be set up and tested on one node, and then exported from there and imported into the second and subsequent nodes.
+
+## Troubleshooting
+
+The Troubleshooting feature of the Connector Admin Console can be used to detect issues with the environment that may prevent the AD/LDAP connector from working properly.  It will check things like network connectivity, clock skew, etc.
+
+This feature will also display the contents of the AD/LDAP connector log file.
+
+## Search
+The Search feature of the Connector Admin Console is designed to allow the testing of search queries used by the AD/LDAP connector against the target AD/LDAP directory.  This can be an aid in debugging search filters used in the AD/LDAP connector configuration file, `config.json`, (see below).
+
+## Update
+The Update feature of the Connector Admin Console provides a convenient way to update the AD/LDAP connector to a new version. 
+ 
 ## Using the configuration file
 
-The `config.json` is the AD/LDAP Connector's configuration file in which the following settings are supported:
+The `config.json` file is the AD/LDAP Connector's configuration file.  It can be edited to make changes that are not possible via the AD/LDAP Connector Admin Console. The file is located in the install directory for the AD/LDAP Connector. The following settings are supported in this file:
 
  - `AD_HUB`: The Auth0 endpoint to which the connector will connect. This value is maintained by the connector.
  - `CA_CERT`: An authority certificate or array of authority certificates to check the remote host against.


### PR DESCRIPTION
Added section on profile mapper so I can refer to it in user profile doc, and added brief section on other tabs because it would have been weird to add documentation for only one tab.
