### PR TITLE
AWS Tutorials: Fix tutorials to show use of Rules instead of API call querystrings

### DIFF
--- a/articles/aws-api-setup.md
+++ b/articles/aws-api-setup.md
@@ -97,7 +97,7 @@ In this example, you will create a policy that grants full access to the S3 reso
 
   ![](/media/articles/aws-api-setup/aws-api-setup-13.png)
 
-2. From the summary page of the identity provider you created previously, copy the **Provider ARN** value. You will use this value as the **Principal ARN** when calling the `/delegation` endpoint in Auth0.
+2. From the summary page of the identity provider you created previously, copy the **Provider ARN** value. You will use this value as the **Principal ARN** in the [Rule you will build to be used in conjunction with the call to Auth0's `/delegation` endpoint](/integrations/aws#get-the-aws-token-for-an-authenticated-user).
 
   ![](/media/articles/aws-api-setup/aws-api-setup-14.png)
 

--- a/articles/integrations/aws.md
+++ b/articles/integrations/aws.md
@@ -179,8 +179,6 @@ Content-Type: 'application/json'
   "id_token":    "{YOUR_ID_TOKEN}",
   "target":      "${account.clientId}",
   "api_type":    "aws",
-  "role":        "arn:aws:iam::010616021751:role/access-to-s3-per-user"
-  "principal":   "arn:aws:iam::010616021751:saml-provider/auth0-provider"
 }
 ```
 
@@ -190,7 +188,25 @@ Where:
 * **id_token** identifies the user you are requesting this on behalf-of
 * **target** identifies this API endpoint in Auth0 (often the same as client_id).
 * **api_type** must be aws
-* **role** and **principal** are two additional parameters used for AWS
+
+Additionally, AWS requires two additional parameters, **role** and **principal**. To modify the `role` and `principal` strings, specify the appropriate values via [Rules](https://manage.auth0.com/#/rules):
+
+```js
+function (user, context, callback) {
+  if (context.clientID === 'CLIENT_ID' &&
+      context.protocol === 'delegation') {
+    // set AWS settings
+    context.addonConfiguration = context.addonConfiguration || {};
+    context.addonConfiguration.aws = context.addonConfiguration.aws || {};
+    context.addonConfiguration.aws.principal = 'arn:aws:iam::[omitted]:saml-provider/auth0-provider';
+    context.addonConfiguration.aws.role = 'arn:aws:iam::[omitted]:role/auth0-role';
+  }
+
+  callback(null, user, context);
+}
+
+```
+
 
 **NOTE:** Copy the Provider ARN, and use this as the Principal ARN when obtaining the delegation token.
 


### PR DESCRIPTION
### Your checklist for this pull request

Please review the [guidelines for contributing](https://github.com/auth0/docs#contributing) to this repository.
- [ ] Content conforms to our [Contributing Guidelines](https://github.com/auth0/docs#contributing-guidelines)
- [ ] If applicable, you have added details to the [update feed](https://github.com/auth0/docs/tree/master/updates) 
### Description

Please describe your pull request.

Thank you!
