### PR TITLE
Added warning on Katana cookies issue [review]

### DIFF
--- a/articles/server-platforms/aspnet-owin/01-login.md
+++ b/articles/server-platforms/aspnet-owin/01-login.md
@@ -93,6 +93,29 @@ The user profile is normalized regardless of where the user came from, and the c
 
 ----
 
+## Katana issue with cookies
+
+There is an bug with the Katana OWIN implementation (Microsoft.Owin.Host.SystemWeb), that causes cookies set in an OWIN middleware to sometimes disappear. This results in the authentication flow not being able to complete. The sympton in this case is that the `AuthenticationManager.GetExternalLoginInfo()` or similar calls that depend on a cookie being set will fail. 
+
+The issue is described [here](https://katanaproject.codeplex.com/workitem/197), and the current workaround is installing the [Kentor.OwinCookieSaver package](https://www.nuget.org/packages/Kentor.OwinCookieSaver/). 
+
+First install the package:
+
+```
+Install-Package Kentor.OwinCookieSaver
+```
+
+and then configure the middleware. The `Kentor.OwinCookieSaver` middleware should be added before other cookie handling middleware:
+
+```
+app.UseKentorOwinCookieSaver();
+
+app.UseCookieAuthentication(new CookieAuthenticationOptions(...));
+```
+
+Further details are provided at https://github.com/KentorIT/owin-cookie-saver.
+----
+
 ### More information
 
 #### Authorization


### PR DESCRIPTION
Microsoft's OWIN implementation for ASP.Net has a bug that clears authentication cookies on occasions (not always, which makes it difficult to troubleshoot). This change includes a workaround.

Please see the changes. It's currently a note at the end of the tutorial, but adding it as an additional step might be a better idea. Let me know if you want me to modify this.
