### PR TITLE
Fix broken rate limit link in policies page

### DIFF
--- a/articles/policies/index.md
+++ b/articles/policies/index.md
@@ -9,4 +9,4 @@ Auth0 has established the following operational policies.
 -  [Data Transfer](/policies/data-transfer)
 -  [Dashboard Authentication](/policies/dashboard-authentication)
 -  [Load Testing](/policies/load-testing)
--  [Rate Limits](/policies/rate-limits)
+-  [Rate Limits](/rate-limits)


### PR DESCRIPTION
Alternatively, we could move `/rate-limits.md` to the `/policies` directory. I'm not sure if they would break other links. Someone on the docs team can confirm.
