### PR TITLE
Normalize local storage item name for idToken

### DIFF
--- a/articles/libraries/lock/index.md
+++ b/articles/libraries/lock/index.md
@@ -70,7 +70,7 @@ lock.on("authenticated", function(authResult) {
       return;
     }
 
-    localStorage.setItem('token', authResult.idToken);
+    localStorage.setItem('idToken', authResult.idToken);
     localStorage.setItem('profile', JSON.stringify(profile));
   });
 });


### PR DESCRIPTION
Founded try to pull the [`userProfile`](https://auth0.com/docs/libraries/lock#displaying-the-user-s-profile) in the example is using a different _localstorage_ _itemname_
