### PR TITLE
[update] Metadata-in-rules - Added client_metadata samples, overall edits

### DIFF
--- a/articles/rules/metadata-in-rules.md
+++ b/articles/rules/metadata-in-rules.md
@@ -1,10 +1,39 @@
+---
+description: This article explains how to work with metadata in Rules code. 
+---
+
 # Metadata in Rules
 
-Auth0 allows you to store data related to each user that has not come from the identity provider. This is known as metadata. There are two kinds of metadata, **user_metadata** and **app_metadata**. You can read about both of these at [app_metadata and user_metadata](/api/v2/changes#app-_metadata-and-user-_metadata).
+Auth0 allows you to store data that has not come from the identity provider. This is known as metadata. 
 
 This article explains how to work with metadata in [Rules](/rules) code. 
 
-Each sample rule in this article assumes the user is represented by the following JSON:
+* [Metadata types](#metadata-types)
+* [User object metadata](#user-object-metadata)
+  * [Read](#read)
+  * [Update](#update)
+  * [Delete](#delete)
+* [Client object metadata](#client-object-metadata)
+* [Considerations](#considerations)
+
+
+## Metadata types
+
+There are two types of metadata in the user object related to each user: **user_metadata** and **app_metadata**. You can read about both of these at [app\_metadata and user\_metadata](/api/management/v2/changes#app_metadata-and-user_metadata).
+
+Also available is **client_metadata**, where you can store information that is related to your client application.
+
+| Object | Metadata | Use |
+| :--- | :--- | :--- |
+| user | user_metadata | user-specific properties |
+|      | app_metadata | app-specific properties |
+| client | client_metadata | client-specific properties |
+
+## User object metadata
+
+All rules have available an `auth0` object (an instance of the [node-auth0 SDK](https://github.com/auth0/node-auth0/tree/v2) that can use API v2) which is pre-configured with permissions to update users.
+
+Each sample rule below assumes that the user is represented by the following JSON:
 
 ```json
 {
@@ -21,13 +50,13 @@ Each sample rule in this article assumes the user is represented by the followin
 }
 ```
 
-## Reading metadata
+### Read
 
 To read metadata from a rule, you only need to access the correct user property.
 
-### Reading app_metadata
+#### app_metadata
 
-To make a decision based on the user's roles, you would write the following code:
+To make a decision based on the user's roles, you would use the following code:
 
 ```js
 function(user, context, callback){
@@ -40,9 +69,9 @@ function(user, context, callback){
 }
 ```
 
-### Reading user_metadata
+#### user_metadata
 
-Similarly, you can use the color preference:
+Similarly, to make decisions based on the user's the color preference:
 
 ```js
 function(user, context, callback){
@@ -55,11 +84,11 @@ function(user, context, callback){
 }
 ```
 
-## Updating
+### Update
 
-All rules have available an `auth0` object (which is an instance of the [node-auth0 SDK](https://github.com/auth0/node-auth0/tree/v2) that can use API v2) which is pre-configured with permissions to update users.
+To update a property, use the `push' method.
 
-### Updating app_metadata
+#### app_metadata
 
 To add the admin role to a user:
 
@@ -98,7 +127,7 @@ The resulting user is:
 }
 ```
 
-### Updating user_metadata
+#### user_metadata
 
 To add the add a `fontSize` preference:
 
@@ -138,7 +167,7 @@ The resulting user is:
 }
 ```
 
-### Updating app_metadata and user_metadata in the same rule
+#### Update app\_metadata and user\_metadata in the same rule
 
 You can update both `user_metadata` and `app_metadata` in the same rule in parallel to reduce the rule's processing time:
 
@@ -189,13 +218,13 @@ The resulting user is:
 }
 ```
 
-## Deleting
+### Delete
 
-There are different ways of deleting properties. This section explains them with examples.
+To delete a property, set the value to `null`.
 
-### Deleting all user's roles
+#### app_metadata
 
-To delete a property, set it to the `null` value. For example, to delete the user's roles:
+To delete all of the user's roles:
 
 ```js
 function(user, context, callback){
@@ -230,9 +259,7 @@ The resulting user is:
 }
 ```
 
-### Deleting a user's roles
-
-To delete the user's writer role:
+To delete the user's `writer` role:
 
 ```js
 function(user, context, callback){
@@ -274,7 +301,7 @@ The resulting user is:
 }
 ```
 
-### Deleting the user's color preference
+#### user_metadata
 
 To delete the user's color preference:
 
@@ -311,16 +338,109 @@ The resulting user is:
 }
 ```
 
-### Considerations
+## Client object metadata
+
+The sample rules below assume that the client is represented by the following JSON:
+
+```js
+{
+  ...
+  "client_metadata": {
+  "key1": "valueforkey"
+  }
+...
+}
+```
+
+### Read
+
+To read metadata from a rule, you only need to access the correct client property.
+
+```js
+function(client, context, callback){
+  client.client_metadata = client.client_metadata || {};
+  if (client.client_metadata.key1 === 'valueforkey'){
+  // this code would be executed
+  }
+...
+}
+```
+
+### Update
+
+To update a property, use the `push' method.
+
+```js
+function(client, context, callback){
+  client.client_metadata = client.client_metadata || {};
+  // update the client_metadata that will be part of the response
+  client.client_metadata.key1 = client.client_metadata.key1 || [];
+  client.client_metadata.key1.push('admin');
+
+  // persist the client_metadata update
+  auth0.clients.updateClientMetadata(client.client_id, client.client_metadata)
+    .then(function(){
+      callback(null, client, context);
+    })
+    .catch(function(err){
+      callback(err);
+    });
+}
+```
+
+The resulting client is:
+
+```js
+{
+...
+  "client_metadata": {
+  "key1": "newValue"
+  }
+...
+}
+```
+
+### Delete
+
+To delete a property, set the value to `null`.
+
+```js
+function(client, context, callback){
+  client.client_metadata = client.client_metadata || {};
+  // update the client_metadata that will be part of the response
+  client.client_metadata.key1 = null;
+
+  // persist the client_metadata update
+  auth0.clients.updateClientMetadata(client.client_id, client.client_metadata)
+    .then(function(){
+      callback(null, client, context);
+    })
+    .catch(function(err){
+      callback(err);
+    });
+}
+```
+
+The resulting client is:
+
+```js
+{
+...
+  "client_metadata": {
+  "key1": ""
+  }
+...
+}
+```
+
+## Considerations
 
 The metadata must be a valid JSON object and can not contain a dot in key field names in `user_metadata` or `app_metadata`.
 
 The following is not allowed.
 ```js
 {
-
-"preference.color" : "pink"
-
+  "preference.color" : "pink"
 }
 ```
 
@@ -328,9 +448,7 @@ The following is accepted, however.
 
 ```js
 {
-
-"color" : "light.blue"
-
+  "color" : "light.blue"
 }
 ```
 
@@ -338,15 +456,13 @@ If you use a key field name with a dot in it you will get an Internal Server (50
 
 A few workarounds are listed below:
 
-You can convert the first example to something like this.
+1. You can convert the first example to something like this.
 
-```js
+  ```js
 {
-
-"preference" : {"color" : "pink" }
-
+  "preference" : {"color" : "pink" }
 }
-```
+  ```
 
-Or you could use a different delimiter character besides `.` (dot) or `$` (dollar sign).
+2. You could use a different delimiter character besides `.` (dot) or `$` (dollar sign).
 

--- a/articles/rules/metadata-in-rules.md
+++ b/articles/rules/metadata-in-rules.md
@@ -340,97 +340,59 @@ The resulting user is:
 
 ## Client object metadata
 
-The sample rules below assume that the client is represented by the following JSON:
+The sample rules below assume that context.client is contains the following:
 
 ```js
 {
-  ...
-  "client_metadata": {
-  "key1": "valueforkey"
+  clientID: 'abcde',
+  clientName: 'name',
+  clientMetadata: {
+    Key1: "Value1",
+    Key2: "Value2"
   }
-...
 }
 ```
 
 ### Read
 
-To read metadata from a rule, you only need to access the correct client property.
+To read `clientMetadata` from a rule, you only need to access the correct property.
 
 ```js
-function(client, context, callback){
-  client.client_metadata = client.client_metadata || {};
-  if (client.client_metadata.key1 === 'valueforkey'){
+function(user, context, callback){
+  context.clientMetadata  = context.clientMetadata  || {};
+  if (context.clientMetadata.Key1 === 'Value1'){
   // this code would be executed
   }
-...
+…
 }
 ```
 
 ### Update
 
-To update a property, use the `push' method.
+To update a property, 
 
 ```js
-function(client, context, callback){
-  client.client_metadata = client.client_metadata || {};
-  // update the client_metadata that will be part of the response
-  client.client_metadata.key1 = client.client_metadata.key1 || [];
-  client.client_metadata.key1.push('newValue');
 
-  // persist the client_metadata update
-  auth0.clients.updateClientMetadata(client.client_id, client.client_metadata)
-    .then(function(){
-      callback(null, client, context);
-    })
-    .catch(function(err){
-      callback(err);
-    });
-}
 ```
 
 The resulting client is:
 
 ```js
-{
-...
-  "client_metadata": {
-  "key1": "newValue"
-  }
-...
-}
+
 ```
 
 ### Delete
 
-To delete a property, set the value to `null`.
+To delete a property, 
 
 ```js
-function(client, context, callback){
-  client.client_metadata = client.client_metadata || {};
-  // update the client_metadata that will be part of the response
-  client.client_metadata.key1 = null;
 
-  // persist the client_metadata update
-  auth0.clients.updateClientMetadata(client.client_id, client.client_metadata)
-    .then(function(){
-      callback(null, client, context);
-    })
-    .catch(function(err){
-      callback(err);
-    });
-}
 ```
 
 The resulting client is:
 
 ```js
-{
-...
-  "client_metadata": {
-  "key1": ""
-  }
-...
-}
+
 ```
 
 ## Considerations

--- a/articles/rules/metadata-in-rules.md
+++ b/articles/rules/metadata-in-rules.md
@@ -375,7 +375,7 @@ function(client, context, callback){
   client.client_metadata = client.client_metadata || {};
   // update the client_metadata that will be part of the response
   client.client_metadata.key1 = client.client_metadata.key1 || [];
-  client.client_metadata.key1.push('admin');
+  client.client_metadata.key1.push('newValue');
 
   // persist the client_metadata update
   auth0.clients.updateClientMetadata(client.client_id, client.client_metadata)


### PR DESCRIPTION
New client_metadata feature added to rules doc.

Need an engineer to review code samples, I simply copied existing samples and replaced "user" with "client".

Does the rules `auth0` object include a `clients` property, as in:
`auth0.clients.updateClientMetadata(client.client_id, client.client_metadata)`

Also, might help to have real-world key/value examples in the sample code instead of just `key1` and `valuefor Key` but I do not know of actual scenarios to pull these from.
