### PR TITLE
Removed JSX markdown flag

### DIFF
--- a/articles/client-platforms/react.md
+++ b/articles/client-platforms/react.md
@@ -102,7 +102,7 @@ React.render(
 
 Use the `token` to retrieve the user profile and display the user's nickname:
 
-```jsx
+```js
 var LoggedIn = React.createClass({
   getInitialState: function() {
     return {


### PR DESCRIPTION
Doesn't look like markdown supports the jsx flag for the code snippet. It just renders without any styling.
