### PR TITLE
[update] Rename auth0-java to auth0-servlet

### DIFF
--- a/articles/server-apis/java.md
+++ b/articles/server-apis/java.md
@@ -26,14 +26,14 @@ This tutorial and seed project have been tested with the following:
 :::
 
 <%= include('../_includes/_package', {
-  pkgRepo: 'auth0-java',
+  pkgRepo: 'auth0-servlet',
   pkgBranch: 'master',
   pkgPath: 'examples/java-api',
   pkgFilePath: null,
   pkgType: 'none'
 }) %>
 
-Then, you just need to specify your Auth0 account configuration as enviroment variables. [Check it here](https://github.com/auth0/auth0-java/blob/master/examples/java-api/README.md#running-the-example)
+Then, you just need to specify your Auth0 account configuration as enviroment variables. [Check it here](https://github.com/auth0/auth0-servlet/blob/master/examples/java-api/README.md#running-the-example)
 
 **If you have an existing application, please follow the steps below.**
 

--- a/articles/server-platforms/java.md
+++ b/articles/server-platforms/java.md
@@ -25,7 +25,7 @@ This tutorial and seed project have been tested with the following:
 :::
 
 <%= include('../_includes/_package', {
-  pkgRepo: 'auth0-java',
+  pkgRepo: 'auth0-servlet',
   pkgBranch: 'master',
   pkgPath: 'examples/java-regular-webapp',
   pkgFilePath: 'examples/java-regular-webapp/src/main/webapp/WEB-INF/web.xml',
@@ -79,7 +79,7 @@ http://yourUrl/callback
 
 ${lockSDK}
 
-> **Warning:** Auth0 Java requires that you specify the `state` parameter in Auth0 Widget or [Auth0 Lock](/libraries/lock/customization#authparams-object). The Login servlet must propagate [the nonce](https://github.com/auth0/auth0-java/blob/2836d13c0a766e3a2fd28fc95bb582fa79e57c52/examples/java-regular-webapp/src/main/java/com/auth0/example/LoginServlet.java#L22) and pass it [to the JSP page](https://github.com/auth0/auth0-java/blob/master/examples/java-regular-webapp/src/main/webapp/login.jsp#L45). For an example of this, check the seed project above.
+> **Warning:** Auth0 Java requires that you specify the `state` parameter in Auth0 Widget or [Auth0 Lock](/libraries/lock/customization#authparams-object). The Login servlet must propagate [the nonce](https://github.com/auth0/auth0-servlet/blob/2836d13c0a766e3a2fd28fc95bb582fa79e57c52/examples/java-regular-webapp/src/main/java/com/auth0/example/LoginServlet.java#L22) and pass it [to the JSP page](https://github.com/auth0/auth0-servlet/blob/master/examples/java-regular-webapp/src/main/webapp/login.jsp#L45). For an example of this, check the seed project above.
 
 > **Note:** Please note that the `callbackURL` specified in the `Auth0Lock` constructor **must match** the one specified in the previous step
 

--- a/config/navigation.yml
+++ b/config/navigation.yml
@@ -190,7 +190,7 @@ categories:
       -
         name: "Java"
         slug: "java"
-        href: "https://github.com/auth0/auth0-java"
+        href: "https://github.com/auth0/auth0-servlet"
       -
         name: ".NET"
         slug: "net"


### PR DESCRIPTION
### Your checklist for this pull request

Please review the [guidelines for contributing](https://github.com/auth0/docs#contributing) to this repository.
- [x] Commit messages conforms to our [commit message standards](https://github.com/auth0/docs#commit-messages)
- [x] Content conforms to our [Contributing Guidelines](https://github.com/auth0/docs#contributing-guidelines)
- [x] If applicable, you have added details to the [update feed](https://github.com/auth0/docs/tree/master/updates) 
### Description

The repository of auth0-java was renamed to auth0-servlet since a Auth0 API java client will be released under that name.
