### PR TITLE
Correct offline_access scope name

### DIFF
--- a/articles/libraries/lock-android/refresh-jwt-tokens.md
+++ b/articles/libraries/lock-android/refresh-jwt-tokens.md
@@ -5,7 +5,7 @@ description: Keeping your user logged in
 
 # Lock Android: Refreshing JWT Tokens
 
-When an authentication is performed with the `offline_scope` included, it will return a [refresh token](/refresh-token) that can be used to request a new JWT token and avoid asking the user their credentials again.
+When an authentication is performed with the `offline_access` scope included, it will return a [refresh token](/refresh-token) that can be used to request a new JWT token and avoid asking the user their credentials again.
 
 > Lock.Android will include the `offline_scope` scope by default.
 

--- a/articles/libraries/lock-ios/save-and-refresh-jwt-tokens.md
+++ b/articles/libraries/lock-ios/save-and-refresh-jwt-tokens.md
@@ -5,7 +5,7 @@ description: Keeping your user logged in
 
 # Lock iOS: Saving and Refreshing JWT Tokens
 
-When an authentication is performed with the `offline_scope` included, it will return a [refresh token](/refresh-token) that can be used to request a new JWT token and avoid asking the user his/her
+When an authentication is performed with the `offline_access` scope included, it will return a [refresh token](/refresh-token) that can be used to request a new JWT token and avoid asking the user his/her
 credentials again.
 
 > We are using [SimpleKeychain](https://github.com/auth0/SimpleKeychain) to handle iOS Keychain access.


### PR DESCRIPTION
### Your checklist for this pull request

Please review the [guidelines for contributing](https://github.com/auth0/docs#contributing) to this repository.
- [x] Content conforms to our [Contributing Guidelines](https://github.com/auth0/docs#contributing-guidelines)
- [x] If applicable, you have added details to the [update feed](https://github.com/auth0/docs/tree/master/updates) 
### Description

The offline_access scope name referenced in the [Lock Android: Refreshing JWT Tokens](https://auth0.com/docs/libraries/lock-android/refresh-jwt-tokens) and [Lock iOS: Saving and Refreshing JWT Tokens](https://auth0.com/docs/libraries/lock-ios/save-and-refresh-jwt-tokens) docs page was incorrectly `offline_scope` instead of `offline_access`. This is corrected in the PR.

/cc @hzalaz @lbalmaceda 
