### PR TITLE
Fix for issue 338

### DIFF
--- a/articles/client-platforms/vanillajs.md
+++ b/articles/client-platforms/vanillajs.md
@@ -137,3 +137,10 @@ window.location.href = "/";
 ### 7. All done!
 
 You have completed the implementation of Login and Signup with Auth0 and VanillaJS.
+
+
+### Troubleshooting
+
+#### Window.location.hash contains an empty string after the user is logged in
+
+Programatically setting a value to `window.location.href` will cause this. Please avoid writing to `window.location.href` while the user is logged in.


### PR DESCRIPTION
Advice the reader to avoid setting a value to window.location.href
while the user is logged in. Otherwise Lock will loss track of
window.location.hash and the token is lost.
