### PR TITLE
Update authenticate.md

### DIFF
--- a/articles/server-apis/nodejs/authenticate.md
+++ b/articles/server-apis/nodejs/authenticate.md
@@ -29,6 +29,7 @@ ${snippet(meta.snippets.dependencies)}
 
 You need to set the ClientID and ClientSecret in `express-jwt`'s configuration so that it can validate and sign [JWT](/jwt)s for you.
 
+> Make sure to base64 encode your secret: `new Buffer('your_auth0_secret', 'base64')`
 ${snippet(meta.snippets.setup)}
 
 ### 3. Secure your API


### PR DESCRIPTION
When copy pasting the basic lock example for the client side, and the basic express-jwt example from this document for the server side, you end up with `401: invalid token`.

This isn't a great "getting started" experience.

When base64 encoding your secret on the server side, it starts working.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
