### PR TITLE
Add icons to all quickstart articles

### DIFF
--- a/articles/client-platforms/angular2/00-intro.md
+++ b/articles/client-platforms/angular2/00-intro.md
@@ -1,6 +1,7 @@
 ---
 title: Introduction
 description: A simple, multi-step quickstart guide to setup and manage authentication in your Angular2 JS app using Auth0.
+budicon: 715
 ---
 
 This multistep quickstart guide will walk you through setting up and managing authentication in your Angular 2 apps using Auth0.

--- a/articles/client-platforms/angular2/01-login.md
+++ b/articles/client-platforms/angular2/01-login.md
@@ -1,6 +1,7 @@
 ---
 title: Login
 description: This tutorial demonstrates how to integrate Auth0 with Angular 2 to add user login to your app
+budicon: 448
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/client-platforms/angular2/02-custom-login.md
+++ b/articles/client-platforms/angular2/02-custom-login.md
@@ -1,6 +1,7 @@
 ---
 title: Custom Login
 description: This tutorial will show you how to use the Auth0 library to add custom authentication and authorization to your web app.
+budicon: 448
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/client-platforms/angular2/03-session-handling.md
+++ b/articles/client-platforms/angular2/03-session-handling.md
@@ -1,6 +1,7 @@
 ---
 title: Session Handling
 description: This tutorial will show you how to integrate Auth0 with angular2 to add session handling and logout to your web app.
+budicon: 280
 ---
 
 <%= include('../../_includes/_package', {
@@ -13,7 +14,7 @@ description: This tutorial will show you how to integrate Auth0 with angular2 to
   pkgType: 'replace'
 }) %>
 
-In the previous steps of this tutorial, we enabled user login with the `Lock` widget and then with `auth0.js`. 
+In the previous steps of this tutorial, we enabled user login with the `Lock` widget and then with `auth0.js`.
 
 In this step, we will create a session for the user and also allow them to log out.
 

--- a/articles/client-platforms/angular2/04-user-profile.md
+++ b/articles/client-platforms/angular2/04-user-profile.md
@@ -1,6 +1,7 @@
 ---
 title: User Profile
 description: This tutorial will show you how to integrate Auth0 with Angular2 to authenticate and fetch/show profile information.
+budicon: 292
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/client-platforms/angular2/05-linking-accounts.md
+++ b/articles/client-platforms/angular2/05-linking-accounts.md
@@ -1,6 +1,7 @@
 ---
 title: Linking Accounts
 description: This tutorial will show you how to integrate Auth0 with Angular 2 to link accounts.
