### PR TITLE
Fixed a typo in user profile article

### DIFF
--- a/articles/user-profile/user-profile-details.md
+++ b/articles/user-profile/user-profile-details.md
@@ -61,7 +61,7 @@ Auth0 also supports the ability for users to [link their profile to multiple ide
 
 You can use `user_profile` to store custom attributes such as the user's favorite color or phone number.
 
-Auth0 provides a [JS widget](https://github.com/auth0/auth0-editprofile-widget) that allosws the user to update their profile information.
+Auth0 provides a [JS widget](https://github.com/auth0/auth0-editprofile-widget) that allows the user to update their profile information.
 
 ## Application Access to User Profile
 


### PR DESCRIPTION
I found a typo in the "User Profile" article and fixed it.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs#contributing-guidelines)
- If applicable, added details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
