### PR TITLE
Fixes for already merged tutorials (0, 1, 2, 3, 4 and 5)

### DIFF
--- a/articles/native-platforms/ios-swift/00-introduction.md
+++ b/articles/native-platforms/ios-swift/00-introduction.md
@@ -13,13 +13,7 @@ This tutorial and seed project have been tested with the following:
 * iOS 9.3 (13E230)
   :::
 
-<%= include('../../_includes/_package', {
-  pkgRepo: 'native-mobile-samples',
-  pkgBranch: 'master',
-  pkgPath: 'iOS/basic-sample-swift',
-  pkgFilePath: 'iOS/basic-sample-swift/SwiftSample/Info.plist',
-  pkgType: 'replace'
-}) %>
+<%= include('../../_includes/_github', { link: 'https://github.com/auth0-samples/auth0-ios-swift-sample/tree/master/00-Starter-Seed', }) %>
 
 ### Before Starting
 

--- a/articles/native-platforms/ios-swift/00-introduction.md
+++ b/articles/native-platforms/ios-swift/00-introduction.md
@@ -10,7 +10,7 @@ This tutorial and seed project have been tested with the following:
 
 * CocoaPods 1.0.0
 * XCode 7.3 (7D175)
-* Simulator - iPhone 6 - iOS 9.3 (13E230)
+* iOS 9.3 (13E230)
   :::
 
 <%= include('../../_includes/_package', {

--- a/articles/native-platforms/ios-swift/01-login.md
+++ b/articles/native-platforms/ios-swift/01-login.md
@@ -11,13 +11,7 @@ This tutorial and seed project have been tested with the following:
 * Simulator - iPhone 6 - iOS 9.3 (13E230)
   :::
 
-<%= include('../../_includes/_package', {
-  pkgRepo: 'native-mobile-samples',
-  pkgBranch: 'master',
-  pkgPath: 'iOS/basic-sample-swift',
-  pkgFilePath: 'iOS/basic-sample-swift/SwiftSample/Info.plist',
-  pkgType: 'replace'
-}) %>
+<%= include('../../_includes/_github', { link: 'https://github.com/auth0-samples/auth0-ios-swift-sample/tree/master/01-Login', }) %>
 
 ### Before Starting
 

--- a/articles/native-platforms/ios-swift/01-login.md
+++ b/articles/native-platforms/ios-swift/01-login.md
@@ -8,7 +8,7 @@ This tutorial and seed project have been tested with the following:
 
 * CocoaPods 1.0.0
 * XCode 7.3 (7D175)
-* Simulator - iPhone 6 - iOS 9.3 (13E230)
+* iOS 9.3 (13E230)
   :::
 
 <%= include('../../_includes/_github', { link: 'https://github.com/auth0-samples/auth0-ios-swift-sample/tree/master/01-Login', }) %>

--- a/articles/native-platforms/ios-swift/02-custom-login.md
+++ b/articles/native-platforms/ios-swift/02-custom-login.md
@@ -11,13 +11,7 @@ This tutorial and seed project have been tested with the following:
 * Simulator - iPhone 6 - iOS 9.3 (13E230)
   :::
 
-<%= include('../../_includes/_package', {
-  pkgRepo: 'native-mobile-samples',
-  pkgBranch: 'master',
-  pkgPath: 'iOS/basic-sample-swift',
-  pkgFilePath: 'iOS/basic-sample-swift/SwiftSample/Info.plist',
-  pkgType: 'replace'
-}) %>
+<%= include('../../_includes/_github', { link: 'https://github.com/auth0-samples/auth0-ios-swift-sample/tree/master/02-Custom-Login', }) %>
 
 ### Before Starting
 

--- a/articles/native-platforms/ios-swift/02-custom-login.md
+++ b/articles/native-platforms/ios-swift/02-custom-login.md
@@ -157,7 +157,8 @@ Auth0
     .authentication()
     .signUp("foo@email.com",
         password: "123456",
-        connection: "Username-Password-Authentication"
+        connection: "Username-Password-Authentication",
+        userMetadata: ["first_name": "Foo", "last_name": "Bar"] // or any extra user data you need
     )
     .start { result in
             switch result {
@@ -172,4 +173,71 @@ Auth0
 }
 ```
 
-As you might have observed, this code looks almost exactly the same as the Login snippet presented before. The code skeleton remains the same, the only thing that changes here is the function that you call.
+Notice that any extra information, other than the `email` and `password`, that you need to add to the user's profile, goes within the `userMetadata` dictionary, which is passed as a parameter to this function.
+
+### 4. Perform Social Authentication
+
+First, go to your [Client Dashboard](${uiAppSettingsURL}/${account.clientId}/settings) and make sure that *Allowed Callback URLs* contains the following:
+
+```shell
+{YOUR_APP_BUNDLE_IDENTIFIER}://${account.domain}/ios/{YOUR_APP_BUNDLE_IDENTIFIER}/callback
+```
+
+In your application's `Info.plist` file, register your iOS Bundle Identifier as a custom scheme. To do so, open the `Info.plist` as source code, and add this chunk of code under the main `<dict>` entry:
+
+```xml
+<key>CFBundleURLTypes</key>
+<array>
+    <dict>
+        <key>CFBundleTypeRole</key>
+        <string>None</string>
+        <key>CFBundleURLName</key>
+        <string>auth0</string>
+        <key>CFBundleURLSchemes</key>
+        <array>
+            <string>{YOUR_APP_BUNDLE_IDENTIFIER}</string>
+        </array>
+    </dict>
+</array>
+```
+
+Remember to replace all the `{YOUR_APP_BUNDLE_IDENTIFIER}` appearances with your actual app's bundle identifier, which you can get from your project settings.
+
+> The **Auth0.swift** toolkit will only handle URLs with your Auth0 domain as host, for instance: `com.auth0.MyApp://samples.auth0.com/ios/com.auth0.MyApp/callback`
+
+Then, add the following function in your application's `AppDelegate`:
+
+```swift
+import Auth0
+```
+
+```swift
+func application(app: UIApplication, openURL url: NSURL, options: [String : AnyObject]) -> Bool {
+    return Auth0.resumeAuth(url, options: options)
+}
+```
+
+Finally, this is how you perform webauth social authentication. You have to specify a social connection, for instance, Facebook:
+
+```swift
+Auth0
+    .webAuth()
+    .connection("facebook")
+    .scope("openid")
+    .start { result in
+        switch result {
+        case .Success(let credentials):
+            // You've got your credentials
+        case .Failure(let error):
+            // Deal with error
+        }
+    }
+```
+
+Once you get the `credentials` object, upon a successful authentication, you deal with them as always. For more information on that, check out the [login](01-login.md) and [session handling](session-handling.md) tutorials.
+
+### Done!
+
+You've just implemented your own Login and Sign Up forms!
+
+

--- a/articles/native-platforms/ios-swift/02-custom-login.md
+++ b/articles/native-platforms/ios-swift/02-custom-login.md
@@ -8,7 +8,7 @@ This tutorial and seed project have been tested with the following:
 
 * CocoaPods 1.0.0
 * XCode 7.3 (7D175)
-* Simulator - iPhone 6 - iOS 9.3 (13E230)
+* iOS 9.3 (13E230)
   :::
 
 <%= include('../../_includes/_github', { link: 'https://github.com/auth0-samples/auth0-ios-swift-sample/tree/master/02-Custom-Login', }) %>

--- a/articles/native-platforms/ios-swift/03-session-handling.md
+++ b/articles/native-platforms/ios-swift/03-session-handling.md
@@ -8,7 +8,7 @@ This tutorial and seed project have been tested with the following:
 
 * CocoaPods 1.0.0
 * XCode 7.3 (7D175)
-* Simulator - iPhone 6 - iOS 9.3 (13E230)
+* iOS 9.3 (13E230)
   :::
 
 <%= include('../../_includes/_github', { link: 'https://github.com/auth0-samples/auth0-ios-swift-sample/tree/master/03-Session-Handling', }) %>

--- a/articles/native-platforms/ios-swift/03-session-handling.md
+++ b/articles/native-platforms/ios-swift/03-session-handling.md
@@ -11,13 +11,7 @@ This tutorial and seed project have been tested with the following:
 * Simulator - iPhone 6 - iOS 9.3 (13E230)
   :::
 
-<%= include('../../_includes/_package', {
-  pkgRepo: 'native-mobile-samples',
-  pkgBranch: 'master',
-  pkgPath: 'iOS/basic-sample-swift',
-  pkgFilePath: 'iOS/basic-sample-swift/SwiftSample/Info.plist',
-  pkgType: 'replace'
-}) %>
+<%= include('../../_includes/_github', { link: 'https://github.com/auth0-samples/auth0-ios-swift-sample/tree/master/03-Session-Handling', }) %>
 
 ### Before Starting
 

--- a/articles/native-platforms/ios-swift/04-user-profile.md
+++ b/articles/native-platforms/ios-swift/04-user-profile.md
@@ -11,13 +11,7 @@ This tutorial and seed project have been tested with the following:
 * Simulator - iPhone 6 - iOS 9.3 (13E230)
   :::
 
-<%= include('../../_includes/_package', {
-  pkgRepo: 'native-mobile-samples',
-  pkgBranch: 'master',
-  pkgPath: 'iOS/basic-sample-swift',
-  pkgFilePath: 'iOS/basic-sample-swift/SwiftSample/Info.plist',
-  pkgType: 'replace'
-}) %>
+<%= include('../../_includes/_github', { link: 'https://github.com/auth0-samples/auth0-ios-swift-sample/tree/master/04-User-Profile', }) %>
 
 ### Before Starting
 

--- a/articles/native-platforms/ios-swift/04-user-profile.md
+++ b/articles/native-platforms/ios-swift/04-user-profile.md
@@ -8,7 +8,7 @@ This tutorial and seed project have been tested with the following:
 
 * CocoaPods 1.0.0
 * XCode 7.3 (7D175)
-* Simulator - iPhone 6 - iOS 9.3 (13E230)
+* iOS 9.3 (13E230)
   :::
 
 <%= include('../../_includes/_github', { link: 'https://github.com/auth0-samples/auth0-ios-swift-sample/tree/master/04-User-Profile', }) %>

--- a/articles/native-platforms/ios-swift/05-linking-accounts.md
+++ b/articles/native-platforms/ios-swift/05-linking-accounts.md
@@ -8,7 +8,7 @@ This tutorial and seed project have been tested with the following:
 
 * CocoaPods 1.0.0
 * XCode 7.3 (7D175)
-* Simulator - iPhone 6 - iOS 9.3 (13E230)
+* iOS 9.3 (13E230)
   :::
 
 <%= include('../../_includes/_github', { link: 'https://github.com/auth0-samples/auth0-ios-swift-sample/tree/master/05-Linking-Accounts', }) %>

--- a/articles/native-platforms/ios-swift/05-linking-accounts.md
+++ b/articles/native-platforms/ios-swift/05-linking-accounts.md
@@ -11,13 +11,7 @@ This tutorial and seed project have been tested with the following:
 * Simulator - iPhone 6 - iOS 9.3 (13E230)
   :::
 
-<%= include('../../_includes/_package', {
-  pkgRepo: 'native-mobile-samples',
-  pkgBranch: 'master',
-  pkgPath: 'iOS/basic-sample-swift',
-  pkgFilePath: 'iOS/basic-sample-swift/SwiftSample/Info.plist',
-  pkgType: 'replace'
-}) %>
+<%= include('../../_includes/_github', { link: 'https://github.com/auth0-samples/auth0-ios-swift-sample/tree/master/05-Linking-Accounts', }) %>
 
 ### Before Starting
 


### PR DESCRIPTION
- This patch includes a fix for the link to the sample project on each iOS-Swift tutorial that has already been merged to master, i. e. tutorials numbers 1, 2, 3, 4 and 5.
- The rest of the tutorials, which haven't been merged yet, are fixed already on each corresponding branch.
