### PR TITLE
Prepare lock v10 docs to beta 2

### DIFF
--- a/articles/libraries/lock/v10/index.md
+++ b/articles/libraries/lock/v10/index.md
@@ -15,7 +15,6 @@ Lock 10 is a new version of the Auth0 authentication widget that provides:
 Auth0 plans to have a few beta releases and a release candidate.
 
 Please note that the following features, which are available on Lock 9 (the current stable release), are not yet available with Lock 10:
-- Enterprise connection support;
 - Out of the box localization (i10n) for foreign languages;
 - Widget lifecycle events.
 
@@ -23,7 +22,7 @@ Please note that the following features, which are available on Lock 9 (the curr
 
 * Lock now uses Redirect Mode by default. To use Popup Mode, you must enable this explicitly.
 * The Lock Public API has been updated so there are not significant differences between Redirect and Popup Mode. This makes Redirect Mode, which is the recommended mode, much easier to use. Also, related options are grouped together.
-* The Beta 1 release of Lock does not support foreign languages, but you can still translate the widget via `languageDictionary`.
+* The current beta release of Lock does not support foreign languages, but you can still translate the widget via `languageDictionary`.
 * You can create simple Lock themes using JavaScript to via `primaryColor` and `logo` properties of the `theme` option. You may also make customizations with CSS.
 * The improved Lock UX comes with smoother transitions and animations and is keyboard friendly.
 * Lock comes with support for pre-filled fields and custom avatar implementations.

--- a/articles/libraries/lock/v10/installation.md
+++ b/articles/libraries/lock/v10/installation.md
@@ -1,7 +1,7 @@
 ## Migrating to Lock 10
 
 ::: panel-warning Version Notice
-Because this is an early preview of Lock 10, we recommend installing the full version (10.0.0-beta.1).
+Because this is an early preview of Lock 10, we recommend installing the full version (10.0.0-beta.2).
 :::
 
 You can get the required Lock installation package from several sources.
@@ -9,13 +9,13 @@ You can get the required Lock installation package from several sources.
 CDN:
 
 ```html
-<script src="https://cdn.auth0.com/js/lock/10.0.0-beta.1/lock.min.js"></script>
+<script src="https://cdn.auth0.com/js/lock/10.0.0-beta.2/lock.min.js"></script>
 ```
 
 [Bower](http://bower.io):
 
 ```sh
-bower install auth0-lock#10.0.0-beta.1
+bower install auth0-lock#10.0.0-beta.2
 ```
 
 ```html
@@ -121,6 +121,8 @@ function showLoggedIn() {
 
 ## Migration Guide
 
+The following instructions assume you are migrating from Lock v9 to the latest beta of v10 available. If you are upgrading from a previous beta release, please refer to the [beta changes](#beta-changes).
+
 - The constructor now takes all the options and the authentication callback.
 - The authentication callback now has just two arguments `error` and `result`. The `result` argument is an object that contains properties for the arguments provided in the previous versions: `profile`, `idToken`, `accessToken`, `state`, and `refreshToken`.
 - Lock now uses Redirect Mode by default. To use Popup Mode, you must enable this explicitly with the `authentication: { redirect: true }` option.
@@ -131,7 +133,9 @@ function showLoggedIn() {
 - Some existing options suffered changes:
   - The `authParams` option was renamed to `params` and namespaced under `auth`. Now you use it like this `auth: {params: {myparam: "myvalue"}}`.
   - The `callbackURL` option was renamed to `redirectUrl` and namespaced under `auth`. Now you use it like this `auth: {redirectUrl: "https://example.com/callback"}`.
-  - The `dict` option was renamed to `languageDictionary`.
+  - The `connections` option was renamed to `allowedConnections`.
+  - The `defaultUserPasswordConnection` option has been replaced by the `defaultDatabaseConnection` and the `defaultEnterpriseConnection` options.
+  - The `dict` option was renamed to `languageDictionary`. Also it's structure has been changed, see the project's [README](https://github.com/auth0/lock/tree/v10#language-dictionary-specification) for more inforamtion.
   - The `disableResetAction` option was renamed to `allowForgotPassword`.
   - The `disableSignUpAction` option was renamed to `allowSignUp`.
   - The `focusInput` option was renamed to `autofocus`.
@@ -145,3 +149,14 @@ function showLoggedIn() {
   - The `socialBigButtons` option was renamed to `socialButtonStyle` and its possible values are `"small"` or `"big"` instead of `true` or `false`.
   - The `sso` option was namespaced under `auth`.  Now you use it like this `auth: {sso: false}`.
 - Some other options were added, see [New Features page](/libraries/lock/v10/new-features) for details.
+
+### Beta changes
+
+This is a summary of what you absolutely need to know before upgrading between beta releases. For the full list of changes, please see the project's [CHANGELOG](https://github.com/auth0/lock/blob/v10/CHANGELOG.md).
+
+#### Upgrading from v10.0.0-beta.1 to v10.0.0-beta.2
+
+- Renamed `close` method to `hide`.
+- Renamed `connections` option to `allowedConnections`.
+- Renamed `signUp.footerText` dict key to `signUp.terms`.
+- Requiring the npm package has been fixed, you need to `require('auth0-lock')` instead of `require('auth0-lock/lib/classic')`.

--- a/articles/libraries/lock/v10/new-features.md
+++ b/articles/libraries/lock/v10/new-features.md
@@ -149,3 +149,24 @@ var lock = new AuthLock(
     // handle auth
 });
 ```
+
+## Sign Up Terms Agreement
+
+You can ask the user to accept the terms and conditions by clicking a checkbox input before signing up with the `mustAcceptTerms` option.
+
+```js
+var lock = new AuthLock(
+  '${account.clientId}',
+  '${account.namespace}',
+  {
+    languageDictionary: {
+      signUp: {
+        terms: "I agree to the <a href='/terms' target='_new'>terms of service</a> and <a href='/privacy' target='_new'>privacy policy</a>."
+      }
+    },
+    mustAcceptTerms: true
+  },
+  function(error, result) {
+    // handle auth
+});
+```


### PR DESCRIPTION
### Your checklist for this pull request

Please review the [guidelines for contributing](https://github.com/auth0/docs#contributing) to this repository.
- [ ] Content conforms to our [Contributing Guidelines](https://github.com/auth0/docs#contributing-guidelines)
- [ ] If applicable, you have added details to the [update feed](https://github.com/auth0/docs/tree/master/updates) 
### Description
- Update installation and migration instructions for the 2nd beta of Lock v10
- Add instructions for updating from beta 1
