### PR TITLE
Fixed sample code

### DIFF
--- a/articles/mfa.md
+++ b/articles/mfa.md
@@ -105,7 +105,7 @@ Auth0 computes a hash with the request IP address and the `userAgent` string. If
 ```
 function (user, context, callback) {
 
-  var deviceFingerPrint = deviceFingerPrint();
+  var deviceFingerPrint = getDeviceFingerPrint();
 
   if( user.lastLoginDeviceFingerPrint !== deviceFingerPrint ){
 


### PR DESCRIPTION
The "Access an app from a different device/location" sample was referring to deviceFingerPrint() instead of getDeviceFingerPrint().
