### PR TITLE
Fix Android snippets

### DIFF
--- a/articles/native-platforms/android/02-custom-login.md
+++ b/articles/native-platforms/android/02-custom-login.md
@@ -28,11 +28,12 @@ This tutorial and seed project have been tested with the following:
 
 ### Before Starting
 
-Go to the [Client Settings](${uiURL}/#/applications/${account.clientId}/settings) section in the Auth0 dashboard and make sure that **Allowed Callback URLs** contains the following value:
+Go to the [Client Settings](${uiURL}/#/applications/${account.clientId}/settings) section in the Auth0 dashboard and make sure that **Allowed Callback URLs** contains the value:
 
 
-<pre><code>https://${account.namespace}/android/YOUR_APP_PACKAGE_NAME/callback</pre></code>
-</div>
+```
+https://${account.namespace}/android/YOUR_APP_PACKAGE_NAME/callback
+```
 
 ### 1. Add the Auth0 Android Dependency
 
@@ -52,7 +53,8 @@ Then, run "Sync project with Gradle files" inside Android Studio or `./gradlew c
 
 ### 2. Configure your Manifest File
 
-You need to add the following permissions inside the ``AndroidManifest.xml``:
+You need to add the following permissions inside the `AndroidManifest.xml`:
+
 ```xml
 <uses-permission android:name="android.permission.INTERNET" />
 ```


### PR DESCRIPTION
The Custom Login page of the Android quickstart had a "funny" layout when you went to the page using the [link](https://auth0.com/docs/quickstart/native/android/02-custom-login) (if you navigated to the page using clicks from the docs home page, Custom Login was displayed ok).

Bug was due to some errors in code snippets markdown.

![image](https://cloud.githubusercontent.com/assets/11715799/18080150/dea3c5e2-6e9c-11e6-91dc-0a613a0f3cc3.png)
