### PR TITLE
Make angularjs sample work with `npm`

### DIFF
--- a/articles/client-platforms/angularjs/01-login.md
+++ b/articles/client-platforms/angularjs/01-login.md
@@ -45,8 +45,10 @@ The easiest way to add authentication to any app with Auth0 is to use the Lock w
 **Installing Dependencies with npm**
 
 ```bash
-npm install auth0-lock angular-lock angular-jwt
+npm install angular-lock angular-jwt
 ```
+
+or,
 
 **Installing Dependencies with Bower**
 
@@ -61,12 +63,14 @@ Once installed, the scripts for these libraries can be included in your project.
 ```html
 ...
 
-<script src="node_modules/auth0-lock/build/lock.js"></script>
+<script type="text/javascript" src="https://cdn.auth0.com/js/lock-10.min.js"></script>
 <script src="node_modules/angular-lock/dist/angular-lock.js"></script>
 <script src="node_modules/angular-jwt/dist/angular-jwt.js"></script>
 
 ...
 ```
+
+or,
 
 **After Installation with Bower**
 


### PR DESCRIPTION
<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs#contributing-guidelines)
- If applicable, added details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->

This sample fails when following `npm` instructions because `lock` npm component is not packaged with the `dist` files nor has a `postinstall` script to build it, so the `/dist` folder doesn't exist and the sample fails.
With this change, `lock` library will be included from the CDN instead of including it from the `node_modules` folder.
Also added an `or` between `npm` and `bower` sections to make sure the user understands that just one of them is required.
