### PR TITLE
Note that Azure AD can cause large token with 'openid profile'

### DIFF
--- a/articles/libraries/lock-android/sending-authentication-parameters.md
+++ b/articles/libraries/lock-android/sending-authentication-parameters.md
@@ -42,7 +42,7 @@ Map<String, Object> parameters = builder
 There are different values supported for scope:
 
 * `'openid'`: It will return, not only the `access_token`, but also an `id_token` which is a Json Web Token (JWT). The JWT will only contain the user id (sub claim). You can use constant `ParemterBuilder.SCOPE_OPENID`.
-* `'openid profile'`: (not recommended): will return all the user attributes in the token. This can cause problems when sending or receiving tokens in URLs (e.g. when using response_type=token) and will likely create an unnecessarily large token. Keep in mind that JWTs are sent on every API request, so it is desirable to keep them as small as possible.
+* `'openid profile'`: (not recommended): will return all the user attributes in the token. This can cause problems when sending or receiving tokens in URLs (e.g. when using response_type=token) and will likely create an unnecessarily large token(especially with Azure AD which returns a fairly long JWT). Keep in mind that JWTs are sent on every API request, so it is desirable to keep them as small as possible.
 * `'openid {attr1} {attr2} {attrN}'`: If you want only specific user's attributes to be part of the `id_token` (For example: `scope: 'openid name email picture'`).
 
 Also when need to keep the `id_token` alive, you can request a refresh_token adding to the scope the value `offline_access` (Or use the constant `ParameterBuilder.SCOPE_OFFLINE_ACCESS`).

--- a/articles/libraries/lock-ios/sending-authentication-parameters.md
+++ b/articles/libraries/lock-ios/sending-authentication-parameters.md
@@ -41,7 +41,7 @@ A0AuthParameters *parameters = [A0AuthParameters newDefaultParams];
 There are different values supported for scope:
 
 * `'openid'`: It will return, not only the `access_token`, but also an `id_token` which is a Json Web Token (JWT). The JWT will only contain the user id (sub claim). You can use objc constant `A0ScopeOpenId`.
-* `'openid profile'`:(not recommended): will return all the user attributes in the token. This can cause problems when sending or receiving tokens in URLs (e.g. when using response_type=token) and will likely create an unnecessarily large token. Keep in mind that JWTs are sent on every API request, so it is desirable to keep them as small as possible. You can use objc constant `A0ScopeProfile`.
+* `'openid profile'`:(not recommended): will return all the user attributes in the token. This can cause problems when sending or receiving tokens in URLs (e.g. when using response_type=token) and will likely create an unnecessarily large token(especially with Azure AD which returns a fairly long JWT). Keep in mind that JWTs are sent on every API request, so it is desirable to keep them as small as possible. You can use objc constant `A0ScopeProfile`.
 * `'openid {attr1} {attr2} {attrN}'`: If you want only specific user's attributes to be part of the `id_token` (For example: `scope: 'openid name email picture'`).
 
 Also when need to keep the `id_token` alive, you can request a refresh_token adding to the scope the value `offline_access` (Or use the constant `A0ScopeOfflineAccess`).

