### PR TITLE
Fixed _callback.md typo

### DIFF
--- a/articles/client-platforms/_callback.md
+++ b/articles/client-platforms/_callback.md
@@ -6,12 +6,12 @@ public: false
 
 <div class="setup-callback">
 <% if (account.userName && hasCallback) { %>
-<p>Please remember that for security purposes, you have to register the URL of your app on the <a href="<%= uiAppSettingsURL %>">Settings Section</a> section on Auth0 Admin app as the callbackURL.</p>
+<p>Please remember that for security purposes, you have to register the URL of your app on the <a href="<%= uiAppSettingsURL %>">Application Settings</a> section on Auth0 Admin app as the callbackURL.</p>
 <p>Right now, that callback is set to the following:
 <pre><code><%= account.callback %></code></pre>
 </p>
 <% } else { %>
-<p>Please remember that for security purposes, you have to register the URL of your app on the <a href="${uiURL}/#/applications">Settings Section</a> section on Auth0 Admin app as the callbackURL.</p>
+<p>Please remember that for security purposes, you have to register the URL of your app on the <a href="${uiURL}/#/applications">Application Settings</a> section on Auth0 Admin app as the callbackURL.</p>
 <% } %>
 
 </div>


### PR DESCRIPTION
Changed "Settings section" to "Application Settings" to avoid having the word section written twice. https://github.com/auth0/docs/issues/460
