### PR TITLE
[edit] Yammer - Removed public:false, added description

### DIFF
--- a/articles/connections/social/yammer.md
+++ b/articles/connections/social/yammer.md
@@ -1,7 +1,7 @@
 ---
 connection: Yammer
 image: /media/connections/yammer.png
-public: false
+description: How to obtain the credentials required to configure your Auth0 connection to Yammer.
 ---
 
 # Obtain an *App ID* and *App Secret* for Yammer


### PR DESCRIPTION
I had not made this page public after creating it. Deleted the 'public:false' line because I dont see 'public:true' being used anywhere.
