### PR TITLE
Decorators in python are not annotations

### DIFF
--- a/articles/server-apis/python/authenticate.md
+++ b/articles/server-apis/python/authenticate.md
@@ -27,15 +27,15 @@ In this example, we'll be using Flask and we'll be validating the JWT. For that,
 
 ${snippet(meta.snippets.dependencies)}
 
-### 2. Create the JWT Validation annotation
+### 2. Create the JWT Validation decorator
 
-Now, you need to validate the [JWT](/jwt). For that, we'll create a custom annotation.
+Now, you need to validate the [JWT](/jwt). For that, we'll create a custom decorator.
 
 ${snippet(meta.snippets.setup)}
 
-### 3. Use this annotation in your methods
+### 3. Use this decorator in your methods
 
-Now, you can just use this annotation in your methods
+Now, you can just decorate any route's method that requires authentication
 
 ${snippet(meta.snippets.use)}
 


### PR DESCRIPTION
<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->

Decorators in python are quite different from annotations (From Java's perspective). Though syntax-wise they're similar, Python decorators are just another way of passing a function as an argument to another function.