### PR TITLE
Fix domain and clientID values in vanillajs custom login

### DIFF
--- a/articles/client-platforms/vanillajs/02-custom-login.md
+++ b/articles/client-platforms/vanillajs/02-custom-login.md
@@ -34,8 +34,8 @@ You will need an `Auth0` instance. Create one using your client credentials. Inc
 /* ===== ./app.js ===== */
 window.addEventListener('load', function() {
   auth0 = new Auth0({
-    domain: '<%= account.clientId %>',
-    clientID: '<%= account.namespace %>',
+    domain: '<%= account.namespace %>',
+    clientID: '<%= account.clientId %>',
     callbackURL: '<%= account.callback %>',
     responseType: 'token'
   });


### PR DESCRIPTION
Right now, the domain and clientID values in the vanillajs custom login example are in the wrong order. This PR fixes the issue.
