### PR TITLE
Added Base DOCS url to seed projects link

### DIFF
--- a/articles/_includes/package.md
+++ b/articles/_includes/package.md
@@ -13,7 +13,7 @@ public: false
     <% } %>
     </div>
     <div class="button-area">
-      <a href="/${pkgRepo}/${pkgBranch}/create-package?path=${pkgPath}&filePath=${pkgFilePath}&type=${pkgType}" class="btn btn-sm btn-success">Get Seed Project</a>
+      <a href="${env.BASE_URL}/${pkgRepo}/${pkgBranch}/create-package?path=${pkgPath}&filePath=${pkgFilePath}&type=${pkgType}" class="btn btn-sm btn-success">Get Seed Project</a>
     </div>
   </div>
 </div>


### PR DESCRIPTION
This PR adds the Doc's url to seed project's link so it doesn't fail ouside docs
- Fix: auth0/manage/issues/989
