### PR TITLE
Changed language format from 'jsx' to 'js'

### DIFF
--- a/snippets/client-platforms/react/use.md
+++ b/snippets/client-platforms/react/use.md
@@ -1,4 +1,4 @@
-```jsx
+```js
 var Home = React.createClass({
   // ...
   showLock: function() {


### PR DESCRIPTION
This is to fix the fact that syntax highlighting is not working here: https://auth0.com/docs/quickstart/spa/react/nodejs#3-implement-the-login
