### PR TITLE
[edit] Change FAQ page to point to public forum

### DIFF
--- a/articles/faq.md
+++ b/articles/faq.md
@@ -1,10 +1,5 @@
 # FAQ
 
-This page contains pointers to frequently asked questions.
+We have moved the list of frequently asked questions to our [forum](https://ask.auth0.com/c/faqs).
 
-
-* [How to customize the "Oops" page](https://ask.auth0.com/t/is-it-possible-to-customize-the-oops-page-for-errors-after-login/2627 )
-
-* [How to debug custom code like rules, custom DB scripts, webtasks](https://ask.auth0.com/t/how-to-debug-custom-code-like-rules-custom-db-scripts-webtasks/2626)
-
-* [User profile attributes available in custom email templates](https://ask.auth0.com/t/what-user-profile-attributes-are-available-in-custom-email-templates/2628)
+If you cannot find in there what you are looking for, please try the [search page](https://ask.auth0.com/search) to search for similar questions that might have been already answered.


### PR DESCRIPTION
@yvonnewilson thought it would be better to directly point users to the public forum's FAQ category instead of having to add a question to this file each time a new FAQ topic was created in the forum.

I also added a message to encourage users to use the search feature to prevent duplicated questions in case they don't find what they're looking for in the FAQ category.
