### PR TITLE
AuthN API: Fix script that calculates debugger URL

### DIFF
--- a/articles/_includes/_test-this-endpoint.md
+++ b/articles/_includes/_test-this-endpoint.md
@@ -1,7 +1,11 @@
 Your can use our **Authentication API Debugger** extension to test this endpoint. Click on **Install Debugger** to go to the article that explains how (you only have to do this once).
 
 <%
-  if(account.tenant.indexOf('.') !== -1){
+  var tenantWithLoc = account.namespace.slice(0, account.namespace.length - 10);
+%>
+
+<%
+  if(tenantWithLoc.indexOf('.') !== -1){
     var debugURL = 'https://' + account.tenant + '.webtask.io/auth0-authentication-api-debugger';
   } else {
     var debugURL = 'https://' + account.tenant + '.us.webtask.io/auth0-authentication-api-debugger';

--- a/articles/_includes/_test-this-endpoint.md
+++ b/articles/_includes/_test-this-endpoint.md
@@ -1,4 +1,6 @@
-Your can use our **Authentication API Debugger** extension to test this endpoint. Click on **Install Debugger** to go to the article that explains how (you only have to do this once).
+Your can use our **Authentication API Debugger** extension to test this endpoint. In order to do so you need to be logged in and have installed the [Authentication API Debugger extension](/extensions/authentication-api-debugger).
+
+Click on **Install Debugger** to go to the article that explains how (you only have to do this once).
 
 <%
   var tenantWithLoc = account.namespace.slice(0, account.namespace.length - 10);


### PR DESCRIPTION
The debugger URL defers according to the tenant's account location (us, eu, au). The script was not calculating this correctly, since the `account.tenant` variable does not include the location (`.eu` or `.au`). This fixes the bug by retrieving the tenant's domain and deducing the location from that.

(I used two script blocks because if I use one the build fails)