### PR TITLE
Add GitLab doc under Rules

### DIFF
--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -55,11 +55,14 @@ articles:
       - title: "User Metadata in Rules"
         url: "/rules/metadata-in-rules"
 
-      - title: "Deploy Rules with Github"
+      - title: "Deploy Rules with GitHub"
         url: "/extensions/github-deploy"
 
       - title: "Deploy Rules with Bitbucket"
         url: "/extensions/bitbucket-deploy"
+      
+      - title: "Deploy Rules with GitLab"
+        url: "/extensions/gitlab-deploy"
 
   - title: "API Authorization"
     url: "/api-auth"


### PR DESCRIPTION
Add GitLab extension link under the Articles > Rules menu.

![image](https://cloud.githubusercontent.com/assets/11715799/19554739/91e3b9e4-96c2-11e6-9666-f1b2a12dab63.png)
