### PR TITLE
Add settings for VS Code to make editing Markdown easier

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+  "editor.wrappingColumn": 0
+}


### PR DESCRIPTION
I like editing Markdown files in VS Code. This contains a Workspace settings file which will configure Markdown documents to automatically wrap at the edge of the editor, which makes them easier to edit.
