### PR TITLE
Update docs on scopes for ASP.NET Core quickstarts

### DIFF
--- a/articles/server-platforms/aspnet-core/02-login-embedded-lock.md
+++ b/articles/server-platforms/aspnet-core/02-login-embedded-lock.md
@@ -197,7 +197,7 @@ For the Login screen you can create a Razor view and embed the code for Lock. Yo
       redirectUrl: '@Model.CallbackUrl',
       responseType: 'code',
       params: {
-        scope: 'openid profile',
+        scope: 'openid',
         state: '@Model.State' ,
         nonce: '@Model.Nonce'
       }
@@ -209,8 +209,6 @@ For the Login screen you can create a Razor view and embed the code for Lock. Yo
 ```
 
 Be sure to set the Client ID, Domain and Callback URL values from the ones supplied by the `LockContext` model. Also be sure to set the correct `state` and `nonce` parameters as shown above, as this is the key to getting everyting to work together.
-
-Also note that the `scope` parameter has been changed to add the `profile` scope. The reason for this is that you want the user's `name` returned so you can set the correct `ClaimTypes.Name` claim. This is discussed in more detail in the [User Profile step](/quickstart/webapp/aspnet-core/05-user-profile)
 
 ## Add Login and Logout links
 

--- a/articles/server-platforms/aspnet-core/04-storing-tokens.md
+++ b/articles/server-platforms/aspnet-core/04-storing-tokens.md
@@ -35,61 +35,64 @@ The value will be stored as a property with the name ".Token." suffixed with the
 Once you have retrieved the value of the token, you can then simply store it as a claim for the `ClaimsIdentity`:
 
 ```csharp
-app.UseOpenIdConnectAuthentication(new OpenIdConnectOptions("Auth0")
+var options = new OpenIdConnectOptions("Auth0")
 {
-  // Set the authority to your Auth0 domain
-  Authority = $"https://{auth0Settings.Value.Domain}",
+    // Set the authority to your Auth0 domain
+    Authority = $"https://{auth0Settings.Value.Domain}",
 
-  // Configure the Auth0 Client ID and Client Secret
-  ClientId = auth0Settings.Value.ClientId,
-  ClientSecret = auth0Settings.Value.ClientSecret,
+    // Configure the Auth0 Client ID and Client Secret
+    ClientId = auth0Settings.Value.ClientId,
+    ClientSecret = auth0Settings.Value.ClientSecret,
 
-  // Do not automatically authenticate and challenge
-  AutomaticAuthenticate = false,
-  AutomaticChallenge = false,
+    // Do not automatically authenticate and challenge
+    AutomaticAuthenticate = false,
+    AutomaticChallenge = false,
 
-  // Set response type to code
-  ResponseType = "code",
+    // Set response type to code
+    ResponseType = "code",
 
-  // Set the callback path, so Auth0 will call back to http://localhost:60856/signin-auth0
-  // Also ensure that you have added the URL as an Allowed Callback URL in your Auth0 dashboard
-  CallbackPath = new PathString("/signin-auth0"),
+    // Set the callback path, so Auth0 will call back to http://localhost:5000/signin-auth0 
+    // Also ensure that you have added the URL as an Allowed Callback URL in your Auth0 dashboard 
+    CallbackPath = new PathString("/signin-auth0"),
 
-  // Configure the Claims Issuer to be Auth0
-  ClaimsIssuer = "Auth0",
+    // Configure the Claims Issuer to be Auth0
+    ClaimsIssuer = "Auth0",
 
-  // Saves tokens to the AuthenticationProperties
-  SaveTokens = true,
+    // Saves tokens to the AuthenticationProperties
+    SaveTokens = true,
 
-  Events = new OpenIdConnectEvents()
-  {
-    OnTicketReceived = context =>
+    Events = new OpenIdConnectEvents()
     {
-      // Get the ClaimsIdentity
-      var identity = context.Principal.Identity as ClaimsIdentity;
-      if (identity != null)
-      {
-        // Check if token names are stored in Properties
-        if (context.Properties.Items.ContainsKey(".TokenNames"))
+        OnTicketReceived = context =>
         {
-          // Token names a semicolon separated
-          string[] tokenNames = context.Properties.Items[".TokenNames"].Split(';');
+            // Get the ClaimsIdentity
+            var identity = context.Principal.Identity as ClaimsIdentity;
+            if (identity != null)
+            {
+                // Check if token names are stored in Properties
+                if (context.Properties.Items.ContainsKey(".TokenNames"))
+                {
+                    // Token names a semicolon separated
+                    string[] tokenNames = context.Properties.Items[".TokenNames"].Split(';');
 
-          // Add each token value as Claim
-          foreach (var tokenName in tokenNames)
-          {
-            // Tokens are stored in a Dictionary with the Key ".Token.<token name>"
-            string tokenValue = context.Properties.Items[$".Token.{tokenName}"];
+                    // Add each token value as Claim
+                    foreach (var tokenName in tokenNames)
+                    {
+                        // Tokens are stored in a Dictionary with the Key ".Token.<token name>"
+                        string tokenValue = context.Properties.Items[$".Token.{tokenName}"];
 
-            identity.AddClaim(new Claim(tokenName, tokenValue));
-          }
+                        identity.AddClaim(new Claim(tokenName, tokenValue));
+                    }
+                }
+            }
+
+            return Task.FromResult(0);
         }
-      }
-
-      return Task.FromResult(0);
     }
-  }
-});
+};
+options.Scope.Clear();
+options.Scope.Add("openid");
+app.UseOpenIdConnectAuthentication(options);
 ```
 
 The `access_token` will now be stored as a claim called "access_token", so to retrieve it inside a controller you can simply use `User.Claims.FirstOrDefault("access_token").Value`

--- a/articles/server-platforms/aspnet-core/05-user-profile.md
+++ b/articles/server-platforms/aspnet-core/05-user-profile.md
@@ -102,52 +102,63 @@ Go to the `Views/Shared/_Layout.cshtml` file and update the Navbar section which
 </ul>
 ```
 
