### PR TITLE
Correcting and clarifying ommittance of connection in OIDC protocol.

### DIFF
--- a/articles/protocols/index.md
+++ b/articles/protocols/index.md
@@ -22,7 +22,7 @@ Someone using a browser hits a protected resource in your web app (a page that r
 
     https://${account.namespace}/authorize/?client_id=${account.clientId}&response_type=code&redirect_uri=${account.callback}&state=OPAQUE_VALUE&connection=YOUR_CONNECTION
 
- `connection` is the only parameter that is Auth0 specific. The rest you will find in the spec. Its purpose is to instruct Auth0 where to send the user to authenticate. If you omit it, you will get an error.
+ `connection` is the only parameter that is Auth0 specific. The rest you will find in the spec. Its purpose is to instruct Auth0 where to send the user to authenticate. If you omit it, the user will be redirected to a hosted login page.
 
 > A note on `state`. This is an optional parameter, but we __strongly__ recommend you use it as it mitigates [CSRF attacks](http://en.wikipedia.org/wiki/Cross-site_request_forgery).
 


### PR DESCRIPTION
You don't get an error if you ommit the connection parameter in oidc, you get the hosted login page.

As specified in discussion: https://auth0.slack.com/archives/pipeline-unity/p1474453623001083

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs#contributing-guidelines)
- If applicable, added details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
