### PR TITLE
Update clients URL at sidebar menu

### DIFF
--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -13,7 +13,7 @@ articles:
         url: /overview
 
       - title: "Clients"
-        url: "/applications"
+        url: "/clients"
 
       - title: "APIs"
         url: "/apis"


### PR DESCRIPTION
Clicking on the Clients menu of the sidebar was redirecting the user to `https://auth0.com/docs/applications`. The doc was displayed correctly, but I updated the URL in order to display the correct one at the browser's address bar.

![image](https://cloud.githubusercontent.com/assets/11715799/19516251/d8304896-9603-11e6-9787-cf1fc2dde9c7.png)
