### PR TITLE
Fix rules link

### DIFF
--- a/articles/blacklist-attributes.md
+++ b/articles/blacklist-attributes.md
@@ -76,4 +76,4 @@ For `SAMLP` connections, if you enable 'Debug' mode, your logs will contain info
 
 ### Working with the Limitations
 
-If any of the above limitations regarding blacklisted attributes are unacceptable, you may write a [rule](/rule) to encrypt the data and have the data persist the `user.app_metadata` object.
+If any of the above limitations regarding blacklisted attributes are unacceptable, you may write a [rule](/rules) to encrypt the data and have the data persist the `user.app_metadata` object.


### PR DESCRIPTION
https://auth0.com/docs/rule doesn't exist. But https://auth0.com/docs/rules yes.

Also I see another broken link (https://github.com/auth0/docs/blob/master/articles/multifactor-authentication/index.md):

```
URL        `/docs/connections/social'
Name       `Social Connections'
Parent URL https://auth0.com/docs/multifactor-authentication, line 350, col 349
Real URL   https://auth0.com/docs/connections/social
Check time 3.311 seconds
Size       19.26KB
Result     Error: 404 Not Found
```
