### PR TITLE
Remove Notify Dashboard Owners action

### DIFF
--- a/articles/anomaly-detection/index.md
+++ b/articles/anomaly-detection/index.md
@@ -19,7 +19,6 @@ A **trigger** is a suspicious event that is detected when someone is trying to l
 **Trigger:** *10* failed login attempts into a single account from the same IP address.
 
 **Actions**:
-* Notify dashboard owners
 * Send an email to the affected user
 * Block the suspicious IP address
 


### PR DESCRIPTION
**Notify Dashboard Owners** is not available as an action for the 1st level Brute Force Protection. 
I'm removing it from the docs so that we don't confuse users.
