### PR TITLE
[Rule] Specify that the callback should use `UnauthorizedError`

### DIFF
--- a/articles/rules/index.md
+++ b/articles/rules/index.md
@@ -131,7 +131,7 @@ function (user, context, callback) {
 }
 ```
 
-This will cause a redirect to your callback url with an `error` querystring parameter containing the message you set. (e.g.: `https://yourapp.com/callback?error=unauthorized&error_description=Only%20admins%20can%20use%20this`)
+This will cause a redirect to your callback url with an `error` querystring parameter containing the message you set. (e.g.: `https://yourapp.com/callback?error=unauthorized&error_description=Only%20admins%20can%20use%20this`). Make sure to call the callback with an instance of `UnauthorizedError` (not `Error`).
 
 > Error reporting to the app depends on the protocol. OpenID Connect apps will receive the error in the querystring. SAML apps will receive the error in a `SAMLResponse`.
 


### PR DESCRIPTION
I think this has to be stated explicitly, since it is pretty common to just use the standard `Error` class in JavaScript.