+budicon: 345
 ---
 
 <%= include('../../_includes/_package', {
@@ -144,15 +145,15 @@ public linkAccount() {
 
 ## User Profile Linked Accounts Information
 
-The user profile contains an array of identities which includes the profile information from linked providers. 
+The user profile contains an array of identities which includes the profile information from linked providers.
 
-To view a user's identities, access the [Users](${manage_url}/#/users) page on the Auth0 dashboard, select a user, and scroll down to `identities`. 
+To view a user's identities, access the [Users](${manage_url}/#/users) page on the Auth0 dashboard, select a user, and scroll down to `identities`.
 
 This example shows a user with a linked Google account:
 
 ![User identities](/media/articles/users/user-identities-linked.png)
 
-If you fetch the profile after linking accounts, this same information will be available. 
+If you fetch the profile after linking accounts, this same information will be available.
 
 You can display this information and provide an **Unlink** button:
 

--- a/articles/client-platforms/angular2/06-rules.md
+++ b/articles/client-platforms/angular2/06-rules.md
@@ -1,6 +1,7 @@
 ---
 title: Rules
 description: This tutorial demonstrates how to use Auth0 rules
+budicon: 173
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/client-platforms/angular2/07-authorization.md
+++ b/articles/client-platforms/angular2/07-authorization.md
@@ -1,6 +1,7 @@
 ---
 title: Authorization
 description: This tutorial demonstrates how to assign roles to your users and use those claims to authorize or deny a user to access certain routes in the app
+budicon: 500
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/client-platforms/angular2/08-calling-apis.md
+++ b/articles/client-platforms/angular2/08-calling-apis.md
@@ -1,6 +1,7 @@
 ---
 title: Calling APIs
 description: This tutorial demonstrates how to use angular2-jwt in Angular 2 applications to make authenticated API calls
+budicon: 546
 ---
 
 <%= include('../../_includes/_package', {
@@ -112,7 +113,7 @@ export class Ping {
         error => this.message = error._body
       );
   }
-  
+
   ...
 }
 ```

--- a/articles/client-platforms/angular2/09-mfa.md
+++ b/articles/client-platforms/angular2/09-mfa.md
@@ -1,6 +1,7 @@
 ---
 title: Multifactor Authentication
 description: This tutorial demonstartes how to add Multifactor Authentication to your Angular 2 app with Auth0.
+budicon: 243
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/client-platforms/angular2/10-customizing-lock.md
+++ b/articles/client-platforms/angular2/10-customizing-lock.md
@@ -1,6 +1,7 @@
 ---
 title: Customizing Lock
 description: This tutorial demonstrates how to customize Lock.
+budicon: 285
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/client-platforms/angularjs/01-login.md
+++ b/articles/client-platforms/angularjs/01-login.md
@@ -1,6 +1,7 @@
 ---
 title: Auth0 Angular 1.x Tutorial
 description: This tutorial will show you how to use the Auth0 with Angular 1.x applications.
+budicon: 448
 ---
 
 <%= include('../../_includes/_package2', {
@@ -57,7 +58,7 @@ Authentication for Angular apps isn't that useful if it can't be used to access 
 
       ...
 
-    });    
+    });
 
 })();
 ```

--- a/articles/client-platforms/aurelia/01-login.md
+++ b/articles/client-platforms/aurelia/01-login.md
@@ -2,6 +2,7 @@
 title: Login
 default: true
 description: This tutorial demonstrates how to use Auth0 to add authentication and authorization to Aurelia apps
+budicon: 448
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/client-platforms/cyclejs/01-login.md
+++ b/articles/client-platforms/cyclejs/01-login.md
@@ -2,6 +2,7 @@
 title: Login
 default: true
 description: This tutorial will show you how to use the Auth0 Cycle.js driver to add authentication and authorization to your web app.
+budicon: 448
 ---
 
 ::: panel-info System Requirements

--- a/articles/client-platforms/ember2js/01-login.md
+++ b/articles/client-platforms/ember2js/01-login.md
@@ -2,6 +2,7 @@
 title: Login
 default: true
 description: This tutorial will show you how to use the Auth0 EmberJS 2 SDK to add authentication and authorization to your web app.
+budicon: 448
 ---
 
 You can get started by either downloading the seed project or if you would like to add Auth0 to an existing application you can follow the tutorial steps.

--- a/articles/client-platforms/emberjs/01-login.md
+++ b/articles/client-platforms/emberjs/01-login.md
@@ -2,6 +2,7 @@
 title: Login
 default: true
 description: This tutorial will show you how to use the Auth0 EmberJS SDK to add authentication and authorization to your web app.
+budicon: 448
 ---
 
 You can get started by either downloading the seed project or if you would like to add Auth0 to an existing application you can follow the tutorial steps.

--- a/articles/client-platforms/jquery/00-intro.md
+++ b/articles/client-platforms/jquery/00-intro.md
@@ -1,6 +1,7 @@
 ---
 title: Introduction
 description: A multi-step quickstart guide to setup and manage authentication in your jQuery app using Auth0.
+budicon: 715
 ---
 
 This multistep quickstart guide will walk you through setting up and managing authentication in your jQuery apps using Auth0.

--- a/articles/client-platforms/jquery/01-login.md
+++ b/articles/client-platforms/jquery/01-login.md
@@ -1,6 +1,7 @@
 ---
 title: Login
 description: This tutorial demonstrates how to use the Auth0 jQuery SDK to add authentication and authorization to your web app
+budicon: 448
 ---
 
 <%= include('../../_includes/_package2', {

--- a/articles/client-platforms/jquery/02-custom-login.md
+++ b/articles/client-platforms/jquery/02-custom-login.md
@@ -1,6 +1,7 @@
 ---
 title: Custom Login
 description: This tutorial demonstrates how to use the Auth0 library to add custom authentication and authorization to your web app.
+budicon: 448
 ---
 
 <%= include('../../_includes/_package2', {

--- a/articles/client-platforms/jquery/03-session-handling.md
+++ b/articles/client-platforms/jquery/03-session-handling.md
@@ -1,6 +1,7 @@
 ---
 title: Session Handling
 description: This tutorial demonstrates how to integrate Auth0 with jQuery to add session handling and logout to your web app.
+budicon: 280
 ---
 
 <%= include('../../_includes/_package2', {
@@ -26,7 +27,7 @@ Once the user is logged in, you will want to create a session for that user. To 
 
 var lock = new Auth0Lock(AUTH0_CLIENT_ID, AUTH0_DOMAIN, {
   auth: {
-    params: { 
+    params: {
       scope: 'openid email'
     } //Details: https://auth0.com/docs/scopes
   }

--- a/articles/client-platforms/jquery/04-user-profile.md
+++ b/articles/client-platforms/jquery/04-user-profile.md
@@ -1,6 +1,7 @@
 ---
 title: User Profile
 description: This tutorial demonstrates how to integrate Auth0 with jQuery to authenticate and fetch/show/update profile information.
+budicon: 292
 ---
 
 <%= include('../../_includes/_package2', {
@@ -23,7 +24,7 @@ $(document).ready(function() {
 
   lock = new Auth0Lock('${account.clientId}', '${account.namespace}', {
     auth: {
-      params: { 
+      params: {
         scope: 'openid email'
       } //Details: https://auth0.com/docs/scopes
     }

--- a/articles/client-platforms/jquery/05-linking-accounts.md
+++ b/articles/client-platforms/jquery/05-linking-accounts.md
@@ -1,6 +1,7 @@
 ---
 title: Linking Accounts
 description: This tutorial demonstrates how to integrate Auth0 with jQuery to link accounts.
+budicon: 345
 ---
 
 <%= include('../../_includes/_package2', {

--- a/articles/client-platforms/jquery/06-rules.md
+++ b/articles/client-platforms/jquery/06-rules.md
@@ -1,6 +1,7 @@
 ---
 title: Rules
 description: This tutorial demonstrates how to use Auth0 rules to extend what Auth0 has to offer.
+budicon: 173
 ---
 
 <%= include('../../_includes/_package2', {

--- a/articles/client-platforms/jquery/07-authorization.md
+++ b/articles/client-platforms/jquery/07-authorization.md
@@ -1,6 +1,7 @@
 ---
 title: Authorization
 description: This tutorial demonstrates how to assign roles to your users, and use those claims to authorize or deny a user to access certain routes in the app.
+budicon: 500
 ---
 
 <%= include('../../_includes/_package2', {

--- a/articles/client-platforms/jquery/08-calling-apis.md
+++ b/articles/client-platforms/jquery/08-calling-apis.md
@@ -1,6 +1,7 @@
 ---
 title: Calling APIs
 description: This tutorial demonstrates how to use $.ajaxSetup() to make authenticated API calls.
+budicon: 546
 ---
 
 <%= include('../../_includes/_package2', {

--- a/articles/client-platforms/jquery/09-mfa.md
+++ b/articles/client-platforms/jquery/09-mfa.md
@@ -1,6 +1,7 @@
 ---
 title: Multifactor Authentication
 description: This tutorial demonstrates how to add Multifactor Authentication to your jQuery app with auth0.
+budicon: 243
 ---
 
 <%= include('../../_includes/_package2', {

--- a/articles/client-platforms/jquery/10-customizing-lock.md
+++ b/articles/client-platforms/jquery/10-customizing-lock.md
@@ -1,6 +1,7 @@
 ---
 title: Customizing Lock
 description: This tutorial demonstrates how to customize Lock.
+budicon: 285
 ---
 
 <%= include('../../_includes/_package2', {

--- a/articles/client-platforms/jquery/11-api-authorization.md
+++ b/articles/client-platforms/jquery/11-api-authorization.md
@@ -1,6 +1,7 @@
 ---
 title: OAuth2 API Authorization
 description: This tutorial demonstrates how to use Auth0 to make authorized API calls from your web app.
+budicon: 500
 ---
 
 <%= include('../../_includes/_api_auth_intro') %>
@@ -22,7 +23,7 @@ description: This tutorial demonstrates how to use Auth0 to make authorized API 
 
 Be sure to register the URL of your app in the Allowed Callback URLs in your Application Settings.
 
-## 3. Create a Resource Server (API) 
+## 3. Create a Resource Server (API)
 
 <%= include('../../_includes/_new_api') %>
 

--- a/articles/client-platforms/react/00-intro.md
+++ b/articles/client-platforms/react/00-intro.md
@@ -1,6 +1,7 @@
 ---
 title: Introduction
 description: This tutorial will show you how to set up and run the React seed project provided by Auth0.
+budicon: 715
 ---
 
 This quickstart guide contains individual sections which demonstrate how to use various Auth0 features in your React applications. Each section has its own sample project which can be downloaded directly from the doc or forked on Github. If you are logged in to your Auth0 account, the samples will have your Auth0 credentials pre-populated for you.

--- a/articles/client-platforms/react/01-login.md
+++ b/articles/client-platforms/react/01-login.md
@@ -1,6 +1,7 @@
 ---
 title: Login
 description: This tutorial demonstrates how to integrate Auth0 with ReactJS to add authentication and authorization to your app
+budicon: 448
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/client-platforms/react/02-custom-login.md
+++ b/articles/client-platforms/react/02-custom-login.md
@@ -1,6 +1,7 @@
 ---
 title: Custom Login
 description: This tutorial demonstrates how to use the auth0.js library to add custom authentication and authorization to your ReactJS web application
+budicon: 448
 ---
 
 <%= include('../../_includes/_package', {
@@ -22,7 +23,7 @@ First, you will create the `AuthService` helper class to encapsulate the login f
 
 Inside this class, you will create an `Auth0` instance that receives your Auth0 credentials. Instead of hard-coding your credentials in this class, they are passed from the `AuthService` constructor parameters to the `Auth0` instance.
 
-This class also provides `login` and `signup` methods that simply pass parameters to the equivalent `Auth0` library methods. 
+This class also provides `login` and `signup` methods that simply pass parameters to the equivalent `Auth0` library methods.
 
 Below is the full code for `AuthService.js` file:
 
@@ -84,7 +85,7 @@ export default class AuthService {
 }
 ```
 
-`Auth0` uses [redirect mode](/libraries/auth0js#redirect-mode) by default. Therefore, after a successful login, your app will be redirected to the `callbackURL` set for your client in the [Auth0 dashboard](${manage_url}/#/applications). 
+`Auth0` uses [redirect mode](/libraries/auth0js#redirect-mode) by default. Therefore, after a successful login, your app will be redirected to the `callbackURL` set for your client in the [Auth0 dashboard](${manage_url}/#/applications).
 
 `Auth0` appends authentication data to the callbackURL as hash parameters. The `parseHash` method above extracts this data from the URL hash and saves the user authentication token(`idToken`) to `localStorage`.
 
@@ -133,17 +134,17 @@ export default makeMainRoutes
 ```
 ${snippet(meta.snippets.envFile)}
 
-In the updated `routes.js`, you now have two routes with `onEnter` callbacks assigned. 
+In the updated `routes.js`, you now have two routes with `onEnter` callbacks assigned.
 
 First, `/home` route calls `requireAuth`, which checks if there is an authenticated user, and redirects to `/login` if not.
 
-The other route catches the `access_token=:token` URL format and parses those parameters in `parseAuthHash`. 
+The other route catches the `access_token=:token` URL format and parses those parameters in `parseAuthHash`.
 
 Now you can create the Login component.
 
 ## 3. Create the Login view
 
-Login is a new view component that should be saved in `src/views/Main/Login/`. It is is a React Component that accepts into its props an `auth` object as an instance of `AuthService`. It renders an authentication form that allows users to enter their email and password to sign in. 
+Login is a new view component that should be saved in `src/views/Main/Login/`. It is is a React Component that accepts into its props an `auth` object as an instance of `AuthService`. It renders an authentication form that allows users to enter their email and password to sign in.
 
 The Login component code looks like this:
 
@@ -206,7 +207,7 @@ Now, if you run the application, you will see an error in the Login component be
 
 ## 4. Send `auth` from router to Container children
 
-To fix the Login component's missing dependency, you need to propagate the `auth` parameter from the `Container` component (that receives it from the route) to the container's children. 
+To fix the Login component's missing dependency, you need to propagate the `auth` parameter from the `Container` component (that receives it from the route) to the container's children.
 
 The updated `src/views/Main/Container.js` is:
 
@@ -243,7 +244,7 @@ Now, the Login button should work and the user will be redirected to the home pa
 
 ## 5. Add Sign Up
 
-The simplest way to allow sign up is to add a new button to the login form and call the Auth0 signup API, instead of login. 
+The simplest way to allow sign up is to add a new button to the login form and call the Auth0 signup API, instead of login.
 
 The required changes in the Login component are included below:
 

--- a/articles/client-platforms/react/03-session-handling.md
+++ b/articles/client-platforms/react/03-session-handling.md
@@ -1,6 +1,7 @@
 ---
 title: Session Handling
 description: This tutorial demonstrates how to integrate Auth0 with ReactJS to add session handling and logout to your web app
+budicon: 280
 ---
 
 <%= include('../../_includes/_package', {
@@ -12,13 +13,13 @@ description: This tutorial demonstrates how to integrate Auth0 with ReactJS to a
   pkgType: 'server'
 }) %>
 
-The previous steps of this tutorial explain how to implement login using either `Lock` or the `Auth0.js` library to authenticate users in your application. 
+The previous steps of this tutorial explain how to implement login using either `Lock` or the `Auth0.js` library to authenticate users in your application.
 
 Usually, when a user logs in, you will want to create a session for that user and also allow the user to logout. The following steps show you how to implement this.
 
 ## 1. Create a Session
 
-Once the user is logged in, you can create a session for that user by storing the `idToken` attribute, which is passed as a Lock `authenticated` event callback parameter. 
+Once the user is logged in, you can create a session for that user by storing the `idToken` attribute, which is passed as a Lock `authenticated` event callback parameter.
 
 The `AuthService` helper class uses `localStorage` to keep the current user idToken valid for the session:
 
@@ -68,7 +69,7 @@ export default class AuthService {
 }
 ```
 
-In the code, you see the `login` method using `Lock` to show the sign in window, and the `_doAuthentication` private method, which stores the `idToken` provided by Auth0 to `localStorage`. The `logout` method removes the stored token, and `loggedIn` checks if there is a token and returns a boolean. 
+In the code, you see the `login` method using `Lock` to show the sign in window, and the `_doAuthentication` private method, which stores the `idToken` provided by Auth0 to `localStorage`. The `logout` method removes the stored token, and `loggedIn` checks if there is a token and returns a boolean.
 
 However, just checking if there is a stored token is not enough to validate the session because the returned [JSON Web Token](/jwt) has an expiration date. The next section explains how to properly validate the session.
 
@@ -131,7 +132,7 @@ export default class AuthService {
 
 ## 3. Logout Button
 
-In Home view, you may want to show a logout button that destroys the user session and redirects to the `/login` page. Since the `AuthService` helper class already includes a `logout` function, you can simply hook it to a logout button. 
+In Home view, you may want to show a logout button that destroys the user session and redirects to the `/login` page. Since the `AuthService` helper class already includes a `logout` function, you can simply hook it to a logout button.
 
 The updated Home component code with the logout button is as follows:
 

--- a/articles/client-platforms/react/04-user-profile.md
+++ b/articles/client-platforms/react/04-user-profile.md
@@ -1,6 +1,7 @@
 ---
 title: User Profile
 description: This tutorial demonstrates how to integrate Auth0 with ReactJS to authenticate and fetch/show profile information
+budicon: 292
 ---
 
 <%= include('../../_includes/_package', {
@@ -12,13 +13,13 @@ description: This tutorial demonstrates how to integrate Auth0 with ReactJS to a
   pkgType: 'server'
 }) %>
 
-The [Login step](/quickstart/spa/react/01-login) of this tutorial explains how to use Auth0 Lock to show a login window and authenticate a user and how to protect routes by making them available only for authenticated users. 
+The [Login step](/quickstart/spa/react/01-login) of this tutorial explains how to use Auth0 Lock to show a login window and authenticate a user and how to protect routes by making them available only for authenticated users.
 
 This step demonstrates how to retrieve and show user profile information.
 
 ## 1. Create the AuthService class
 
-The best way to have authentication utilities available across your application is to create a helper class. Then you can share an instance of this class by passing it to the React Component as a prop. 
+The best way to have authentication utilities available across your application is to create a helper class. Then you can share an instance of this class by passing it to the React Component as a prop.
 
 First, you will create the `AuthService` helper class to encapsulate the login functionality and save it inside the `src/utils` folder as `AuthService.js`.
 
@@ -76,7 +77,7 @@ The other helper methods shown above include: `login` (to call `lock.show()` and
 
 ## 2. Request User Profile Data
 
-To fetch user profile information, call the `lock.getProfile` function, specifying the token and a callback to process the response. 
+To fetch user profile information, call the `lock.getProfile` function, specifying the token and a callback to process the response.
 
 Below you can see the `getProfile` code that has been added to fetch the user profile after successful authentication and store the response in `localStorage`. Also, since the profile data request is asynchronous, `EventEmitter` has been added to allow sending notifications after a profile update.
 
@@ -227,7 +228,7 @@ Now, after authentication, the home page will display the user's avatar and info
 
 ## 4. Custom Sign Up Fields
 
-If you need extra fields on user sign up, you can add the `additionalSignUpFields` key to the Lock options parameter. For more information, see: [additionalSignUpFields](/libraries/lock/v10/customization#additionalsignupfields-array-). 
+If you need extra fields on user sign up, you can add the `additionalSignUpFields` key to the Lock options parameter. For more information, see: [additionalSignUpFields](/libraries/lock/v10/customization#additionalsignupfields-array-).
 
 As an example, the `AuthService` constructor can be modified to request a user's `address`:
 
@@ -297,7 +298,7 @@ export class ProfileDetails extends React.Component {
 
 <%= include('../_includes/_profile-metadata-explanation') %>
 
-To update the user profile, call the [Update a user](/api/management/v2#!/Users/patch_users_by_id) endpoint with the new profile values. 
+To update the user profile, call the [Update a user](/api/management/v2#!/Users/patch_users_by_id) endpoint with the new profile values.
 
 Update the `AuthService` class to add a new `updateProfile` method to make the http request with the correct request headers using the [fetch standard](https://fetch.spec.whatwg.org/).
 

--- a/articles/client-platforms/react/05-linking-accounts.md
+++ b/articles/client-platforms/react/05-linking-accounts.md
@@ -1,6 +1,7 @@
 ---
 title: Linking Accounts
 description: This tutorial demonstrates how to integrate Auth0 with ReactJS to link accounts.
+budicon: 345
 ---
 
 <%= include('../../_includes/_package', {
@@ -16,7 +17,7 @@ description: This tutorial demonstrates how to integrate Auth0 with ReactJS to l
 
 ## 1. Show Linked Accounts Information
 
-The user profile contains an array of identities which consists of profile information from all linked providers. You can verify this by accessing the Auth0 [Users page](${manage_url}/#/users), selecting a user and scrolling down to `identities` under **Identity Provider Attributes**. 
+The user profile contains an array of identities which consists of profile information from all linked providers. You can verify this by accessing the Auth0 [Users page](${manage_url}/#/users), selecting a user and scrolling down to `identities` under **Identity Provider Attributes**.
 
 This is how a profile looks after linking to Gmail:
 
@@ -24,7 +25,7 @@ This is how a profile looks after linking to Gmail:
 
 If you fetch a profile containing linked accounts, you will have all this information available.
 
-To display this data, create two new components: `LinkedAccountsList` (to render a list of linked accounts) and `LinkedAccountItem` (to render an html row for each identity). 
+To display this data, create two new components: `LinkedAccountsList` (to render a list of linked accounts) and `LinkedAccountItem` (to render an html row for each identity).
 
 ```javascript
 /* ===== ./src/components/LinkedAccount/LinkedAccountItem.js ===== */
@@ -150,7 +151,7 @@ export class Home extends React.Component {
 export default Home;
 ```
 
-Note that `Home.js` has been updated to render a left column with profile information such as name and avatar, and a **Logout** button. The `LinkedAccountsList` is rendered in right column. 
+Note that `Home.js` has been updated to render a left column with profile information such as name and avatar, and a **Logout** button. The `LinkedAccountsList` is rendered in right column.
 
 If you run the application, you should see the new home page after a successful login. The __Linked Accounts__ list will only show the main account. The next section shows how to add a button to link an account from another provider.
 
@@ -185,10 +186,10 @@ export default class LinkAccountService {
 }
 ```
 
-`AuthService` continues to listen to `authenticated` events, but you will need to determine if a callback was triggered by the regular sign in process or the linking one. 
+`AuthService` continues to listen to `authenticated` events, but you will need to determine if a callback was triggered by the regular sign in process or the linking one.
 
 In the code above, the new `Auth0Lock` instance receives specific options, in this case `auth: {params: {state: 'linking'}}`. (For more information, see:
-[Authentication Options](/libraries/lock/v10/customization#authentication-options).) 
+[Authentication Options](/libraries/lock/v10/customization#authentication-options).)
 
 In the updated `AuthService` class, the `_doAuthentication` callback checks for the `linking` state and calls the `LinkAccount` method if present.
 
@@ -271,7 +272,7 @@ export default class AuthService extends EventEmitter {
 }
 ```
 
-This code also introduces two new methods: `fetchApi` (which constructs a request to the Auth0 API with the required headers and parses the response to JSON) and `linkAccount` (which uses `fetchApi` to send a _POST_ request to create a new identity in the user account, and updates the stored profile after a successful response). 
+This code also introduces two new methods: `fetchApi` (which constructs a request to the Auth0 API with the required headers and parses the response to JSON) and `linkAccount` (which uses `fetchApi` to send a _POST_ request to create a new identity in the user account, and updates the stored profile after a successful response).
 
 **NOTE**: For more details, see the [Link a user account](/api/management/v2#!/Users/post_identities) endpoint documentation.
 
@@ -314,9 +315,9 @@ Now, if you run the application, you will be able to click the __Link Account__ 
 
 ## 3. Un-Linking Accounts
 
-You can dissociate a linked account by calling the [Delete a linked user account](/api/management/v2#!/Users/delete_provider_by_user_id) Auth0 API endpoint. 
+You can dissociate a linked account by calling the [Delete a linked user account](/api/management/v2#!/Users/delete_provider_by_user_id) Auth0 API endpoint.
 
-You will need to include the primary account `user_id`, and the `provider/user_id` of the identity you want to unlink. 
+You will need to include the primary account `user_id`, and the `provider/user_id` of the identity you want to unlink.
 
 Update `AuthService` to provide an `UnlinkAccount` method:
 

--- a/articles/client-platforms/react/06-rules.md
+++ b/articles/client-platforms/react/06-rules.md
@@ -1,6 +1,7 @@
 ---
 title: Rules
 description: This tutorial will show you how to use Auth0 rules to extend what Auth0 has to offer.
+budicon: 173
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/client-platforms/react/07-authorization.md
+++ b/articles/client-platforms/react/07-authorization.md
@@ -1,6 +1,7 @@
 ---
 title: Authorization
 description: This tutorial will show you how assign roles to your users, and use those claims to authorize or deny a user to access certain routes in the app.
+budicon: 500
 ---
 
 <%= include('../../_includes/_package', {
@@ -20,7 +21,7 @@ description: This tutorial will show you how assign roles to your users, and use
 
 ## 2. Check if a User's Role is Present
 
-After creating the new rule, update the `AuthService` helper class with a new `isAdmin` method. This method will be useful in other parts of your application. It returns `true` for admin users and `false` otherwise. 
+After creating the new rule, update the `AuthService` helper class with a new `isAdmin` method. This method will be useful in other parts of your application. It returns `true` for admin users and `false` otherwise.
 
 Included this snippet in the `AuthService.js` file:
 
@@ -40,9 +41,9 @@ export default class AuthService extends EventEmitter {
 
 ## 3. Restrict a Route based on User's Roles
 
-To demonstrate how to restrict access to certain routes based on a user's roles, you can update the `routes.js` file as shown below. 
+To demonstrate how to restrict access to certain routes based on a user's roles, you can update the `routes.js` file as shown below.
 
-The new `/admin` route requires the current user to have an __admin__ role, and redirects to `/unauthorized` if `auth.isAdmin()` returns `false`. 
+The new `/admin` route requires the current user to have an __admin__ role, and redirects to `/unauthorized` if `auth.isAdmin()` returns `false`.
 
 Here is the complete `routes.js` code:
 

--- a/articles/client-platforms/react/08-calling-apis.md
+++ b/articles/client-platforms/react/08-calling-apis.md
@@ -1,6 +1,7 @@
 ---
 title: Calling APIs
 description: This tutorial will show you how to make authenticated api calls with ReactJS.
+budicon: 546
 ---
 
 <%= include('../../_includes/_package', {
@@ -92,7 +93,7 @@ app.listen(3001);
 console.log('Listening on http://localhost:3001');
 ```
 
-Both endpoints send a JSON response with a message attribute, but `/api/private` uses the __authenticate__ callback to validate the token received in the `Authorization` header. `express-jwt` is responsible for parsing and validating the token. (For more details, see the [express-jwt](https://github.com/auth0/express-jwt) documentation). 
+Both endpoints send a JSON response with a message attribute, but `/api/private` uses the __authenticate__ callback to validate the token received in the `Authorization` header. `express-jwt` is responsible for parsing and validating the token. (For more details, see the [express-jwt](https://github.com/auth0/express-jwt) documentation).
 
 Note that the `dotenv` package is used to load `process.env.AUTH0_SECRET` and `process.env.AUTH0_CLIENT_ID` from the `.env` file.
 
@@ -115,7 +116,7 @@ To test the server, run `node server.js`. It should be listening on port 3001 of
 
 ## 3. Add a Proxy and Start the Server
 
-Since you will be calling the server API from the client code and to prevent having to use [`cors`](https://github.com/expressjs/cors), you will need to proxy the calls from the client on port 3000 to the server API on 3001. 
+Since you will be calling the server API from the client code and to prevent having to use [`cors`](https://github.com/expressjs/cors), you will need to proxy the calls from the client on port 3000 to the server API on 3001.
 
 To create the proxy, add a new setting to [webpack-dev-server](https://webpack.github.io/docs/webpack-dev-server.html) in the `webpack.config.js` file:
 
@@ -150,7 +151,7 @@ var config = getConfig({
 ...
 ```
 
-With the proxy ready, update the `start` script to start both `webpack-dev-server` and `server.js` at the same time. As both servers will stay running in development mode, you will need to introduce the [`npm-run-all`](https://github.com/mysticatea/npm-run-all) tool in order to run them in parallel. 
+With the proxy ready, update the `start` script to start both `webpack-dev-server` and `server.js` at the same time. As both servers will stay running in development mode, you will need to introduce the [`npm-run-all`](https://github.com/mysticatea/npm-run-all) tool in order to run them in parallel.
 
 The updated `scripts` entry in `package.json` looks like:
 
@@ -167,7 +168,7 @@ Now, when you run `npm start`, both servers should be up and the proxy active.
 
 ## 4. Show Public and Private Responses
 
-Now that you have updated `AuthService` to provide a custom `fetch` method for private requests and created a sample server, you are ready to update your ReactJS application to render the server responses. 
+Now that you have updated `AuthService` to provide a custom `fetch` method for private requests and created a sample server, you are ready to update your ReactJS application to render the server responses.
 
 Create a new component named `Messages` in the folder `src/components/Messages`:
 
@@ -225,7 +226,7 @@ Note that both server endpoints will receive requests as soon as the component i
 
 Also note that `auth` is an `AuthService` instance expected as a prop, and that the component renders a `ListGroup` with two `ListGroupItem` to display the server messages.
 
-Lastly, include the `Messages` component in an application view. 
+Lastly, include the `Messages` component in an application view.
 
 To show how this component works in both authenticated and not authenticated situations, do not only include it in `Home` (where the user is already authenticated) but also in `Login`, to demonstrate that the private API requests fails:
 

--- a/articles/client-platforms/react/09-mfa.md
+++ b/articles/client-platforms/react/09-mfa.md
@@ -1,6 +1,7 @@
 ---
 title: Multifactor Authentication
 description: This tutorial will show you how to add Multifactor Authentication to your ReactJS with auth0.
+budicon: 243
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/client-platforms/react/10-customizing-lock.md
+++ b/articles/client-platforms/react/10-customizing-lock.md
@@ -1,6 +1,7 @@
 ---
 title: Customizing Lock
 description: This tutorial will show you how to customize lock widget.
+budicon: 285
 ---
 
 <%= include('../../_includes/_package', {
@@ -47,7 +48,7 @@ export default class AuthService extends EventEmitter {
 
 ### Language Dictionary Specification
 
-You can also customize the text that `Lock` will display with the `languageDictionary` option parameter. 
+You can also customize the text that `Lock` will display with the `languageDictionary` option parameter.
  For more information, see: [Language Dictionary Specification](/libraries/lock/v10/customization#languagedictionary-object-).
 
 ```javascript

--- a/articles/client-platforms/socket-io/01-login.md
+++ b/articles/client-platforms/socket-io/01-login.md
@@ -1,6 +1,7 @@
 ---
 title: Login
 description: This tutorial demonstrates how to use the Auth0 Socket.io SDK to add authentication and authorization to your web app
+budicon: 448
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/client-platforms/vanillajs/00-intro.md
+++ b/articles/client-platforms/vanillajs/00-intro.md
@@ -1,6 +1,7 @@
 ---
 title: Introduction
 description: This is a multi-step quickstart guide that demonstrates how to setup and manage authentication in your JavaScript app using Auth0
+budicon: 715
 ---
 
 This multi-step quickstart guide will walk you through setting up and managing authentication in your vanilla JS apps using Auth0.

--- a/articles/client-platforms/vanillajs/01-login.md
+++ b/articles/client-platforms/vanillajs/01-login.md
@@ -1,6 +1,7 @@
 ---
 title: Login
 description: This tutorial demonstrates how to use Auth0 to add authentication and authorization to your web app
+budicon: 448
 ---
 
 <%= include('../../_includes/_package2', {

--- a/articles/client-platforms/vanillajs/02-custom-login.md
+++ b/articles/client-platforms/vanillajs/02-custom-login.md
@@ -1,6 +1,7 @@
 ---
 title: Custom Login
 description: This tutorial demonstrates how to use the Auth0 library to add custom authentication and authorization to your web app
+budicon: 448
 ---
 
 <%= include('../../_includes/_package2', {

--- a/articles/client-platforms/vanillajs/03-session-handling.md
+++ b/articles/client-platforms/vanillajs/03-session-handling.md
@@ -1,6 +1,7 @@
 ---
 title: Session Handling
 description: This tutorial demonstrates how to add session handling and logout to your web app
+budicon: 280
 ---
 
 <%= include('../../_includes/_package2', {

--- a/articles/client-platforms/vanillajs/04-user-profile.md
+++ b/articles/client-platforms/vanillajs/04-user-profile.md
@@ -1,6 +1,7 @@
 ---
 title: User Profile
 description: This tutorial demonstrates how to fetch, show, and update user profile information in your web app
+budicon: 292
 ---
 
 <%= include('../../_includes/_package2', {

--- a/articles/client-platforms/vanillajs/05-linking-accounts.md
+++ b/articles/client-platforms/vanillajs/05-linking-accounts.md
@@ -1,6 +1,7 @@
 ---
 title: Linking Accounts
 description: This tutorial demonstrates how to link different user accounts in your web app
+budicon: 345
 ---
 
 <%= include('../../_includes/_package2', {

--- a/articles/client-platforms/vanillajs/06-rules.md
+++ b/articles/client-platforms/vanillajs/06-rules.md
@@ -1,6 +1,7 @@
 ---
 title: Rules
 description: This tutorial demonstrates how to use rules to easily customize and extend Auth0's capabilities
+budicon: 173
 ---
 
 <%= include('../../_includes/_package2', {

--- a/articles/client-platforms/vanillajs/07-authorization.md
+++ b/articles/client-platforms/vanillajs/07-authorization.md
@@ -1,6 +1,7 @@
 ---
 title: Authorization
 description: This tutorial demonstrates how to assign roles to your users, and use those claims to authorize or deny a user to access certain routes in the app
+budicon: 500
 ---
 
 <%= include('../../_includes/_package2', {

--- a/articles/client-platforms/vanillajs/08-calling-apis.md
+++ b/articles/client-platforms/vanillajs/08-calling-apis.md
@@ -1,6 +1,7 @@
 ---
 title: Calling APIs
 description: This tutorial demonstrates how to make authenticated API calls
+budicon: 546
 ---
 
 <%= include('../../_includes/_package2', {

--- a/articles/client-platforms/vanillajs/09-mfa.md
+++ b/articles/client-platforms/vanillajs/09-mfa.md
@@ -1,6 +1,7 @@
 ---
 title: Multifactor Authentication
 description: This tutorial demonstrates how to add Multifactor Authentication to your web app
+budicon: 243
 ---
 
 <%= include('../../_includes/_package2', {

--- a/articles/client-platforms/vanillajs/10-customizing-lock.md
+++ b/articles/client-platforms/vanillajs/10-customizing-lock.md
@@ -1,6 +1,7 @@
 ---
 title: Customizing Lock
 description: This tutorial demonstrates how to customize the Lock widget
+budicon: 285
 ---
 
 <%= include('../../_includes/_package2', {

--- a/articles/client-platforms/vuejs/01-login.md
+++ b/articles/client-platforms/vuejs/01-login.md
@@ -1,6 +1,7 @@
 ---
 title: Login
 description: This tutorial will show you how to use the Auth0 Vue.js SDK to add authentication and authorization to your web app.
+budicon: 448
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/native-platforms/android/00-introduction.md
+++ b/articles/native-platforms/android/00-introduction.md
@@ -1,6 +1,7 @@
 ---
 title: Introduction
 description: Short Introduction to the Auth0 Android Quickstarts.
+budicon: 715
 ---
 
 This multistep quickstart guide will walk you through managing authentication in your android apps with Auth0.

--- a/articles/native-platforms/android/01-login.md
+++ b/articles/native-platforms/android/01-login.md
@@ -1,6 +1,7 @@
 ---
 title: Login
 description: This tutorial will show you how to integrate Lock v2 in your Android project in order to present a login screen.
+budicon: 448
 ---
 
 This tutorial will show you how to integrate Lock v2 in your Android project in order to present a login screen.

--- a/articles/native-platforms/android/02-custom-login.md
+++ b/articles/native-platforms/android/02-custom-login.md
@@ -2,6 +2,7 @@
 title: Custom Login
 description: This tutorial will show you how to use the Auth0 authentication API in your Android project to create a custom login screen.
 seo_alias: android
+budicon: 448
 ---
 
 This quickstart will show you how to add Auth0 login capabilities while using a customized login screen.
@@ -57,10 +58,10 @@ First, in your customized login method, instantiate the Authentication API:
 ```java
 private void login(String email, String password) {
     Auth0 auth0 = new Auth0(${account.clientId}, ${account.namespace});
-    AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);  
+    AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
 
     // proper login
-}      
+}
 ```
 
 Then, login using the newly created client:

--- a/articles/native-platforms/android/03-session-handling.md
+++ b/articles/native-platforms/android/03-session-handling.md
@@ -1,6 +1,7 @@
 ---
 title: Session Handling
 description: This tutorial will show you how to use Lock v2 to maintain a session’s connectivity.
+budicon: 280
 ---
 
 This tutorial will show you how to use Lock to maintain an active session with Auth0.
@@ -76,7 +77,7 @@ aClient.tokenInfo(CredentialsManager.getCredentials(this).getIdToken())
 
   @Override
   public void onFailure(AuthenticationException error) {
-    // Invalid ID Scenario    
+    // Invalid ID Scenario
   }
 });
 ```
@@ -116,7 +117,7 @@ client.delegationWithIdToken(idToken)
     //Show error to the user
   }
 });
-```         
+```
 
 ### ii. Using refreshToken
 
@@ -139,7 +140,7 @@ client.delegationWithRefreshToken(refreshToken)
 
   }
 });
-```     
+```
 
 > It is recommended that you read and understand the [refresh token documentation](/refresh-token) before proceeding. For example, you should remember that even though the refresh token cannot expire, it can be revoked.
 

--- a/articles/native-platforms/android/04-user-profile.md
+++ b/articles/native-platforms/android/04-user-profile.md
@@ -1,6 +1,7 @@
 ---
 title: User Profile
 description: This tutorial will show you how to use Lock to get the user's profile data.
+budicon: 292
 ---
 
 This tutorial will show you how to use Lock to get the user's profile data in your Android apps with Auth0.
@@ -34,7 +35,7 @@ new Auth0(${account.clientId}, ${account.namespace}));
 
 Then, use your previously stored credentials (in this example, stored in the Application Singleton) to request the data.
 
-```java        
+```java
 client.tokenInfo(App.getInstance().getUserCredentials().getIdToken())
                 .start(new BaseCallback<UserProfile, AuthenticationException>() {
   @Override
@@ -45,7 +46,7 @@ client.tokenInfo(App.getInstance().getUserCredentials().getIdToken())
   public void onFailure(AuthenticationException error){
   }
 });
-```                
+```
 
 ## Access The Data Inside The UserProfile
 

--- a/articles/native-platforms/android/05-linking-accounts.md
+++ b/articles/native-platforms/android/05-linking-accounts.md
@@ -1,6 +1,7 @@
 ---
 title: Linking Accounts
 description: This tutorial will show you how to use Lock within your Android project to link two different accounts for the same user.
+budicon: 345
 ---
 
 This tutorial will show you how to use Lock within your Android project to link two different accounts for the same user.
@@ -69,7 +70,7 @@ Now we can link the accounts. You have a main user along with another account yo
 UsersAPIClient client = new UsersAPIClient(auth0, credentials.getIdToken());
   String primaryUserId = mUserProfile.getId();
   client.link(primaryUserId, secondaryCredentials.getIdToken());
-```   
+```
 
 ## Retrieve Linked Accounts
 

--- a/articles/native-platforms/android/06-rules.md
+++ b/articles/native-platforms/android/06-rules.md
@@ -2,6 +2,7 @@
 title: Rules
 description: This tutorial will show you how to add customized Auth0 rules to your app.
 seo_alias: android
+budicon: 173
 ---
 
 Rules are functions written in JavaScript that are executed in Auth0 as part of the transaction every time a user authenticates to your application. For more information about Auth0 rules, please refer to [the full documentation](/rules).
@@ -51,12 +52,12 @@ client.tokenInfo(${account.clientId})
         // Get the country from the user profile
         if (payload.getExtraInfo().containsKey("country")){
           String country = (String) payload.getExtraInfo().get("country");
-          //Show the country          
+          //Show the country
         }
       }
     });
   }
-  
+
   @Override
   public void onFailure(AuthenticationException error) {
 

--- a/articles/native-platforms/android/07-authorization.md
+++ b/articles/native-platforms/android/07-authorization.md
@@ -2,6 +2,7 @@
 title: Authorization
 description: This tutorial will show you how to use the Auth0 authentication API in your Android project to create a custom login screen.
 seo_alias: android
+budicon: 500
 ---
 
 This step demonstrates how to use Auth0 to create access roles for your users. With access roles, you can authorize or deny content to different users based on the level of access they have.

--- a/articles/native-platforms/android/08-calling-apis.md
+++ b/articles/native-platforms/android/08-calling-apis.md
@@ -2,6 +2,7 @@
 title: Calling APIs
 description: This tutorial will show you how to use the Auth0 tokens to make authenticated API calls.
 seo_alias: android
+budicon: 546
 ---
 
 This tutorial demonstrates how to use a previously saved token to authenticate your API calls.
@@ -48,7 +49,7 @@ String url = "YOUR API URL";
 
 Next you need to add the token to the request header so that authenticated requests can be made. In this example we use Android's `Volley` and a custom `JsonObjectRequest`.
 
-```java     
+```java
 // Retrieve the credentials from where you saved them
 String tokenID = getCredentials.getTokenID();
 
@@ -100,7 +101,7 @@ At this point, you only need to schedule the request.
 
 ```java
 // Add the request to the RequestQueue.
-queue.add(authorizationRequest);        
+queue.add(authorizationRequest);
 ```
 
 From here, check that the request was made and that the response came back as expected. You will need to configure your server-side to protect your API endpoints with the secret key for our Auth0 application.

--- a/articles/native-platforms/android/09-mfa.md
+++ b/articles/native-platforms/android/09-mfa.md
@@ -1,6 +1,7 @@
 ---
 title: Multifactor Authentication
 description: This tutorial will show you how to configure Multifactor Authentication (MFA) via Google Authenticator in your app.
+budicon: 243
 ---
 
  <%= include('../../_includes/_package', {
@@ -11,7 +12,7 @@ description: This tutorial will show you how to configure Multifactor Authentica
   pkgPath: '09-MFA',
   pkgFilePath: '09-MFA/app/src/main/res/values/strings.xml',
   pkgType: 'replace'
-}) %>  
+}) %>
 
 ## Enable Multifactor Authentication In Your Account
 

--- a/articles/native-platforms/cordova/01-login.md
+++ b/articles/native-platforms/cordova/01-login.md
@@ -1,6 +1,7 @@
 ---
 title: Login
 description: This tutorial will show you how to use the Auth0 Cordova SDK to add authentication and authorization to your mobile app.
+budicon: 448
 ---
 
 You can get started by either downloading the seed project or if you would like to add Auth0 to an existing application you can follow the tutorial steps.

--- a/articles/native-platforms/electron/01-login.md
+++ b/articles/native-platforms/electron/01-login.md
@@ -1,6 +1,7 @@
 ---
 title: Login
 description: This tutorial will show you how to use the Auth0 Electron SDK to add authentication and authorization to your app.
+budicon: 448
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/native-platforms/ionic/00-intro.md
+++ b/articles/native-platforms/ionic/00-intro.md
@@ -1,6 +1,7 @@
 ---
 title: Introduction
 description: This quickstart guide demonstrates how to add authentication to an Ionic application using Auth0
+budicon: 715
 ---
 
 This multistep quickstart guide will walk you through setting up and managing authentication in your Ionic apps using Auth0.

--- a/articles/native-platforms/ionic/01-login.md
+++ b/articles/native-platforms/ionic/01-login.md
@@ -1,6 +1,7 @@
 ---
 title: Login
 description: This tutorial demonstrates how to use the Auth0 Ionic SDK to add authentication and authorization to your mobile app
+budicon: 448
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/native-platforms/ionic/02-custom-login.md
+++ b/articles/native-platforms/ionic/02-custom-login.md
@@ -1,6 +1,7 @@
 ---
 title: Custom Login
 description: This tutorial demonstrates how to use Auth0 to add authentication and authorization to your Ionic app
+budicon: 448
 ---
 
 <%= include('../../_includes/_package', {
@@ -34,7 +35,7 @@ The custom login uses the `auth0.js` library, so it needs to be referenced inste
 
 ## Implement the Login
 
-For the login view, you must display fields for **Username** and **Password**, along with a **Login** to allow users to log in with their email address. For social login, a signle button can be supplied. 
+For the login view, you must display fields for **Username** and **Password**, along with a **Login** to allow users to log in with their email address. For social login, a signle button can be supplied.
 
 ```html
 <!-- www/components/login/login.html -->

--- a/articles/native-platforms/ionic/03-user-profile.md
+++ b/articles/native-platforms/ionic/03-user-profile.md
@@ -1,6 +1,7 @@
 ---
 title: User Profile
 description: This example demonstrates how to display the user's profile
+budicon: 292
 ---
 
 <%= include('../../_includes/_package', {
@@ -27,7 +28,7 @@ At any given time, you can call `getProfile` on `lock` passing in a token and ca
 (function() {
 
     ...
-  
+
   function authService($rootScope, lock, authManager, jwtHelper) {
 
     ...
@@ -36,9 +37,9 @@ At any given time, you can call `getProfile` on `lock` passing in a token and ca
     // This method is called from app.run.js
     function registerAuthenticationListener() {
       lock.on('authenticated', function(authResult) {
-    
+
     ...
-    
+
         lock.getProfile(authResult.idToken, function(error, profile) {
           if (error) {
             console.log(error);
@@ -47,15 +48,15 @@ At any given time, you can call `getProfile` on `lock` passing in a token and ca
           localStorage.setItem('profile', JSON.stringify(profile));
 
         });
-    
+
     ...
-    
+
       });
     }
 
     ...
 
-  
+
   }
 })();
 

--- a/articles/native-platforms/ionic/04-linking-accounts.md
+++ b/articles/native-platforms/ionic/04-linking-accounts.md
@@ -1,6 +1,7 @@
 ---
 title: Linking Accounts
 description: This tutorial demonstrates how to integrate Auth0 with Ionic to link accounts
+budicon: 345
 ---
 
 <%= include('../../_includes/_package', {
@@ -23,7 +24,7 @@ description: This tutorial demonstrates how to integrate Auth0 with Ionic to lin
 (function () {
 
   ...
-  
+
   function authService($rootScope, lock, authManager, jwtHelper, $http, $q) {
 
   ...
@@ -64,9 +65,9 @@ description: This tutorial demonstrates how to integrate Auth0 with Ionic to lin
 
     return {
       ...
-    
+
       linkAccount: linkAccount,
-    
+
       ...
     }
   }
@@ -80,7 +81,7 @@ Now that the second login is handled, you will need to actually do the linking.
 
 
 lockLink.on('authenticated', function (authResult) {
- 
+
     $http({
       method: 'POST',
       url: 'https://' + AUTH0_DOMAIN + '/api/v2/users/' + profile.user_id + '/identities',
@@ -93,7 +94,7 @@ lockLink.on('authenticated', function (authResult) {
     })
       .then(function () {
         lockLink.hide();
-   
+
         lock.getProfile(token, function (error, profile) {
           if (!error) {
             deferred.resolve(profile);
@@ -101,10 +102,10 @@ lockLink.on('authenticated', function (authResult) {
             deferred.reject(error);
           }
         });
-   
+
       });
 
-});  
+});
 ```
 
 This function posts to the API, passing the `link_with` parameter with the JWT value in the body. It then fetches the profile on success to check that the accounts are linked.
@@ -139,15 +140,15 @@ Now to begin the link process, call the `linkAccount` method and update the user
 
 ## User Profile Linked Accounts Information
 
-The user profile contains an array of identities which includes the profile information from linked providers. 
+The user profile contains an array of identities which includes the profile information from linked providers.
 
-To view a user's identities, access the [Users](${manage_url}/#/users) page on the Auth0 dashboard, select a user, and scroll down to `identities`. 
+To view a user's identities, access the [Users](${manage_url}/#/users) page on the Auth0 dashboard, select a user, and scroll down to `identities`.
 
 This example shows a user with a linked Google account:
 
 ![User identities](/media/articles/users/user-identities-linked.png)
 
-If you fetch the profile after linking accounts, this same information will be available. 
+If you fetch the profile after linking accounts, this same information will be available.
 
 You can display this information and provide an **Unlink** button:
 
@@ -251,7 +252,7 @@ You can dissociate a linked account by calling the [unlink a user account](/api/
 
     return {
       ...
-    
+
       unLinkAccount: unLinkAccount
     }
   }

--- a/articles/native-platforms/ionic/05-rules.md
+++ b/articles/native-platforms/ionic/05-rules.md
@@ -1,6 +1,7 @@
 ---
 title: Rules
 description: This tutorial demonstrates how to use rules to extend what Auth0 has to offer
+budicon: 173
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/native-platforms/ionic/06-authorization.md
+++ b/articles/native-platforms/ionic/06-authorization.md
@@ -1,6 +1,7 @@
 ---
 title: Authorization
 description: This tutorial demonstrates how to assign roles to your users and use those claims to authorize or deny a user to access secure content in the app
+budicon: 500
 ---
 
 <%= include('../../_includes/_package', {
@@ -27,7 +28,7 @@ To restrict secure content to users with a role of `admin`, start by providing a
 
 ```js
 // www/components/home/home.controller.js
- 
+
 // Restrict access to secure content
 function showAdminContent() {
 
@@ -174,7 +175,7 @@ The `showAdminContent` method checks if the user is an admin using a new `isAdmi
     }
 
     return {
-      
+
     ...
 
       isAdmin: isAdmin

--- a/articles/native-platforms/ionic/07-calling-api.md
+++ b/articles/native-platforms/ionic/07-calling-api.md
@@ -1,6 +1,7 @@
 ---
 title: Calling APIs
 description: This tutorial demonstrates how to make secure calls to an API
+budicon: 546
 ---
 
 <%= include('../../_includes/_package', {
@@ -27,7 +28,7 @@ To attach the user's JWT as an `Authorization` header, we could write a service 
 (function () {
 
   ...
- 
+
   function config($stateProvider, $urlRouterProvider, lockProvider, jwtOptionsProvider, $httpProvider) {
 
     ...
@@ -53,18 +54,18 @@ To attach the user's JWT as an `Authorization` header, we could write a service 
 
 This basic example will attach the JWT as an `Authorization` header to all requests. This may not be desired as some requests don't require authentication. You can choose not to send the JWT by specifying `skipAuthorization: true`.
 
-```js 
+```js
 // www/components/home/home.service.js
 
 (function () {
 
   ...
-  
+
   function HomeController($state, authService, $scope, $http, $ionicPopup) {
     var vm = this;
 
   ...
-  
+
     vm.ping = ping;
 
   ...
@@ -91,7 +92,7 @@ Remember that template requests via `ui-router` or `ng-route` are HTTP requests.
 (function () {
 
   ...
- 
+
   function config($stateProvider, $urlRouterProvider, lockProvider, jwtOptionsProvider, $httpProvider) {
 
     ...
@@ -103,7 +104,7 @@ Remember that template requests via `ui-router` or `ng-route` are HTTP requests.
     if (options.url.substr(options.url.length - 5) == '.html') {
       return null;
     }
-    
+
         return localStorage.getItem('id_token');
       },
       whiteListedDomains: ['localhost'],
@@ -128,7 +129,7 @@ If for any reason you would want to send different tokens based on different URL
 (function () {
 
   ...
- 
+
   function config($stateProvider, $urlRouterProvider, lockProvider, jwtOptionsProvider, $httpProvider) {
 
     ...
@@ -141,7 +142,7 @@ If for any reason you would want to send different tokens based on different URL
         } else {
           return localStorage.getItem('id_token');
         }
-    
+
         return localStorage.getItem('id_token');
       },
       whiteListedDomains: ['localhost'],

--- a/articles/native-platforms/ionic/08-mfa.md
+++ b/articles/native-platforms/ionic/08-mfa.md
@@ -1,6 +1,7 @@
 ---
 title: Multifactor Authentication
 description: This tutorial demonstrates how to add Multifactor Authentication to your Ionic app
+budicon: 546
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/native-platforms/ionic/09-customizing-lock.md
+++ b/articles/native-platforms/ionic/09-customizing-lock.md
@@ -1,6 +1,7 @@
 ---
 title: Customizing Lock
 description: This tutorial demonstrates how to customize the Lock widget
+budicon: 243
 ---
 
 <%= include('../../_includes/_package', {
@@ -33,7 +34,7 @@ You can set custom theme properties, such as a different logo or primary color, 
   ...
 
   function config($stateProvider, $urlRouterProvider, lockProvider, jwtOptionsProvider) {
-   
+
     ...
 
     lockProvider.init({
@@ -73,7 +74,7 @@ You can also customize the text that `Lock` will display with the `languageDicti
   ...
 
   function config($stateProvider, $urlRouterProvider, lockProvider, jwtOptionsProvider) {
-   
+
     ...
 
     lockProvider.init({

--- a/articles/native-platforms/ionic2/01-login.md
+++ b/articles/native-platforms/ionic2/01-login.md
@@ -2,6 +2,7 @@
 title: Login
 default: true
 description: This tutorial demonstrates how to add authentication and authorization to an Ionic 2 app
+budicon: 448
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/native-platforms/ios-objc/01-login.md
+++ b/articles/native-platforms/ios-objc/01-login.md
@@ -2,6 +2,7 @@
 title: iOS Objective-C
 default: true
 description: This tutorial demonstrates how to use the Auth0 iOS Objective-C SDK to add authentication and authorization to your mobile app
+budicon: 448
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/native-platforms/ios-objc/02-custom-login.md
+++ b/articles/native-platforms/ios-objc/02-custom-login.md
@@ -1,6 +1,7 @@
 ---
 title: Custom Login
 description: This tutorial will teach you how to perform Login and Sign Up by using your own View Controllers, without using the Lock widget interface.
+budicon: 448
 ---
 
 ::: panel-info System Requirements

--- a/articles/native-platforms/ios-objc/03-session-handling.md
+++ b/articles/native-platforms/ios-objc/03-session-handling.md
@@ -1,6 +1,7 @@
 ---
 title: Session Handling
 description: This tutorial will show you how to handle sessions in your app, with the aim of preventing the user from being asked for credentials each time the app is launched.
+budicon: 280
 ---
 
 ::: panel-info System Requirements

--- a/articles/native-platforms/ios-swift/00-introduction.md
+++ b/articles/native-platforms/ios-swift/00-introduction.md
@@ -1,6 +1,7 @@
 ---
 title: Introduction
 description: Brief introduction to the iOS Swift tutorials. First steps required to follow any of the tutorials.
+budicon: 715
 ---
 
 This multi-step quickstart guide will walk you through managing authentication in your iOS apps with Auth0.

--- a/articles/native-platforms/ios-swift/01-login.md
+++ b/articles/native-platforms/ios-swift/01-login.md
@@ -1,6 +1,7 @@
 ---
 title: Login
 description: This tutorial demonstrates how to integrate Lock in your iOS Swift project in order to present a login screen.
+budicon: 448
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/native-platforms/ios-swift/02-custom-login.md
+++ b/articles/native-platforms/ios-swift/02-custom-login.md
@@ -1,6 +1,7 @@
 ---
 title: Custom Login
 description: This tutorial demonstrates how to perform Login and Sign Up by using your own View Controllers, without using the Lock widget interface.
+budicon: 448
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/native-platforms/ios-swift/03-session-handling.md
+++ b/articles/native-platforms/ios-swift/03-session-handling.md
@@ -1,6 +1,7 @@
 ---
 title: Session Handling
 description: This tutorial will show you how to handle sessions in your app, with the aim of preventing the user from being asked for credentials each time the app is launched.
+budicon: 280
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/native-platforms/ios-swift/04-user-profile.md
+++ b/articles/native-platforms/ios-swift/04-user-profile.md
@@ -1,6 +1,7 @@
 ---
 title: User Profile
 description: This tutorial will show you how to access the user profile from within your app, as well as how to update it.
+budicon: 292
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/native-platforms/ios-swift/05-linking-accounts.md
+++ b/articles/native-platforms/ios-swift/05-linking-accounts.md
@@ -1,6 +1,7 @@
 ---
 title: Linking Accounts
 description: This tutorial will show you how to link multiple accounts within the same user.
+budicon: 345
 ---
 
 <%= include('../../_includes/_package', {
@@ -87,7 +88,7 @@ import Lock
 let client = A0Lock.sharedLock().apiClient()
 client.fetchUserProfileWithIdToken(idToken,
     success: { profile in
-        let identities = profile.identities as! [A0UserIdentity] 
+        let identities = profile.identities as! [A0UserIdentity]
         // you've got the linked accounts here
         // do something with them, e.g. display them on a table view
     }, failure: { error in

--- a/articles/native-platforms/ios-swift/06-rules.md
+++ b/articles/native-platforms/ios-swift/06-rules.md
@@ -1,6 +1,7 @@
 ---
 title: Rules
 description: This tutorial will show you how to create a basic rule that you can use in your app.
+budicon: 173
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/native-platforms/ios-swift/07-authorization.md
+++ b/articles/native-platforms/ios-swift/07-authorization.md
@@ -1,6 +1,7 @@
 ---
 title: Authorization
 description: This tutorial will show you how assign roles to your users, and use those claims to authorize or deny a user to perform certain actions in the app.
+budicon: 500
 ---
 
 <%= include('../../_includes/_package', {
@@ -27,7 +28,7 @@ It's required that you've got [Lock](https://github.com/auth0/Lock.iOS-OSX) inte
 
 First, you will create a rule that assigns your users either an `admin` role, or a single `user` role. To do so, go to the [new rule page](${manage_url}/#/rules/new) and select the "*Set Roles To A User*" template, under *Access Control*. Then, replace this line from the default script:
 
-``` 
+```
 if (user.email.indexOf('@example.com') > -1)
 ```
 

--- a/articles/native-platforms/ios-swift/08-calling-apis.md
+++ b/articles/native-platforms/ios-swift/08-calling-apis.md
@@ -1,6 +1,7 @@
 ---
 title: Calling APIs
 description: This tutorial will show you how to manage tokens to make authenticated API calls, using NSURLSession.
+budicon: 546
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/native-platforms/ios-swift/09-mfa.md
+++ b/articles/native-platforms/ios-swift/09-mfa.md
@@ -1,6 +1,7 @@
 ---
 title: MFA
 description: This tutorial will show you how to configure Multi Factor Authentication (MFA) via Google Authenticator in your app.
+budicon: 243
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/native-platforms/ios-swift/10-customizing-lock.md
+++ b/articles/native-platforms/ios-swift/10-customizing-lock.md
@@ -1,6 +1,7 @@
 ---
 title: Customizing Lock
 description: This tutorial will show you how to customize the Lock widget UI.
+budicon: 285
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/native-platforms/phonegap/01-login.md
+++ b/articles/native-platforms/phonegap/01-login.md
@@ -2,6 +2,7 @@
 title: Login
 default: true
 description: This tutorial will show you how to use the Auth0 Phonegap SDK to add authentication and authorization to your mobile app.
+budicon: 448
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/native-platforms/react-native-android/01-login.md
+++ b/articles/native-platforms/react-native-android/01-login.md
@@ -2,6 +2,7 @@
 title: Login
 default: true
 description: This tutorial demonstrates how to use the Auth0 React Native Android SDK to add authentication and authorization to your mobile app
+budicon: 448
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/native-platforms/react-native-ios/01-login.md
+++ b/articles/native-platforms/react-native-ios/01-login.md
@@ -2,6 +2,7 @@
 title: Login
 default: true
 description: This tutorial demonstrates how to use the Auth0 React Native iOS SDK to add authentication and authorization to your mobile app.
+budicon: 448
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/native-platforms/windows-uwp-csharp/01-login.md
+++ b/articles/native-platforms/windows-uwp-csharp/01-login.md
@@ -2,6 +2,7 @@
 title: Login
 default: true
 description: This tutorial will show you how to use the Auth0 Windows Universal App C# SDK to add authentication and authorization to your app.
+budicon: 448
 ---
 
 

--- a/articles/native-platforms/windows-uwp-javascript/01-login.md
+++ b/articles/native-platforms/windows-uwp-javascript/01-login.md
@@ -2,6 +2,7 @@
 title: Login
 default: true
 description: This tutorial will show you how to use the Auth0 Windows Universal App Javascript SDK to add authentication and authorization to your app.
+budicon: 448
 ---
 
 

--- a/articles/native-platforms/windowsphone/01-login.md
+++ b/articles/native-platforms/windowsphone/01-login.md
@@ -2,6 +2,7 @@
 title: Login
 default: true
 description: This tutorial will show you how to use the Auth0 Windows Phone SDK to add authentication and authorization to your mobile app.
+budicon: 448
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/native-platforms/wpf-winforms/01-login.md
+++ b/articles/native-platforms/wpf-winforms/01-login.md
@@ -2,6 +2,7 @@
 title: Login
 default: true
 description: This tutorial will show you how to use the Auth0 WPF and Winforms SDK to add authentication and authorization to your app.
+budicon: 448
 ---
 
 <%= include('../../_includes/_package2', {

--- a/articles/native-platforms/xamarin/01-login.md
+++ b/articles/native-platforms/xamarin/01-login.md
@@ -2,6 +2,7 @@
 title: Login
 default: true
 description: This tutorial will show you how to use the Auth0 Xamarin SDK to add authentication and authorization to your mobile app.
+budicon: 448
 ---
 
 ::: panel-info System Requirements

--- a/articles/server-apis/aspnet-core-webapi/00-intro.md
+++ b/articles/server-apis/aspnet-core-webapi/00-intro.md
@@ -2,6 +2,7 @@
 title: Introduction
 name: Introduction to the Quickstart, and configuring environment
 description: This Quickstart will guide you through the various tasks related to using Auth0-issued JSON Web Tokens to secure your ASP.NET Core Web API.
+budicon: 715
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/server-apis/aspnet-core-webapi/01-authentication-rs256.md
+++ b/articles/server-apis/aspnet-core-webapi/01-authentication-rs256.md
@@ -2,6 +2,7 @@
 title: Authentication (RS256)
 name: Shows how to secure your API using the standard JWT middeware
 description: Shows how to secure your API using the standard JWT middeware.
+budicon: 500
 ---
 
 <%= include('../../_includes/_package', {
@@ -24,11 +25,11 @@ To configure the JWT Signature Algorithm, go to the settings for your applicatio
 
 Save your changes.
 
-![Configure JWT Signature Algorithm as RS256](/media/articles/server-apis/aspnet-core-webapi/jwt-signature-rs256.png)   
+![Configure JWT Signature Algorithm as RS256](/media/articles/server-apis/aspnet-core-webapi/jwt-signature-rs256.png)
 
 ## 2. Configure the JWT Middleware
 
-You will need to add the JWT middleware to your application's middleware pipeline. 
+You will need to add the JWT middleware to your application's middleware pipeline.
 
 Go to the `Configure` method of your `Startup` class and add a call to `UseJwtBearerAuthentication` passing in the configured `JwtBearerOptions`. The `JwtBearerOptions` needs to specify your Auth0 Client ID as the `Audience`, and the full path to your Auth0 domain as the `Authority`:
 
@@ -52,7 +53,7 @@ Before we carry on, a quick word about the verification of the JWT, as the confi
 
 The JWT middleware will automatically use the `Authority` to verify the issuer of the JWT, and the `Audience` to verify the audience. These values need match the values in the token exactly, so ensure you specify the trailing backslash (`/`) for the `Authority` as this is a fairly common reason for tokens not verifying correctly.
 
-Next it will seem as though the JWT middleware configuration above is insecure since the signature is not explicitly verified anywhere. This is however not true, as the JWT middleware will go to the `/.well-known/openid-configuration` endpoint at the URL specified in the `Authority` property to discover the JSON Web Key Set (JWK) document. It will then download the JSON Web Key which is used to subsequently verify the token.  
+Next it will seem as though the JWT middleware configuration above is insecure since the signature is not explicitly verified anywhere. This is however not true, as the JWT middleware will go to the `/.well-known/openid-configuration` endpoint at the URL specified in the `Authority` property to discover the JSON Web Key Set (JWK) document. It will then download the JSON Web Key which is used to subsequently verify the token.
 
 This can be confirmed by looking and the Fiddler trace in the screenshot below:
 
@@ -62,7 +63,7 @@ If someone tries to create a JWT with another key set the signature verification
 
 ![Console output with incorrectly signed JWT](/media/articles/server-apis/aspnet-core-webapi/console-output.png)
 
-## 3. Securing an API endpoint 
+## 3. Securing an API endpoint
 
 The JWT middleware integrates with the standard ASP.NET Core [Authentication](https://docs.asp.net/en/latest/security/authentication/index.html) and [Authorization](https://docs.asp.net/en/latest/security/authorization/index.html) mechanisms.
 

--- a/articles/server-apis/aspnet-core-webapi/02-authentication-hs256.md
+++ b/articles/server-apis/aspnet-core-webapi/02-authentication-hs256.md
@@ -2,6 +2,7 @@
 title: Authentication (HS256)
 name: Shows how to secure your API using the standard JWT middeware
 description: Shows how to secure your API using the standard JWT middeware
+budicon: 500
 ---
 
 <%= include('../../_includes/_package', {
@@ -24,11 +25,11 @@ To configure the JWT Signature Algorithm, go to the settings for your applicatio
 
 Save your changes.
 
-![Configure JWT Signature Algorithm as HS256](/media/articles/server-apis/aspnet-core-webapi/jwt-signature-hs256.png)   
+![Configure JWT Signature Algorithm as HS256](/media/articles/server-apis/aspnet-core-webapi/jwt-signature-hs256.png)
 
 ## 2. Update your settings
 
-When using HS256, you will need your application's **Client Secret** when configuring the JWT middleware, so be sure update the `appsettings.json` file included in the seed project to also add a **ClientSecret** attribute, and be sure to set the correct values for the **Domain**, **ClientId** and **ClientSecret** attributes:   
+When using HS256, you will need your application's **Client Secret** when configuring the JWT middleware, so be sure update the `appsettings.json` file included in the seed project to also add a **ClientSecret** attribute, and be sure to set the correct values for the **Domain**, **ClientId** and **ClientSecret** attributes:
 
 ```json
 {
@@ -42,9 +43,9 @@ When using HS256, you will need your application's **Client Secret** when config
 
 ## 3. Configure the JWT Middleware
 
-You will need to add the JWT middleware to your application's middleware pipeline. 
+You will need to add the JWT middleware to your application's middleware pipeline.
 
-Go to the `Configure` method of your `Startup` class and add a call to `UseJwtBearerAuthentication` passing in the configured `JwtBearerOptions`. The `JwtBearerOptions` needs to specify your Auth0 Domain as the issuer, the Client ID as the Audience, and the Base64-decoded Client Secret as the issuer signing key: 
+Go to the `Configure` method of your `Startup` class and add a call to `UseJwtBearerAuthentication` passing in the configured `JwtBearerOptions`. The `JwtBearerOptions` needs to specify your Auth0 Domain as the issuer, the Client ID as the Audience, and the Base64-decoded Client Secret as the issuer signing key:
 
 ```csharp
 public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
@@ -58,7 +59,7 @@ public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerF
         {
             ValidIssuer = $"https://{Configuration["auth0:domain"]}/",
             ValidAudience = Configuration["auth0:clientId"],
-            IssuerSigningKey = new SymmetricSecurityKey(keyAsBytes)                
+            IssuerSigningKey = new SymmetricSecurityKey(keyAsBytes)
         }
     };
     app.UseJwtBearerAuthentication(options);
@@ -68,10 +69,10 @@ public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerF
 ```
 
 ::: panel-warning Do not forget the trailing backslash
-Please ensure that the URL specified for `ValidIssuer` contains a trailing backslash as this needs to match exactly with the issuer claim of the JWT. This is a common misconfiguration error which will cause your API calls to not be authenticated correctly.   
+Please ensure that the URL specified for `ValidIssuer` contains a trailing backslash as this needs to match exactly with the issuer claim of the JWT. This is a common misconfiguration error which will cause your API calls to not be authenticated correctly.
 :::
 
-## 4. Securing an API endpoint 
+## 4. Securing an API endpoint
 
 The JWT middleware integrates with the standard ASP.NET Core [Authentication](https://docs.asp.net/en/latest/security/authentication/index.html) and [Authorization](https://docs.asp.net/en/latest/security/authorization/index.html) mechanisms.
 

--- a/articles/server-apis/aspnet-core-webapi/03-authorization.md
+++ b/articles/server-apis/aspnet-core-webapi/03-authorization.md
@@ -1,6 +1,7 @@
 ---
 title: Authorization
 description: This tutorial will show you how assign roles to your users, and use those claims to authorize or deny a user to access certain API endpoints.
+budicon: 500
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/server-apis/java-spring-security/00-intro.md
+++ b/articles/server-apis/java-spring-security/00-intro.md
@@ -1,6 +1,7 @@
 ---
 title: Introduction
 name: Introduction to the Quickstart, and configuring environment
+budicon: 715
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/server-apis/java-spring-security/01-authentication.md
+++ b/articles/server-apis/java-spring-security/01-authentication.md
@@ -1,6 +1,7 @@
 ---
 title: Authentication
 name: Shows how to secure your API
+budicon: 500
 ---
 
 You can get started by either downloading the seed project or if you would like to add Auth0 to an existing application you can follow the tutorial steps.

--- a/articles/server-apis/java-spring-security/02-authorization.md
+++ b/articles/server-apis/java-spring-security/02-authorization.md
@@ -1,6 +1,7 @@
 ---
 title: Authorization
 description: This tutorial will show you how assign roles to your users, and use those claims to authorize or deny a user to access certain API endpoints.
+budicon: 500
 ---
 
 You can get started by either downloading the seed project or if you would like to add Auth0 to an existing application you can follow the tutorial steps.

--- a/articles/server-apis/webapi-owin/00-intro.md
+++ b/articles/server-apis/webapi-owin/00-intro.md
@@ -1,6 +1,7 @@
 ---
 title: Introduction
 name: Introduction to the Quickstart, and configuring environment
+budicon: 715
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/server-apis/webapi-owin/01-authentication-rs256.md
+++ b/articles/server-apis/webapi-owin/01-authentication-rs256.md
@@ -1,6 +1,7 @@
 ---
 title: Authentication (RS256)
 name: Shows how to secure your API using the standard JWT middeware
+budicon: 500
 ---
 
 <%= include('../../_includes/_package', {
@@ -23,13 +24,13 @@ To configure the JWT Signature Algorithm, go to the settings for your applicatio
 
 Save your changes.
 
-![Configure JWT Signature Algorithm as RS256](/media/articles/server-apis/webapi-owin/jwt-signature-rs256.png)   
+![Configure JWT Signature Algorithm as RS256](/media/articles/server-apis/webapi-owin/jwt-signature-rs256.png)
 
 ## 2. Configure the JWT Middleware
 
-You will need to add the Active Directory Services Bearer Token middleware to your application's middleware pipeline. 
+You will need to add the Active Directory Services Bearer Token middleware to your application's middleware pipeline.
 
-Go to the `Configuration` method of your `Startup` class and add a call to `UseActiveDirectoryFederationServicesBearerAuthentication` passing in the configured `ActiveDirectoryFederationServicesBearerAuthenticationOptions`. 
+Go to the `Configuration` method of your `Startup` class and add a call to `UseActiveDirectoryFederationServicesBearerAuthentication` passing in the configured `ActiveDirectoryFederationServicesBearerAuthenticationOptions`.
 
 The `ActiveDirectoryFederationServicesBearerAuthenticationOptions` needs to specify your Auth0 Client ID in the `ValidAudience` property, and the full path to your Auth0 domain as the `ValidIssuer`. You will also need to specify the `MetadataEndpoint` property which will allow the middleware to automatically download the public key from Auth0 in order to verify the signature of the JSON Web Tokens.
 
@@ -52,7 +53,7 @@ public void Configuration(IAppBuilder app)
             // Setting the MetadataEndpoint so the middleware can download the RS256 certificate
             MetadataEndpoint = $"{issuer.TrimEnd('/')}/wsfed/{audience}/FederationMetadata/2007-06/FederationMetadata.xml"
         });
-            
+
 
     // Configure Web API
     WebApiConfig.Configure(app);
@@ -60,10 +61,10 @@ public void Configuration(IAppBuilder app)
 ```
 
 ::: panel-warning Do not forget the trailing backslash
-Please ensure that the URL specified for `ValidIssuer` contains a trailing backslash as this needs to match exactly with the issuer claim of the JWT. This is a common misconfiguration error which will cause your API calls to not be authenticated correctly.   
+Please ensure that the URL specified for `ValidIssuer` contains a trailing backslash as this needs to match exactly with the issuer claim of the JWT. This is a common misconfiguration error which will cause your API calls to not be authenticated correctly.
 :::
 
-## 3. Securing an API endpoint 
+## 3. Securing an API endpoint
 
 The JWT middleware integrates with the standard ASP.NET Authentication and Authorization mechanisms, so you only need to decorate your controller action with the `[Authorize]` attribute to secure an endpoint:
 

--- a/articles/server-apis/webapi-owin/02-authentication-hs256.md
+++ b/articles/server-apis/webapi-owin/02-authentication-hs256.md
@@ -1,6 +1,7 @@
 ---
 title: Authentication (HS256)
 name: Shows how to secure your API using the standard JWT middeware
+budicon: 500
 ---
 
 <%= include('../../_includes/_package', {
@@ -23,11 +24,11 @@ To configure the JWT Signature Algorithm, go to the settings for your applicatio
 
 Save your changes.
 
-![Configure JWT Signature Algorithm as HS256](/media/articles/server-apis/webapi-owin/jwt-signature-hs256.png)   
+![Configure JWT Signature Algorithm as HS256](/media/articles/server-apis/webapi-owin/jwt-signature-hs256.png)
 
 ## 2. Update your settings
 
-When using HS256, you will need your application's **Client Secret** when configuring the JWT middleware, so be sure update the `web.config` file included in the seed project to also add a **Auth0ClientSecret** key, and be sure to set the correct values for the **Auth0Domain**, **Auth0ClientID** and **Auth0ClientSecret** elements:   
+When using HS256, you will need your application's **Client Secret** when configuring the JWT middleware, so be sure update the `web.config` file included in the seed project to also add a **Auth0ClientSecret** key, and be sure to set the correct values for the **Auth0Domain**, **Auth0ClientID** and **Auth0ClientSecret** elements:
 
 ```json
 <appSettings>
@@ -39,9 +40,9 @@ When using HS256, you will need your application's **Client Secret** when config
 
 ## 3. Configure the JWT Middleware
 
-You will need to add the JWT middleware to your application's middleware pipeline. 
+You will need to add the JWT middleware to your application's middleware pipeline.
 
-Go to the `Configuration` method of your `Startup` class and add a call to `UseJwtBearerAuthentication` passing in the configured `JwtBearerAuthenticationOptions`. The `JwtBearerAuthenticationOptions` needs to specify the Client ID in the `AllowedAudiences` property and the Auth0 Domain as the `issuer` and the Base64-decoded Client Secret as the `key` parameters of the `SymmetricKeyIssuerSecurityTokenProvider`: 
+Go to the `Configuration` method of your `Startup` class and add a call to `UseJwtBearerAuthentication` passing in the configured `JwtBearerAuthenticationOptions`. The `JwtBearerAuthenticationOptions` needs to specify the Client ID in the `AllowedAudiences` property and the Auth0 Domain as the `issuer` and the Base64-decoded Client Secret as the `key` parameters of the `SymmetricKeyIssuerSecurityTokenProvider`:
 
 ```csharp
 public void Configuration(IAppBuilder app)
@@ -68,10 +69,10 @@ public void Configuration(IAppBuilder app)
 ```
 
 ::: panel-warning Do not forget the trailing backslash
-Please ensure that the URL specified for the `issuer` parameter contains a trailing backslash as this needs to match exactly with the issuer claim of the JWT. This is a common misconfiguration error which will cause your API calls to not be authenticated correctly.   
+Please ensure that the URL specified for the `issuer` parameter contains a trailing backslash as this needs to match exactly with the issuer claim of the JWT. This is a common misconfiguration error which will cause your API calls to not be authenticated correctly.
 :::
 
-## 4. Securing an API endpoint 
+## 4. Securing an API endpoint
 
 The JWT middleware integrates with the standard ASP.NET Authentication and Authorization mechanisms. You only need to decorate your controller action with the `[Authorize]` attribute to secure an endpoint:
 

--- a/articles/server-apis/webapi-owin/03-authorization.md
+++ b/articles/server-apis/webapi-owin/03-authorization.md
@@ -1,6 +1,7 @@
 ---
 title: Authorization
 description: This tutorial will show you how assign roles to your users, and use those claims to authorize or deny a user to access certain API endpoints.
+budicon: 500
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/server-platforms/apache/01-login.md
+++ b/articles/server-platforms/apache/01-login.md
@@ -2,6 +2,7 @@
 title: Login
 default: true
 description: This tutorial demonstrates how to use the Auth0 Apache SDK to add authentication and authorization to your web app.
+budicon: 448
 ---
 
 ::: panel-info System Requirements

--- a/articles/server-platforms/asp-classic/01-login.md
+++ b/articles/server-platforms/asp-classic/01-login.md
@@ -2,6 +2,7 @@
 title: Login
 default: true
 description: This tutorial demonstrates how to use the Auth0 ASP Classic SDK to add authentication and authorization to your web app.
+budicon: 448
 ---
 
 ::: panel-info System Requirements

--- a/articles/server-platforms/aspnet-core/00-intro.md
+++ b/articles/server-platforms/aspnet-core/00-intro.md
@@ -2,6 +2,7 @@
 title: Introduction
 name: Introduction to the quickstart guide and configuring the environment
 description: Introduction to the quickstart guide and configuring the environment.
+budicon: 715
 ---
 
 This quickstart guide will walk you through the various tasks related to integrating Auth0 into your ASP.NET Core MVC application.

--- a/articles/server-platforms/aspnet-core/01-login.md
+++ b/articles/server-platforms/aspnet-core/01-login.md
@@ -1,6 +1,7 @@
 ---
 title: Login
 description: This tutorial will show you how to use the standard OpenID Connect middleware to add authentication to your web app.
+budicon: 448
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/server-platforms/aspnet-core/02-login-embedded-lock.md
+++ b/articles/server-platforms/aspnet-core/02-login-embedded-lock.md
@@ -1,6 +1,7 @@
 ---
 title: Login with Embedded Lock
 description: This tutorial will show you can host the Lock widget inside your application instead of using the Lock widget which is hosted on the Auth0 domain.
+budicon: 448
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/server-platforms/aspnet-core/03-login-custom.md
+++ b/articles/server-platforms/aspnet-core/03-login-custom.md
@@ -1,6 +1,7 @@
 ---
 title: Custom Login
 description: This tutorial will show you how to create a custom login page for your web application by using the Auth0 .NET SDK and OpenID Connect middleware.
+budicon: 448
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/server-platforms/aspnet-core/04-storing-tokens.md
+++ b/articles/server-platforms/aspnet-core/04-storing-tokens.md
@@ -1,6 +1,7 @@
 ---
 title: Storing Tokens
 description: This tutorial will show you how store the tokens returned from Auth0 in order to use them later on.
+budicon: 280
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/server-platforms/aspnet-core/05-user-profile.md
+++ b/articles/server-platforms/aspnet-core/05-user-profile.md
@@ -1,6 +1,7 @@
 ---
 title: User Profile
 description: This tutorial will show you how to display get the user's profile and display it.
+budicon: 292
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/server-platforms/aspnet-core/07-rules.md
+++ b/articles/server-platforms/aspnet-core/07-rules.md
@@ -1,6 +1,7 @@
 ---
 title: Rules
 description: This tutorial will show you how to use Auth0 rules to extend what Auth0 has to offer.
+budicon: 173
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/server-platforms/aspnet-core/08-authorization.md
+++ b/articles/server-platforms/aspnet-core/08-authorization.md
@@ -1,6 +1,7 @@
 ---
 title: Authorization
 description: This tutorial will show you how assign roles to your users, and use those claims to authorize or deny a user to access certain routes in the app.
+budicon: 546
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/server-platforms/aspnet-owin/00-intro.md
+++ b/articles/server-platforms/aspnet-owin/00-intro.md
@@ -2,6 +2,7 @@
 title: Introduction
 name: Introduction to the quickstart guide and configuring the environment
 description: This quickstart guide will walk you through the various tasks related to integrating Auth0 into your ASP.NET MVC 5 application.
+budicon: 715
 ---
 
 This quickstart guide will walk you through the various tasks related to integrating Auth0 into your ASP.NET MVC 5 application.

--- a/articles/server-platforms/aspnet-owin/01-login.md
+++ b/articles/server-platforms/aspnet-owin/01-login.md
@@ -1,6 +1,7 @@
 ---
 title: Login
 description: This tutorial demonstrates how to use the Auth0 OAuth2 middleware to add authentication to your web app
+budicon: 448
 ---
 
 <%= include('../../_includes/_package2', {

--- a/articles/server-platforms/aspnet-owin/02-login-custom.md
+++ b/articles/server-platforms/aspnet-owin/02-login-custom.md
@@ -1,6 +1,7 @@
 ---
 title: Custom Login
 description: This tutorial demonstrates how to create a custom login page for your web application by using the Auth0 .NET SDK and OpenID Connect middleware.
+budicon: 448
 ---
 
 <%= include('../../_includes/_package2', {

--- a/articles/server-platforms/aspnet-owin/03-storing-tokens.md
+++ b/articles/server-platforms/aspnet-owin/03-storing-tokens.md
@@ -1,6 +1,7 @@
 ---
 title: Storing Tokens
 description: This tutorial demonstrates how store the tokens returned from Auth0 in order to use them later on.
+budicon: 280
 ---
 
 <%= include('../../_includes/_package2', {

--- a/articles/server-platforms/aspnet-owin/04-user-profile.md
+++ b/articles/server-platforms/aspnet-owin/04-user-profile.md
@@ -1,6 +1,7 @@
 ---
 title: User Profile
 description: This tutorial demonstrates how to get the user's profile and display it.
+budicon: 292
 ---
 
 <%= include('../../_includes/_package2', {

--- a/articles/server-platforms/aspnet-owin/05-rules.md
+++ b/articles/server-platforms/aspnet-owin/05-rules.md
@@ -1,6 +1,7 @@
 ---
 title: Rules
 description: This tutorial demonstrates how to use Auth0 rules to extend what Auth0 has to offer.
+budicon: 173
 ---
 
 <%= include('../../_includes/_package2', {

--- a/articles/server-platforms/aspnet-owin/06-authorization.md
+++ b/articles/server-platforms/aspnet-owin/06-authorization.md
@@ -1,6 +1,7 @@
 ---
 title: Authorization
 description: This tutorial demonstrates how assign roles to your users, and use those claims to authorize or deny a user to access certain routes in the app.
+budicon: 500
 ---
 
 <%= include('../../_includes/_package2', {

--- a/articles/server-platforms/aspnet/01-login.md
+++ b/articles/server-platforms/aspnet/01-login.md
@@ -2,6 +2,7 @@
 title: Login
 default: true
 description: This tutorial demonstrates how to use the Auth0 ASP.NET SDK to add authentication and authorization to your web app
+budicon: 448
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/server-platforms/golang/01-login.md
+++ b/articles/server-platforms/golang/01-login.md
@@ -1,6 +1,7 @@
 ---
 title: Login
 description: This tutorial will demonstrates how to use the Auth0 Go SDK to add authentication and authorization to your web app
+budicon: 448
 ---
 
 <%= include('../../_includes/_package2', {

--- a/articles/server-platforms/java-spring-mvc/00-intro.md
+++ b/articles/server-platforms/java-spring-mvc/00-intro.md
@@ -1,6 +1,7 @@
 ---
 title: Introduction
 description: This tutorial demonstrates how to use the Auth0 Java Spring MVC SDK to add authentication and authorization to your web app.
+budicon: 715
 ---
 
 

--- a/articles/server-platforms/java-spring-mvc/01-login.md
+++ b/articles/server-platforms/java-spring-mvc/01-login.md
@@ -1,6 +1,7 @@
 ---
 title: Login
 description: This tutorial demonstrates how to use the Auth0 Java Spring MVC SDK to add authentication and authorization to your web app
+budicon: 448
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/server-platforms/java-spring-mvc/09-mfa.md
+++ b/articles/server-platforms/java-spring-mvc/09-mfa.md
@@ -1,6 +1,7 @@
 ---
 title: Multifactor Authentication
 description: This tutorial demonstrates how to add Multifactor Authentication to your Java Spring web app with Auth0.
+budicon: 243
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/server-platforms/java-spring-security-mvc/00-intro.md
+++ b/articles/server-platforms/java-spring-security-mvc/00-intro.md
@@ -1,6 +1,7 @@
 ---
 title: Introduction
 description: This tutorial demonstrates how to use the Auth0 Java Spring Security MVC SDK to add authentication and authorization to your web app, using Spring Boot
+budicon: 715
 ---
 
 

--- a/articles/server-platforms/java-spring-security-mvc/01-login.md
+++ b/articles/server-platforms/java-spring-security-mvc/01-login.md
@@ -1,6 +1,7 @@
 ---
 title: Login
 description: This tutorial demonstrates how to use the Auth0 Java Spring Security MVC SDK to add authentication and authorization to your web app
+budicon: 448
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/server-platforms/java-spring-security-mvc/02-custom-login.md
+++ b/articles/server-platforms/java-spring-security-mvc/02-custom-login.md
@@ -1,6 +1,7 @@
 ---
 title: Custom Login
 description: This tutorial demonstrates how to use the Auth0 library to add custom authentication and authorization to your web app
+budicon: 448
 ---
 
 <%= include('../../_includes/_package', {
@@ -25,19 +26,19 @@ First we will create a new database connection and we will name it `custom-login
 
 **NOTE:** If you have an existing user store, or wish to store user credentials on your own server, see the custom database connection tutorial at [Authenticate Users with Username and Password using a Custom Database](/connections/database/mysql) for detailed steps on how to setup and configure it.
 
-Log into Auth0, and select the [Connections > Database](${manage_url}/#/connections/database) menu option. 
+Log into Auth0, and select the [Connections > Database](${manage_url}/#/connections/database) menu option.
 
 Click the **Create DB Connection** button and provide a name for the database.
 
-You will be navigated to the connection's settings. 
+You will be navigated to the connection's settings.
 
 At the **Clients Using This Connection** section, enable the connection for your app.
 
-Now let's create a user. 
+Now let's create a user.
 
-Select the [Users](${manage_url}/#/users) menu option. 
+Select the [Users](${manage_url}/#/users) menu option.
 
-Click the **Create User** button and fill in the email, password, and the database at which the user will be created. Use an email address you have access to since creating the user will trigger a verification email to be sent. 
+Click the **Create User** button and fill in the email, password, and the database at which the user will be created. Use an email address you have access to since creating the user will trigger a verification email to be sent.
 
 Click **Save**.
 
@@ -80,7 +81,7 @@ We have also added code to retrieve the connection name, the value of the `auth0
 
 ## Test the App
 
-We are now ready to test the application! 
+We are now ready to test the application!
 
 Build and run the project using `mvn spring-boot:run`. Then, go to [http://localhost:3099/login](http://localhost:3099/login).
 

--- a/articles/server-platforms/java-spring-security-mvc/06-rules.md
+++ b/articles/server-platforms/java-spring-security-mvc/06-rules.md
@@ -1,6 +1,7 @@
 ---
 title: Rules
 description: This tutorial demonstrates how to use Auth0 rules to extend what Auth0 has to offer
+budicon: 173
 ---
 
 <%= include('../../_includes/_package', {
@@ -19,9 +20,9 @@ Rules are one of the cool features of Auth0. The reason is their flexibility, wh
 
 ## Create a Rule
 
-To create a rule go to the [Create Rule page](${manage_url}/#/rules/new). You can create it from scratch or use an existing template. These templates are written by Auth0 team to assist you complete common tasks. 
+To create a rule go to the [Create Rule page](${manage_url}/#/rules/new). You can create it from scratch or use an existing template. These templates are written by Auth0 team to assist you complete common tasks.
 
-Let's create a rule to implement some basic role-based authorization. If the user logs in using a `@gmail.com` or a `@auth0.com` email, the user will be assigned the `ROLE_ADMIN` role, otherwise the user will be assigned the `ROLE_USER` role. We will print some text on screen to see how this works. 
+Let's create a rule to implement some basic role-based authorization. If the user logs in using a `@gmail.com` or a `@auth0.com` email, the user will be assigned the `ROLE_ADMIN` role, otherwise the user will be assigned the `ROLE_USER` role. We will print some text on screen to see how this works.
 
 The template you can use for this example is called `Set roles to a user`.
 
@@ -31,7 +32,7 @@ ${snippet(meta.snippets.rulesSetRoles)}
 
 Once you are done, save the rule.
 
-**NOTE**: Keep in mind that this is just a starting template, you can edit it to meet your business needs. 
+**NOTE**: Keep in mind that this is just a starting template, you can edit it to meet your business needs.
 
 ## Retrieve the Role
 
@@ -52,7 +53,7 @@ with this:
 
 ## Display Result
 
-Let's display some info to see that our rule actually works. 
+Let's display some info to see that our rule actually works.
 
 Add the following code at the `src/main/webapp/WEB-INF/jsp/home.jsp`, inside your `jumbotron` div:
 
@@ -78,7 +79,7 @@ Create a new `AdminService.java` under `/src/main/java/com/auth0/example`. Paste
 
 ${snippet(meta.snippets.rulesAdminService)}
 
-Let's edit our `HomeController.java` to use this AdminService resource. We will autowire the AdminService resource, create a new `adminChecks` method and invoke it from the `HomeController`. 
+Let's edit our `HomeController.java` to use this AdminService resource. We will autowire the AdminService resource, create a new `adminChecks` method and invoke it from the `HomeController`.
 
 Paste the following code:
 

--- a/articles/server-platforms/java-spring-security-mvc/09-mfa.md
+++ b/articles/server-platforms/java-spring-security-mvc/09-mfa.md
@@ -1,6 +1,7 @@
 ---
 title: Multifactor Authentication
 description: This tutorial demonstrates how to add Multifactor Authentication to your Java Spring Security web app with Auth0.
+budicon: 243
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/server-platforms/java/00-intro.md
+++ b/articles/server-platforms/java/00-intro.md
@@ -1,6 +1,7 @@
 ---
 title: Introduction
 description: This tutorial demonstrates how to use the Auth0 Java SDK to add authentication and authorization to your web app
+budicon: 715
 ---
 
 

--- a/articles/server-platforms/java/01-login.md
+++ b/articles/server-platforms/java/01-login.md
@@ -1,6 +1,7 @@
 ---
 title: Login
 description: This tutorial demonstrates how to use the Auth0 Java SDK to add authentication and authorization to your web app
+budicon: 448
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/server-platforms/java/09-mfa.md
+++ b/articles/server-platforms/java/09-mfa.md
@@ -1,6 +1,7 @@
 ---
 title: Multifactor Authentication
 description: This tutorial demonstrates how to add Multifactor Authentication to your Java web app with Auth0
+budicon: 243
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/server-platforms/laravel/01-login.md
+++ b/articles/server-platforms/laravel/01-login.md
@@ -2,6 +2,7 @@
 title: Login
 default: true
 description: This tutorial demonstrates how to use the Auth0 PHP Laravel SDK to add authentication and authorization to your web app.
+budicon: 448
 ---
 
 <%= include('../../_includes/_package2', {

--- a/articles/server-platforms/nancyfx/01-login.md
+++ b/articles/server-platforms/nancyfx/01-login.md
@@ -2,6 +2,7 @@
 title: Login
 default: true
 description: This tutorial will show you how to use the Auth0 NancyFX SDK to add authentication and authorization to your web app.
+budicon: 448
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/server-platforms/nodejs/00-intro.md
+++ b/articles/server-platforms/nodejs/00-intro.md
@@ -1,6 +1,7 @@
 ---
 title: Introduction
 description: This tutorial demonstrates how to setup and run the nodejs webapp sample project provided by Auth0
+budicon: 715
 ---
 
 This multistep quickstart guide will walk you through setting up and managing authentication in your Node.js web apps using Auth0. Each step demonstrates how to implement a specific feature of Auth0 and is accompanied by a downloadable sample project showing the complete solution.

--- a/articles/server-platforms/nodejs/01-login.md
+++ b/articles/server-platforms/nodejs/01-login.md
@@ -1,6 +1,7 @@
 ---
 title: Login
 description: This tutorial demonstrates how to add authentication to a Node.js and Express web app
+budicon: 448
 ---
 
 <%= include('../../_includes/_package2', {

--- a/articles/server-platforms/nodejs/02-login-custom.md
+++ b/articles/server-platforms/nodejs/02-login-custom.md
@@ -1,6 +1,7 @@
 ---
 title: Custom Login
 description: This tutorial demonstrates how to create a custom login page for your web application by using the auth0.js library
+budicon: 448
 ---
 
 <%= include('../../_includes/_package2', {

--- a/articles/server-platforms/nodejs/04-user-profile.md
+++ b/articles/server-platforms/nodejs/04-user-profile.md
@@ -1,6 +1,7 @@
 ---
 title: User Profile
 description: This tutorial demonstrates how to fetch user profile information
+budicon: 292
 ---
 
 <%= include('../../_includes/_package2', {

--- a/articles/server-platforms/nodejs/05-linking-accounts.md
+++ b/articles/server-platforms/nodejs/05-linking-accounts.md
@@ -1,6 +1,7 @@
 ---
 title: Linking Accounts
 description: This tutorial demonstrates how to integrate Auth0 with NodeJS to link accounts
+budicon: 345
 ---
 
 <%= include('../../_includes/_package2', {

--- a/articles/server-platforms/nodejs/06-rules.md
+++ b/articles/server-platforms/nodejs/06-rules.md
@@ -1,6 +1,7 @@
 ---
 title: Rules
 description: This tutorial demonstrates how to use Auth0 rules
+budicon: 173
 ---
 
 <%= include('../../_includes/_package2', {

--- a/articles/server-platforms/nodejs/07-authorization.md
+++ b/articles/server-platforms/nodejs/07-authorization.md
@@ -1,6 +1,7 @@
 ---
 title: Authorization
 description: This tutorial demonstrates how assign roles to your users and how to use those claims to authorize or deny a user to access certain routes in the app
+budicon: 500
 ---
 
 <%= include('../../_includes/_package2', {

--- a/articles/server-platforms/nodejs/09-mfa.md
+++ b/articles/server-platforms/nodejs/09-mfa.md
@@ -1,6 +1,7 @@
 ---
 title: Multifactor Authentication
 description: This tutorial will show you how to add Multifactor Authentication to your NodeJS WebApp with auth0.
+budicon: 243
 ---
 
 <%= include('../_includes/_mfa-introduction') %>

--- a/articles/server-platforms/nodejs/10-customizing-lock.md
+++ b/articles/server-platforms/nodejs/10-customizing-lock.md
@@ -1,6 +1,7 @@
 ---
 title: Customizing Lock
 description: This tutorial will show you how to customize lock widget.
+budicon: 285
 ---
 
 <%= include('../../_includes/_package2', {

--- a/articles/server-platforms/php/01-login.md
+++ b/articles/server-platforms/php/01-login.md
@@ -2,6 +2,7 @@
 title: Login
 default: true
 description: This tutorial demonstrates how to use the Auth0 PHP SDK to add authentication and authorization to your web app
+budicon: 448
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/server-platforms/python/01-login.md
+++ b/articles/server-platforms/python/01-login.md
@@ -2,6 +2,7 @@
 title: Login
 default: true
 description: This tutorial demonstrates how to use the Auth0 Python SDK to add authentication and authorization to your web app
+budicon: 448
 ---
 
 You can get started by either downloading the seed project or if you would like to add Auth0 to an existing application you can follow the tutorial steps.

--- a/articles/server-platforms/rails/01-login.md
+++ b/articles/server-platforms/rails/01-login.md
@@ -2,6 +2,7 @@
 title: Login
 default: true
 description: This tutorial demonstrates how to use the Auth0 Ruby On Rails SDK to add authentication and authorization to your web app
+budicon: 448
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/server-platforms/scala/01-login.md
+++ b/articles/server-platforms/scala/01-login.md
@@ -2,6 +2,7 @@
 title: Login
 default: true
 description: This tutorial demonstrates how to use the Auth0 Play 2 Scala SDK to add authentication and authorization to your web app
+budicon: 448
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/server-platforms/servicestack/01-login.md
+++ b/articles/server-platforms/servicestack/01-login.md
@@ -2,6 +2,7 @@
 title: Login
 default: true
 description: This tutorial demonstrates how to use the Auth0 ServiceStack SDK to add authentication and authorization to your web app
+budicon: 448
 ---
 
 <%= include('../../_includes/_package', {

--- a/articles/server-platforms/symfony/01-login.md
+++ b/articles/server-platforms/symfony/01-login.md
@@ -2,6 +2,7 @@
 title: Login
 default: true
 description: This tutorial demonstrates how to use the Auth0 Symfony SDK to add authentication and authorization to your web app
+budicon: 448
 ---
 
 <%= include('../../_includes/_package', {


### PR DESCRIPTION
In support of https://github.com/auth0/manage/pull/2382.

This adds a `budicon` property to the front-matter of all quickstart articles. This value is used in the `TutorialNextSteps` component of `auth0-tutorial-navigator` when it is set to single-article mode.

Since there are quite a few articles, I double-checked that they were all given an icon using:

``` bash
find . -iname '[0-9][0-9]-*' | xargs grep -L "budicon"
```

That should have caught them all. Also, sorry about the clutter in this patch; my IDE is set to remove trailing whitespace on save!
