### PR TITLE
Fix reported issues on Java docs

### DIFF
--- a/articles/server-platforms/java-spring-mvc/01-login.md
+++ b/articles/server-platforms/java-spring-mvc/01-login.md
@@ -34,10 +34,6 @@ Create a new `CallbackController.java` file and set the following contents:
 
 ${snippet(meta.snippets.use)}
 
-By default, this library expects a Nonce value in the state query param as follows `state=nonce=B4AD596E418F7CE02A703B42F60BAD8F`, where `xyz` is a randomly generated UUID.
-
-The NonceFactory can be used to generate such a nonce value. State may be needed to hold other attribute values hence why it has its own keyed value of `nonce=B4AD596E418F7CE02A703B42F60BAD8F`. For instance in SSO you may need an `externalCallbackUrl` which also needs to be stored down in the state param: `state=nonce=B4AD596E418F7CE02A703B42F60BAD8F&externalCallbackUrl=http://localhost:3099/callback`.
-
 
 ### Display Lock widget
 

--- a/articles/server-platforms/java-spring-mvc/01-login.md
+++ b/articles/server-platforms/java-spring-mvc/01-login.md
@@ -93,7 +93,9 @@ First, we initialize `Auth0Lock` with a `clientID` and the account's `domain`.
 var lock = new Auth0Lock('${account.clientId}', '${account.namespace}');
 ```
 
-Afterwards, we use the `showSignin` method to open the widget on signin mode. We set several parameters as input, like `authParams` and `responseType`. For details on what each parameter does, refer to [Lock: User configurable options](/libraries/lock/customization).
+We set several parameters as input, like `redirectUrl` and `responseType`. For details on what each parameter does, refer to [Lock: User configurable options](/libraries/lock/customization).
+
+Once the `Auth0Lock` is initialized we display the widget using `lock.show()`.
 
 
 ### Display user information

--- a/articles/server-platforms/java-spring-mvc/01-login.md
+++ b/articles/server-platforms/java-spring-mvc/01-login.md
@@ -12,16 +12,16 @@ This tutorial and seed project have been tested with the following:
 :::
 
 <%= include('../../_includes/_package', {
-githubUrl: 'https://github.com/auth0-samples/auth0-spring-mvc-sample/tree/master/01-Login',
-pkgOrg: 'auth0-samples',
-pkgRepo: 'auth0-spring-mvc-sample',
-pkgBranch: 'master',
-pkgPath: '01-Login',
-pkgFilePath: '01-Login/src/main/resources/auth0.properties',
-pkgType: 'replace'
+  githubUrl: 'https://github.com/auth0-samples/auth0-spring-mvc-sample/tree/master/01-Login',
+  pkgOrg: 'auth0-samples',
+  pkgRepo: 'auth0-spring-mvc-sample',
+  pkgBranch: 'master',
+  pkgPath: '01-Login',
+  pkgFilePath: '01-Login/src/main/resources/auth0.properties',
+  pkgType: 'replace'
 }) %>
 
-In this step we will enable login with the [Lock widget](/libraries/lock). 
+In this step we will enable login with the [Lock widget](/libraries/lock).
 
 
 ### Authenticate the user
@@ -48,43 +48,43 @@ ${'<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>'}
 <!DOCTYPE html>
 <html>
 <head>
-  <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
-  <title>Login</title>
-  <link rel="stylesheet" type="text/css" href="/css/bootstrap.css"/>
-  <link rel="stylesheet" type="text/css" href="/css/jquery.growl.css"/>
-  <script src="http://code.jquery.com/jquery.js"></script>
-  <script src="http://cdn.auth0.com/js/lock-9.min.js"></script>
-  <script src="/js/jquery.growl.js" type="text/javascript"></script>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+    <title>Login</title>
+    <link rel="stylesheet" type="text/css" href="/css/bootstrap.css"/>
+    <link rel="stylesheet" type="text/css" href="/css/jquery.growl.css"/>
+    <script src="http://code.jquery.com/jquery.js"></script>
+    <script src="https://cdn.auth0.com/js/lock/10.0/lock.min.js"></script>
+    <script src="/js/jquery.growl.js" type="text/javascript"></script>
 </head>
 <body>
-  <div class="container">
+<div class="container">
     <script type="text/javascript">
-      $(function () {
-        var error = <%= "${error}" %>;
-        if (error) {
-          $.growl.error({message: "An error was detected. Please log in"});
-        } else {
-          $.growl({title: "Welcome!", message: "Please log in"});
-        }
-      });
-
-      $(function () {
-        var lock = new Auth0Lock('${account.clientId}', '${account.namespace}', {
-          auth: {
-            params: {
-              state: {state},
-              // change scopes to whatever you like, see https:///scopes
-              // claims are added to JWT id_token - openid profile gives everything
-              scope: 'openid user_id name nickname email picture'
-            },
-            responseType: 'code',
-            redirectUrl: '${account.callback}'
-          }
+        $(function () {
+            var error = <%= "${error}" %>;
+            if (error) {
+                $.growl.error({message: "Please log in"});
+            } else {
+                $.growl({title: "Welcome!", message: "Please log in"});
+            }
         });
-        lock.show();
-      });
+        $(function () {
+            var lock = new Auth0Lock('${account.clientId}', '${account.namespace}', {
+                auth: {
+                    redirectUrl: '<%= "${fn:replace(pageContext.request.requestURL, pageContext.request.requestURI, '')}" %>${account.callback}',
+                    responseType: 'code',
+                    params: {
+                        state: '<%= "${state}" %>',
+                        scope: 'openid user_id name nickname email picture'
+                    }
+                }
+            });
+            // delay to allow welcome message..
+            setTimeout(function () {
+                lock.show();
+            }, 1500);
+        });
     </script>
-  </div>
+</div>
 </body>
 </html>
 ```

