### PR TITLE
Migration state redirect after rule 

### DIFF
--- a/articles/email/templates.md
+++ b/articles/email/templates.md
@@ -29,7 +29,7 @@ The **From Address** field supports the following macros:
 * `{application.name}`
 * `{connection.name}`
 
-You can use these macros to set the display name of the **From Address** to something that relates to the application for which the user signed up. For example, the field could display `{application.name} <support@fabrikamcorp.com>`, as opposed to simply `<support@fabrikamcorp.com>`.
+You can use these macros to set the display name of the **From Address** to something that relates to the application for which the user signed up. For example, the field could display `{application.name} <support@fabrikamcorp.com>`, as opposed to simply `<support@fabrikamcorp.com>`. Use of liquid syntax in the from field is not supported. 
 
 You must add the [Sender Policy Framework (SPF)](http://en.wikipedia.org/wiki/Sender_Policy_Framework) and [DomainKeys Identified Mail (DKIM)](http://en.wikipedia.org/wiki/DKIM) DNS records to your domain's zone file to allow Auth0 to send digitally-signed emails on your behalf. Without these records, the emails may end up in your users' junkmail folders. Additionally, your users may see the following as the **From Address**:
 

--- a/articles/migrations/index.md
+++ b/articles/migrations/index.md
@@ -31,8 +31,7 @@ Current migrations are listed below, newest first.
 
 When a redirect is done from an Auth0 rule, Auth0 takes care of generating and sending a state parameter in HTTP and Auth0 will check for a valid state parameter when flow returns to the /continue endpoint.  The site to which the redirect goes has to capture the value of the state parameter and return it by adding it as a parameter when returning to the /continue endpoint. 
 
-This is documented at:
-https://auth0.com/docs/rules/redirect#what-to-do-after-redirecting
+This is documented [here](/rules/redirect#what-to-do-after-redirecting)
 
 #### Am I affected by the change? 
 You are effected by the change only if you redirect from rules, and do not yet capture and return (to the /continue end point) the state parameter.  

--- a/articles/migrations/index.md
+++ b/articles/migrations/index.md
@@ -23,6 +23,21 @@ If you need help with the migration, create a ticket in our [Support Center](htt
 ## Current Migrations
 Current migrations are listed below, newest first.
 
+### State Parameter required on redirect from rule
+
+| Severity | Effective Date |
+| --- | --- | --- | --- |
+| High | 2016-11-01 |
+
+When a redirect is done from an Auth0 rule, Auth0 takes care of generating and sending a state parameter in HTTP and Auth0 will check for a valid state parameter when flow returns to the /continue endpoint.  The site to which the redirect goes has to capture the value of the state parameter and return it by adding it as a parameter when returning to the /continue endpoint. 
+
+This is documented at:
+https://auth0.com/docs/rules/redirect#what-to-do-after-redirecting
+
+#### Am I affected by the change? 
+You are effected by the change only if you redirect from rules, and do not yet capture and return (to the /continue end point) the state parameter.  
+
+
 ### Delete All Users Endpoint Change
 
 | Severity | Effective Date |


### PR DESCRIPTION
+### State Parameter required on redirect from rule
 +
 +| Severity | Effective Date |
 +| --- | --- | --- | --- |
 +| High | 2016-11-01 |
 +
 +When a redirect is done from an Auth0 rule, Auth0 takes care of generating and sending a state parameter in HTTP and Auth0 will check for a valid state parameter when flow returns to the /continue endpoint.  The site to which the redirect goes has to capture the value of the state parameter and return it by adding it as a parameter when returning to the /continue endpoint. 
 +
 +This is documented [here](/rules/redirect#what-to-do-after-redirecting)
 +
 +#### Am I affected by the change? 
 +You are effected by the change only if you redirect from rules, and do not yet capture and return (to the /continue end point) the state parameter.
 +
 <!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
