### PR TITLE
[bug] Remove JWTDecode from quickstart deps

### DIFF
--- a/snippets/native-platforms/ios-objc/dependencies.md
+++ b/snippets/native-platforms/ios-objc/dependencies.md
@@ -1,4 +1,3 @@
 ```ruby
 pod 'Lock', '~> 1.22'
-pod 'JWTDecode', '~> 1.0'
 ```

--- a/snippets/native-platforms/ios-swift/dependencies.md
+++ b/snippets/native-platforms/ios-swift/dependencies.md
@@ -1,5 +1,4 @@
 ```ruby
 use_frameworks!
-pod 'Lock', '~> 1.21'
-pod 'JWTDecode', '~> 1.0'
+pod 'Lock', '~> 1.22'
 ```


### PR DESCRIPTION
### Your checklist for this pull request

Please review the [guidelines for contributing](https://github.com/auth0/docs#contributing) to this repository.
- [x] Commit messages conforms to our [commit message standards](https://github.com/auth0/docs#commit-messages)
- [x] Content conforms to our [Contributing Guidelines](https://github.com/auth0/docs#contributing-guidelines)
- [x] If applicable, you have added details to the [update feed](https://github.com/auth0/docs/tree/master/updates) 
### Description

In ObjC was requiring version 1.x of JWTDecode, which is a swift library and it
will only work if the flag 'use_frameworks!' is set in the Podfile. Since it's
not used by Lock or required in the quickstart it was removed.
