### PR TITLE
[edit] Fixed FacebookAppID Typo in iOS docs

### DIFF
--- a/articles/libraries/lock-ios/native-social-authentication.md
+++ b/articles/libraries/lock-ios/native-social-authentication.md
@@ -22,10 +22,10 @@ pod 'Lock-Google'
 Lock uses Facebook iOS SDK to obtain user's access token so you'll need to configure it using your Facebook App info:
 
 First, add the following entries to the `Info.plist`:
-* _FacebookAppId_: `YOUR_FACEBOOK_APP_ID`
+* _FacebookAppID_: `YOUR_FACEBOOK_APP_ID`
 * _FacebookDisplayName_: `YOUR_FACEBOOK_DISPLAY_NAME`
 
-Then register a custom URL Type with the format `fb<FacebookAppId>`. For more information please check [Facebook Getting Started Guide](https://developers.facebook.com/docs/ios/getting-started).
+Then register a custom URL Type with the format `fb<FacebookAppID>`. For more information please check [Facebook Getting Started Guide](https://developers.facebook.com/docs/ios/getting-started).
 
 Here's an example of how the entries should look like in your `Info.plist` file:
 


### PR DESCRIPTION
### Your checklist for this pull request

Please review the [guidelines for contributing](https://github.com/auth0/docs#contributing) to this repository.
- [x] Content conforms to our [Contributing Guidelines](https://github.com/auth0/docs#contributing-guidelines)
- [x] If applicable, you have added details to the [update feed](https://github.com/auth0/docs/tree/master/updates) 
### Description

The actual key is `FacebookAppID` and not `FacebookAppId`. If people just copypaste this into their Info.plist, it will crash, telling them the key isn't found. Sure, it's easy to fix, but it would be nice if it didn't happen 😃 

I didn't think this change was significant enough, so I left the update feed alone.
