### PR TITLE
Add a snippet to the Spring Security tutorial demonstrating JavaConfig annotations. 

### DIFF
--- a/articles/server-apis/java-spring-security.md
+++ b/articles/server-apis/java-spring-security.md
@@ -13,6 +13,7 @@ image: /media/platforms/java.png
 tags:
   - quickstart
 snippets:
+  configure: server-apis/java-spring-security/configure
   dependencies: server-apis/java-spring-security/dependencies
   dependenciesGradle: server-apis/java-spring-security/dependencies-gradle
   setup: server-apis/java-spring-security/setup
@@ -60,7 +61,11 @@ For that, just add the following to the `application-context.xml`
 <context:property-placeholder location="classpath:auth0.properties" />
 ```
 
-and create the `auth0.properties` file with the following information:
+Or, alternately, add these annotations to your application class:
+
+${snippet(meta.snippets.configure)}
+
+Once you've done either of those, then create the `auth0.properties` file with the following information:
 
 ${snippet(meta.snippets.setup)}
 

--- a/snippets/server-apis/java-spring-security/configure.md
+++ b/snippets/server-apis/java-spring-security/configure.md
@@ -1,0 +1,11 @@
+```java
+import org.springframework.context.annotation.*;
+
+@Configuration
+@ComponentScan("com.auth0")
+@ImportResource("classpath:auth0-security-context.xml")
+@PropertySource("classpath:auth0.properties")
+/*
+ * Your application class
+ */
+```


### PR DESCRIPTION
Spring JavaConfig annotations are presented as an alternative to XML configuration. 
