### PR TITLE
[edit] Fix grammar on email section index

### DIFF
--- a/articles/email/index.md
+++ b/articles/email/index.md
@@ -6,9 +6,9 @@ url: /email
 You can use Auth0 built-in email services to communicate with your users to: 
 
 * validate email addresses at sign up;
-* confirm a password change requests.
+* confirm password change requests.
 
-> Auth0's email provider will no longer be supported for use in a production environment. You can use our built-in email service for testing but you must switch to an Auth0-supported [third-party service](/email/providers) ([Amazon SES](https://aws.amazon.com/ses/), [Mandrill](https://www.mandrill.com/signup/) or [Sendgrid](https://sendgrid.com/pricing)) or a [custom provider](/email/custom) when moving your apps to production.
+> Auth0's email provider will no longer be supported for use in a production environment. You can use our built-in email service for testing but you must switch to an Auth0-supported [third-party service](/email/providers) ([Amazon SES](https://aws.amazon.com/ses/), [Mandrill](https://www.mandrill.com/signup/) or [SendGrid](https://sendgrid.com/pricing)) or a [custom provider](/email/custom) when moving your apps to production.
 
 The [Emails](${uiURL}/#/emails) dashboard allows you to customize your emails with markdown templates and macros, which can include references to the context of the current application or user.
 


### PR DESCRIPTION
Fix a small error on `email/index.md`:

```
confirm a password change requests.
```

to:

```
confirm password change requests.
```

And correct `SendGrid` capitalization.