-One remaining issue is that the `User.Identity.Name` property used in the Navbar snippet above will look for a claim of type `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name` on the user, but hat claim will not be set and the property will therefor be null.
+A remaining issue is that the `User.Identity.Name` property used in the Navbar snippet above will look for a claim of type `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name` on the user, but hat claim will not be set and the property will therefor be null.
 
-Auth0 will however pass back a `name` claim, so in the `OnTicketReceived` event you will have to retrieve the value of the `name` claim and add a new claim of type `ClaimTypes.Name` (which resolves to `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name`):
+Added to that, none of the user's profile details will be returned in the `id_token` as we a currently only requesting the `openid` scope. Ensure to also request the `name`, `email` and `picture` scopes to ensure that the user's Name, Email address and Profile Image is returned as claims in the `id_token`.  
+
+Once Auth0 passed back the `name` claim, you will have to retrieve the value of the `name` claim in the `OnTicketReceived` event and add a new claim of type `ClaimTypes.Name` (which resolves to `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name`). This will ensure that the user's name is returned when accessing the `User.Identity.Name` property.
 
 ```csharp
-app.UseOpenIdConnectAuthentication(new OpenIdConnectOptions("Auth0")
+var options = new OpenIdConnectOptions("Auth0")
 {
-  // Set the authority to your Auth0 domain
-  Authority = $"https://{auth0Settings.Value.Domain}",
+    // Set the authority to your Auth0 domain
+    Authority = $"https://{auth0Settings.Value.Domain}",
 
-  // Configure the Auth0 Client ID and Client Secret
-  ClientId = auth0Settings.Value.ClientId,
-  ClientSecret = auth0Settings.Value.ClientSecret,
+    // Configure the Auth0 Client ID and Client Secret
+    ClientId = auth0Settings.Value.ClientId,
+    ClientSecret = auth0Settings.Value.ClientSecret,
 
-  // Do not automatically authenticate and challenge
-  AutomaticAuthenticate = false,
-  AutomaticChallenge = false,
+    // Do not automatically authenticate and challenge
+    AutomaticAuthenticate = false,
+    AutomaticChallenge = false,
 
-  // Set response type to code
-  ResponseType = "code",
+    // Set response type to code
+    ResponseType = "code",
 
-  // Set the callback path, so Auth0 will call back to http://localhost:60856/signin-auth0
-  // Also ensure that you have added the URL as an Allowed Callback URL in your Auth0 dashboard
-  CallbackPath = new PathString("/signin-auth0"),
+    // Set the callback path, so Auth0 will call back to http://localhost:5000/signin-auth0 
+    // Also ensure that you have added the URL as an Allowed Callback URL in your Auth0 dashboard 
+    CallbackPath = new PathString("/signin-auth0"),
 
-  // Configure the Claims Issuer to be Auth0
-  ClaimsIssuer = "Auth0",
+    // Configure the Claims Issuer to be Auth0
+    ClaimsIssuer = "Auth0",
 
-  Events = new OpenIdConnectEvents
-  {
-    OnTicketReceived = context =>
+    // Saves tokens to the AuthenticationProperties
+    SaveTokens = true,
+
+    Events = new OpenIdConnectEvents
     {
-      // Get the ClaimsIdentity
-      var identity = context.Principal.Identity as ClaimsIdentity;
-      if (identity != null)
-      {
-        // Add the Name ClaimType. This is required if we want User.Identity.Name to actually return something!
-        if (!context.Principal.HasClaim(c => c.Type == ClaimTypes.Name) &&
-            identity.HasClaim(c => c.Type == "name"))
-            identity.AddClaim(new Claim(ClaimTypes.Name, identity.FindFirst("name").Value));
-      }
+        OnTicketReceived = context =>
+        {
+            // Get the ClaimsIdentity
+            var identity = context.Principal.Identity as ClaimsIdentity;
+            if (identity != null)
+            {
+                // Add the Name ClaimType. This is required if we want User.Identity.Name to actually return something!
+                if (!context.Principal.HasClaim(c => c.Type == ClaimTypes.Name) &&
+                    identity.HasClaim(c => c.Type == "name"))
+                    identity.AddClaim(new Claim(ClaimTypes.Name, identity.FindFirst("name").Value));
+            }
 
-      return Task.FromResult(0);
+            return Task.FromResult(0);
+        }
     }
-  }
-});
+};
+options.Scope.Clear();
+options.Scope.Add("openid");
+options.Scope.Add("name");
+options.Scope.Add("email");
+options.Scope.Add("picture");
+app.UseOpenIdConnectAuthentication(options);
 ```
 
 Now, after the user has signed it you will be able to see the user's name in the top right corner of the Navbar:

