### PR TITLE
Added requirement for Connection string

### DIFF
--- a/articles/libraries/lock-android/use-your-own-ui.md
+++ b/articles/libraries/lock-android/use-your-own-ui.md
@@ -77,7 +77,12 @@ description: Customize the UI of Lock in your App
   ```java
       String email = ... // Get email
       String password = ... // Get password
-      Map<String, Object> authenticationParameters = ... // Additional authentication parameters
+      //add your DB connection name, since you are using email / pwd login
+      //will throw a 400 error if not set
+      ParameterBuilder parameterBuilder = ParameterBuilder.newBuilder();
+      Map<String, Object> authenticationParameters = parameterBuilder
+                .setConnection("YOUR_DB_CONNECTION_NAME")
+                .asDictionary();
       client.login(email, password)
           .addParameters(authenticationParameters)
           .start(new AuthenticationCallback() {


### PR DESCRIPTION
<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs#contributing-guidelines)
- If applicable, added details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->

The example will not work if the developer does not specify a Connection string - at least for email/pwd auth. This is not in the current doc and is also not in the generated, downloadable Android example. I could not get my app nor the example to connect without adding the setConnection auth parameter. BTW it's also not clear in the documentation link below what setConnection() actually does:

https://auth0.com/docs/libraries/lock-android/sending-authentication-parameters
