### PR TITLE
Remove openid profile references

### DIFF
--- a/articles/apps-apis.md
+++ b/articles/apps-apis.md
@@ -10,7 +10,7 @@
 
 * **Token-based authentication** is implemented by generating a token when the user authenticates and then setting that token in the `Authorization` header of each subsequent request to your API. You want that token to be something standard, like JSON Web Tokens since you will find libraries in most of the platforms and you don't want to do your own crypto.
 
-* For both approaches you can get the **same amount of information from the user**. That's controlled by the `scope` parameter sent in the login request (either using the [Auth0Lock](/lock), our [JavaScript library](https://github.com/auth0/auth0.js) or a plain link). The `scope` is a parameter of the `.signin({scope: 'openid profile'})` method which ends up being part of the querystring in the login request. Specifying `scope=openid profile` will write the full user profile in the token. Specifying `scope=openid` without profile, will write only the `user_id`.
+* For both approaches you can get the **same amount of information from the user**. That's controlled by the `scope` parameter sent in the login request (either using the [Auth0Lock](/lock), our [JavaScript library](https://github.com/auth0/auth0.js) or a plain link). The `scope` is a parameter of the `.signin({scope: 'openid name email'})` method which ends up being part of the querystring in the login request. You can get more details about this in the [Scopes Documentation](https://auth0.com/docs/scopes).
 
 * By default we use `scope=openid` in **token-based authentication** to avoid having a huge token (since the token will be traveling in the `Authorization` header for each request as mentioned above). You can control the attributes that you want to get in the token by doing `scope=openid name email another_attribute`.
 

--- a/articles/jwt.md
+++ b/articles/jwt.md
@@ -41,7 +41,7 @@ The minimum information will be:
 * `exp` the __expiration__, set to 10 hours.
 * `iat` the __issued at timestamp__.
 
