### PR TITLE
Remove required icon

### DIFF
--- a/articles/api-auth/tutorials/password-grant.md
+++ b/articles/api-auth/tutorials/password-grant.md
@@ -43,7 +43,7 @@ Where:
 * `password`: Resource Owner's secret.
 * `audience`: API Identifier that the client is requesting access to.
 * `client_id`: Client ID of the client making the request.
-* `client_secret`: Client Secret of the client making the request. This should be set only for highly trusted clients. You can make this parameter optional for SPAs and native apps, by setting the **Token Endpoint Authentication Method** at your [Client Settings](${manage_url}/#/clients/${account.clientId}/settings) to `None`.
+* `client_secret`: Client Secret of the client making the request. Required when the **Token Endpoint Authentication Method** field at your [Client Settings](${manage_url}/#/clients/${account.clientId}/settings) is `Post` or `Basic`. Do not set this parameter if your client is not highly trusted (for example, SPA).
 * `scope`: String value of the different scopes the client is asking for. Multiple scopes are separated with whitespace.
 
 The response from `/oauth/token` (if successful) contains an `access_token`, for example:

--- a/articles/api/authentication/api-authz/_get-token.md
+++ b/articles/api/authentication/api-authz/_get-token.md
@@ -364,7 +364,7 @@ This is the OAuth 2.0 grant that highly trusted apps utilize in order to access 
 |:-----------------|:------------|
 | `grant_type` <br/><span class="label label-danger">Required</span> | Denotes the flow you are using. For Resource Owner Password use  `password`. |
 | `client_id` <br/><span class="label label-danger">Required</span> | Your application's Client ID. |
-| `client_secret` <br/><span class="label label-danger">Required</span> | Your application's Client Secret. Required when the **Token Endpoint Authentication Method** field at your [Client Settings](${manage_url}/#/clients/${account.clientId}/settings) is `Post` or `Basic`. Do not set this parameter if your client is not highly trusted. |
+| `client_secret` <br/> | Your application's Client Secret. **Required** when the **Token Endpoint Authentication Method** field at your [Client Settings](${manage_url}/#/clients/${account.clientId}/settings) is `Post` or `Basic`. Do not set this parameter if your client is not highly trusted (for example, SPA). |
 | `audience` <br/><span class="label label-danger">Required</span> | The unique identifier of the target API you want to access. |
 | `username` <br/><span class="label label-danger">Required</span> | Resource Owner's identifier. |
 | `password` <br/><span class="label label-danger">Required</span> | Resource Owner's secret. |


### PR DESCRIPTION
The grant will be used also from SPAs and the `required` confused people.
