### PR TITLE
Added fullWidth metadata property to new auth api doc

### DIFF
--- a/articles/api/authentication/index.md
+++ b/articles/api/authentication/index.md
@@ -1,5 +1,6 @@
 ---
 title: Authorization API Explorer
+fullWidth: true
 ---
 
 <div class="api-section" data-section="none">


### PR DESCRIPTION
This supports the new method of handling full-width documents added as part of https://github.com/auth0/auth0-docs/pull/1257.