### PR TITLE
Add link to a list of 3rd party OAuth libs

### DIFF
--- a/articles/what-to-do-once-the-user-is-logged-in/calling-an-external-idp-api.md
+++ b/articles/what-to-do-once-the-user-is-logged-in/calling-an-external-idp-api.md
@@ -51,3 +51,5 @@ lock.show(function(err, token, profile) {
   getGoogleContactsWithToken(googleToken);
 })
 ```
+
+> When you need to call an external IdP that uses OAuth, you can use a third-party library that does the heavy-lifting for you. A non-exhaustive list of such libraries is available at [this page](http://oauth.net/code/).


### PR DESCRIPTION
### Your checklist for this pull request

Please review the [guidelines for contributing](https://github.com/auth0/docs#contributing) to this repository.
- [x] Content conforms to our [Contributing Guidelines](https://github.com/auth0/docs#contributing-guidelines)
- [ ] If applicable, you have added details to the [update feed](https://github.com/auth0/docs/tree/master/updates) 
### Description

Some customers have been not aware of how to call external IdPs after a user is authenticated. A particular frustrated customer had even tried to create OAuth requests from scratch, unaware that he could use a 3rd-party library. Hopefully this note would shed some light.

Thank you!
