### PR TITLE
Updated to include info regarding OWIN middleware

### DIFF
--- a/articles/server-apis/webapi-owin.md
+++ b/articles/server-apis/webapi-owin.md
@@ -49,16 +49,11 @@ using Microsoft.Owin.Security;
 using WebConfigurationManager = System.Web.Configuration.WebConfigurationManager;
 ```
 
-Update the `Configuration` method with the following code, ensuring that it is placed *before* registering WebApi as the ordering of OWIN middleware is important.
+Update the `Configuration` method with the following code:
 
-```cs
-// this should occur after the JWT handler has been registered
-app.UseWebApi(config);
-```
+> Important: The JWT handler *must* be registered before `app.UseWebApi(config)` as ordering of OWIN middleware is important.
 
 ${snippet(meta.snippets.use)}
-
-
 
 ### 3. Update the web.config file with your app's credentials
 Open the **web.config** file located at the solution's root.

--- a/articles/server-apis/webapi-owin.md
+++ b/articles/server-apis/webapi-owin.md
@@ -49,9 +49,16 @@ using Microsoft.Owin.Security;
 using WebConfigurationManager = System.Web.Configuration.WebConfigurationManager;
 ```
 
-Update the `Configuration` method with the following code:
+Update the `Configuration` method with the following code, ensuring that it is placed *before* registering WebApi as the ordering of OWIN middleware is important.
+
+```cs
+// this should occur after the JWT handler has been registered
+app.UseWebApi(config);
+```
 
 ${snippet(meta.snippets.use)}
+
+
 
 ### 3. Update the web.config file with your app's credentials
 Open the **web.config** file located at the solution's root.


### PR DESCRIPTION
I ran into problems trying to get this example working because I registered the JWT handler after I had already registered Web API with the app. Ensuring that JWT is registered first will avoid confusion for others following these instructions in the future
