### PR TITLE
Fix broken link /articles/server-apis

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ When testing a document or tutorial below are several areas to look for.
 1. Check for outdated dependencies (both auth0 dependencies and third-party i.e. node modules, nuget packages, gems, etc.)
 
 ## Quickstarts
-All quickstart data comes directly from the docs API at `/meta/quickstart`. This means that the quickstart on docs and manage will both consume the same datasource and will always be up to date. To add a new quickstart you simply need to add the markdown document in the appropriate folder: [server-apis](/articles/server-apids), [server-platforms](/articles/server-platforms), [native-platforms](/articles/native-platforms), or [client-platforms](/articles/client-platforms). The only requirement is that you need to specify the correct front matter.
+All quickstart data comes directly from the docs API at `/meta/quickstart`. This means that the quickstart on docs and manage will both consume the same datasource and will always be up to date. To add a new quickstart you simply need to add the markdown document in the appropriate folder: [server-apis](/articles/server-apis), [server-platforms](/articles/server-platforms), [native-platforms](/articles/native-platforms), or [client-platforms](/articles/client-platforms). The only requirement is that you need to specify the correct front matter.
 
 For all quickstart docs, provide the following:
 


### PR DESCRIPTION
The server-apis link was pointing to /articles/server-apids probably due to a typo. 
Changed it to /articles/server-apis
