### PR TITLE
Improve silent authentication wording

### DIFF
--- a/articles/api-auth/tutorials/silent-authentication.md
+++ b/articles/api-auth/tutorials/silent-authentication.md
@@ -8,22 +8,7 @@ Single Page web applications (SPAs) normally use the [Implicit Grant flow](/api-
 This flow returns an ID token and optionally an access token to authenticate and authorize the user.
 These tokens, however, expire after some time and must be renewed to keep a user authenticated without them having to log in again.
 
-## Detect expired tokens
-
-The ID token and access token can have different expiration times, depending on the client and resource server's configuration.
-
-### ID token expiration
-
-ID tokens are [JWTs](/jwt) that clients can validate and inspect. 
-
-An [ID token's expiration date is determined by the `exp` claim](https://openid.net/specs/openid-connect-core-1_0.html#IDToken), which is a Unix time number. Client applications can read this value to schedule a time when the ID token should be renewed:
-
-```js
-const idToken = // validated and decoded ID token JWT
-const expirationDate = new Date(idToken.exp * 1000);
-```
-
-### Access token expiration
+## Access token expiration
 
 Access tokens are opaque to clients. This means that clients are unable to inspect the contents of access tokens to determine their expiration date.
 
@@ -45,10 +30,9 @@ https://myapp.example.com/
 ```
 
 This parameter indicates how many seconds the access token will be valid for.
+With this information we can call `setTimeout` or some other scheduling mechanism to renew the access token when needed.
 
-With this information, we can call `setTimeout` or some other scheduling mechanism to renew the access token when needed.
-
-## Use `prompt=none` to retrieve new tokens
+## Use `prompt=none` to retrieve a new token
 
 When you authenticate a user to your application, you would normally redirect them to the [`/authorize` endpoint of Auth0's authentication API](/api/authentication#social).
 
@@ -57,4 +41,5 @@ This endpoint supports a `prompt` query parameter; if it is set to `none`, the f
 * If the user is still authenticated, Auth0 will call back to your application immediately with renewed ID and access tokens.
 * If the user is no longer authenticated or had never authenticated, Auth0 will call back to your application with an error.
 
-You can use the [`silentAuthentication` method from auth0.js](https://github.com/auth0/auth0.js#silent-authentication) to authenticate users with `prompt=none`.
+You can use the [`renewAuth` method from auth0.js](https://github.com/auth0/auth0.js#api) to authenticate users with `prompt=none` in an iframe.
+This lets you keep users logged in without needing to refresh or redirect away from your application.


### PR DESCRIPTION
The focus of silent authentication should be on access tokens, since in the vast majority of cases it's not necessary to even store ID tokens at all - usually only user profiles are stored, and not the actual ID token.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
