### PR TITLE
Fix doc

### DIFF
--- a/articles/server-apis/rails/authenticate.md
+++ b/articles/server-apis/rails/authenticate.md
@@ -96,7 +96,7 @@ config.token_audience = -> { Rails.application.secrets.auth0_client_id }
 ```
 
 ```ruby
-config.token_secret_signature_key = -> { JWT.base64url_decode Rails.application.secrets.auth0_client_secret }
+config.token_secret_signature_key = -> { Rails.application.secrets.auth0_client_secret }
 ```
 
 ### 4. Call Your API


### PR DESCRIPTION
JWT.base64url_decode doesn't need for default settings.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
