### PR TITLE
[edit]: added port 443 for docker.it.auth0.com

### DIFF
--- a/articles/appliance/infrastructure/ip-domain-port-list.md
+++ b/articles/appliance/infrastructure/ip-domain-port-list.md
@@ -95,7 +95,7 @@ Auth0 strives to keep these IP addresses stable, though this is not a given. Fro
     <td>Updates</td>
     <td>Outbound</td>
     <td>docker.it.auth0.com (52.9.124.234)</td>
-    <td>5000</td>
+    <td>5000/443</td>
     <td>Provides updates for Appliance Docker Packages</td>
     <td>Yes</td>
   </tr>


### PR DESCRIPTION
<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->

from the latest version of the appliance (8986)
https://auth0.com/changelog/appliance
The docker repository can now use port 443 instead of port 5000 for getting updates. In some environments using a non-standard port was problematic.
