### PR TITLE
Fixes issue #60

### DIFF
--- a/articles/native-platforms/android.md
+++ b/articles/native-platforms/android.md
@@ -43,13 +43,13 @@ ${snippet(meta.snippets.dependencies)}
 
 ### 2. Configuring Auth0 Credentials & Callbacks
 
-Add the `android.permission.INTERNET` permission:
+Add the `android.permission.INTERNET` permission to `AndroidManifest.xml` inside the `<manifest>` tag:
 
 ```xml
 <uses-permission android:name="android.permission.INTERNET"/>
 ```
 
-Then add the following entries to `AndroidManifest.xml` inside the `<application>` tag:
+Then add the following entries inside the `<application>` tag in the same file:
 
 ```xml
 <!--Auth0 Lock-->


### PR DESCRIPTION
Makes it clear that the permission indicated in step 2 of the Android
tutorial, should be added to AndroidManifest.xml. Fixes
https://github.com/auth0/docs/issues/60 .
