### PR TITLE
Add note on email notification when adfs cert close to expiration

### DIFF
--- a/articles/connections/enterprise/adfs.md
+++ b/articles/connections/enterprise/adfs.md
@@ -18,7 +18,7 @@ Provide this information to your ADFS administrator:
 
 **Note:** If you want to use the [/oauth/ro](/auth-api#post--oauth-ro) endpoint you must enable `/adfs/services/trust/13/usernamemixed`.
 
-**Note**: The Federation Metadata file contains information about the ADFS server's certificates. If the Federation Metadata endpoint (`/FederationMetadata/2007-06/FederationMetadata.xml`) is enabled in ADFS, Auth0 can periodically (once a day) look for changes in the configuration, like a new signing certificate added to prepare for a rollover. Because of this, enabling the Federation Metadata endpoint is preferred to providing a standalone metadata file.
+**Note**: The Federation Metadata file contains information about the ADFS server's certificates. If the Federation Metadata endpoint (`/FederationMetadata/2007-06/FederationMetadata.xml`) is enabled in ADFS, Auth0 can periodically (once a day) look for changes in the configuration, like a new signing certificate added to prepare for a rollover. Because of this, enabling the Federation Metadata endpoint is preferred to providing a standalone metadata file. If you provide a standalone metadata file, we will notify you via email when the certificates are close to their expiration date.
 
 ### Scripted setup
 


### PR DESCRIPTION
This PR elaborates on the fact that we send email notifications when a customer's AFDS connection certificate is close to expiration, only in the case of an uploaded standalone metadata file.