### PR TITLE
Fix typo in Swift TouchID and SMS code.

### DIFF
--- a/articles/libraries/lock-ios/index.md
+++ b/articles/libraries/lock-ios/index.md
@@ -177,7 +177,7 @@ controller.onAuthenticationBlock = ^(A0UserProfile *profile, A0Token *token) {
 ```swift
 let lock = ... //Fetch Lock from where its stored
 let controller = lock.newTouchIDViewController()
-lock.onAuthenticationBlock = {(profile: A0UserProfile!, token: A0Token!) -> () in
+controller.onAuthenticationBlock = {(profile: A0UserProfile!, token: A0Token!) -> () in
     // Do something with token & profile. e.g.: save them.
     // Lock will not save the Token and the profile for you.
     // And dismiss the UIViewController.
@@ -218,8 +218,8 @@ controller.onAuthenticationBlock = ^(A0UserProfile *profile, A0Token *token) {
 ```swift
 let lock = ... //Fetch Lock from where its stored
 let controller = lock.newSMSViewController()
-lock.auth0APIToken = {() -> String in return "Copy API v2 token here"}
-lock.onAuthenticationBlock = {(profile: A0UserProfile!, token: A0Token!) -> () in
+controller.auth0APIToken = {() -> String in return "Copy API v2 token here"}
+controller.onAuthenticationBlock = {(profile: A0UserProfile!, token: A0Token!) -> () in
     // Do something with token & profile. e.g.: save them.
     // Lock will not save the Token and the profile for you.
     // And dismiss the UIViewController.


### PR DESCRIPTION
### Your checklist for this pull request

Please review the [guidelines for contributing](https://github.com/auth0/docs#contributing) to this repository.
- [x] Content conforms to our [Contributing Guidelines](https://github.com/auth0/docs#contributing-guidelines)
- [ ] If applicable, you have added details to the [update feed](https://github.com/auth0/docs/tree/master/updates) 
### Description

Fix code typos in Swift examples of TouchID and SMS for iOS SDK.

Thank you!
