### PR TITLE
Add seo_alias

### DIFF
--- a/articles/addons/aws.md
+++ b/articles/addons/aws.md
@@ -5,5 +5,5 @@ help: Enabling this add-on allows exchanging Auth0 tokens with AWS tokens that c
 logo_class: AWS
 public: false
 image: /media/addons/aws.svg
-authCatalogIndex: aws
+seo_alias: aws
 ---

--- a/articles/addons/aws.md
+++ b/articles/addons/aws.md
@@ -5,4 +5,5 @@ help: Enabling this add-on allows exchanging Auth0 tokens with AWS tokens that c
 logo_class: AWS
 public: false
 image: /media/addons/aws.svg
+authCatalogIndex: aws
 ---

--- a/articles/addons/azure-blob.md
+++ b/articles/addons/azure-blob.md
@@ -5,4 +5,5 @@ help: Enabling this add-on allows exchanging Auth0 tokens with Azure Blob Storag
 logo_class: Azure Blob Storage
 public: false
 image: /media/addons/azure_blob.svg
+authCatalogIndex: azure-blob
 ---

--- a/articles/addons/azure-blob.md
+++ b/articles/addons/azure-blob.md
@@ -5,5 +5,5 @@ help: Enabling this add-on allows exchanging Auth0 tokens with Azure Blob Storag
 logo_class: Azure Blob Storage
 public: false
 image: /media/addons/azure_blob.svg
-authCatalogIndex: azure-blob
+seo_alias: azure-blob
 ---

--- a/articles/addons/azure-sb.md
+++ b/articles/addons/azure-sb.md
@@ -5,4 +5,5 @@ help: Enabling this add-on allows exchanging Auth0 tokens with Azure Service Bus
 logo_class: Windows Azure Service Bus
 image: /media/addons/azure_sb.svg
 public: false
+authCatalogIndex: azure-sb
 ---

--- a/articles/addons/azure-sb.md
+++ b/articles/addons/azure-sb.md
@@ -5,5 +5,5 @@ help: Enabling this add-on allows exchanging Auth0 tokens with Azure Service Bus
 logo_class: Windows Azure Service Bus
 image: /media/addons/azure_sb.svg
 public: false
-authCatalogIndex: azure-sb
+seo_alias: azure-sb
 ---

--- a/articles/addons/box.md
+++ b/articles/addons/box.md
@@ -7,4 +7,5 @@ configRoute: /add-ons/box
 callback: https://sso.services.box.net/sp/ACS.saml2
 public: false
 image: /media/addons/box.svg
+authCatalogIndex: box
 ---

--- a/articles/addons/box.md
+++ b/articles/addons/box.md
@@ -7,5 +7,5 @@ configRoute: /add-ons/box
 callback: https://sso.services.box.net/sp/ACS.saml2
 public: false
 image: /media/addons/box.svg
-authCatalogIndex: box
+seo_alias: box
 ---

--- a/articles/addons/cloudbees.md
+++ b/articles/addons/cloudbees.md
@@ -7,4 +7,5 @@ configRoute: /add-ons/cloudbees
 callback: https://grandcentral.cloudbees.com/authenticate/saml/consume
 public: false
 image: /media/addons/cloudbees.svg
+authCatalogIndex: cloudbees
 ---

--- a/articles/addons/cloudbees.md
+++ b/articles/addons/cloudbees.md
@@ -7,5 +7,5 @@ configRoute: /add-ons/cloudbees
 callback: https://grandcentral.cloudbees.com/authenticate/saml/consume
 public: false
 image: /media/addons/cloudbees.svg
-authCatalogIndex: cloudbees
+seo_alias: cloudbees
 ---

--- a/articles/addons/concur.md
+++ b/articles/addons/concur.md
@@ -7,4 +7,5 @@ configRoute: /add-ons/concur
 callback: https://www.concursolutions.com/SAMLRedirector/ClientSAMLLogin.aspx
 public: false
 image: /media/addons/concur.svg
+authCatalogIndex: concur
 ---

--- a/articles/addons/concur.md
+++ b/articles/addons/concur.md
@@ -7,5 +7,5 @@ configRoute: /add-ons/concur
 callback: https://www.concursolutions.com/SAMLRedirector/ClientSAMLLogin.aspx
 public: false
 image: /media/addons/concur.svg
-authCatalogIndex: concur
+seo_alias: concur
 ---

--- a/articles/addons/dropbox.md
+++ b/articles/addons/dropbox.md
@@ -7,5 +7,5 @@ configRoute: /add-ons/dropbox
 callback: https://www.dropbox.com/saml_login
 public: false
 image: /media/addons/dropbox.svg
-authCatalogIndex: dropbox
+seo_alias: dropbox
 ---

--- a/articles/addons/dropbox.md
+++ b/articles/addons/dropbox.md
@@ -7,4 +7,5 @@ configRoute: /add-ons/dropbox
 callback: https://www.dropbox.com/saml_login
 public: false
 image: /media/addons/dropbox.svg
+authCatalogIndex: dropbox
 ---

--- a/articles/addons/echosign.md
+++ b/articles/addons/echosign.md
@@ -8,4 +8,5 @@ public: false
 image: /media/addons/echosign.svg
 alias:
   - echo-sign
+authCatalogIndex: echosign
 ---

--- a/articles/addons/echosign.md
+++ b/articles/addons/echosign.md
@@ -8,5 +8,5 @@ public: false
 image: /media/addons/echosign.svg
 alias:
   - echo-sign
-authCatalogIndex: echosign
+seo_alias: echosign
 ---

--- a/articles/addons/egnyte.md
+++ b/articles/addons/egnyte.md
@@ -6,4 +6,5 @@ logo_class: Egnyte
 configRoute: /add-ons/egnyte
 public: false
 image: /media/addons/egnyte.svg
+authCatalogIndex: egnyte
 ---

--- a/articles/addons/egnyte.md
+++ b/articles/addons/egnyte.md
@@ -6,5 +6,5 @@ logo_class: Egnyte
 configRoute: /add-ons/egnyte
 public: false
 image: /media/addons/egnyte.svg
-authCatalogIndex: egnyte
+seo_alias: egnyte
 ---

--- a/articles/addons/firebase.md
+++ b/articles/addons/firebase.md
@@ -5,5 +5,5 @@ help: Enabling this add-on allows exchanging Auth0 tokens with Firebase tokens t
 logo_class: Firebase
 public: false
 image: /media/addons/firebase.svg
-authCatalogIndex: firebase
+seo_alias: firebase
 ---

--- a/articles/addons/firebase.md
+++ b/articles/addons/firebase.md
@@ -5,4 +5,5 @@ help: Enabling this add-on allows exchanging Auth0 tokens with Firebase tokens t
 logo_class: Firebase
 public: false
 image: /media/addons/firebase.svg
+authCatalogIndex: firebase
 ---

--- a/articles/addons/layer.md
+++ b/articles/addons/layer.md
@@ -5,4 +5,5 @@ help: Enabling this add-on allows exchanging Auth0 tokens with Layer tokens that
 logo_class: Layer
 public: false
 image: /media/addons/layer.svg
+authCatalogIndex: layer
 ---

--- a/articles/addons/layer.md
+++ b/articles/addons/layer.md
@@ -5,5 +5,5 @@ help: Enabling this add-on allows exchanging Auth0 tokens with Layer tokens that
 logo_class: Layer
 public: false
 image: /media/addons/layer.svg
-authCatalogIndex: layer
+seo_alias: layer
 ---

--- a/articles/addons/mscrm.md
+++ b/articles/addons/mscrm.md
@@ -8,5 +8,5 @@ public: false
 image: /media/addons/mscrm.svg
 alias:
   - dynamics-crm
-authCatalogIndex: mscrm
+seo_alias: mscrm
 ---

--- a/articles/addons/mscrm.md
+++ b/articles/addons/mscrm.md
@@ -8,4 +8,5 @@ public: false
 image: /media/addons/mscrm.svg
 alias:
   - dynamics-crm
+authCatalogIndex: mscrm
 ---

--- a/articles/addons/newrelic.md
+++ b/articles/addons/newrelic.md
@@ -8,5 +8,5 @@ public: false
 image: /media/addons/newrelic.svg
 alias:
   - new-relic
-authCatalogIndex: newrelic
+seo_alias: newrelic
 ---

--- a/articles/addons/newrelic.md
+++ b/articles/addons/newrelic.md
@@ -8,4 +8,5 @@ public: false
 image: /media/addons/newrelic.svg
 alias:
   - new-relic
+authCatalogIndex: newrelic
 ---

--- a/articles/addons/office365.md
+++ b/articles/addons/office365.md
@@ -8,5 +8,5 @@ public: false
 image: /media/addons/office365.svg
 alias:
   - office-365
-authCatalogIndex: office365
+seo_alias: office365
 ---

--- a/articles/addons/office365.md
+++ b/articles/addons/office365.md
@@ -8,4 +8,5 @@ public: false
 image: /media/addons/office365.svg
 alias:
   - office-365
+authCatalogIndex: office365
 ---

--- a/articles/addons/rms.md
+++ b/articles/addons/rms.md
@@ -8,4 +8,5 @@ public: false
 image: /media/addons/rms.svg
 alias:
   - active-directory-rms
+authCatalogIndex: rms
 ---

--- a/articles/addons/rms.md
+++ b/articles/addons/rms.md
@@ -8,5 +8,5 @@ public: false
 image: /media/addons/rms.svg
 alias:
   - active-directory-rms
-authCatalogIndex: rms
+seo_alias: rms
 ---

