### PR TITLE
 PHP api snippet formatting

### DIFF
--- a/snippets/server-apis/php/setup.md
+++ b/snippets/server-apis/php/setup.md
@@ -19,7 +19,7 @@
       exit();
     }
 
-    // // validate the token
+    // validate the token
     $token = str_replace('Bearer ', '', $authorizationHeader);
     $secret = '${account.clientSecret}';
     $client_id = '${account.clientId}';


### PR DESCRIPTION
removed the extra tabulation and extra slashes from 2nd step of php api tutorial snippet.
