### PR TITLE
Don't use context.redirect for Zendesk JWT rule

### DIFF
--- a/articles/scenarios/zendesk-sso.md
+++ b/articles/scenarios/zendesk-sso.md
@@ -21,15 +21,8 @@ We want to create a JWT with a user's information after login that Zendesk can u
 This can be achieved by [using a rule](/rules).
 In this example the Zendesk **Shared secret** is being stored as an encrypted key-value pair, which can be accessed with `configuration.ZENDESK_JWT_SECRET` in the rule's code.
 
-Remember to replace `YOUR_ZENDESK_CLIENT_ID` with the actual client ID of your Zendesk application in Auth0.
-
 ```js
 function (user, context, callback) {
-
-  // If logging in to a different application, skip this rule
-  if (context.clientID !== YOUR_ZENDESK_CLIENT_ID) {
-    return callback(null, user, context);
-  }
 
   // Assuming your Zendesk URL is https://foo.zendesk.com
   var ZENDESK_SUBDOMAIN = 'foo';
@@ -47,35 +40,44 @@ function (user, context, callback) {
     external_id: user.user_id
   };
 
-  // Sign the token and redirect the user to Zendesk directly
+  // Sign the token and add it to the profile
   var zendesk_token = jwt.sign(payload, configuration.ZENDESK_JWT_SECRET);
-  var zendesk_url = 'https://' + ZENDESK_SUBDOMAIN + '.zendesk.com/access/jwt?jwt=' + zendesk_token;
-  context.redirect = {
-    url: zendesk_url
-  };
+  user.zendesk_jwt_url = 'https://' + ZENDESK_SUBDOMAIN + '.zendesk.com/access/jwt?jwt=' + zendesk_token;
 
   callback(null, user, context);
 }
+```
+
+## 3. Redirect users to the URL returned by Zendesk
+
+The rule returned in the previous step will return a user property named `zendesk_jwt_url`, which will allow your user to log in.
+If using [Lock](/lock), for example:
+
+```js
+lock.show(function (err, profile, id_token) {
+  if (err) {
+    console.error('Something went wrong!', err);
+  } else if (profile.zendesk_jwt_url) {
+    window.location = profile.zendesk_jwt_url;
+  }
+});
 ```
 
 ### Optional: Redirecting users to the URL they originally visited
 
 When Zendesk redirects users to your login page, a [`return_to` query parameter](https://support.zendesk.com/hc/en-us/articles/203663816-Setting-up-single-sign-on-with-JWT-JSON-Web-Token-#topic_hkm_kst_kk) is added to your login page URL.
 This parameter contains the Zendesk URL where your users should be redirected after login.
-It should be added to the Zendesk URL returned by the above rule as follows:
+It should be added to the Zendesk URL returned by the above rule:
 
 ```js
-function (user, context, callback) {
-  // build Zendesk token as usual
-  
-  var return_to = context.request.query.state;
-  var zendesk_url = 'https://' + ZENDESK_SUBDOMAIN + '.zendesk.com/access/jwt?jwt=' + zendesk_token + '&return_to=' + return_to;
-  context.redirect = {
-    url: zendesk_url
-  };
-  callback(null, user, context);
-}
-```
+// Using URI.js, see http://medialize.github.io/URI.js/
+return_to = URI(document.URL).query(true).return_to;
 
-The rule fragment assumes that you are sending an URL in the `state` parameter when initiating a login transaction.
-This can be set as a query string parameter when calling the [`/authorize` endpoint directly](/auth-api#!#get--authorize_social) or as an [authentication parameter when using Lock](/libraries/lock/sending-authentication-parameters).
+lock.show(function (err, profile, id_token) {
+  if (err) {
+    console.error('Something went wrong!', err);
+  } else if (profile.zendesk_jwt_url) {
+    document.getElementById('zendesk_url').href = URI(profile.zendesk_jwt_url).addSearch({return_to: return_to});
+  }
+});
+```


### PR DESCRIPTION
Using context.redirect and never calling /continue doesn't finish the
authentication pipeline properly, so the SSO cookie is never set. This
causes SSO not to work when logging in to Zendesk using the original
rule.

This reverts commit a040be63c6a4cbf0ad7d61491af4857460eb2792.