--- a/articles/addons/salesforce-api.md
+++ b/articles/addons/salesforce-api.md
@@ -5,4 +5,5 @@ help: Enabling this add-on allows exchanging Auth0 tokens with Salesforce tokens
 logo_class: SalesforceAPI
 public: false
 image: /media/addons/salesforce-api.svg
+authCatalogIndex: salesforce-api
 ---

--- a/articles/addons/salesforce-api.md
+++ b/articles/addons/salesforce-api.md
@@ -5,5 +5,5 @@ help: Enabling this add-on allows exchanging Auth0 tokens with Salesforce tokens
 logo_class: SalesforceAPI
 public: false
 image: /media/addons/salesforce-api.svg
-authCatalogIndex: salesforce-api
+seo_alias: salesforce-api
 ---

--- a/articles/addons/salesforce-sandbox-api.md
+++ b/articles/addons/salesforce-sandbox-api.md
@@ -5,5 +5,5 @@ help: Enabling this add-on allows exchanging Auth0 tokens with Salesforce (sandb
 logo_class: SalesforceSandbox
 public: false
 image: /media/addons/salesforce_sandbox_api.svg
-authCatalogIndex: salesforce-sandbox-api
+seo_alias: salesforce-sandbox-api
 ---

--- a/articles/addons/salesforce-sandbox-api.md
+++ b/articles/addons/salesforce-sandbox-api.md
@@ -5,4 +5,5 @@ help: Enabling this add-on allows exchanging Auth0 tokens with Salesforce (sandb
 logo_class: SalesforceSandbox
 public: false
 image: /media/addons/salesforce_sandbox_api.svg
+authCatalogIndex: salesforce-sandbox-api
 ---

--- a/articles/addons/salesforce.md
+++ b/articles/addons/salesforce.md
@@ -7,5 +7,5 @@ configRoute: /add-ons/salesforce
 callback: https://login.salesforce.com
 public: false
 image: /media/addons/salesforce.svg
-authCatalogIndex: salesforce
+seo_alias: salesforce
 ---

--- a/articles/addons/salesforce.md
+++ b/articles/addons/salesforce.md
@@ -7,4 +7,5 @@ configRoute: /add-ons/salesforce
 callback: https://login.salesforce.com
 public: false
 image: /media/addons/salesforce.svg
+authCatalogIndex: salesforce
 ---

--- a/articles/addons/samlp.md
+++ b/articles/addons/samlp.md
@@ -5,4 +5,5 @@ title: SAML2 Web App
 help: Enables the SAML protocol for this application.
 public: false
 image: /media/addons/samlp.svg
+authCatalogIndex: samlp
 ---

--- a/articles/addons/samlp.md
+++ b/articles/addons/samlp.md
@@ -5,5 +5,5 @@ title: SAML2 Web App
 help: Enables the SAML protocol for this application.
 public: false
 image: /media/addons/samlp.svg
-authCatalogIndex: samlp
+seo_alias: samlp
 ---

--- a/articles/addons/sap-api.md
+++ b/articles/addons/sap-api.md
@@ -5,5 +5,5 @@ help: Enabling this add-on allows exchanging Auth0 tokens with SAP OData compati
 logo_class: SAP
 public: false
 image: /media/addons/sap_api.svg
-authCatalogIndex: sap-api
+seo_alias: sap-api
 ---

--- a/articles/addons/sap-api.md
+++ b/articles/addons/sap-api.md
@@ -5,4 +5,5 @@ help: Enabling this add-on allows exchanging Auth0 tokens with SAP OData compati
 logo_class: SAP
 public: false
 image: /media/addons/sap_api.svg
+authCatalogIndex: sap-api
 ---

--- a/articles/addons/sharepoint.md
+++ b/articles/addons/sharepoint.md
@@ -6,5 +6,5 @@ logo_class: Sharepoint
 configRoute: /add-ons/sharepoint
 public: false
 image: /media/addons/sharepoint.svg
-authCatalogIndex: sharepoint
+seo_alias: sharepoint
 ---

--- a/articles/addons/sharepoint.md
+++ b/articles/addons/sharepoint.md
@@ -6,4 +6,5 @@ logo_class: Sharepoint
 configRoute: /add-ons/sharepoint
 public: false
 image: /media/addons/sharepoint.svg
+authCatalogIndex: sharepoint
 ---

--- a/articles/addons/slack.md
+++ b/articles/addons/slack.md
@@ -6,5 +6,5 @@ logo_class: Slack
 configRoute: /add-ons/slack
 public: false
 image: /media/addons/slack.svg
-authCatalogIndex: slack
+seo_alias: slack
 ---

--- a/articles/addons/slack.md
+++ b/articles/addons/slack.md
@@ -6,4 +6,5 @@ logo_class: Slack
 configRoute: /add-ons/slack
 public: false
 image: /media/addons/slack.svg
+authCatalogIndex: slack
 ---

--- a/articles/addons/springcm.md
+++ b/articles/addons/springcm.md
@@ -6,5 +6,5 @@ logo_class: SpringCM
 configRoute: /add-ons/springcm
 public: false
 image: /media/addons/springcm.svg
-authCatalogIndex: springcm
+seo_alias: springcm
 ---

--- a/articles/addons/springcm.md
+++ b/articles/addons/springcm.md
@@ -6,4 +6,5 @@ logo_class: SpringCM
 configRoute: /add-ons/springcm
 public: false
 image: /media/addons/springcm.svg
+authCatalogIndex: springcm
 ---

--- a/articles/addons/wams.md
+++ b/articles/addons/wams.md
@@ -15,4 +15,5 @@ alias:
   - azure
   - azure-mobile
   - azure-mobile-services
+authCatalogIndex: wams
 ---

--- a/articles/addons/wams.md
+++ b/articles/addons/wams.md
@@ -15,5 +15,5 @@ alias:
   - azure
   - azure-mobile
   - azure-mobile-services
-authCatalogIndex: wams
+seo_alias: wams
 ---

--- a/articles/addons/wsfed.md
+++ b/articles/addons/wsfed.md
@@ -5,4 +5,5 @@ title: WS-Fed (WIF) Web App
 help: Enables the WS-Fed protocol typically used by Microsoft applications (through Windows Identity Foundation).
 public: false
 image: /media/addons/wsfed.svg
+authCatalogIndex: wsfed
 ---

--- a/articles/addons/wsfed.md
+++ b/articles/addons/wsfed.md
@@ -5,5 +5,5 @@ title: WS-Fed (WIF) Web App
 help: Enables the WS-Fed protocol typically used by Microsoft applications (through Windows Identity Foundation).
 public: false
 image: /media/addons/wsfed.svg
-authCatalogIndex: wsfed
+seo_alias: wsfed
 ---

--- a/articles/addons/zendesk.md
+++ b/articles/addons/zendesk.md
@@ -6,4 +6,5 @@ logo_class: Zendesk
 configRoute: /add-ons/zendesk
 public: false
 image: /media/addons/zendesk.svg
+authCatalogIndex: zendesk
 ---

--- a/articles/addons/zendesk.md
+++ b/articles/addons/zendesk.md
@@ -6,5 +6,5 @@ logo_class: Zendesk
 configRoute: /add-ons/zendesk
 public: false
 image: /media/addons/zendesk.svg
-authCatalogIndex: zendesk
+seo_alias: zendesk
 ---

--- a/articles/addons/zoom.md
+++ b/articles/addons/zoom.md
@@ -6,5 +6,5 @@ logo_class: Zoom
 configRoute: /add-ons/zoom
 public: false
 image: /media/addons/zoom.svg
-authCatalogIndex: zoom
+seo_alias: zoom
 ---

--- a/articles/addons/zoom.md
+++ b/articles/addons/zoom.md
@@ -6,4 +6,5 @@ logo_class: Zoom
 configRoute: /add-ons/zoom
 public: false
 image: /media/addons/zoom.svg
+authCatalogIndex: zoom
 ---

--- a/articles/client-platforms/angular2.md
+++ b/articles/client-platforms/angular2.md
@@ -23,7 +23,7 @@ snippets:
   use: client-platforms/angular2/use
 alias:
   - angular
-authCatalogIndex: angular2
+seo_alias: angular2
 ---
 
 ## Angular 2 SDK Tutorial

--- a/articles/client-platforms/angular2.md
+++ b/articles/client-platforms/angular2.md
@@ -23,6 +23,7 @@ snippets:
   use: client-platforms/angular2/use
 alias:
   - angular
+authCatalogIndex: angular2
 ---
 
 ## Angular 2 SDK Tutorial

--- a/articles/client-platforms/angularjs.md
+++ b/articles/client-platforms/angularjs.md
@@ -19,7 +19,7 @@ snippets:
   use: client-platforms/angularjs/use
 alias:
   - angular
-authCatalogIndex: angularjs
+seo_alias: angularjs
 ---
 
 ## AngularJS SDK Tutorial

--- a/articles/client-platforms/angularjs.md
+++ b/articles/client-platforms/angularjs.md
@@ -19,6 +19,7 @@ snippets:
   use: client-platforms/angularjs/use
 alias:
   - angular
+authCatalogIndex: angularjs
 ---
 
 ## AngularJS SDK Tutorial

--- a/articles/client-platforms/aurelia.md
+++ b/articles/client-platforms/aurelia.md
@@ -26,6 +26,7 @@ snippets:
   tokenisexpired: client-platforms/aurelia/tokenisexpired
 alias:
   - aurelia
+authCatalogIndex: aurelia
 ---
 
 ## Aurelia SDK Tutorial

--- a/articles/client-platforms/aurelia.md
+++ b/articles/client-platforms/aurelia.md
@@ -26,7 +26,7 @@ snippets:
   tokenisexpired: client-platforms/aurelia/tokenisexpired
 alias:
   - aurelia
-authCatalogIndex: aurelia
+seo_alias: aurelia
 ---
 
 ## Aurelia SDK Tutorial

--- a/articles/client-platforms/ember2js.md
+++ b/articles/client-platforms/ember2js.md
@@ -12,7 +12,7 @@ framework:
 image: /media/platforms/emberjs.png
 tags:
   - quickstart
-authCatalogIndex: ember2js
+seo_alias: ember2js
 ---
 ## EmberJS 2 Tutorial
 

--- a/articles/client-platforms/ember2js.md
+++ b/articles/client-platforms/ember2js.md
@@ -12,6 +12,7 @@ framework:
 image: /media/platforms/emberjs.png
 tags:
   - quickstart
+authCatalogIndex: ember2js
 ---
 ## EmberJS 2 Tutorial
 

--- a/articles/client-platforms/emberjs.md
+++ b/articles/client-platforms/emberjs.md
@@ -12,7 +12,7 @@ framework:
 image: /media/platforms/emberjs.png
 tags:
   - quickstart
-authCatalogIndex: emberjs
+seo_alias: emberjs
 ---
 ## EmberJS Tutorial
 

--- a/articles/client-platforms/emberjs.md
+++ b/articles/client-platforms/emberjs.md
@@ -12,6 +12,7 @@ framework:
 image: /media/platforms/emberjs.png
 tags:
   - quickstart
+authCatalogIndex: emberjs
 ---
 ## EmberJS Tutorial
 

--- a/articles/client-platforms/jquery.md
+++ b/articles/client-platforms/jquery.md
@@ -15,6 +15,7 @@ snippets:
   dependencies: client-platforms/jquery/dependencies
   setup: client-platforms/jquery/setup
   use: client-platforms/jquery/use
+authCatalogIndex: jquery
 ---
 
 ## jQuery Tutorial

--- a/articles/client-platforms/jquery.md
+++ b/articles/client-platforms/jquery.md
@@ -15,7 +15,7 @@ snippets:
   dependencies: client-platforms/jquery/dependencies
   setup: client-platforms/jquery/setup
   use: client-platforms/jquery/use
-authCatalogIndex: jquery
+seo_alias: jquery
 ---
 
 ## jQuery Tutorial

--- a/articles/client-platforms/react.md
+++ b/articles/client-platforms/react.md
@@ -16,7 +16,7 @@ snippets:
   dependencies: client-platforms/react/dependencies
   setup: client-platforms/react/setup
   use: client-platforms/react/use
-authCatalogIndex: react
+seo_alias: react
 ---
 
 ## React Tutorial

--- a/articles/client-platforms/react.md
+++ b/articles/client-platforms/react.md
@@ -16,6 +16,7 @@ snippets:
   dependencies: client-platforms/react/dependencies
   setup: client-platforms/react/setup
   use: client-platforms/react/use
+authCatalogIndex: react
 ---
 
 ## React Tutorial

--- a/articles/client-platforms/socket-io.md
+++ b/articles/client-platforms/socket-io.md
@@ -15,7 +15,7 @@ snippets:
   dependencies: client-platforms/socket-io/dependencies
   setup: client-platforms/socket-io/setup
   use: client-platforms/socket-io/use
-authCatalogIndex: socket-io
+seo_alias: socket-io
 ---
 
 ## Socket.io Tutorial

--- a/articles/client-platforms/socket-io.md
+++ b/articles/client-platforms/socket-io.md
@@ -15,6 +15,7 @@ snippets:
   dependencies: client-platforms/socket-io/dependencies
   setup: client-platforms/socket-io/setup
   use: client-platforms/socket-io/use
+authCatalogIndex: socket-io
 ---
 
 ## Socket.io Tutorial

--- a/articles/client-platforms/vanillajs.md
+++ b/articles/client-platforms/vanillajs.md
@@ -20,6 +20,7 @@ alias:
   - html5
   - backendless
   - javascript-app
+authCatalogIndex: vanillajs
 ---
 
 ## Generic SPA / Vanilla JS Tutorial

--- a/articles/client-platforms/vanillajs.md
+++ b/articles/client-platforms/vanillajs.md
@@ -20,7 +20,7 @@ alias:
   - html5
   - backendless
   - javascript-app
-authCatalogIndex: vanillajs
+seo_alias: vanillajs
 ---
 
 ## Generic SPA / Vanilla JS Tutorial

--- a/articles/client-platforms/vuejs.md
+++ b/articles/client-platforms/vuejs.md
@@ -23,6 +23,7 @@ snippets:
   routing: client-platforms/vuejs/routing
 alias:
   - vuejs
+authCatalogIndex: vuejs
 ---
 
 ## Vue.js Tutorial

--- a/articles/client-platforms/vuejs.md
+++ b/articles/client-platforms/vuejs.md
@@ -23,7 +23,7 @@ snippets:
   routing: client-platforms/vuejs/routing
 alias:
   - vuejs
-authCatalogIndex: vuejs
+seo_alias: vuejs
 ---
 
 ## Vue.js Tutorial

--- a/articles/connections/database/mysql.md
+++ b/articles/connections/database/mysql.md
@@ -2,6 +2,7 @@
 title: Authenticate Users with Username and Password using a Custom Database
 connection: MySQL
 image: /media/connections/mysql.svg
+authCatalogIndex: mysql
 ---
 
 # Authenticate Users with Username and Password using a Custom Database

--- a/articles/connections/database/mysql.md
+++ b/articles/connections/database/mysql.md
@@ -2,7 +2,7 @@
 title: Authenticate Users with Username and Password using a Custom Database
 connection: MySQL
 image: /media/connections/mysql.svg
-authCatalogIndex: mysql
+seo_alias: mysql
 ---
 
 # Authenticate Users with Username and Password using a Custom Database

--- a/articles/connections/enterprise/active-directory.md
+++ b/articles/connections/enterprise/active-directory.md
@@ -4,6 +4,7 @@ connection: Active Directory
 image: /media/connections/windows.png
 alias:
   - ad
+authCatalogIndex: active-directory
 ---
 
 

--- a/articles/connections/enterprise/active-directory.md
+++ b/articles/connections/enterprise/active-directory.md
@@ -4,7 +4,7 @@ connection: Active Directory
 image: /media/connections/windows.png
 alias:
   - ad
-authCatalogIndex: active-directory
+seo_alias: active-directory
 ---
 
 

--- a/articles/connections/enterprise/adfs.md
+++ b/articles/connections/enterprise/adfs.md
@@ -5,7 +5,7 @@ image: /media/connections/windows.png
 alias:
   - active-directory-federation-services
   - adfs-2
-authCatalogIndex: adfs
+seo_alias: adfs
 ---
 
 # Connect ADFS with Auth0

--- a/articles/connections/enterprise/adfs.md
+++ b/articles/connections/enterprise/adfs.md
@@ -5,6 +5,7 @@ image: /media/connections/windows.png
 alias:
   - active-directory-federation-services
   - adfs-2
+authCatalogIndex: adfs
 ---
 
 # Connect ADFS with Auth0

--- a/articles/connections/enterprise/azure-active-directory-native.md
+++ b/articles/connections/enterprise/azure-active-directory-native.md
@@ -9,6 +9,7 @@ alias:
   - windows-azure-active-directory-native-resource-owner
   - microsoft-azure-ad-native-resource-owner
   - microsoft-azure-active-directory-native-resource-owner
+authCatalogIndex: azure-active-directory-native
 ---
 
 # Native Azure Active Directory applications with Auth0 (Resource Owner flow)
@@ -39,13 +40,13 @@ In this application, you'll need to configure the following permissions to other
 
  - **Windows Azure Active Directory**: *Read directory data* and *Enable sign-on and read users' profiles*
  - Your **Web Application and/or Web API**: *Access your API*
- 
+
 ![](/media/articles/connections/enterprise/azure-active-directory/azure-active-directory-native-app-permissions.png)
 
 ## 3. Configure the connection in Auth0
 
 After creating both applications in Azure Active Directory, the Auth0 connection can be configured. The `App ID Uri` must be set to the Uri which was configured previously in the *Web Application and/or Web API* and the `Client ID` must be set to the `Client ID` of the *Native Client Application*. In this setup, the `Client Secret` does not matter and can be set to any value.
- 
+
 ![](/media/articles/connections/enterprise/azure-active-directory/azure-active-directory-create-native-connection.png)
 
 ## 4. Test the connection

--- a/articles/connections/enterprise/azure-active-directory-native.md
+++ b/articles/connections/enterprise/azure-active-directory-native.md
@@ -9,7 +9,7 @@ alias:
   - windows-azure-active-directory-native-resource-owner
   - microsoft-azure-ad-native-resource-owner
   - microsoft-azure-active-directory-native-resource-owner
-authCatalogIndex: azure-active-directory-native
+seo_alias: azure-active-directory-native
 ---
 
 # Native Azure Active Directory applications with Auth0 (Resource Owner flow)

--- a/articles/connections/enterprise/azure-active-directory.md
+++ b/articles/connections/enterprise/azure-active-directory.md
@@ -9,7 +9,7 @@ alias:
   - windows-azure-active-directory
   - microsoft-azure-ad
   - microsoft-azure-active-directory
-authCatalogIndex: azure-active-directory
+seo_alias: azure-active-directory
 ---
 
 # Obtain a *ClientId* and *Client Secret* for a Microsoft Azure Active Directory

--- a/articles/connections/enterprise/azure-active-directory.md
+++ b/articles/connections/enterprise/azure-active-directory.md
@@ -9,6 +9,7 @@ alias:
   - windows-azure-active-directory
   - microsoft-azure-ad
   - microsoft-azure-active-directory
+authCatalogIndex: azure-active-directory
 ---
 
 # Obtain a *ClientId* and *Client Secret* for a Microsoft Azure Active Directory

--- a/articles/connections/enterprise/google-apps.md
+++ b/articles/connections/enterprise/google-apps.md
@@ -3,5 +3,5 @@ title: Connecting Google Apps with Auth0
 connection: Google Apps
 image: /media/connections/gmail.png
 public: false
-authCatalogIndex: google-apps
+seo_alias: google-apps
 ---

--- a/articles/connections/enterprise/google-apps.md
+++ b/articles/connections/enterprise/google-apps.md
@@ -3,4 +3,5 @@ title: Connecting Google Apps with Auth0
 connection: Google Apps
 image: /media/connections/gmail.png
 public: false
+authCatalogIndex: google-apps
 ---

--- a/articles/connections/enterprise/ip-address.md
+++ b/articles/connections/enterprise/ip-address.md
@@ -7,7 +7,7 @@ alias:
   - ip-based-auth
   - ip
   - address-authentication
-authCatalogIndex: ip-address
+seo_alias: ip-address
 ---
 
 In this type of connection Auth0 will simply check that the request is coming from an IP address that is within the range specified in the configuration. An optional `username` can be assigned to a given range.

--- a/articles/connections/enterprise/ip-address.md
+++ b/articles/connections/enterprise/ip-address.md
@@ -7,6 +7,7 @@ alias:
   - ip-based-auth
   - ip
   - address-authentication
+authCatalogIndex: ip-address
 ---
 
 In this type of connection Auth0 will simply check that the request is coming from an IP address that is within the range specified in the configuration. An optional `username` can be assigned to a given range.
@@ -14,4 +15,3 @@ In this type of connection Auth0 will simply check that the request is coming fr
 ![](/media/articles/connections/enterprise/ip-address/ip.png)
 
 Notice that ranges are specified in the [CIDR-notation](http://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing). Multiple ranges can be added by separating them with a comma.
-

--- a/articles/connections/enterprise/ldap.md
+++ b/articles/connections/enterprise/ldap.md
@@ -3,5 +3,5 @@ title: Using LDAP Authentication with Auth0
 connection: LDAP
 image: /media/connections/windows.svg
 public: false
-authCatalogIndex: ldap
+seo_alias: ldap
 ---

--- a/articles/connections/enterprise/ldap.md
+++ b/articles/connections/enterprise/ldap.md
@@ -3,4 +3,5 @@ title: Using LDAP Authentication with Auth0
 connection: LDAP
 image: /media/connections/windows.svg
 public: false
+authCatalogIndex: ldap
 ---

--- a/articles/connections/enterprise/o365-deprecated.md
+++ b/articles/connections/enterprise/o365-deprecated.md
@@ -4,6 +4,7 @@ connection: Office 365 (Deprecated)
 image: /media/connections/office-365.png
 alias:
   - office365
+authCatalogIndex: o365-deprecated
 ---
 
 ::: warning-banner
@@ -45,5 +46,3 @@ This is your only opportunity in Office 365 to copy the `ClientSecret`, it is no
 In your Auth0 dashboard, select **Connections > Enterprise**, then select **Office 365**.
 
 Copy the `ClientId` and `ClientSecret` from the Seller Dashboard into your Office 365 connection settings on this page.
-
-

--- a/articles/connections/enterprise/o365-deprecated.md
+++ b/articles/connections/enterprise/o365-deprecated.md
@@ -4,7 +4,7 @@ connection: Office 365 (Deprecated)
 image: /media/connections/office-365.png
 alias:
   - office365
-authCatalogIndex: o365-deprecated
+seo_alias: o365-deprecated
 ---
 
 ::: warning-banner

--- a/articles/connections/enterprise/ping-federate.md
+++ b/articles/connections/enterprise/ping-federate.md
@@ -5,5 +5,5 @@ image: /media/connections/pingfederate.png
 public: false
 alias:
   - pingfederate
-authCatalogIndex: pingfederate
+seo_alias: ping-federate
 ---

--- a/articles/connections/enterprise/ping-federate.md
+++ b/articles/connections/enterprise/ping-federate.md
@@ -5,4 +5,5 @@ image: /media/connections/pingfederate.png
 public: false
 alias:
   - pingfederate
+authCatalogIndex: pingfederate
 ---

--- a/articles/connections/enterprise/samlp.md
+++ b/articles/connections/enterprise/samlp.md
@@ -5,5 +5,5 @@ image: /media/connections/saml.png
 public: false
 alias:
   - saml
-authCatalogIndex: samlp
+seo_alias: samlp
 ---

--- a/articles/connections/enterprise/samlp.md
+++ b/articles/connections/enterprise/samlp.md
@@ -5,4 +5,5 @@ image: /media/connections/saml.png
 public: false
 alias:
   - saml
+authCatalogIndex: samlp
 ---

--- a/articles/connections/enterprise/sharepoint-apps.md
+++ b/articles/connections/enterprise/sharepoint-apps.md
@@ -5,7 +5,7 @@ image: /media/connections/sharepoint.png
 alias:
   - sharepoint-online
   - sharepoint
-authCatalogIndex: sharepoint-apps
+seo_alias: sharepoint-apps
 ---
 
 # Obtaining a App Id and App Secret for SharePoint

--- a/articles/connections/enterprise/sharepoint-apps.md
+++ b/articles/connections/enterprise/sharepoint-apps.md
@@ -5,6 +5,7 @@ image: /media/connections/sharepoint.png
 alias:
   - sharepoint-online
   - sharepoint
+authCatalogIndex: sharepoint-apps
 ---
 
 # Obtaining a App Id and App Secret for SharePoint

--- a/articles/connections/enterprise/ws-fed.md
+++ b/articles/connections/enterprise/ws-fed.md
@@ -3,5 +3,5 @@ title: Connecting WS-Federation Providers with Auth0
 connection: WS-Federation
 image: /media/connections/windows.svg
 public: false
-authCatalogIndex: ws-fed
+seo_alias: ws-fed
 ---

--- a/articles/connections/enterprise/ws-fed.md
+++ b/articles/connections/enterprise/ws-fed.md
@@ -3,4 +3,5 @@ title: Connecting WS-Federation Providers with Auth0
 connection: WS-Federation
 image: /media/connections/windows.svg
 public: false
+authCatalogIndex: ws-fed
 ---

--- a/articles/connections/passwordless/email.md
+++ b/articles/connections/passwordless/email.md
@@ -5,6 +5,7 @@ url: /connections/passwordless/email
 image:
 alias:
   - email
+authCatalogIndex: email
 ---
 
 # Authenticate users with using Passwordless Authentication via Email

--- a/articles/connections/passwordless/email.md
+++ b/articles/connections/passwordless/email.md
@@ -5,7 +5,7 @@ url: /connections/passwordless/email
 image:
 alias:
   - email
-authCatalogIndex: email
+seo_alias: email
 ---
 
 # Authenticate users with using Passwordless Authentication via Email

--- a/articles/connections/passwordless/ios-touch-id-swift.md
+++ b/articles/connections/passwordless/ios-touch-id-swift.md
@@ -5,6 +5,7 @@ image: /media/connections/touchid.svg
 alias:
   - ios-touchid
   - ios
+authCatalogIndex: ios-touch-id-swift
 ---
 
 <%= include('./_using-lock-ios-touchid', { language: 'swift' }) %>

--- a/articles/connections/passwordless/ios-touch-id-swift.md
+++ b/articles/connections/passwordless/ios-touch-id-swift.md
@@ -5,7 +5,7 @@ image: /media/connections/touchid.svg
 alias:
   - ios-touchid
   - ios
-authCatalogIndex: ios-touch-id-swift
+seo_alias: ios-touch-id-swift
 ---
 
 <%= include('./_using-lock-ios-touchid', { language: 'swift' }) %>

--- a/articles/connections/passwordless/sms.md
+++ b/articles/connections/passwordless/sms.md
@@ -5,7 +5,7 @@ url: /connections/passwordless/sms
 image:
 alias:
   - sms
-authCatalogIndex: sms
+seo_alias: sms
 ---
 
 # Authenticate users with a one-time code via SMS

--- a/articles/connections/passwordless/sms.md
+++ b/articles/connections/passwordless/sms.md
@@ -5,6 +5,7 @@ url: /connections/passwordless/sms
 image:
 alias:
   - sms
+authCatalogIndex: sms
 ---
 
 # Authenticate users with a one-time code via SMS

--- a/articles/connections/social/37signals.md
+++ b/articles/connections/social/37signals.md
@@ -4,6 +4,7 @@ image: /media/connections/37signals.jpg
 alias:
   - basecamp
   - thirtysevensignals
+seo_alias: 37signals
 ---
 
 # Obtain a *Client Id* and *Client Secret* for 37Signals

--- a/articles/connections/social/amazon.md
+++ b/articles/connections/social/amazon.md
@@ -4,6 +4,7 @@ image: /media/connections/amazon.png
 alias:
   - aws
   - amazon-web-services
+seo_alias: amazon
 ---
 
 # Obtain a *Client Id* and *Client Secret* for Amazon
@@ -32,4 +33,3 @@ Expand the **Web Settings** section. Enter your Auth0 callback URL in the **Allo
 Go to your Auth0 Dashboard and select **Connections > Social**, then choose **Amazon**. Copy the `Client Id` and `Client Secret` from the **Web Settings** of your app on Amazon into the fields on this page on Auth0.
 
 ![](/media/articles/connections/social/amazon/amazon-add-connection.png)
-

--- a/articles/connections/social/aol.md
+++ b/articles/connections/social/aol.md
@@ -1,6 +1,7 @@
 ---
 connection: AOL
 image: /media/connections/aol.png
+seo_alias: aol
 ---
 
 # Obtain an *Client Id* and *Client Secret* for AOL Reader
@@ -13,4 +14,3 @@ To configure an AOL Reader connection with Auth0, contact [AOL Reader Support](h
 * Your callback URL:
 
     `https://${account.namespace}/login/callback`
-

--- a/articles/connections/social/auth0-oidc.md
+++ b/articles/connections/social/auth0-oidc.md
@@ -1,5 +1,6 @@
 ---
 connection: Auth0 OpenIDConnect
+seo_alias: auth0-oidc
 ---
 
 # Authenticate using OpenIDConnect to another Auth0 account
@@ -63,7 +64,7 @@ A direct link would look like:
 
 **NOTE:** To add a custom connection in lock, you can add a custom button as described in [Adding a new UI element using JavaScript](/libraries/lock/ui-customization#adding-a-new-ui-element-using-javascript) and use the direct link as the button `href`.
 
-The user will be redirected to the built-in login page of the child Auth0 account where they can choose their identity provider (from the enabled connections of the target App) and enter their credentials. 
+The user will be redirected to the built-in login page of the child Auth0 account where they can choose their identity provider (from the enabled connections of the target App) and enter their credentials.
 
 ![](/media/articles/connections/social/auth0-oidc/login-page.png)
 
@@ -96,7 +97,7 @@ Once the user is authenticated, the resulting profile will contain the [Auth0 No
 }
 ```
 
-Note that the generated `user_id` has the following format: 
+Note that the generated `user_id` has the following format:
 
 ```sh
 auth0-oidc|YOUR_AUTH0_CONNECTION_NAME|THE_CHILD_AUTH0_CONNECTION|THE_CHILD_USER_ID

--- a/articles/connections/social/baidu.md
+++ b/articles/connections/social/baidu.md
@@ -1,6 +1,7 @@
 ---
 connection: Baidu
 image: /media/connections/baidu.png
+seo_alias: baidu
 ---
 
 # Obtain an API Key and Secret Key for Baidu

--- a/articles/connections/social/box.md
+++ b/articles/connections/social/box.md
@@ -1,6 +1,7 @@
 ---
 connection: Box
 image: /media/connections/box.png
+seo_alias: box
 ---
 
 # Obtain a *Client Id* and *Client Secret* for Box

--- a/articles/connections/social/dwolla.md
+++ b/articles/connections/social/dwolla.md
@@ -1,6 +1,7 @@
 ---
 connection: Dwolla
 image: /media/connections/dwolla.png
+seo_alias: dwolla
 ---
 
 # Obtain a *Client ID* and *Client Secret* for Dwolla

--- a/articles/connections/social/evernote.md
+++ b/articles/connections/social/evernote.md
@@ -1,6 +1,7 @@
 ---
 connection: Evernote
 image: /media/connections/evernote.svg
+seo_alias: evernote
 ---
 
 # Obtain a *Consumer Key* and *Consumer Secret* for Evernote

--- a/articles/connections/social/exact.md
+++ b/articles/connections/social/exact.md
@@ -1,6 +1,7 @@
 ---
 connection: Exact
 image:
+seo_alias: exact
 ---
 
 # Obtain a *Client Id* and *Client Secret* for Exact
@@ -46,5 +47,3 @@ Go to your Auth0 Dashboard and select **Connections > Social**, then choose **Ex
 ![](/media/articles/connections/social/exact/exact-register-6.png)
 
 **NOTE:** You can register applications in multiple regions with Exact. By default Auth0 will use `https://start.exactonline.nl`, but this value can be overridden with the `Base URL` parameter.
-
-

--- a/articles/connections/social/facebook.md
+++ b/articles/connections/social/facebook.md
@@ -1,6 +1,7 @@
 ---
 connection: Facebook
 image: /media/connections/facebook.png
+seo_alias: facebook
 ---
 
 # Obtain an *App ID* and *App Secret* for Facebook
@@ -35,7 +36,7 @@ Once your app is created, copy the `App ID` and `App Secret` from the **Dashboar
 
 ## 4. Enter your callback URL
 
-Go to **Settings** and select the **Advanced** tab. 
+Go to **Settings** and select the **Advanced** tab.
 
 Scroll down to the **Client OAuth Settings** section and enter the following URL in the **Valid OAuth redirect URIs** field:
 
@@ -45,7 +46,7 @@ Scroll down to the **Client OAuth Settings** section and enter the following URL
 
 ## 5. Set the App ID and Secret in Auth0
 
-Go to your Auth0 [Dashboard](${uiURL}/#/connections/social) and select **Connections > Social**, then choose **Facebook**. 
+Go to your Auth0 [Dashboard](${uiURL}/#/connections/social) and select **Connections > Social**, then choose **Facebook**.
 
 Copy the `App ID` and `App Secret` from the **Basic Settings** of your app on Facebook into the fields on this page on Auth0 and click **Save**:
 

--- a/articles/connections/social/fitbit.md
+++ b/articles/connections/social/fitbit.md
@@ -1,6 +1,7 @@
 ---
 connection: Fitbit
 image: /media/connections/fitbit.png
+seo_alias: fitbit
 ---
 
 # Obtain a *Consumer Key* and *Consumer Secret* for Fitbit
@@ -34,4 +35,3 @@ Go to your Auth0 Dashboard and select **Connections > Social**, then choose **Fi
 ![](/media/articles/connections/social/fitbit/fitbit-register-3.png)
 
 **NOTE:** Fitbit is a registered trademark and service mark of Fitbit, Inc. Auth0 is designed for use with the Fitbit platform. This product is not part out by Fitbit, and Fitbit does not service or warrant the functionality of this product.
-

--- a/articles/connections/social/github.md
+++ b/articles/connections/social/github.md
@@ -1,6 +1,7 @@
 ---
 connection: Github
 image: /media/connections/github.png
+seo_alias: github
 ---
 
 # Obtain a *Client Id* and *Client Secret* for GitHub

--- a/articles/connections/social/goodreads.md
+++ b/articles/connections/social/goodreads.md
@@ -1,6 +1,7 @@
 ---
 connection: Goodreads
 image:
+seo_alias: goodreads
 ---
 
 # Obtain a Consumer Keys and Consumer Secret for Goodreads

--- a/articles/connections/social/google.md
+++ b/articles/connections/social/google.md
@@ -6,6 +6,7 @@ alias:
  - gmail
  - google-oauth
  - google-oauth2
+seo_alias: google
 ---
 
 # Connect your app to Google
@@ -32,7 +33,7 @@ Google will take a moment to create your project. You will receive a notificatio
 
 ## 3. Set up the Consent Screen
 
-In the left sidebar, select **Credentials**, then select the **OAuth consent screen** tab. 
+In the left sidebar, select **Credentials**, then select the **OAuth consent screen** tab.
 
 On this page, provide a **Product Name** that will be shown to users when they log in through Google. Click **Save**:
 
@@ -118,5 +119,3 @@ Click **Save**.
 3. If you have configured everything correctly, you will see the **It works!!!** page:
 
   ![](/media/articles/connections/social/google/goog-api-works.png)
-
-

--- a/articles/connections/social/instagram.md
+++ b/articles/connections/social/instagram.md
@@ -1,6 +1,7 @@
 ---
 connection: Instagram
 image: /media/connections/instagram.png
+seo_alias: instagram
 ---
 
 # Obtain a *Client ID* and *Client Secret* for Instagram

--- a/articles/connections/social/linkedin.md
+++ b/articles/connections/social/linkedin.md
@@ -1,6 +1,7 @@
 ---
 connection: LinkedIn
 image: /media/connections/linkedin.png
+seo_alias: linkedin
 ---
 
 # Obtain a *Client ID* and *Client Secret* for LinkedIn
@@ -27,7 +28,7 @@ Complete the form and click **Submit**:
 
 ## 4. Enter your callback URL
 
-Enter the following URL in the **Authorized Redirect URLs** field and click **Add**: 
+Enter the following URL in the **Authorized Redirect URLs** field and click **Add**:
 
 	https://${account.namespace}/login/callback
 

--- a/articles/connections/social/microsoft-account.md
+++ b/articles/connections/social/microsoft-account.md
@@ -6,6 +6,7 @@ alias:
  - microsoft-live
  - windowslive
  - windows-live
+seo_alias: microsoft-account
 ---
 
 # Obtain a *Client Id* and *Client Secret* for Microsoft account

--- a/articles/connections/social/miicard.md
+++ b/articles/connections/social/miicard.md
@@ -1,6 +1,7 @@
 ---
 connection: miiCard
 image: /media/connections/miicard.png
+seo_alias: miicard
 ---
 
 # Obtain a Consumer Key and Consumer Secret for miiCard

--- a/articles/connections/social/oauth2.md
+++ b/articles/connections/social/oauth2.md
@@ -1,6 +1,7 @@
 ---
 connection: Generic OAuth2 Provider
 image:
+seo_alias: oauth2
 ---
 
 # Add a generic OAuth2 Authorization Server to Auth0

--- a/articles/connections/social/paypal.md
+++ b/articles/connections/social/paypal.md
@@ -1,6 +1,7 @@
 ---
 connection: PayPal
 image: /media/connections/paypal.png
+seo_alias: paypal
 ---
 
 # Obtain a Client Id and Secret for PayPal
@@ -44,4 +45,3 @@ Your `Client Id` and `Secret` are displayed in the **Sandbox API Credentials** s
 Go to your Auth0 Dashboard and select **Connections > Social**, then choose **PayPal**. Copy the `Client Id` and `Client Secret` from the **PayPal Developer** portal into the fields on this page on Auth0 and click **Save**:
 
 ![](/media/articles/connections/social/paypal/paypal-5.png)
-

--- a/articles/connections/social/planning-center.md
+++ b/articles/connections/social/planning-center.md
@@ -1,6 +1,7 @@
 ---
 connection: Planning Center
 image:
+seo_alias: planning-center
 ---
 
 # Obtain a *Client ID* and *Secret* for Planning Center
@@ -36,4 +37,3 @@ Go to the [Social Connections](${uiURL}/#/connections/social) page of your Auth0
 Copy the `Client Id` and `Secret` from the **Developer Applications** page of the Planning Center Developer portal into the fields on this page on Auth0.
 
 ![](/media/articles/connections/social/planning-center/planning-center-api-4.png)
-

--- a/articles/connections/social/renren.md
+++ b/articles/connections/social/renren.md
@@ -1,6 +1,7 @@
 ---
 connection: RenRen
 image: /media/connections/renren.png
+seo_alias: renren
 ---
 
 # Obtain an *API Key* and *Secret Key* for RenRen

--- a/articles/connections/social/salesforce.md
+++ b/articles/connections/social/salesforce.md
@@ -1,6 +1,7 @@
 ---
 connection: Salesforce
 image: /media/connections/salesforce.png
+seo_alias: salesforce
 ---
 
 # Obtain a *Client Id* and *Client Secret* for Salesforce
@@ -15,8 +16,8 @@ Log into [Salesforce](https://login.salesforce.com/). Click on **Setup** in the 
 
 ## 2. Complete the *New Connected App* form
 
-1. Enter the required basic information (*Connected App Name*, *API Name* and *Contact Email*). 
-2. Select **Enable OAuth Settings**  under **API (Enable OAuth Settings)**. 
+1. Enter the required basic information (*Connected App Name*, *API Name* and *Contact Email*).
+2. Select **Enable OAuth Settings**  under **API (Enable OAuth Settings)**.
 3. Enter your callback URL: `https://${account.namespace}/login/callback`
 4. Add *Access your basic information* to the **Selected OAuth Scopes**.
 5. Click **Save**.
@@ -31,7 +32,7 @@ Once your app is registered, the page will diplay your `Consumer Key` and `Consu
 
 ## 4. Copy your *Consumer Key* and *Consumer Secret*
 
-Go to your Auth0 [Dashboard](${uiURL}/#/connections/social) and select **Connections > Social**, then choose **Salesforce**. 
+Go to your Auth0 [Dashboard](${uiURL}/#/connections/social) and select **Connections > Social**, then choose **Salesforce**.
 
 Copy the `Consumer Key` and `Consumer Secret` from the **Connected App** page of your app on Salesforce into the fields on this page on Auth0 and click **Save**:
 

--- a/articles/connections/social/shopify.md
+++ b/articles/connections/social/shopify.md
@@ -1,6 +1,7 @@
 ---
 connection: Shopify
 image: /media/connections/shopify.png
+seo_alias: shopify
 ---
 
 # Obtaining a API Key and Shared Secret for Shopify

--- a/articles/connections/social/soundcloud.md
+++ b/articles/connections/social/soundcloud.md
@@ -1,6 +1,7 @@
 ---
 connection: SoundCloud
 image: /media/connections/soundcloud.png
+seo_alias: soundcloud
 ---
 
 # Obtaining a Client ID and Client Secret for SoundCloud

--- a/articles/connections/social/thecity.md
+++ b/articles/connections/social/thecity.md
@@ -1,6 +1,7 @@
 ---
 connection: The City
 image: /media/connections/the-city.svg
+seo_alias: thecity
 ---
 
 # Obtaining a App ID and Secret with The City

--- a/articles/connections/social/twitter.md
+++ b/articles/connections/social/twitter.md
@@ -2,6 +2,7 @@
 connection: Twitter
 image: /media/connections/twitter.png
 description: This page shows you how to connect your Auth0 app to Twitter. You will need to generate keys, copy these into your Auth0 settings, and enable the connection.
+seo_alias: twitter
 ---
 
 # Connect your app to Twitter.

--- a/articles/connections/social/vkontakte.md
+++ b/articles/connections/social/vkontakte.md
@@ -1,6 +1,7 @@
 ---
 connection: vKontakte
 image: /media/connections/vkontakte.png
+seo_alias: vkontakte
 ---
 
 # Obtaining an Application ID and Secure Key for vKontakte

--- a/articles/connections/social/weibo.md
+++ b/articles/connections/social/weibo.md
@@ -1,6 +1,7 @@
 ---
 connection: Weibo
 image: /media/connections/weibo.png
+seo_alias: weibo
 ---
 
 # Obtaining a App ID and App Secret for Weibo

--- a/articles/connections/social/wordpress.md
+++ b/articles/connections/social/wordpress.md
@@ -1,6 +1,7 @@
 ---
 connection: WordPress
 image: /media/connections/wordpress.png
+seo_alias: wordpress
 ---
 
 # Obtaining a Client ID and Client Secret for WordPress

--- a/articles/connections/social/yahoo.md
+++ b/articles/connections/social/yahoo.md
@@ -1,6 +1,7 @@
 ---
 connection: Yahoo!
 image: /media/connections/yahoo.png
+seo_alias: yahoo
 ---
 
 # Obtaining a Consumer Key and Consumer Secret for Yahoo!

--- a/articles/connections/social/yammer.md
+++ b/articles/connections/social/yammer.md
@@ -2,6 +2,7 @@
 connection: Yammer
 image: /media/connections/yammer.png
 description: How to obtain the credentials required to configure your Auth0 connection to Yammer.
+seo_alias: yammer
 ---
 
 # Obtain an *App ID* and *App Secret* for Yammer
@@ -24,7 +25,7 @@ Then click **Register New App**:
 
 ## 2. Name your application
 
-Name your app and complete the form. 
+Name your app and complete the form.
 For the **Redirect URI**, enter `https://${account.namespace}/login/callback`.
 Click **Continue**.
 
@@ -48,7 +49,7 @@ Click **Save**:
 
 Go back to the [Connections > Social](${uiURL}/#/connections/social) section of the Auth0 dashboard.
 
-If you have configured your app correctly, you will see a Try icon next to the Yammer logo. 
+If you have configured your app correctly, you will see a Try icon next to the Yammer logo.
 Toggle on the switch to enable Yammer authentication:
 
 ![](/media/articles/connections/social/yammer/yammer-connect-7.png)

--- a/articles/connections/social/yandex.md
+++ b/articles/connections/social/yandex.md
@@ -1,6 +1,7 @@
 ---
 connection: Yandex
 image: /media/connections/yandex.png
+seo_alias: yandex
 ---
 
 # Obtaining an Application ID and Application Password for Yandex

--- a/articles/native-platforms/android.md
+++ b/articles/native-platforms/android.md
@@ -15,6 +15,7 @@ snippets:
   dependencies: native-platforms/android/dependencies
   setup: native-platforms/android/setup
   use: native-platforms/android/use
+authCatalogIndex: android
 ---
 
 ## Android Tutorial

--- a/articles/native-platforms/android.md
+++ b/articles/native-platforms/android.md
@@ -15,7 +15,7 @@ snippets:
   dependencies: native-platforms/android/dependencies
   setup: native-platforms/android/setup
   use: native-platforms/android/use
-authCatalogIndex: android
+seo_alias: android
 ---
 
 ## Android Tutorial

--- a/articles/native-platforms/cordova.md
+++ b/articles/native-platforms/cordova.md
@@ -18,7 +18,7 @@ snippets:
   use: native-platforms/jquery/use
 alias:
   - apache-cordova
-authCatalogIndex: cordova
+seo_alias: cordova
 ---
 
 ## Cordova Tutorial

--- a/articles/native-platforms/cordova.md
+++ b/articles/native-platforms/cordova.md
@@ -18,6 +18,7 @@ snippets:
   use: native-platforms/jquery/use
 alias:
   - apache-cordova
+authCatalogIndex: cordova
 ---
 
 ## Cordova Tutorial

--- a/articles/native-platforms/electron.md
+++ b/articles/native-platforms/electron.md
@@ -18,7 +18,7 @@ snippets:
   dependencies: native-platforms/electron/dependencies
 alias:
   - electron
-authCatalogIndex: electron
+seo_alias: electron
 ---
 
 ## Electron Tutorial

--- a/articles/native-platforms/electron.md
+++ b/articles/native-platforms/electron.md
@@ -18,6 +18,7 @@ snippets:
   dependencies: native-platforms/electron/dependencies
 alias:
   - electron
+authCatalogIndex: electron
 ---
 
 ## Electron Tutorial

--- a/articles/native-platforms/ionic.md
+++ b/articles/native-platforms/ionic.md
@@ -17,7 +17,7 @@ snippets:
   dependencies: native-platforms/ionic/dependencies
   setup: native-platforms/ionic/setup
   use: native-platforms/ionic/use
-authCatalogIndex: ionic
+seo_alias: ionic
 ---
 
 ## Ionic Framework Tutorial

--- a/articles/native-platforms/ionic.md
+++ b/articles/native-platforms/ionic.md
@@ -17,6 +17,7 @@ snippets:
   dependencies: native-platforms/ionic/dependencies
   setup: native-platforms/ionic/setup
   use: native-platforms/ionic/use
+authCatalogIndex: ionic
 ---
 
 ## Ionic Framework Tutorial

--- a/articles/native-platforms/ionic2.md
+++ b/articles/native-platforms/ionic2.md
@@ -24,7 +24,7 @@ snippets:
   refresh: native-platforms/ionic2/refresh
   setup: native-platforms/ionic2/setup
   use: native-platforms/ionic2/use
-authCatalogIndex: ionic2
+seo_alias: ionic2
 ---
 
 ## Ionic 2 Framework Tutorial

--- a/articles/native-platforms/ionic2.md
+++ b/articles/native-platforms/ionic2.md
@@ -24,6 +24,7 @@ snippets:
   refresh: native-platforms/ionic2/refresh
   setup: native-platforms/ionic2/setup
   use: native-platforms/ionic2/use
+authCatalogIndex: ionic2
 ---
 
 ## Ionic 2 Framework Tutorial

--- a/articles/native-platforms/ios-objc.md
+++ b/articles/native-platforms/ios-objc.md
@@ -20,6 +20,7 @@ alias:
   - objective-c
   - iphone
   - ipad
+authCatalogIndex: ios-objc
 ---
 
 ## iOS Objective-C Tutorial

--- a/articles/native-platforms/ios-objc.md
+++ b/articles/native-platforms/ios-objc.md
@@ -20,7 +20,7 @@ alias:
   - objective-c
   - iphone
   - ipad
-authCatalogIndex: ios-objc
+seo_alias: ios-objc
 ---
 
 ## iOS Objective-C Tutorial

--- a/articles/native-platforms/ios-swift.md
+++ b/articles/native-platforms/ios-swift.md
@@ -20,6 +20,7 @@ snippets:
   use: native-platforms/ios-swift/use
 alias:
   - ios
+authCatalogIndex: ios-swift
 ---
 
 ## iOS Swift Tutorial

--- a/articles/native-platforms/ios-swift.md
+++ b/articles/native-platforms/ios-swift.md
@@ -20,7 +20,7 @@ snippets:
   use: native-platforms/ios-swift/use
 alias:
   - ios
-authCatalogIndex: ios-swift
+seo_alias: ios-swift
 ---
 
 ## iOS Swift Tutorial

--- a/articles/native-platforms/phonegap.md
+++ b/articles/native-platforms/phonegap.md
@@ -16,7 +16,7 @@ snippets:
   dependencies: native-platforms/phonegap/dependencies
   setup: native-platforms/jquery/setup
   use: native-platforms/jquery/use
-authCatalogIndex: phonegap
+seo_alias: phonegap
 ---
 
 ## Phonegap Tutorial

--- a/articles/native-platforms/phonegap.md
+++ b/articles/native-platforms/phonegap.md
@@ -16,6 +16,7 @@ snippets:
   dependencies: native-platforms/phonegap/dependencies
   setup: native-platforms/jquery/setup
   use: native-platforms/jquery/use
+authCatalogIndex: phonegap
 ---
 
 ## Phonegap Tutorial

--- a/articles/native-platforms/react-native-android.md
+++ b/articles/native-platforms/react-native-android.md
@@ -16,7 +16,7 @@ tags:
 snippets:
   setup: native-platforms/reactnative-android/setup
   use: native-platforms/reactnative-android/use
-authCatalogIndex: react-native-android
+seo_alias: react-native-android
 ---
 
 ## Android React Native Tutorial

--- a/articles/native-platforms/react-native-android.md
+++ b/articles/native-platforms/react-native-android.md
@@ -16,6 +16,7 @@ tags:
 snippets:
   setup: native-platforms/reactnative-android/setup
   use: native-platforms/reactnative-android/use
+authCatalogIndex: react-native-android
 ---
 
 ## Android React Native Tutorial

--- a/articles/native-platforms/react-native-ios.md
+++ b/articles/native-platforms/react-native-ios.md
@@ -16,7 +16,7 @@ tags:
 snippets:
   setup: native-platforms/reactnative-ios/setup
   use: native-platforms/reactnative-ios/use
-authCatalogIndex: react-native-ios
+seo_alias: react-native-ios
 ---
 
 ## React Native iOS Tutorial

--- a/articles/native-platforms/react-native-ios.md
+++ b/articles/native-platforms/react-native-ios.md
@@ -16,6 +16,7 @@ tags:
 snippets:
   setup: native-platforms/reactnative-ios/setup
   use: native-platforms/reactnative-ios/use
+authCatalogIndex: react-native-ios
 ---
 
 ## React Native iOS Tutorial

--- a/articles/native-platforms/windows-uwp-csharp.md
+++ b/articles/native-platforms/windows-uwp-csharp.md
@@ -15,6 +15,7 @@ snippets:
   dependencies: native-platforms/windows-uwp-csharp/dependencies
   setup: native-platforms/windows-uwp-csharp/setup
   use: native-platforms/windows-uwp-csharp/use
+authCatalogIndex: windows-uwp-csharp
 ---
 
 # Windows UWP App in C# Tutorial

--- a/articles/native-platforms/windows-uwp-csharp.md
+++ b/articles/native-platforms/windows-uwp-csharp.md
@@ -15,7 +15,7 @@ snippets:
   dependencies: native-platforms/windows-uwp-csharp/dependencies
   setup: native-platforms/windows-uwp-csharp/setup
   use: native-platforms/windows-uwp-csharp/use
-authCatalogIndex: windows-uwp-csharp
+seo_alias: windows-uwp-csharp
 ---
 
 # Windows UWP App in C# Tutorial

--- a/articles/native-platforms/windows-uwp-javascript.md
+++ b/articles/native-platforms/windows-uwp-javascript.md
@@ -19,7 +19,7 @@ alias:
   - windows-10
   - windows-tablet
   - surface
-authCatalogIndex: windows-uwp-javascript
+seo_alias: windows-uwp-javascript
 ---
 
 # Windows UWP App in Javascript Tutorial

--- a/articles/native-platforms/windows-uwp-javascript.md
+++ b/articles/native-platforms/windows-uwp-javascript.md
@@ -19,6 +19,7 @@ alias:
   - windows-10
   - windows-tablet
   - surface
+authCatalogIndex: windows-uwp-javascript
 ---
 
 # Windows UWP App in Javascript Tutorial

--- a/articles/native-platforms/windowsphone.md
+++ b/articles/native-platforms/windowsphone.md
@@ -21,7 +21,7 @@ alias:
   - windows-phone
   - windows-phone-8
   - microsoft-phone
-authCatalogIndex: windowsphone
+seo_alias: windowsphone
 ---
 
 ## Windows Phone Tutorial

--- a/articles/native-platforms/windowsphone.md
+++ b/articles/native-platforms/windowsphone.md
@@ -21,6 +21,7 @@ alias:
   - windows-phone
   - windows-phone-8
   - microsoft-phone
+authCatalogIndex: windowsphone
 ---
 
 ## Windows Phone Tutorial

--- a/articles/native-platforms/wpf-winforms.md
+++ b/articles/native-platforms/wpf-winforms.md
@@ -21,7 +21,7 @@ alias:
   - wiforms
   - rich-client-application
   - rich-client
-authCatalogIndex: wpf-winforms
+seo_alias: wpf-winforms
 ---
 
 # WPF and Winforms Tutorial

--- a/articles/native-platforms/wpf-winforms.md
+++ b/articles/native-platforms/wpf-winforms.md
@@ -21,6 +21,7 @@ alias:
   - wiforms
   - rich-client-application
   - rich-client
+authCatalogIndex: wpf-winforms
 ---
 
 # WPF and Winforms Tutorial

--- a/articles/native-platforms/xamarin.md
+++ b/articles/native-platforms/xamarin.md
@@ -14,6 +14,7 @@ snippets:
   dependencies: native-platforms/xamarin/dependencies
   setup: native-platforms/xamarin/setup
   use: native-platforms/xamarin/use
+authCatalogIndex: xamarin
 ---
 
 # Xamarin Tutorial

--- a/articles/native-platforms/xamarin.md
+++ b/articles/native-platforms/xamarin.md
@@ -14,7 +14,7 @@ snippets:
   dependencies: native-platforms/xamarin/dependencies
   setup: native-platforms/xamarin/setup
   use: native-platforms/xamarin/use
-authCatalogIndex: xamarin
+seo_alias: xamarin
 ---
 
 # Xamarin Tutorial

--- a/articles/server-platforms/apache.md
+++ b/articles/server-platforms/apache.md
@@ -9,6 +9,7 @@ snippets:
   dependencies: server-platforms/apache/dependencies
   setup: server-platforms/apache/setup
   use: server-platforms/apache/use
+authCatalogIndex: apache
 ---
 
 ## Apache Tutorial

--- a/articles/server-platforms/apache.md
+++ b/articles/server-platforms/apache.md
@@ -9,7 +9,7 @@ snippets:
   dependencies: server-platforms/apache/dependencies
   setup: server-platforms/apache/setup
   use: server-platforms/apache/use
-authCatalogIndex: apache
+seo_alias: apache
 ---
 
 ## Apache Tutorial

--- a/articles/server-platforms/asp-classic.md
+++ b/articles/server-platforms/asp-classic.md
@@ -8,7 +8,7 @@ tags:
 snippets:
   setup: server-platforms/asp-classic/setup
   use: server-platforms/asp-classic/use
-authCatalogIndex: asp-classic
+seo_alias: asp-classic
 ---
 
 ## ASP Classic Tutorial

--- a/articles/server-platforms/asp-classic.md
+++ b/articles/server-platforms/asp-classic.md
@@ -8,6 +8,7 @@ tags:
 snippets:
   setup: server-platforms/asp-classic/setup
   use: server-platforms/asp-classic/use
+authCatalogIndex: asp-classic
 ---
 
 ## ASP Classic Tutorial

--- a/articles/server-platforms/aspnet-owin.md
+++ b/articles/server-platforms/aspnet-owin.md
@@ -12,6 +12,7 @@ snippets:
 alias:
   - aspnetowin
   - owin
+authCatalogIndex: aspnet-owin
 ---
 
 # ASP.NET (OWIN) Tutorial

--- a/articles/server-platforms/aspnet-owin.md
+++ b/articles/server-platforms/aspnet-owin.md
@@ -12,7 +12,7 @@ snippets:
 alias:
   - aspnetowin
   - owin
-authCatalogIndex: aspnet-owin
+seo_alias: aspnet-owin
 ---
 
 # ASP.NET (OWIN) Tutorial

--- a/articles/server-platforms/aspnet.md
+++ b/articles/server-platforms/aspnet.md
@@ -13,7 +13,7 @@ alias:
   - microsoft-net
   - aspnet-mvc
   - net-mvc
-authCatalogIndex: aspnet
+seo_alias: aspnet
 ---
 
 # ASP.NET Tutorial

--- a/articles/server-platforms/aspnet.md
+++ b/articles/server-platforms/aspnet.md
@@ -13,6 +13,7 @@ alias:
   - microsoft-net
   - aspnet-mvc
   - net-mvc
+authCatalogIndex: aspnet
 ---
 
 # ASP.NET Tutorial

--- a/articles/server-platforms/golang.md
+++ b/articles/server-platforms/golang.md
@@ -9,6 +9,7 @@ snippets:
   dependencies: server-platforms/golang/dependencies
   setup: server-platforms/golang/setup
   use: server-platforms/golang/use
+authCatalogIndex: golang
 ---
 
 ## Go Web App Tutorial

--- a/articles/server-platforms/golang.md
+++ b/articles/server-platforms/golang.md
@@ -9,7 +9,7 @@ snippets:
   dependencies: server-platforms/golang/dependencies
   setup: server-platforms/golang/setup
   use: server-platforms/golang/use
-authCatalogIndex: golang
+seo_alias: golang
 ---
 
 ## Go Web App Tutorial

--- a/articles/server-platforms/java.md
+++ b/articles/server-platforms/java.md
@@ -12,7 +12,7 @@ snippets:
 alias:
   - spring
   - spring-security
-authCatalogIndex: java
+seo_alias: java
 ---
 
 ## Java Web App Tutorial

--- a/articles/server-platforms/java.md
+++ b/articles/server-platforms/java.md
@@ -12,6 +12,7 @@ snippets:
 alias:
   - spring
   - spring-security
+authCatalogIndex: java
 ---
 
 ## Java Web App Tutorial

--- a/articles/server-platforms/laravel.md
+++ b/articles/server-platforms/laravel.md
@@ -9,7 +9,7 @@ snippets:
   dependencies: server-platforms/laravel/dependencies
   setup: server-platforms/laravel/setup
   use: server-platforms/laravel/use
-authCatalogIndex: laravel
+seo_alias: laravel
 ---
 
 # Laravel Tutorial

--- a/articles/server-platforms/laravel.md
+++ b/articles/server-platforms/laravel.md
@@ -9,6 +9,7 @@ snippets:
   dependencies: server-platforms/laravel/dependencies
   setup: server-platforms/laravel/setup
   use: server-platforms/laravel/use
+authCatalogIndex: laravel
 ---
 
 # Laravel Tutorial

--- a/articles/server-platforms/meteor.md
+++ b/articles/server-platforms/meteor.md
@@ -15,7 +15,7 @@ snippets:
   dependencies: server-platforms/meteor/dependencies
   setup: server-platforms/meteor/setup
   use: server-platforms/meteor/use
-authCatalogIndex: meteor
+seo_alias: meteor
 ---
 
 ## Meteor Tutorial

--- a/articles/server-platforms/meteor.md
+++ b/articles/server-platforms/meteor.md
@@ -15,6 +15,7 @@ snippets:
   dependencies: server-platforms/meteor/dependencies
   setup: server-platforms/meteor/setup
   use: server-platforms/meteor/use
+authCatalogIndex: meteor
 ---
 
 ## Meteor Tutorial

--- a/articles/server-platforms/nancyfx.md
+++ b/articles/server-platforms/nancyfx.md
@@ -9,7 +9,7 @@ snippets:
   dependencies: server-platforms/nancyfx/dependencies
   setup: server-platforms/nancyfx/setup
   use: server-platforms/nancyfx/use
-authCatalogIndex: nancyfx
+seo_alias: nancyfx
 ---
 
 ## NancyFX Tutorial

--- a/articles/server-platforms/nancyfx.md
+++ b/articles/server-platforms/nancyfx.md
@@ -9,6 +9,7 @@ snippets:
   dependencies: server-platforms/nancyfx/dependencies
   setup: server-platforms/nancyfx/setup
   use: server-platforms/nancyfx/use
+authCatalogIndex: nancyfx
 ---
 
 ## NancyFX Tutorial

--- a/articles/server-platforms/nodejs.md
+++ b/articles/server-platforms/nodejs.md
@@ -14,6 +14,7 @@ alias:
   - express
   - node-connect
   - passport
+authCatalogIndex: nodejs
 ---
 
 ## NodeJS Web App Tutorial

--- a/articles/server-platforms/nodejs.md
+++ b/articles/server-platforms/nodejs.md
@@ -14,7 +14,7 @@ alias:
   - express
   - node-connect
   - passport
-authCatalogIndex: nodejs
+seo_alias: nodejs
 ---
 
 ## NodeJS Web App Tutorial

--- a/articles/server-platforms/php.md
+++ b/articles/server-platforms/php.md
@@ -9,6 +9,7 @@ snippets:
   dependencies: server-platforms/php/dependencies
   setup: server-platforms/php/setup
   use: server-platforms/php/use
+authCatalogIndex: php
 ---
 
 ##  PHP Web App Tutorial

--- a/articles/server-platforms/php.md
+++ b/articles/server-platforms/php.md
@@ -9,7 +9,7 @@ snippets:
   dependencies: server-platforms/php/dependencies
   setup: server-platforms/php/setup
   use: server-platforms/php/use
-authCatalogIndex: php
+seo_alias: php
 ---
 
 ##  PHP Web App Tutorial

--- a/articles/server-platforms/python.md
+++ b/articles/server-platforms/python.md
@@ -9,6 +9,7 @@ snippets:
   dependencies: server-platforms/python/dependencies
   setup: server-platforms/python/setup
   use: server-platforms/python/use
+authCatalogIndex: python
 ---
 
 ## Python Web App Tutorial

--- a/articles/server-platforms/python.md
+++ b/articles/server-platforms/python.md
@@ -9,7 +9,7 @@ snippets:
   dependencies: server-platforms/python/dependencies
   setup: server-platforms/python/setup
   use: server-platforms/python/use
-authCatalogIndex: python
+seo_alias: python
 ---
 
 ## Python Web App Tutorial

--- a/articles/server-platforms/rails.md
+++ b/articles/server-platforms/rails.md
@@ -13,6 +13,7 @@ alias:
   - ruby-rails
   - sinatra
   - omniauth
+authCatalogIndex: rails
 ---
 
 ## Ruby On Rails Web App Tutorial

--- a/articles/server-platforms/rails.md
+++ b/articles/server-platforms/rails.md
@@ -13,7 +13,7 @@ alias:
   - ruby-rails
   - sinatra
   - omniauth
-authCatalogIndex: rails
+seo_alias: rails
 ---
 
 ## Ruby On Rails Web App Tutorial

--- a/articles/server-platforms/scala.md
+++ b/articles/server-platforms/scala.md
@@ -9,6 +9,7 @@ snippets:
   dependencies: server-platforms/scala/dependencies
   setup: server-platforms/scala/setup
   use: server-platforms/scala/use
+authCatalogIndex: scala
 ---
 
 ## Play 2 Scala Tutorial

--- a/articles/server-platforms/scala.md
+++ b/articles/server-platforms/scala.md
@@ -9,7 +9,7 @@ snippets:
   dependencies: server-platforms/scala/dependencies
   setup: server-platforms/scala/setup
   use: server-platforms/scala/use
-authCatalogIndex: scala
+seo_alias: scala
 ---
 
 ## Play 2 Scala Tutorial

--- a/articles/server-platforms/servicestack.md
+++ b/articles/server-platforms/servicestack.md
@@ -9,7 +9,7 @@ snippets:
   dependencies: server-platforms/servicestack/dependencies
   setup: server-platforms/servicestack/setup
   use: server-platforms/servicestack/use
-authCatalogIndex: servicestack
+seo_alias: servicestack
 ---
 
 # ServiceStack Tutorial

--- a/articles/server-platforms/servicestack.md
+++ b/articles/server-platforms/servicestack.md
@@ -9,6 +9,7 @@ snippets:
   dependencies: server-platforms/servicestack/dependencies
   setup: server-platforms/servicestack/setup
   use: server-platforms/servicestack/use
+authCatalogIndex: servicestack
 ---
 
 # ServiceStack Tutorial

--- a/articles/server-platforms/symfony.md
+++ b/articles/server-platforms/symfony.md
@@ -9,6 +9,7 @@ snippets:
   dependencies: server-platforms/symfony/dependencies
   setup: server-platforms/symfony/setup
   use: server-platforms/symfony/use
+authCatalogIndex: symfony
 ---
 
 # Symfony Tutorial

--- a/articles/server-platforms/symfony.md
+++ b/articles/server-platforms/symfony.md
@@ -9,7 +9,7 @@ snippets:
   dependencies: server-platforms/symfony/dependencies
   setup: server-platforms/symfony/setup
   use: server-platforms/symfony/use
-authCatalogIndex: symfony
+seo_alias: symfony
 ---
 
 # Symfony Tutorial


### PR DESCRIPTION
Add `seo_alias` to lock the path of `auth-catalog` pages (https://auth0.com/authenticate/*) eg:
- https://auth0.com/authenticate/
- https://auth0.com/authenticate/android
- https://auth0.com/authenticate/android/37signals
