### PR TITLE
Remove _preview-warning include

### DIFF
--- a/articles/client-platforms/jquery/11-api-authorization.md
+++ b/articles/client-platforms/jquery/11-api-authorization.md
@@ -6,7 +6,6 @@ budicon: 500
 
 <%= include('../../_includes/_api_auth_intro') %>
 
-<%= include('../../api-auth/_preview-warning') %>
 <%= include('../../_includes/_compat_warning') %>
 
 ### Before Starting


### PR DESCRIPTION
Build fails because this file refers to a file that was deleted
