### PR TITLE
Replace TOC for automatic boolean attribute.

### DIFF
--- a/articles/architecture-scenarios/application/server-api.md
+++ b/articles/architecture-scenarios/application/server-api.md
@@ -4,6 +4,7 @@ title: Server Client + API
 image: /docs/media/articles/architecture-scenarios/server-api.png
 extract: Server to server communication where a server “Client” needs to make secure calls to an API (“Resource Server”), but on behalf of the client vs. a user.
 description: Explains the architecture scenario with server to server communication with secure calls to an API (“Resource Server”), but on behalf of the client vs. a user.
+toc: true
 ---
 
 # Server + API
@@ -11,30 +12,6 @@ description: Explains the architecture scenario with server to server communicat
 In this scenario we will build a Timesheet API for a fictitious company named ABC Inc. The API will allow to add timesheet entries for an employee or a contractor.
 
 We will also be building a cron job which will process timesheet entries from an external system to the centralized timesheet database using the API.
-
-__Table of Contents__
-- [The Premise](#the-premise)
-  - [Goals & Requirements](#goals-requirements)
-- [Overview of the Solution](#overview-of-the-solution)
-  - [API Authentication and Authorization](#api-authentication-and-authorization)
-    - [Participants](#participants)
-  - [Client Credentials Grant](#client-credentials-grant)
-- [Auth0 Configuration](#auth0-configuration)
-  - [Configure the API](#configure-the-api)
-    - [Signing Algorithms](#signing-algorithms)
-  - [Configure the Scopes](#configure-the-scopes)
-  - [Create the Client](#create-the-client)
-  - [Configure Client's access to the API](#configure-client-s-access-to-the-api)
-- [Inside the Implementation](#inside-the-implementation)
-    - [Implement the API](#implement-the-api)
-      - [Define the API endpoints](#define-the-api-endpoints)
-      - [Secure the API endpoints](#secure-the-api-endpoints)
-        - [Get an Access Token](#get-an-access-token)
-      - [Check the Client permissions](#check-the-client-permissions)
-    - [Implement the Non Interactive Client](#implement-the-non-interactive-client)
-      - [Get an Access Token](#get-an-access-token)
-      - [Invoke the API](#invoke-the-api)
-- [Conclusion](#conclusion)
 
 ## The Premise
 

--- a/articles/architecture-scenarios/application/web-app-sso.md
+++ b/articles/architecture-scenarios/application/web-app-sso.md
@@ -4,42 +4,7 @@ title: Single Sign-On for Regular Web Apps
 image: /docs/media/articles/architecture-scenarios/web-oidc.png
 extract: Traditional web application which needs to authenticate users using OpenID Connect.
 description: Regular web app scenario which needs to authenticate users using OpenID Connect.
-toc:
-  -
-    name: The premise
-    children:
-      -
-        name: Goals & Requirements
-        id: goals-requirements
-  -
-    name: Overview of the Solution
-    children:
-      -
-        name: Identity Management
-      -
-        name: Which protocol to use
-      -
-        name: Authentication Flow
-  -
-    name: Auth0 Configuration
-    children:
-      -
-        name: Client
-      -
-        name: Connections
-  -
-    name: Inside the Implementation
-    children:
-      -
-        name: User Login
-      -
-        name: Session Management
-      -
-        name: User Logout
-      -
-        name: Access Control
-  -
-    name: Conclusion
+toc: true
 ---
 
 # Single Sign-On for Regular Web Apps


### PR DESCRIPTION
- Add `toc: true` in article configuration to set automatic table of content configuration.
- TOC hierarchy based in article titles.
- Only support two levels of indentation (`<h2>` and `<h3>` titles)