### PR TITLE
corrected namespacing

### DIFF
--- a/articles/server-apis/php-laravel/authenticate.md
+++ b/articles/server-apis/php-laravel/authenticate.md
@@ -56,7 +56,7 @@ If you want to restrict access with the Auth0 Middleware, you will need to add i
 
 protected $routeMiddleware = [
 	...
-	'auth0.jwt' => 'Auth0\Login\Middleware\Auth0JWTMiddleware',
+	'auth0.jwt' => '\Auth0\Login\Middleware\Auth0JWTMiddleware',
 ];
 
 ...

--- a/articles/server-platforms/laravel/01-login.md
+++ b/articles/server-platforms/laravel/01-login.md
@@ -56,7 +56,7 @@ If you want to restrict access with the Auth0 Middleware, you will need to add i
 
 protected $routeMiddleware = [
 		...
-		'auth0.jwt' => 'Auth0\Login\Middleware\Auth0JWTMiddleware',
+		'auth0.jwt' => '\Auth0\Login\Middleware\Auth0JWTMiddleware',
 	];
 
 ...


### PR DESCRIPTION
### Description

Hi,

First time PR here, so I hope I conform to your rules. 

So after I followed the tutorial on [your site](https://auth0.com/docs/quickstart/backend/php-laravel) I found that the middleware `Auth0\Login\Middleware\Auth0JWTMiddleware` was not being loaded properly becuase the way you wrote it, you are missing a leading backslash in order to prevent php namepsace to look in the current directory `App\Http\Auth0\Login\Middleware\Auth0JWTMiddleware` instead of the approriate vendor package `Auth0\Login\Middleware\Auth0JWTMiddleware` that you have provided.

Thank you!
