### PR TITLE
WebApi - Step 2 potential issue for novice developer

### DIFF
--- a/articles/server-apis/aspnet-webapi.md
+++ b/articles/server-apis/aspnet-webapi.md
@@ -43,9 +43,10 @@ ${snippet(meta.snippets.dependencies)}
 
 Open the **WebApiConfig.cs** file located in the **App_Start** folder and add the following `using` statements:
 ```cs
-using Api.App_Start;
+using YOUR_WEBAPI_PROJECT_NAME.App_Start;
 using System.Web.Configuration;
 ```
+Remember to replace the placeholder for your project name in the first `using` statement.
 
 Add the following code snippet inside the `Register` method.
 


### PR DESCRIPTION
The using statement assumes that the WebApi project is named Api.

This can cause confusion for novice developers. Its better to display a
placeholder in the documentation, that way it is explicit to the
developer that this should be replaced with their current project name.
