### PR TITLE
Ionic Tutorial - Updated the InAppBrowser plugin name

### DIFF
--- a/articles/native-platforms/ionic.md
+++ b/articles/native-platforms/ionic.md
@@ -67,7 +67,7 @@ ${snippet(meta.snippets.dependencies)}
 You must install the `InAppBrowser` plugin from Cordova to be able to show the Login popup. For that, just run the following command:
 
 ```bash
-ionic plugin add org.apache.cordova.inappbrowser
+ionic plugin add cordova-plugin-inappbrowser
 ```
 
 and then add the following configuration to the `config.xml` file:


### PR DESCRIPTION
The old version would throw a warning during the command execution.
“WARNING: org.apache.cordova.inappbrowser has been renamed to
cordova-plugin-inappbrowser. You may not be getting the latest version!
We suggest you `cordova plugin rm org.apache.cordova.inappbrowser` and
`cordova plugin add cordova-plugin-inappbrowser`.”
