### PR TITLE
Ios tutorial patch

### DIFF
--- a/articles/native-platforms/ios-objc.md
+++ b/articles/native-platforms/ios-objc.md
@@ -197,7 +197,7 @@ ${snippet(meta.snippets.use)}
 [![Lock.png](/media/articles/native-platforms/ios-objc/Lock-Widget-Screenshot.png)](https://auth0.com)
 
 > **Note**: There are multiple ways of implementing the login box. What you see above is the Login Widget, but if you want, you can use [your own UI](/libraries/lock-ios/use-your-own-ui).
-> Or you can also try our passwordless Login Widgets: [SMS](/libraries/lock-ios#8) or [TouchID](/libraries/lock-ios#7)
+> Or you can also try our passwordless Login Widgets: [SMS](/libraries/lock-ios#8) or [TouchID](/libraries/lock-ios#touchid)
 
 On successful authentication, `onAuthenticationBlock` will yield the user's profile and tokens.
 

--- a/articles/native-platforms/ios-swift.md
+++ b/articles/native-platforms/ios-swift.md
@@ -208,7 +208,7 @@ ${snippet(meta.snippets.use)}
 [![Lock.png](/media/articles/native-platforms/ios-swift/Lock-Widget-Screenshot.png)](https://auth0.com)
 
 > **Note**: There are multiple ways of implementing the login box. What you see above is the Login Widget, but if you want, you can use [your own UI](/libraries/lock-ios/use-your-own-ui).
-> Or you can also try our passwordless Login Widgets: [SMS](/libraries/lock-ios#8) or [TouchID](/libraries/lock-ios#7)
+> Or you can also try our passwordless Login Widgets: [SMS](/libraries/lock-ios#8) or [TouchID](/libraries/lock-ios#touchid)
 
 On successful authentication, `onAuthenticationBlock` will yield the user's profile and tokens.
 


### PR DESCRIPTION
Updated the ios-objc and ios-swift tutorials to use the proper Anchor Link for Touchid, as stated in this Issue https://github.com/auth0/docs/issues/115