--- a/articles/server-platforms/aspnet-core/07-rules.md
+++ b/articles/server-platforms/aspnet-core/07-rules.md
@@ -14,8 +14,6 @@ budicon: 173
   pkgType: 'replace'
 }) %>
 
-
-
 <%= include('../_includes/_rules-introduction') %>
 
 ## Display the Country in the User Profile
@@ -83,6 +81,26 @@ And finally display the country in the profile view:
   </div>
 </div>
 ```
+
+## Ensure the Country scope is requested
+
+You will also need to ensure that you request the `country` scope. This will ensure that the `country` claim is returned in the `id_token`. Go back to the `Configure` method of the `Startup` class and update the registration of the OIDC middleware to request the `country` scope:
+
+```csharp
+var options = new OpenIdConnectOptions("Auth0")
+{
+    // Code omitted for brevity...
+};
+options.Scope.Clear();
+options.Scope.Add("openid");
+options.Scope.Add("name");
+options.Scope.Add("email");
+options.Scope.Add("picture");
+options.Scope.Add("country");
+app.UseOpenIdConnectAuthentication(options);
+``` 
+
+## Run the application
 
 Now when you run the application you will be able to see the user's country displayed:
 

--- a/articles/server-platforms/aspnet-core/08-authorization.md
+++ b/articles/server-platforms/aspnet-core/08-authorization.md
@@ -14,8 +14,6 @@ budicon: 546
   pkgType: 'replace'
 }) %>
 
-
-
 <%= include('../_includes/_authorization-introduction', { ruleslink: '/docs/quickstart/webapp/aspnet-core/07-rules' }) %>
 
 ## Restrict an Action Based on a User's Roles
@@ -37,3 +35,22 @@ public IActionResult Admin()
   return View();
 }
 ```
+
+## Ensure the Roles scope is requested
+
+You will also need to ensure that you request the `roles` scope. This will ensure that the `roles` claim is returned in the `id_token`. Go back to the `Configure` method of the `Startup` class and update the registration of the OIDC middleware to request the `roles` scope:
+
+```csharp
+var options = new OpenIdConnectOptions("Auth0")
+{
+    // Code omitted for brevity...
+};
+options.Scope.Clear();
+options.Scope.Add("openid");
+options.Scope.Add("name");
+options.Scope.Add("email");
+options.Scope.Add("picture");
+options.Scope.Add("country");
+options.Scope.Add("roles");
+app.UseOpenIdConnectAuthentication(options);
+``` 


### PR DESCRIPTION
I updated the ASP.NET Core quickstart to ensure that we are more explicit about the scopes being requested and not just request the `profile` scope by default.

This is in response to the following Slack request:
https://auth0.slack.com/archives/quickstarts/p1475847386000420
