### PR TITLE
Add warning about disabled impersonation

### DIFF
--- a/articles/api/authentication/_impersonation.md
+++ b/articles/api/authentication/_impersonation.md
@@ -60,6 +60,10 @@ include('../../_includes/_http-method', {
   "link": "#impersonation"
 }) %>
 
+::: panel-warning Advanced Feature
+Impersonation functionality may be disabled by default for your tenant, but can be enabled by [contacting support](https://support.auth0.com/).
+:::
+
 Use this endpoint to obtain an impersonation URL to login as another user. Useful for troubleshooting.
 
 


### PR DESCRIPTION
Warn that impersonation may be disabled by default, and that they should contact support to enable it.

Part of the overall tracked here: https://github.com/auth0/crew-2/issues/247