### PR TITLE
Add warning for custom databases

### DIFF
--- a/articles/connections/database/password-change.md
+++ b/articles/connections/database/password-change.md
@@ -31,13 +31,17 @@ When calling the API, specify the email address of the account you want to reset
   "headers": [
     { "name": "Content-Type", "value": "application/json" }
   ],
-  "postData" : {
-    "client_id" : "${account.clientId}",
-    "email" : "",
+  "postData": {
+    "client_id": "${account.clientId}",
+    "email": "",
     "connection": "Username-Password-Authentication"
   }
 }
 ```
+
+:::panel-warning Custom database
+In case you have a custom database setup for your connection you should first check whether the user exists there and if so invoke the API for `changePassword`.
+:::
 
 In the resulting email, there will be a link to reset the password.
 


### PR DESCRIPTION
Add warning that in case of custom DB the user should first check if the user exists and then invoke the API.

Also, removed some spaces in an attempt to fix the request's postData that are currently not displayed.
