### PR TITLE
Load lock widget from Auth0 CDN via HTTPS

### DIFF
--- a/articles/client-platforms/angular2/_includes/_dependencies.md
+++ b/articles/client-platforms/angular2/_includes/_dependencies.md
@@ -10,7 +10,7 @@ To integrate your Angular 2 application with Auth0, you will need to add the fol
 
   Or the Auth0 CDN:
 
-  `<script src="http://cdn.auth0.com/js/lock/10.2/lock.min.js"></script>`
+  `<script src="https://cdn.auth0.com/js/lock/10.2/lock.min.js"></script>`
 
 - [angular2-jwt](https://github.com/auth0/angular2-jwt) is a helper library for working with [JWTs](http://jwt.io/introduction) in your Angular 2 applications.
 


### PR DESCRIPTION
Client applications delivered via HTTPS (which always is a good idea in authentication contexts) won’t be able to load the lock widget from the Auth0 CDN via HTTP.