### PR TITLE
Replace broken link with correct numeric header

### DIFF
--- a/articles/saml/samlsso-auth0-to-auth0.md
+++ b/articles/saml/samlsso-auth0-to-auth0.md
@@ -312,7 +312,7 @@ If sufficient time has passed, or if you delete your browser cookies before init
 
 Upon successful authentication, you will be redirected to the callback URL specified in the HTML file (jwt.io).
 
-/libraries/lock/customization#rememberlastlogin-boolean-0. Troubleshooting.
+# 10. Troubleshooting
 
 This section has a few ideas for things to check if your sample doesn't work.
 


### PR DESCRIPTION
The broken link was introduced in commit d3e9142.

The problem seems to have been caused by a mass replace for anchor links. There was one other broken link that I could find in `articles/protocols.md`, which I fixed in PR #2238.
