### PR TITLE
Adds "public: false" property to video pages

### DIFF
--- a/articles/video-series/creating-your-first-app/index.md
+++ b/articles/video-series/creating-your-first-app/index.md
@@ -1,4 +1,5 @@
 ---
+public: false
 name: 'Add Authentication to your app in less than 20 minutes with Auth0'
 videos:
   - register-an-application

--- a/articles/video-series/creating-your-first-app/videos/register-an-application.md
+++ b/articles/video-series/creating-your-first-app/videos/register-an-application.md
@@ -1,4 +1,5 @@
 ---
+public: false
 name: Register an application
 description: "In this video, you'll learn how to register a new application in Auth0 and how to configure it."
 timeInSeconds: 241

--- a/articles/video-series/creating-your-first-app/videos/setup-a-social-connection.md
+++ b/articles/video-series/creating-your-first-app/videos/setup-a-social-connection.md
@@ -1,4 +1,5 @@
 ---
+public: false
 name: Setup a Social Connection
 description: "In this video, you'll learn how you can configure any Social Identity Provider with Auth0."
 timeInSeconds: 177

--- a/articles/video-series/creating-your-first-app/videos/setup-username-and-password-storage.md
+++ b/articles/video-series/creating-your-first-app/videos/setup-username-and-password-storage.md
@@ -1,4 +1,5 @@
 ---
+public: false
 name: Setup Username and Password authentication
 description: "In this video you'll leran how you can configure a Username and Password authentication with users stored in Auth0's database"
 timeInSeconds: 154

--- a/articles/video-series/intro.md
+++ b/articles/video-series/intro.md
@@ -1,4 +1,5 @@
 ---
+public: false
 video:
   series: main
   video: intro

--- a/articles/video-series/main/index.md
+++ b/articles/video-series/main/index.md
@@ -1,4 +1,5 @@
 ---
+public: false
 name: Auth0 Intro video
 videos:
   - intro

--- a/articles/video-series/main/videos/intro.md
+++ b/articles/video-series/main/videos/intro.md
@@ -1,4 +1,5 @@
 ---
+public: false
 name: Auth0 Intro video
 description: "In this video, within 6 minutes you'll go from having no app, to having an application that has authentication working with Twitter, Github, Google and Username and Password using Auth0."
 videoId: 27i80efy8c


### PR DESCRIPTION
# Brief

This PR sets the `public: false` property for video articles to avoid showing them in the Docs Search.
