### PR TITLE
Updates to code sample for iOS delegation

### DIFF
--- a/articles/libraries/lock-ios/delegation-api.md
+++ b/articles/libraries/lock-ios/delegation-api.md
@@ -9,12 +9,14 @@ After a successful authentication, you can request credentials to access third p
 
 Here's an example
 ```objc
-NSString *idToken = ...;
+A0Lock *lock = ...; // your shared, single instance of A0Lock
+A0Token *token = ...; // a parameter in Lock's onAuthenticationBlock
+NSString *idToken = token.idToken;
 A0AuthParameters *parameters = [A0AuthParameters newWithDictionary:@{
                                                                      @"id_token": idToken,
                                                                      A0ParameterAPIType: @"firebase",
                                                                      }];
-[[A0APIClient sharedClient] fetchDelegationTokenWithParameters:parameters success:^(NSDictionary *delegationToken) {
+[[lock apiClient] fetchDelegationTokenWithParameters:parameters success:^(NSDictionary *delegationToken) {
     NSLog(@"Firebase credentials %@", delegationToken);
 } failure:^(NSError *error) {
     NSLog(@"Something went wrong");


### PR DESCRIPTION
Changed to use lock -apiClient rather than A0ApiClient sharedInstance which appears to be deprecated.
Added a couple of lines to show where the id_token comes from (took me a bit of trial and error to get this right).