--- a/articles/server-platforms/java-spring-security-mvc/01-login.md
+++ b/articles/server-platforms/java-spring-security-mvc/01-login.md
@@ -63,12 +63,9 @@ First, we initialize `Auth0Lock` with a `clientID` and the account's `domain`.
 var lock = new Auth0Lock('${account.clientId}', '${account.namespace}');
 ```
 
-Afterwards, we use the `showSignin` method to open the widget on signin mode. We set several parameters as input, like `authParams` and `responseType`. For details on what each parameter does, refer to [Lock: User configurable options](/libraries/lock/customization).
+We set several parameters as input, like `redirectUrl` and `responseType`. For details on what each parameter does, refer to [Lock: User configurable options](/libraries/lock/customization).
 
-By default, this library expects a Nonce value in the state query param as follows `state=nonce=B4AD596E418F7CE02A703B42F60BAD8F` where `xyz` is a randomly generated UUID.
-
-The NonceFactory can be used to generate such a nonce value. State may be needed to hold other attribute values hence why it has its own keyed value of `nonce=B4AD596E418F7CE02A703B42F60BAD8F`. For instance in SSO you may need an `externalCallbackUrl` which also needs to be stored down in the state param: `state=nonce=B4AD596E418F7CE02A703B42F60BAD8F&externalCallbackUrl=http://localhost:3099/callback`.
-
+Once the `Auth0Lock` is initialized we display the widget using `lock.show()`.
 
 ## Display user information
 
@@ -88,7 +85,7 @@ ${snippet(meta.snippets.LoginHomeJsp)}
 
 ## Test the app
 
