### PR TITLE
Removed gendered language from the Node.JS quickstart

### DIFF
--- a/articles/server-platforms/nodejs.md
+++ b/articles/server-platforms/nodejs.md
@@ -73,7 +73,7 @@ app.use(passport.session());
 
 ### 5. Add Auth0 callback handler
 
-We need to add the handler for the Auth0 callback so that we can authenticate the user and get his information.
+We need to add the handler for the Auth0 callback so that we can authenticate the user and get their information.
 
 ```js
 // Auth0 callback handler


### PR DESCRIPTION
Changed 'his' to 'their'.

Perhaps we should add a note to avoid gendered language in the contributor guidelines?

I'll keep an eye out for more of these and fix them as I find them.
