### PR TITLE
Fix "caching expensive resources" example

### DIFF
--- a/articles/rules/index.md
+++ b/articles/rules/index.md
@@ -215,7 +215,7 @@ This example, shows how to use the `global` object to keep a mongodb connection:
   ...
 
   //If the db object is there, use it.
-  if(!global.db){
+  if(global.db){
     return query(global.db,callback);
   }
 


### PR DESCRIPTION
The code example here is saying that if global.db is there, to use it, but the boolean logic was backwards.