-We are now ready to test the application! 
+We are now ready to test the application!
 
 Build and run the project using `mvn spring-boot:run`. Then, go to [http://localhost:3099/login](http://localhost:3099/login).
 
@@ -102,7 +99,6 @@ Enter the credentials of the user you created earlier to test the login. You sho
 
 ## Done!
 
-That's it, you're done! You implemented basic login functionality using [Lock](/libraries/lock). 
+That's it, you're done! You implemented basic login functionality using [Lock](/libraries/lock).
 
 Continue to the next tutorial to see how you can create your own custom login.
-

--- a/articles/server-platforms/java/00-intro.md
+++ b/articles/server-platforms/java/00-intro.md
@@ -5,22 +5,22 @@ description: This tutorial will show you how to use the Auth0 Java SDK to add au
 
 This multi-step quickstart will guide you through the process of managing authentication in your Java Servlet Web Application with Auth0.
 
-Auth0 provides and manages a [Servlet SDK](https://github.com/auth0/auth0-servlet). This SDK allows you to use Auth0 with Java for server-side MVC web apps. It presents a simple servlet based solution without introducing specific frameworks or libraries such as Spring. 
+Auth0 provides and manages a [Servlet SDK](https://github.com/auth0/auth0-servlet). This SDK allows you to use Auth0 with Java for server-side MVC web apps. It presents a simple servlet based solution without introducing specific frameworks or libraries such as Spring.
 
-__NOTE:__ You can find a listing of all our Java offerings and several sample projects in [Java technologies and Auth0 libraries](/java-overview). 
+__NOTE:__ You can find a listing of all our Java offerings and several sample projects in [Java technologies and Auth0 libraries](/java-overview).
 
 
 ## Seed &amp; Samples
 
-There are two options to following along this quickstart. You can either download the [seed project](https://github.com/auth0-samples/auth0-servlet-sample/tree/master/00-Start) or the samples provided at each page of this quickstart. 
+There are two options to following along this quickstart. You can either download the [seed project](https://github.com/auth0-samples/auth0-servlet-sample/tree/master/00-Starter-Seed) or the samples provided at each page of this quickstart.
 
-The seed is a regular java app, with all the Auth0 dependencies set, but nothing more. It's an empty canvas meant to be filled as you follow along the steps of this quickstart. If you prefer this option download the seed from our [GitHub repository](https://github.com/auth0-samples/auth0-servlet-sample/tree/master/00-Start) and follow along.
+The seed is a regular java app, with all the Auth0 dependencies set, but nothing more. It's an empty canvas meant to be filled as you follow along the steps of this quickstart. If you prefer this option download the seed from our [GitHub repository](https://github.com/auth0-samples/auth0-servlet-sample/tree/master/00-Starter-Seed) and follow along.
 
-Instead you can choose to follow the samples that are included in each step. Each sample uses the [seed project](https://github.com/auth0-samples/auth0-servlet-sample/tree/master/00-Start) as a starting point and applies to it the configuration of each step, so for example the Login sample would be the [seed project](https://github.com/auth0-samples/auth0-servlet-sample/tree/master/00-Start) plus the configuration required to implement login functionality. If you choose to follow this approach continue reading, the rest of this document will guide you through setting up the required prerequisites.
+Instead you can choose to follow the samples that are included in each step. Each sample uses the [seed project](https://github.com/auth0-samples/auth0-servlet-sample/tree/master/00-Starter-Seed) as a starting point and applies to it the configuration of each step, so for example the Login sample would be the [seed project](https://github.com/auth0-samples/auth0-servlet-sample/tree/master/00-Starter-Seed) plus the configuration required to implement login functionality. If you choose to follow this approach continue reading, the rest of this document will guide you through setting up the required prerequisites.
 
 ### Seed project structure
 
-Let's take some time and explain how our [seed project](https://github.com/auth0-samples/auth0-servlet-sample/tree/master/00-Start) is structured. 
+Let's take some time and explain how our [seed project](https://github.com/auth0-samples/auth0-servlet-sample/tree/master/00-Starter-Seed) is structured.
 
 
 ```

--- a/articles/server-platforms/java/01-login.md
+++ b/articles/server-platforms/java/01-login.md
@@ -20,7 +20,7 @@ This tutorial and seed project have been tested with the following:
   pkgType: 'replace'
 }) %>
 
-In this step we will enable login with the [Lock widget](/libraries/lock). 
+In this step we will enable login with the [Lock widget](/libraries/lock).
 
 
 ### Authenticate the user
@@ -75,7 +75,7 @@ ${'<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>'}
 </html>
 ```
 
-__NOTE__: The sample also includes several css, js, and font files, which are not listed in this document for brevity. These files can be found under the `webapp` directory and you don't need to include them if you don't want to. The only necessary file is the `http://cdn.auth0.com/js/lock-9.min.js`.
+__NOTE__: The sample also includes several css, js, and font files, which are not listed in this document for brevity. These files can be found under the `webapp` directory and you don't need to include them if you don't want to. The only necessary file is the `${widget_url}`.
 
 First, we initialize `Auth0Lock` with a `clientID` and the account's `domain`.
 
@@ -90,7 +90,7 @@ Afterwards, we use the `showSignin` method to open the widget on signin mode. We
 
 Depending on which `scopes` you specified upon login, some user information may be available in the [id_token](/tokens#auth0-id_token-jwt-) received.
 
-The full user profile information is available as a session object keyed on `Auth0User`, you can call `SessionUtils.getAuth0User()` to retrieve it. 
+The full user profile information is available as a session object keyed on `Auth0User`, you can call `SessionUtils.getAuth0User()` to retrieve it.
 
 However, because the authenticated user is also a `java.security.Principal` object we can inject it into the Controller automatically for secured endpoints.
 
@@ -192,4 +192,3 @@ Once you login you are redirected to the home page that displays your profile pi
 Logout by clicking the **Logout** button at the top right of the home page.
 
 That's it, you 're done! You added authentication to your Java Servlet web app using Lock!
-

--- a/snippets/server-platforms/java-spring-security/LoginJsp.md
+++ b/snippets/server-platforms/java-spring-security/LoginJsp.md
@@ -30,7 +30,6 @@ ${'<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>'}
                     responseType: 'code',
                     params: {
                         state: <%= "${state}" %>,
-                        // Learn about scopes: https://auth0.com/docs/scopes
                         scope: 'openid user_id name nickname email picture'
                     }
                 }

--- a/snippets/server-platforms/java-spring-security/setup.md
+++ b/snippets/server-platforms/java-spring-security/setup.md
@@ -1,8 +1,8 @@
 ```properties
-auth0.domain: {DOMAIN}
-auth0.issuer: {ISSUER}
-auth0.clientId: {CLIENT_ID}
-auth0.clientSecret: {CLIENT_SECRET}
+auth0.domain: ${account.namespace}
+auth0.issuer: https://${account.namespace}/
+auth0.clientId: ${account.clientId}
+auth0.clientSecret: ${account.clientSecret}
 auth0.onLogoutRedirectTo: /login
 auth0.securedRoute: /portal/*
 auth0.loginCallback: /callback

--- a/snippets/server-platforms/java/setup.md
+++ b/snippets/server-platforms/java/setup.md
@@ -1,7 +1,7 @@
 ```xml
 <context-param>
     <param-name>auth0.domain</param-name>
-    <param-value>{DOMAIN}</param-value>
+    <param-value>${account.namespace}</param-value>
 </context-param>
 
 <context-param>
@@ -11,7 +11,7 @@
 
 <context-param>
     <param-name>auth0.client_id</param-name>
-    <param-value>{CLIENT_ID}</param-value>
+    <param-value>${account.clientId}</param-value>
 </context-param>
 
 <context-param>
@@ -22,6 +22,6 @@
 
 <context-param>
     <param-name>auth0.client_secret</param-name>
-    <param-value>{CLIENT_SECRET}</param-value>
+    <param-value>${account.clientSecret}</param-value>
 </context-param>
 ```

--- a/snippets/server-platforms/java/setup.md
+++ b/snippets/server-platforms/java/setup.md
@@ -6,7 +6,7 @@
 
 <context-param>
     <param-name>auth0.issuer</param-name>
-    <param-value>{ISSUER}</param-value>
+    <param-value>https://${account.namespace}/</param-value>
 </context-param>
 
 <context-param>


### PR DESCRIPTION
Fixes java quickstarts documentation issues reported by the testing team:
- Broken links on java servlet intro page (Issue: https://github.com/auth0/docs/issues/2179)
- Replace strings with variables at java servlet setup snippet (Issue: https://github.com/auth0/docs/issues/2181)
- Replace strings with variables at java spring security setup snippet (Issue: https://github.com/auth0/docs/issues/2192)
- Outdated Lock reference at java servlet login page (Issue: https://github.com/auth0/docs/issues/2180)
- Outdated Lock reference at java spring mvc login page (Issue: https://github.com/auth0/docs/issues/2183)
- Outdated instructions for Lock at java spring security login page (Issue: https://github.com/auth0/docs/issues/2193)
- Unclear instructions at java spring mvc login page (Issue: https://github.com/auth0/docs/issues/2184)
