### PR TITLE
Fix java server-api sample to use correct Base64 instance

### DIFF
--- a/snippets/server-apis/java/use.md
+++ b/snippets/server-apis/java/use.md
@@ -6,7 +6,7 @@ public class JWTFilter implements Filter {
     @Override
     public void init(FilterConfig filterConfig) throws ServletException {
         jwtVerifier = new JWTVerifier(
-          new Base64(true).decodeBase64("<%= account.clientSecret %>"),
+          new Base64(true).decode("<%= account.clientSecret %>"),
           "<%= account.clientId %>");
     }
 


### PR DESCRIPTION
The init method first created a Base64 instance with urlsafe flag set to true. But then it used the _static_ decodeBase64 method that actually creates a new Base64 instance with the urlsafe flag set to false. This fixes the code to use an instance method on the Base64 class instead.
