### PR TITLE
Add a redirection rule for spa, native, web and backend quickstarts

### DIFF
--- a/redirect-urls.json
+++ b/redirect-urls.json
@@ -574,5 +574,21 @@
   {
     "from": "/password-strength",
     "to": "/connections/database/password-strength"
+  },
+  {
+    "from": "/client-platforms/:platform",
+    "to": "/quickstart/spa/:platform/no-api"
+  },
+  {
+    "from": "/native-platforms/:platform",
+    "to": "/quickstart/native-mobile/:platform/no-api"
+  },
+  {
+    "from": "/server-platforms/:platform",
+    "to": "/quickstart/webapp/:platform"
+  },
+  {
+    "from": "/server-apis/:platform",
+    "to": "/quickstart/backend/:platform"
   }
 ]


### PR DESCRIPTION
### Description

Google is penalizing us for having pages with duplicate content. For instance, `/client-platforms/*` have an equivalent page at `/quickstart/spa/*`.

This PR adds the following redirection rules:

```
  /client-platforms/:platform => /quickstart/spa/:platform/no-api
  /native-platforms/:platform => /quickstart/native-mobile/:platform/no-api
  /server-platforms/:platform => /quickstart/webapp/:platform
  /server-apis/:platform      => /quickstart/backend/:platform
```
