### PR TITLE
Added redirects for old two-step quickstarts

### DIFF
--- a/config/redirect-urls.json
+++ b/config/redirect-urls.json
@@ -568,6 +568,10 @@
     "to": "/quickstart/native-mobile/:platform/rails"
   },
   {
+    "from": "/quickstart/native-mobile/:platform/:api",
+    "to": "/quickstart/native-mobile/:platform"
+  },
+  {
     "from": "/mfa",
     "to": "/multifactor-authentication"
   },


### PR DESCRIPTION
This should fix the error we're seeing where old "two-step" quickstart URLs (including a frontend and backend technology) are redirecting to 404s.