### PR TITLE
Fixed if conditional in _package include

### DIFF
--- a/articles/_includes/_package.html
+++ b/articles/_includes/_package.html
@@ -15,7 +15,7 @@
       <% } %>
     </div>
     <div class="package-buttons">
-      <% if (account.clientId && account.clientId !== 'YOUR_CLIENT_ID') { %>
+      <% if (account.clientId && account.clientId !== '__AUTH0_CLIENT_ID__') { %>
       <a href="/package/v2?org=${org}&repo=${repo}&path=${path}&client_id=${account.clientId}" class="btn btn-sm btn-success" rel="nofollow">Download</a>
       <% } else { %>
       <a href="/package/v2?org=${org}&repo=${repo}&path=${path}" class="btn btn-sm btn-success" rel="nofollow">Download</a>


### PR DESCRIPTION
The default value for `account.clientId` was changed recently as part of enabling work to move user-specific variable replacement to the client. This broke an `if` conditional in `_package.html` which determined whether to link the user to a package customized for their client. This patch fixes the regression by testing it against the new default value.