### PR TITLE
Add meta example to landings

### DIFF
--- a/landings/index.md
+++ b/landings/index.md
@@ -7,7 +7,9 @@ pages:
     description: Say goodbye to multiple credentials.
     banner:
       image: "/media/landings/banner/bg-hero.png"
-
+    meta:
+      title: Single Sign On
+      description: Say goodbye to multiple credentials.
     modules:
       - implementation
       - login


### PR DESCRIPTION
Add meta example to landings (learn) pages. If meta is not include title y value would be the ones at page root level
