### PR TITLE
Add redirect for oauth-web-protocol

### DIFF
--- a/config/redirect-urls.json
+++ b/config/redirect-urls.json
@@ -969,6 +969,10 @@
     "to": "/protocols/oauth2/oauth-web-protocol"
   },
   {
+    "from": "/protocols/oauth-web-protocol",
+    "to": "/protocols/oauth2/oauth-web-protocol"
+  },
+  {
     "from": "/oauth-implicit-protocol",
     "to": "/protocols/oauth2/oauth-implicit-protocol"
   },


### PR DESCRIPTION
https://auth0.com/docs/protocols/oauth-web-protocol gives a `404`

Added redirect to https://auth0.com/docs/protocols/oauth2/oauth-web-protocol