### PR TITLE
Add a note about configuring spring-security-auth0 using Gradle.

### DIFF
--- a/articles/server-apis/java-spring-security.md
+++ b/articles/server-apis/java-spring-security.md
@@ -38,6 +38,10 @@ For that, you can just add it to your `pom.xml` if you're using maven.
 
 ${snippet(meta.snippets.dependencies)}
 
+Or, if you're using Gradle, add it to the dependencies block:
+
+${snippet(meta.snippets.dependencies-gradle)}
+
 ### 2. Configure Spring to use Auth0
 
 Now you need to configure Spring to use Spring Security with Auth0.

--- a/snippets/server-apis/java-spring-security/dependencies-gradle.md
+++ b/snippets/server-apis/java-spring-security/dependencies-gradle.md
@@ -1,0 +1,8 @@
+```groovy
+dependencies {
+  /*
+   * Exisitng dependencies
+   */
+  compile 'com.auth0:spring-security-auth0:0.2'
+}
+```


### PR DESCRIPTION
Official Spring docs typically include configurations for Maven and Gradle. For an example, see the Maven/Gradle switch dingus under Quick Start at http://projects.spring.io/spring-security/
