### PR TITLE
[DO NOT MERGE] Update quickstart pages for Objective-C

### DIFF
--- a/articles/native-platforms/ios-objc/index.yml
+++ b/articles/native-platforms/ios-objc/index.yml
@@ -17,3 +17,5 @@ alias:
 seo_alias: ios-objc
 articles:
   - 01-login
+  - 02-custom-login
+  - 03-session-handling


### PR DESCRIPTION
The Custom Login and Session Handling pages were in the repo, but the index was not updated hence the pages are not displayed.
