### PR TITLE
Remove "don't need to call `getProfile`" instruction.

### DIFF
--- a/articles/libraries/lock/v10/installation.md
+++ b/articles/libraries/lock/v10/installation.md
@@ -143,7 +143,7 @@ The following instructions assume you are migrating from Lock v9 to the latest b
 - The authentication callback now has just two arguments `error` and `result`. The `result` argument is an object that contains properties for the arguments provided in the previous versions: `idToken`, `accessToken`, `state`, and `refreshToken`. It also includes a `idTokenPayload` property.
 - The profile is no longer fetched automatically after a successful login, you need to call `lock.getProfile`.
 - Lock now uses Redirect Mode by default. To use Popup Mode, you must enable this explicitly with the `authentication: { redirect: true }` option.
-- You no longer need to to call the `parseHash` and `getProfile` when implementing Redirect Mode. The data returned by those methods is provided in the `result` parameter of the authentication callback.
+- You no longer need to call `parseHash` when implementing Redirect Mode. The data returned by that method is provided in the `result` parameter of the authentication callback.
 - Is no longer possible to select a language by passing a code, which was done in the previous versions of lock with  `dict: 'es'`.
 - Lifecycle events are not yet available.
 - There's only one `show` method which doesn't take any arguments. `showSignIn`, `showSignUp` and `showReset` are no longer available. You can emulate the behavior of this options with the `initialScreen`, `allowForgotPassword` and `allowSignUp` options.


### PR DESCRIPTION
### Your checklist for this pull request

Please review the [guidelines for contributing](https://github.com/auth0/docs#contributing) to this repository.
- [ ] Content conforms to our [Contributing Guidelines](https://github.com/auth0/docs#contributing-guidelines)
- [ ] If applicable, you have added details to the [update feed](https://github.com/auth0/docs/tree/master/updates) 
### Description

Please describe your pull request.

Thank you!

Removed "you no longer need to call `getProfile`", because two lines before it says "you need to call `lock.getProfile`.
