### PR TITLE
[bug] Remove links of missing images

### DIFF
--- a/articles/client-platforms/vuejs.md
+++ b/articles/client-platforms/vuejs.md
@@ -8,7 +8,7 @@ language:
   - Javascript
 framework:
   - Vue.js
-image: /media/platforms/vuejs.png
+image:
 tags:
   - quickstart
 snippets:

--- a/articles/connections/social/exact.md
+++ b/articles/connections/social/exact.md
@@ -1,6 +1,6 @@
 ---
 connection: Exact
-image: /media/connections/exact.png
+image:
 ---
 
 # Obtain a *Client Id* and *Client Secret* for Exact

--- a/articles/connections/social/goodreads.md
+++ b/articles/connections/social/goodreads.md
@@ -1,6 +1,6 @@
 ---
 connection: Goodreads
-image: /media/connections/goodreads.png
+image:
 ---
 
 # Obtain a Consumer Keys and Consumer Secret for Goodreads

--- a/articles/connections/social/microsoft-account.md
+++ b/articles/connections/social/microsoft-account.md
@@ -1,6 +1,6 @@
 ---
 connection: Microsoft Account (formerly LiveID)
-image: /media/connections/microsoft-account.png
+image:
 alias:
  - live-id
  - microsoft-live

--- a/articles/connections/social/oauth2.md
+++ b/articles/connections/social/oauth2.md
@@ -1,6 +1,6 @@
 ---
 connection: Generic OAuth2 Provider
-image: /media/connections/oauth2.png
+image:
 ---
 
 # Add a generic OAuth2 Authorization Server to Auth0

--- a/articles/connections/social/planning-center.md
+++ b/articles/connections/social/planning-center.md
@@ -1,6 +1,6 @@
 ---
 connection: Planning Center
-image: /media/connections/planning-center.png
+image:
 ---
 
 # Obtain a *Client ID* and *Secret* for Planning Center

--- a/articles/native-platforms/electron.md
+++ b/articles/native-platforms/electron.md
@@ -8,7 +8,7 @@ language:
 framework:
   - Electron
 hybrid: false
-image: /media/platforms/electron.png
+image:
 tags:
   - quickstart
   - electron


### PR DESCRIPTION
Some articles has missing images:
- `articles/client-platforms/vuejs.md`
- `articles/connections/social/exact.md`
- `articles/connections/social/goodreads.md`
- `articles/connections/social/microsoft-account.md`
- `articles/connections/social/oauth2.md`
- `articles/connections/social/planning-center.md`
- `articles/native-platforms/electron.md`
