### PR TITLE
Always send client_id to packager, even if it's the default value

### DIFF
--- a/articles/_includes/_package.html
+++ b/articles/_includes/_package.html
@@ -15,11 +15,7 @@
       <% } %>
     </div>
     <div class="package-buttons">
-      <% if (account.clientId && account.clientId !== '__AUTH0_CLIENT_ID__') { %>
       <a href="/package/v2?org=${org}&repo=${repo}&path=${path}&client_id=${account.clientId}" class="btn btn-sm btn-success" rel="nofollow">Download</a>
-      <% } else { %>
-      <a href="/package/v2?org=${org}&repo=${repo}&path=${path}" class="btn btn-sm btn-success" rel="nofollow">Download</a>
-      <% } %>
       <a href="https://github.com/${org || 'auth0-samples'}/${repo}/tree/master/${path}" class="github-link" rel="nofollow">Fork on Github</a>
     </div>
   </div>


### PR DESCRIPTION
In conjunction with https://github.com/auth0/auth0-docs/pull/1243, closes https://github.com/auth0/auth0-docs/issues/1240.