### PR TITLE
Changed authorizer in ember.js configuration

### DIFF
--- a/articles/client-platforms/emberjs.md
+++ b/articles/client-platforms/emberjs.md
@@ -48,7 +48,7 @@ __Note:__ If you are not already using ember-cli, see [ember-cli migration](http
 ```js
 // config/environment.js
 ENV['simple-auth'] = {
-  authorizer: 'simple-auth-authenticator:lock',
+  authorizer: 'simple-auth-authorizer:jwt',
   authenticationRoute: 'sign_in',
   routeAfterAuthentication: 'home',
   routeIfAlreadyAuthenticated: 'home'


### PR DESCRIPTION
When using the authorizer that is described in the docs I get the following error mesage:

```
Error while processing route: tracking-facts.index ajaxPrefilter.authorizer.authorize is not a function TypeError: ajaxPrefilter.authorizer.authorize is not a function
```

I have changed the authorizer to `simple-auth-authorizer:jwt` which seems to resemble the authorizer that is available in the package and the error has gone away.
