### PR TITLE
Fixed some sample code and added whitespace

### DIFF
--- a/articles/rules/index.md
+++ b/articles/rules/index.md
@@ -171,18 +171,18 @@ This example, shows how to use the `global` object to keep a mongodb connection:
   ...
 
   //If the db object is there, use it.
-  if(!global.db){
-    return query(global.db,callback);
+  if (global.db){
+    return query(global.db, callback);
   }
 
   //If not, get the db (mongodb in this case)
   mongo('mongodb://user:pass@mymongoserver.com/my-db',  function (db){
     global.db = db;
-    return query(db,callback);
+    return query(db, callback);
   });
 
   //Do the actual work
-  function query(db,cb){
+  function query(db, cb){
     //Do something with db
     ...
   });


### PR DESCRIPTION
The `if` condition didn't match the comment and explanation above it, i.e. it's meant to check if `global.db` exists, and if so, to use it.

I also added some whitespace in the function calls to match the style used in the other function calls in the same document.