-If the `scope` in the authorization request is set to `scope=openid profile`, then all the properties of the [user profile](/user-profile) are added to the Body. You can also define specific attributes with the syntax: `scope: 'openid {attr1} {attr2} {attrN}'`. For example: `scope: 'openid name email picture'`.
+You can define specific attributes with the syntax: `scope: 'openid {attr1} {attr2} {attrN}'` which will add those properties of the [user profile](/user-profile) to the Body. For example: `scope: 'openid name email picture'`. More information about scopes can be found in the [Scopes documentation](https://auth0.com/docs/scopes).
 
 > __Beware!__ If you are using the `implicit flow`, as you would if you are issuing the authorization request from a device, the JWT is returned in the URL, not in the response body. Some browsers have restrictions on URL lengths and can give you unexpected results.
 

--- a/articles/libraries/auth0js/index.md
+++ b/articles/libraries/auth0js/index.md
@@ -165,7 +165,8 @@ Once you have succesfully authenticated, Auth0 will redirect to the `callbackURL
   });
 ```
 
-Or just parse the hash (if loginOption.scope is not `openid profile`, then the profile will only contains the `user_id`):
+Or just parse the hash (if loginOption.scope is `openid`, then the profile will only contain the `user_id`):
+Taking this into consideration: " 'openid': It will return, not only the access_token, but also an id_token which is a Json Web Token (JWT). The JWT will only contain the user id (sub claim). You can use the ParameterBuilder.SCOPE_OPENID constant". You can get more information about scopes in the [Scopes documentation](https://auth0.com/docs/scopes).
 
 ```js
   $(function () {

--- a/articles/libraries/lock-android/use-your-own-ui.md
+++ b/articles/libraries/lock-android/use-your-own-ui.md
@@ -272,6 +272,7 @@ lodash: true
 1. Configure Google+ Native integrationApplication class)
   ```java
     this.googleplus = new GooglePlusIdentityProvider(this);
+    this.googleplus.setCallback(callback);
   ```
   > **Note**: Before using Google+, you need to register your Application with Google as explained in this [guide](https://developers.google.com/+/mobile/android/getting-started)
 

--- a/articles/libraries/login-widget.md
+++ b/articles/libraries/login-widget.md
@@ -143,10 +143,9 @@ Common parameters are:
 
 * `response_type`: this could be `code` or `token`. Usually `code` is used in web apps (server-side) and `token` on mobile, native or single page apps. See [server side protocol](/oauth-web-protocol) and [mobile, single page apps and native apps](/oauth-implicit-protocol) sections for more information about one or the other.
 * `state`: arbitrary state value that will be mantained across redirects (useful for XSRF)
-* `scope`: there are various possible values for scope today:
+* `scope`: there are various possible values for scope:
     * `scope=openid`: it will return, not only the `access_token`, but also an `id_token` which is a Json Web Token (JWT). The JWT will only contain the user id.
-    * `scope=openid%20profile`: If you want the entire user profile to be part of the `id_token`.
-    * `scope=openid {attr1} {attr2}`: if you want specific user profile properties returned.
+    * `scope=openid {attr1} {attr2}`: if you want specific user profile properties returned.(For example: `__scope: "openid name email picture"`). You can get more information about this in the [Scopes documentation](https://auth0.com/docs/scopes).
 * `redirect_uri`: by setting this value you can choose what callback url to use if you have multiple registered. Useful when you have multiple environments (e.g. Dev & Test), and a single application in Auth0.
 * `authorize_url`: if specified, it will start the login transaction at that url. This is useful if you want to do something on the server, before redirecting to Auth0. For instance, this is used when integrating with ASP.NET MVC4 which uses DotNetOpenAuth and generates a proprietary "state" parameter that can only be generated on the server side.
 * `protocol`: this could be `oauth2` (default), `samlp` or `wsfed`.

--- a/articles/libraries/login-widget2.md
+++ b/articles/libraries/login-widget2.md
@@ -113,8 +113,9 @@ There are other extra parameters that will depend on the provider. For example, 
 There are different values supported for scope:
 
 * `scope: 'openid'`: _(default)_ It will return, not only the `access_token`, but also an `id_token` which is a Json Web Token (JWT). The JWT will only contain the user id (sub claim).
-* `scope: 'openid profile'`: If you want the entire user profile to be part of the `id_token`.
 * `scope: 'openid {attr1} {attr2} {attrN}'`: If you want only specific user's attributes to be part of the `id_token` (For example: `scope: 'openid name email picture'`).
+
+You can get more information about this in the [Scopes documentation](https://auth0.com/docs/scopes).
 
 ### Connection Scopes
 

--- a/articles/native-platforms/windows-store-csharp.md
+++ b/articles/native-platforms/windows-store-csharp.md
@@ -76,10 +76,12 @@ var user = await auth0.LoginAsync(
 
 #### Scope
 
-Optionally you can specify the `scope` parameter. There are two possible values for scope today:
+Optionally you can specify the `scope` parameter. There are various possible values for `scope`:
 
 * __scope: "openid"__ _(default)_ - It will return, not only the `access_token`, but also an `id_token` which is a Json Web Token (JWT). The JWT will only contain the user id.
-* __scope: "openid profile"__ - If you want the entire user profile to be part of the `id_token`.
+* __scope: "openid {attr1} {attr2} {attrN}"__ - If you want only specific user's attributes to be part of the `id_token` (For example: `__scope: "openid name email picture"`).
+
+You can get more information about this in the [Scopes documentation](https://auth0.com/docs/scopes).
 
 ## Accessing user information
 

--- a/articles/native-platforms/windows-store-javascript.md
+++ b/articles/native-platforms/windows-store-javascript.md
@@ -105,7 +105,9 @@ auth0.Login({
 Optionally you can specify the `scope` parameter. There are two possible values for scope today:
 
 * __scope: "openid"__ _(default)_ - It will return, not only the `access_token`, but also an `id_token` which is a Json Web Token (JWT). The JWT will only contain the user id.
-* __scope: "openid profile"__ - If you want the entire user profile to be part of the `id_token`.
+* __scope: "openid {attr1} {attr2} {attrN}"__ - If you want only specific user's attributes to be part of the `id_token` (For example: `__scope: "openid name email picture"`).
+
+You can get more information about this in the [Scopes documentation](https://auth0.com/docs/scopes).
 
 ## Accessing user information
 

--- a/articles/protocols.md
+++ b/articles/protocols.md
@@ -28,8 +28,9 @@ The `redirect_uri` __must__ match what is defined in your [settings](${uiURL}/#/
 Optionally you can specify a `scope` parameter. There are various possible values for `scope`:
 
 * `scope: 'openid'`: _(default)_ It will return, not only the `access_token`, but also an `id_token` which is a Json Web Token (JWT). The JWT will only contain the user id (`sub` claim).
-* `scope: 'openid profile'`: If you want the entire user profile to be part of the `id_token`.
 * `scope: 'openid {attr1} {attr2} {attrN}'`: If you want only specific user's attributes to be part of the `id_token` (For example: `scope: 'openid name email picture'`).
+
+You can get more information about this in the [Scopes documentation](https://auth0.com/docs/scopes).
 
 ---
 

--- a/articles/saml/identity-providers/ssocircle.md
+++ b/articles/saml/identity-providers/ssocircle.md
@@ -219,7 +219,7 @@ Create an HTML page and insert the following HTML and javascript code:
             callbackURL: 'http://jwt.io'
           , responseType: 'token'
           , authParams: {
-            scope: 'openid profile'
+            scope: 'openid name email' //Details: https://auth0.com/docs/scopes
           }
         });
       }

--- a/articles/scenarios/mqtt.md
+++ b/articles/scenarios/mqtt.md
@@ -108,7 +108,7 @@ Auth0Mosca.prototype.authenticateWithCredentials = function(){
         password:    password.toString(),
         connection:  self.connection,
         grant_type:  "password",
-        scope: 'openid profile'
+        scope: 'openid name email' //Details: https://auth0.com/docs/scopes
     };
 
     request.post({

--- a/articles/user-profile/index.md
+++ b/articles/user-profile/index.md
@@ -16,6 +16,7 @@ Following are topics which will help us gain a better understanding of the User 
 - [Normalized User Profile](#normalized-user-profile)
 - [Caching of the User Profile in Auth0](#caching-of-the-user-profile-in-auth0)
 - [Structure of User Profile Data](#structure-of-user-profile-data)
+- [Storing custom Profile Data](#storing-custom-profile-data)
 - [Application Access to User Profile](#application-access-to-user-profile)
 - [API Access to User Profiles](#api-access-to-user-profiles)
 - [User Profile vs Tokens](#user-profile-vs-tokens)
@@ -51,6 +52,12 @@ At the top of "Details" will be the core User Profile object with basic informat
 The User Profile object then has two **metadata** sub-objects, one called `user_metadata` and the other `app_metadata`.  The metadata objects can be used to store additional User Profile information to augment what comes from the Connections.  The `user_metadata` object should be used to store user attributes, such as user preferences, that don't impact what a user can access.  The `app_metadata` object should be used for user attributes, such as a support plan, security roles, or access control groups, which can impact how an application functions and/or what the user can access. It should also be noted that an authenticated user can modify data in their profile's `user_metadata` but they can't modify anything in their `app_metadata`.
 
 Lastly you will also notice a special property called `identities`, which is an array of identity providers (Connections).  It will always contain at least one identity provider and that one represents the Connection that the user originally authenticated against.  However, Auth0 supports the ability for users to [link their profile to multiple identity providers](/link-accounts), and when they do, those additional identities (Connections) show up in this array.  The contents of an individual identity provider object varies by provider, but will typically include a user identifier, the name of the provider, the name of the connection set up in Auth0 for that provider, whether it is a social provider, and in some cases an API access token that can be used with that provider.
+
+## Storing custom Profile Data
+
+There are cases where you might want to augment the user profile with custom profile information like the user's favourite color or phone number. We encourage to use the `user_profile` to store this kind of information. 
+
+Auth0 provides a [JS widget](https://github.com/auth0/auth0-editprofile-widget) you can use to let the user to update his profile info.
 
 ## Application Access to User Profile
 

--- a/snippets/server-platforms/aspnet-owin/use.md
+++ b/snippets/server-platforms/aspnet-owin/use.md
@@ -9,7 +9,7 @@ function signin() {
       callbackURL: 'http://localhost:CHANGE-TO-YOUR-PORT/signin-auth0'
     , responseType: 'code'
     , authParams: {
-      scope: 'openid profile'
+      scope: 'openid name email' //Details: https://auth0.com/docs/scopes
     }
   });
 }

--- a/snippets/server-platforms/aspnet/use.md
+++ b/snippets/server-platforms/aspnet/use.md
@@ -9,7 +9,7 @@ function signin() {
       callbackURL: 'http://localhost:CHANGE-TO-YOUR-PORT/LoginCallback.ashx'
     , responseType: 'code'
     , authParams: {
-      scope: 'openid profile'
+      scope: 'openid name email' //Details: https://auth0.com/docs/scopes
     }
   });
 }

--- a/snippets/server-platforms/golang/use.md
+++ b/snippets/server-platforms/golang/use.md
@@ -8,7 +8,7 @@ function signin() {
       callbackURL: 'http://localhost:CHANGE-TO-YOUR-PORT/callback'
     , responseType: 'code'
     , authParams: {
-      scope: 'openid profile'
+      scope: 'openid name email' //Details: https://auth0.com/docs/scopes
     }
   });
 }

--- a/snippets/server-platforms/java/use.md
+++ b/snippets/server-platforms/java/use.md
@@ -8,7 +8,7 @@ function signin() {
       callbackURL: 'http://localhost:CHANGE-TO-YOUR-PORT/callback'
     , responseType: 'code'
     , authParams: {
-      scope: 'openid profile'
+      scope: 'openid name email' //Details: https://auth0.com/docs/scopes
     }
   });
 }

--- a/snippets/server-platforms/nancyfx/use.md
+++ b/snippets/server-platforms/nancyfx/use.md
@@ -9,7 +9,7 @@ function signin() {
       callbackURL: 'http://localhost:CHANGE-TO-YOUR-PORT/signin-auth0'
     , responseType: 'code'
     , authParams: {
-      scope: 'openid profile'
+      scope: 'openid name email' //Details: https://auth0.com/docs/scopes
     }
   });
 }

--- a/snippets/server-platforms/nodejs/use.md
+++ b/snippets/server-platforms/nodejs/use.md
@@ -9,7 +9,7 @@ function signin() {
       callbackURL: 'http://localhost:CHANGE-TO-YOUR-PORT/callback'
     , responseType: 'code'
     , authParams: {
-      scope: 'openid profile'
+      scope: 'openid name email' //Details: https://auth0.com/docs/scopes
     }
   });
 }

--- a/snippets/server-platforms/php/use.md
+++ b/snippets/server-platforms/php/use.md
@@ -9,7 +9,7 @@ function signin() {
       callbackURL: 'http://localhost:3000/callback'
     , responseType: 'code'
     , authParams: {
-      scope: 'openid profile'
+      scope: 'openid name email' //Details: https://auth0.com/docs/scopes
     }
   });
 }

--- a/snippets/server-platforms/python/use.md
+++ b/snippets/server-platforms/python/use.md
@@ -9,7 +9,7 @@ function signin() {
       callbackURL: 'http://localhost:CHANGE-TO-YOUR-PORT/callback'
     , responseType: 'code'
     , authParams: {
-      scope: 'openid profile'
+      scope: 'openid name email' //Details: https://auth0.com/docs/scopes
     }
   });
 }

--- a/snippets/server-platforms/rails/use.md
+++ b/snippets/server-platforms/rails/use.md
@@ -9,7 +9,7 @@ function signin() {
       callbackURL: 'http://localhost:CHANGE-TO-YOUR-PORT/callback'
     , responseType: 'code'
     , authParams: {
-      scope: 'openid profile'
+      scope: 'openid name email' //Details: https://auth0.com/docs/scopes
     }
   });
 }

--- a/snippets/server-platforms/scala/use.md
+++ b/snippets/server-platforms/scala/use.md
@@ -9,7 +9,7 @@ function signin() {
       callbackURL: 'http://localhost:CHANGE-TO-YOUR-PORT/callback'
     , responseType: 'code'
     , authParams: {
-      scope: 'openid profile'
+      scope: 'openid name email' //Details: https://auth0.com/docs/scopes
     }
   });
 }

--- a/snippets/server-platforms/servicestack/use.md
+++ b/snippets/server-platforms/servicestack/use.md
@@ -9,7 +9,7 @@ function signin() {
       callbackURL: 'http://localhost:CHANGE-TO-YOUR-PORT/callback'
     , responseType: 'code'
     , authParams: {
-      scope: 'openid profile'
+      scope: 'openid name email' //Details: https://auth0.com/docs/scopes
     }
   });
 }

--- a/snippets/server-platforms/symfony/use.md
+++ b/snippets/server-platforms/symfony/use.md
@@ -9,7 +9,7 @@ function signin() {
       callbackURL: 'http://localhost:CHANGE-TO-YOUR-PORT/callback'
     , responseType: 'code'
     , authParams: {
-      scope: 'openid profile'
+      scope: 'openid name email' //Details: https://auth0.com/docs/scopes
     }
   });
 }


### PR DESCRIPTION
All occurrences of ‘openid profile’ has been replaced by the
appropriate setting. Also, links to scope documentation were added, and
other paragraphs adjusted to the change.
