### PR TITLE
Updates curl command example.

### DIFF
--- a/articles/connector/install-other-platforms.md
+++ b/articles/connector/install-other-platforms.md
@@ -41,6 +41,6 @@ description: A guide on installing the AD/LDAP Connector on different platforms.
         .text('adldap-' + data.version);
 
     $('.curl-example')
-      .text('curl -Lo /tmp/adldap.tar.gz \\\n    https://github.com/auth0/ad-ldap-connector/archive/v' + data.version + '.tar.gz');
+      .text('curl -Lo /tmp/adldap.tar.gz https://github.com/auth0/ad-ldap-connector/archive/v' + data.version + '.tar.gz');
   })
 </script>


### PR DESCRIPTION
The curl command example as cut and pasted from the online documentation (https://auth0.com/docs/connector/install-other-platforms) has a "\\" in the middle of it which results in the following error on Ubuntu and Mint:

    curl: (1) Protocol " https" not supported or disabled in libcurl

Removing the "\\" fixes the issue. There's probably no need for a line-continuation character here, and if there is, it should be at the end of the line.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
