### PR TITLE
Removed double-interpolation in snippets

### DIFF
--- a/snippets/api-auth/hs256/csharp.md
+++ b/snippets/api-auth/hs256/csharp.md
@@ -7,12 +7,12 @@ public class Startup
 {
   public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
   {
-    var keyAsBytes = Encoding.ASCII.GetBytes("${'<%= api.signing_secret %>'}");
+    var keyAsBytes = Encoding.ASCII.GetBytes("<%= api.signing_secret %>");
 
     var options = new JwtBearerOptions
     {
-      Audience = "${'<%= api.identifier %>'}",
-      Authority = "${'https://<%= tenantDomain %>'}/",
+      Audience = "<%= api.identifier %>",
+      Authority = "https://<%= tenantDomain %>/",
       TokenValidationParameters =
       {
         IssuerSigningKey = new SymmetricSecurityKey(keyAsBytes)

--- a/snippets/api-auth/hs256/go.md
+++ b/snippets/api-auth/hs256/go.md
@@ -5,7 +5,7 @@ title: Go
 ```go
 jwtMiddleware := jwtmiddleware.New(jwtmiddleware.Options{
   ValidationKeyGetter: func(token *jwt.Token) (interface{}, error) {
-    return []byte("${'<%= api.signing_secret %>'}"), nil
+    return []byte("<%= api.signing_secret %>"), nil
   },
   SigningMethod: jwt.SigningMethodHS256,
 })

--- a/snippets/api-auth/hs256/java.md
+++ b/snippets/api-auth/hs256/java.md
@@ -3,9 +3,9 @@ title: Java
 ---
 
 ```java
-final String issuer = "${'https://<%= tenantDomain %>'}/";
-final String audience = "${'<%= api.identifier %>'}";
-final String secret = "${'<%= api.signing_secret %>'}";
+final String issuer = "https://<%= tenantDomain %>/";
+final String audience = "<%= api.identifier %>";
+final String secret = "<%= api.signing_secret %>";
 
 final JWTVerifier jwtVerifier = new JWTVerifier(secret, audience, issuer);
 

--- a/snippets/api-auth/hs256/nodejs.md
+++ b/snippets/api-auth/hs256/nodejs.md
@@ -10,9 +10,9 @@ var jwt = require('express-jwt');
 var port = process.env.PORT || 8080;
 
 var jwtCheck = jwt({
-  secret: '${ "<%= api.signing_secret %>" }',
-  audience: '${ "<%= api.identifier %>" }',
-  issuer: "${'https://<%= tenantDomain %>'}/"
+  secret: '<%= api.signing_secret %>',
+  audience: '<%= api.identifier %>',
+  issuer: 'https://<%= tenantDomain %>'
 });
 
 // enforce on all endpoints

--- a/snippets/api-auth/hs256/php.md
+++ b/snippets/api-auth/hs256/php.md
@@ -6,8 +6,8 @@ title: PHP
 use Auth0\SDK\JWTVerifier;
 
 $verifier = new JWTVerifier([
-    'valid_audiences' => ['${"<%= api.identifier %>"}'],
-    'client_secret' => '${"<%= api.signing_secret %>"}'
+    'valid_audiences' => ['<%= api.identifier %>'],
+    'client_secret' => '<%= api.signing_secret %>'
 ]);
 
 $decoded = $verifier->verifyAndDecode($token);

--- a/snippets/api-auth/hs256/python.md
+++ b/snippets/api-auth/hs256/python.md
@@ -7,7 +7,7 @@ import jwt
 
 payload = jwt.decode(
   token,
-  '${"<%= api.signing_secret %>"}',
-  audience='${"<%= api.identifier %>"}'
+  '<%= api.signing_secret %>',
+  audience='<%= api.identifier %>'
   )
 ```

--- a/snippets/api-auth/hs256/ruby.md
+++ b/snippets/api-auth/hs256/ruby.md
@@ -3,7 +3,7 @@ title: Ruby
 ---
 
 ```ruby
-hmac_secret = '${"<%= api.signing_secret %>"}'
+hmac_secret = '<%= api.signing_secret %>'
 
-decoded_token = JWT.decode token, hmac_secret, true, { :iss => '${"https://<%= tenantDomain %>"}/', :verify_iss => true, :aud => '${"<%= api.identifier %>"}', :verify_aud => true, :algorithm => 'HS256' }
+decoded_token = JWT.decode token, hmac_secret, true, { :iss => 'https://<%= tenantDomain %>/', :verify_iss => true, :aud => '<%= api.identifier %>', :verify_aud => true, :algorithm => 'HS256' }
 ```

--- a/snippets/api-auth/rs256/csharp.md
+++ b/snippets/api-auth/rs256/csharp.md
@@ -9,8 +9,8 @@ public class Startup
   {
     var options = new JwtBearerOptions
     {
-      Audience = "${'<%= api.identifier %>'}",
-      Authority = "https://${'<%= tenantDomain %>'}/"
+      Audience = "<%= api.identifier %>",
+      Authority = "https://<%= tenantDomain %>/"
     };
     app.UseJwtBearerAuthentication(options);
 

--- a/snippets/api-auth/rs256/nodejs.md
+++ b/snippets/api-auth/rs256/nodejs.md
@@ -13,8 +13,8 @@ var port = process.env.PORT || 8080;
 var jwtCheck = jwt({
   secret: rsaValidation(),
   algorithms: ['RS256'],
-  issuer: "https://${'<%= tenantDomain %>'}/",
-  audience: '${ "<%= api.identifier %>" }'
+  issuer: 'https://<%= tenantDomain %>',
+  audience: '<%= api.identifier %>'
 });
 
 app.use(jwtCheck);

--- a/snippets/api-auth/rs256/php.md
+++ b/snippets/api-auth/rs256/php.md
@@ -7,8 +7,8 @@ use Auth0\SDK\JWTVerifier;
 use Auth0\SDK\Helpers\Cache\FileSystemCacheHandler;
 
 $verifier = new JWTVerifier([
-    'valid_audiences' => ['${"<%= api.identifier %>"}'],
-    'authorized_iss' => ['https://${"<%= tenantDomain %>"}'],
+    'valid_audiences' => ['<%= api.identifier %>'],
+    'authorized_iss' => ['https://<%= tenantDomain %>'],
     'cache' => new FileSystemCacheHandler() // This parameter is optional. By default no cache is used to fetch the Json Web Keys.
 ]);
 

--- a/snippets/api-auth/rs256/python.md
+++ b/snippets/api-auth/rs256/python.md
@@ -10,5 +10,5 @@ cert_str = "-----BEGIN CERTIFICATE-----MIIDETCCAfm..."
 cert_obj = load_pem_x509_certificate(cert_str, default_backend())
 public_key = cert_obj.public_key()
 
-jwt.decode(token, public_key, audience='${"<%= api.identifier %>"}', algorithms=['RS256'])
+jwt.decode(token, public_key, audience='<%= api.identifier %>', algorithms=['RS256'])
 ```

--- a/snippets/api-auth/rs256/ruby.md
+++ b/snippets/api-auth/rs256/ruby.md
@@ -5,5 +5,5 @@ title: Ruby
 ```ruby
 rsa_public = OpenSSL::PKey.read(File.read(File.join(CERT_PATH, 'cert.pem')))
 
-decoded_token = JWT.decode token, rsa_public, true, { :iss => '${"https://<%= tenantDomain %>"}/', :verify_iss => true, :aud => '${"<%= api.identifier %>"}', :verify_aud => true, :algorithm => 'RS256' }
+decoded_token = JWT.decode token, rsa_public, true, { :iss => 'https://<%= tenantDomain %>/', :verify_iss => true, :aud => '<%= api.identifier %>', :verify_aud => true, :algorithm => 'RS256' }
 ```


### PR DESCRIPTION
Fixes https://github.com/auth0/auth0-docs/issues/1225.

Before the new document compilation pipeline, the contents of snippets were processed as templates. Since the HS256/RS256 snippets contained interpolation statements that are replaced by the management site, these statements had to be double-interpolated in order to "escape" them, such as:

```
${'<%= api.signing_secret %>'}
```

The new pipeline doesn't treat the raw snippet content as a template, only attempting to replace variables if they are actually included in a document via a call to `snippet()`. This means the double-interpolation is no longer needed.

An example of this behavior can be seen in the API response here:
https://auth0.com/docs/meta/snippets/api-auth/hs256/csharp