### PR TITLE
Authentication API Explorer fixes

### DIFF
--- a/articles/api/authentication/_impersonation.md
+++ b/articles/api/authentication/_impersonation.md
@@ -41,7 +41,7 @@ xhr.send(params);
 
 > RESPONSE SAMPLE:
 
-```http
+```text
 https:/YOUR_DOMAIN/users/IMPERSONATOR_ID/impersonate?&bewit=WFh0MUtm...
 ```
 

--- a/articles/api/authentication/_login.md
+++ b/articles/api/authentication/_login.md
@@ -353,7 +353,7 @@ $('.login-dbconn').click(function () {
 }) %>
 
 ::: panel-warning Deprecation Notice
-This endpoint will soon be deprecated. The [POST /oauth/token { grant_type: password }](#resource-owner-password) should be used instead.
+This endpoint will be deprecated. Customers will be notified and given ample time to migrate once an official deprecation notice is posted. The [POST /oauth/token { grant_type: password }](#resource-owner-password) should be used instead.
 :::
 
 Use this endpoint for API-based (active) authentication. Given the user credentials and the `connection` specified, it will do the authentication on the provider and return a JSON with the `access_token` and `id_token`.

--- a/articles/api/authentication/_passwordless.md
+++ b/articles/api/authentication/_passwordless.md
@@ -211,7 +211,7 @@ auth0.verifySMSCode({
 }) %>
 
 ::: panel-warning Deprecation Notice
-This endpoint will soon be deprecated. The [POST /oauth/token { grant_type: password }](#resource-owner-password) should be used instead.
+This endpoint will be deprecated. Customers will be notified and given ample time to migrate once an official deprecation notice is posted. The [POST /oauth/token { grant_type: password }](#resource-owner-password) should be used instead.
 :::
 
 Once you have a verification code, use this endpoint to login the user with their phone number/email and verification code. This is active authentication, so the user must enter the code in your app.

--- a/articles/api/authentication/_userinfo.md
+++ b/articles/api/authentication/_userinfo.md
@@ -149,7 +149,7 @@ auth0.getProfile(idToken, function (err, profile) {
 }) %>
 
 ::: panel-warning Deprecation Notice
-This endpoint will soon be deprecated. The [GET /userinfo](#get-user-info) endpoint should be used instead to retrieve user information.
+This endpoint will be deprecated. Customers will be notified and given ample time to migrate once an official deprecation notice is posted. The [GET /userinfo](#get-user-info) endpoint should be used instead to retrieve user information.
 :::
 
 This endpoint validates a JSON Web Token (signature and expiration) and returns the user information associated with the user id `sub` property of the token.

--- a/articles/api/authentication/api-authz/_authz-client.md
+++ b/articles/api/authentication/api-authz/_authz-client.md
@@ -35,7 +35,7 @@ GET https://${account.namespace}/authorize?
 
 > RESPONSE SAMPLE
 
-```http
+```text
 HTTP/1.1 302 Found
 Location: https://YOUR_APP_URL/callback?code=RESPONSE_CODE&state=YOUR_STATE
 ```
@@ -85,7 +85,7 @@ GET https://${account.namespace}/authorize?
 
 > RESPONSE SAMPLE
 
-```http
+```text
 HTTP/1.1 302 Found
 Location: https://YOUR_APP_URL/callback?code=RESPONSE_CODE
 ```
@@ -140,7 +140,7 @@ GET https://${account.namespace}/authorize?
 
 > RESPONSE SAMPLE
 
-```http
+```text
 HTTP/1.1 302 Found
 Location: http://YOUR_APP_URL/callback#access_token=TOKEN&state=STATE&token_type=TYPE&expires_in=SECONDS
 ```

--- a/articles/api/authentication/api-authz/_resource-owner.md
+++ b/articles/api/authentication/api-authz/_resource-owner.md
@@ -63,7 +63,7 @@ request(options, function (error, response, body) {
 }) %>
 
 ::: panel-warning Deprecation Notice
-This endpoint will be deprecated soon. The `/oauth/token { grant_type: password }` should be used instead.
+This endpoint will be deprecated. Customers will be notified and given ample time to migrate once an official deprecation notice is posted. The `/oauth/token { grant_type: password }` should be used instead.
 :::
 
 Given the user's credentials, this endpoint will authenticate the user with the provider and return a JSON object with the `access_token` and an `id_token`.


### PR DESCRIPTION
- HTTP response snippets are not displayed at the curl/js tabs. Replacing with `text`.
- Update deprecation notice text.