### PR TITLE
[update] Windows UWP Private Network capability information

### DIFF
--- a/articles/native-platforms/windows-uwp-csharp.md
+++ b/articles/native-platforms/windows-uwp-csharp.md
@@ -86,9 +86,9 @@ You can get more information about this in the [Scopes documentation](/scopes).
 
 ### 4. (Optional) Capabilities
 
-In some cases Auth0 may not be able to connect to an identity provider. Showing nothing more than a "Can't connect to the service" message. A reason for this can be that the identity provider endpoint resolves to an Intranet (that has an authenticated domain controller), home or work network. In this case it is required to enable the "Private Networks (Client & Server)" capability.
+In some cases Auth0 may not be able to connect to an identity provider. Showing nothing more than a "Can't connect to the service" message. A reason for this may be that the identity provider endpoint resolves to an Intranet (that has an authenticated domain controller), home or work network. In this case it is required to enable the "Private Networks (Client & Server)" capability.
 
-use the Package Manifest (Solution Explorer > Package.appxmanifest) to enable the capability within the "Capabilities" tab.
+Use the Package Manifest (Solution Explorer > Package.appxmanifest) to enable the capability within the "Capabilities" tab.
 
 ## Accessing user information
 

--- a/articles/native-platforms/windows-uwp-csharp.md
+++ b/articles/native-platforms/windows-uwp-csharp.md
@@ -84,6 +84,12 @@ Optionally you can specify the `scope` parameter. There are various possible val
 
 You can get more information about this in the [Scopes documentation](/scopes).
 
+### 4. (Optional) Capabilities
+
+In some cases Auth0 may not be able to connect to an identity provider. Showing nothing more than a "Can't connect to the service" message. A reason for this can be that the identity provider endpoint resolves to an Intranet (that has an authenticated domain controller), home or work network. In this case it is required to enable the "Private Networks (Client & Server)" capability.
+
+use the Package Manifest (Solution Explorer > Package.appxmanifest) to enable the capability within the "Capabilities" tab.
+
 ## Accessing user information
 
 The `Auth0User` has the following properties:


### PR DESCRIPTION
Include documentation regarding the UWP "Private Networks" capability that may be required to get Auth0 working properly with certain identity providers (in my case Active Directory integration). This fixes the "Can't connect to the service" error which provides no further detail on why this message actually appears.