--- a/articles/libraries/lock/v10/sending-authentication-parameters.md
+++ b/articles/libraries/lock/v10/sending-authentication-parameters.md
@@ -34,7 +34,7 @@ var options = {
 There are different values supported for scope:
 
 * `scope: 'openid'`: _(default)_ It will return not only the `access_token`, but also an `id_token` which is a JSON Web Token (JWT). The JWT will only contain the user ID (`sub` claim).
-* `scope: 'openid profile'`: (not recommended): will return all the user attributes in the token. This can cause problems when sending or receiving tokens in URLs (e.g. when using response_type=token) and will likely create an unnecessarily large token. Keep in mind that JWTs are sent on every API request, so it is desirable to keep them as small as possible.
+* `scope: 'openid profile'`: (not recommended): will return all the user attributes in the token. This can cause problems when sending or receiving tokens in URLs (e.g. when using response_type=token) and will likely create an unnecessarily large token(especially with Azure AD which returns a fairly long JWT). Keep in mind that JWTs are sent on every API request, so it is desirable to keep them as small as possible.
 * `scope: 'openid {attr1} {attr2} {attrN}'`: If you want only specific user attributes to be part of the `id_token` (For example: `scope: 'openid name email picture'`).
 
 ### connection_scopes {Object}

--- a/articles/libraries/lock/v9/sending-authentication-parameters.md
+++ b/articles/libraries/lock/v9/sending-authentication-parameters.md
@@ -30,7 +30,7 @@ lock.show({
 There are different values supported for scope:
 
 * `scope: 'openid'`: _(default)_ It will return not only the `access_token`, but also an `id_token` which is a JSON Web Token (JWT). The JWT will only contain the user ID (`sub` claim).
-* `scope: 'openid profile'`: (not recommended): will return all the user attributes in the token. This can cause problems when sending or receiving tokens in URLs (e.g. when using response_type=token) and will likely create an unnecessarily large token. Keep in mind that JWTs are sent on every API request, so it is desirable to keep them as small as possible.
+* `scope: 'openid profile'`: (not recommended): will return all the user attributes in the token. This can cause problems when sending or receiving tokens in URLs (e.g. when using response_type=token) and will likely create an unnecessarily large token(especially with Azure AD which returns a fairly long JWT). Keep in mind that JWTs are sent on every API request, so it is desirable to keep them as small as possible.
 * `scope: 'openid {attr1} {attr2} {attrN}'`: If you want only specific user attributes to be part of the `id_token` (For example: `scope: 'openid name email picture'`).
 
 ### connection_scopes {Object}

--- a/articles/protocols.md
+++ b/articles/protocols.md
@@ -163,7 +163,7 @@ Optionally (if `scope=openid` is added in the authorization request):
 
 Clients typically extract the URI fragment with the __Access Token__ and cancel the redirection. The client code will then interact with other endpoints using the token in the fragment.
 
-> Note that tokens can become large and under certain conditions the URL might be truncated (e.g. some browsers have URL length limitations). Be especially careful when using the `scope=openid profile` that will generate a JWT with the entire user profile in it. You can define specific attributes to return in the JWT (e.g. `scope=openid email name`).
+> Note that tokens can become large and under certain conditions the URL might be truncated (e.g. some browsers have URL length limitations). Be especially careful when using the `scope=openid profile` that will generate a JWT with the entire user profile in it(especially with Azure AD which returns a fairly long JWT). You can define specific attributes to return in the JWT (e.g. `scope=openid email name`).
 
 ### 4. Calling your API with a JWT (optional)
 

--- a/articles/scopes.md
+++ b/articles/scopes.md
@@ -37,7 +37,7 @@ The attributes included in the issued token can be controlled with the `scope` p
 * `scope=openid`: will only return `iss`, `sub`, `aud`, `exp` and `iat` claims.
 * `scope=openid email nickname favorite_food`: will return claims for `openid` in addition to the `email`, `nickname` and `favorite_food` fields if they are available.
 * `scope=openid profile` (not recommended): will return all the user attributes in the token.
-This can cause problems when sending or receiving tokens in URLs (e.g. when using `response_type=token`) and will likely create an unnecessarily large token.
+This can cause problems when sending or receiving tokens in URLs (e.g. when using `response_type=token`) and will likely create an unnecessarily large token(especially with Azure AD which returns a fairly long JWT).
 Keep in mind that JWTs are sent on every API request, so it is desirable to keep them as small as possible.
 
 > The `scope` parameter can used in the same way when calling the [Resource Owner endpoint](/auth-api#!#post--oauth-ro).


### PR DESCRIPTION
<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs#contributing-guidelines)
- If applicable, added details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->

Add to warning with `openid profile` about Azure AD as this seems to
cause the most issues for customers.

https://trello.com/c/o5p7Ls6g/6-azure-ad-returns-an-access-token-that-is
-long-and-causes-issues-if-someone-uses-openid-profile
https://auth0.zendesk.com/agent/tickets/6818
https://auth0.com/forum/t/id-token-is-too-large/3116/2
