### PR TITLE
Fix issue51 nodejs webapp unclear step2 tutorial

### DIFF
--- a/articles/server-platforms/nodejs.md
+++ b/articles/server-platforms/nodejs.md
@@ -38,6 +38,8 @@ ${snippet(meta.snippets.dependencies)}
 
 We need to configure Passport to use Auth0 strategy.
 
+Create a file called `setup-passport.js` and add these contents to it:
+
 ${snippet(meta.snippets.setup)}
 
 ### 3. Add needed requires & initialize passport configuration


### PR DESCRIPTION
Makes it clear to the user that a file called `setup-passport.js` has
to be created with the contents indicated in step 2 of the nodejs
webapp tutorial. Fixes https://github.com/auth0/docs/issues/51 .
