### PR TITLE
Add realm password grant and removed required from audience parameter

### DIFF
--- a/articles/api/authentication/api-authz/_authz-client.md
+++ b/articles/api/authentication/api-authz/_authz-client.md
@@ -52,7 +52,7 @@ This is the OAuth 2.0 grant that regular web apps utilize in order to access an 
 
 | Parameter        | Description |
 |:-----------------|:------------|
-| `audience` <br/><span class="label label-danger">Required</span> | The unique identifier of the target API you want to access. |
+| `audience` <br/> | The unique identifier of the target API you want to access. |
 | `scope` | The scopes which you want to request authorization for. These must be separated by a space. Include `offline_access` to get a refresh token. |
 | `response_type` <br/><span class="label label-danger">Required</span> | Indicates to the Authorization Server which OAuth 2.0 Flow you want to perform. Use `code` for Authorization Code Grant Flow. |
 | `client_id` <br/><span class="label label-danger">Required</span> | Your application's Client ID. |
@@ -119,7 +119,7 @@ This is the OAuth 2.0 grant that mobile apps utilize in order to access an API. 
 
 | Parameter        | Description |
 |:-----------------|:------------|
-| `audience` <br/><span class="label label-danger">Required</span> | The unique identifier of the target API you want to access. |
+| `audience` <br/> | The unique identifier of the target API you want to access. |
 | `scope` | The scopes which you want to request authorization for. These must be separated by a space. Include `offline_access` to get a refresh token. |
 | `response_type` <br/><span class="label label-danger">Required</span> | Indicates to the Authorization Server which OAuth 2.0 Flow you want to perform. Use `code` for Authorization Code Grant (PKCE) Flow. |
 | `client_id` <br/><span class="label label-danger">Required</span> | Your application's Client ID. |
@@ -189,7 +189,7 @@ This is the OAuth 2.0 grant that Client-side web apps utilize in order to access
 
 | Parameter        | Description |
 |:-----------------|:------------|
-| `audience` <br/><span class="label label-danger">Required</span> | The unique identifier of the target API you want to access. |
+| `audience` <br/> | The unique identifier of the target API you want to access. |
 | `scope` | The scopes which you want to request authorization for. These must be separated by a space. |
 | `response_type` <br/><span class="label label-danger">Required</span> | This will specify the type of token you will receive at the end of the flow. Use `id_token token` to get an `id_token`, or `token` to get both an `id_token` and an `access_token`. |
 | `client_id` <br/><span class="label label-danger">Required</span> | Your application's Client ID. |

--- a/articles/api/authentication/api-authz/_get-token.md
+++ b/articles/api/authentication/api-authz/_get-token.md
@@ -386,6 +386,21 @@ This is the OAuth 2.0 grant that highly trusted apps utilize in order to access 
 
 - The scopes issued to the client may differ from the scopes requested. In this case, a `scope` parameter will be included in the response JSON.
 
+### Realm support
+
+A extension grant that offers similar functionality with the Resource Owner Password Grant, including the ability to indicate a specific realm, is the `http://auth0.com/oauth/grant-type/password-realm`.
+
+Realms allow you to keep separate user directories and specify which one to use to the token endpoint.
+
+To use this variation you will have to change the following request parameters:
+
+* Set the `grant_type` to `http://auth0.com/oauth/grant-type/password-realm`.
+* Set the new request parameter `realm` to the realm the user belongs. This maps to a connection in Auth0. For example, if you have configured a database connection for your internal employees and you have named the connection `employees`, then use this value.
+
+> **Auth0 Connections as Realms**
+
+> You can configure Auth0 Connections as realms, as long as they support active authentication. This includes [Database](/connections/database), [Passwordless](/connections/passwordless), [Active Directory/LDAP](/connections/enterprise/active-directory), [Windows Azure AD](/connections/enterprise/azure-active-directory) and [ADFS](/connections/enterprise/adfs) connections.
+
 ### More Information
 
 - [Calling APIs from Highly Trusted Clients](/api-auth/grant/password)

--- a/articles/api/authentication/api-authz/_get-token.md
+++ b/articles/api/authentication/api-authz/_get-token.md
@@ -365,7 +365,7 @@ This is the OAuth 2.0 grant that highly trusted apps utilize in order to access 
 | `grant_type` <br/><span class="label label-danger">Required</span> | Denotes the flow you are using. For Resource Owner Password use  `password`. |
 | `client_id` <br/><span class="label label-danger">Required</span> | Your application's Client ID. |
 | `client_secret` <br/> | Your application's Client Secret. **Required** when the **Token Endpoint Authentication Method** field at your [Client Settings](${manage_url}/#/clients/${account.clientId}/settings) is `Post` or `Basic`. Do not set this parameter if your client is not highly trusted (for example, SPA). |
-| `audience` <br/><span class="label label-danger">Required</span> | The unique identifier of the target API you want to access. |
+| `audience` <br/> | The unique identifier of the target API you want to access. |
 | `username` <br/><span class="label label-danger">Required</span> | Resource Owner's identifier. |
 | `password` <br/><span class="label label-danger">Required</span> | Resource Owner's secret. |
 | `scope` | String value of the different scopes the client is asking for. Multiple scopes are separated with whitespace. |

--- a/articles/api/authentication/api-authz/_get-token.md
+++ b/articles/api/authentication/api-authz/_get-token.md
@@ -362,13 +362,14 @@ This is the OAuth 2.0 grant that highly trusted apps utilize in order to access 
 
 | Parameter        | Description |
 |:-----------------|:------------|
-| `grant_type` <br/><span class="label label-danger">Required</span> | Denotes the flow you are using. For Resource Owner Password use  `password`. |
+| `grant_type` <br/><span class="label label-danger">Required</span> | Denotes the flow you are using. For Resource Owner Password use  `password`. To add realm support use `http://auth0.com/oauth/grant-type/password-realm`. |
 | `client_id` <br/><span class="label label-danger">Required</span> | Your application's Client ID. |
 | `client_secret` <br/> | Your application's Client Secret. **Required** when the **Token Endpoint Authentication Method** field at your [Client Settings](${manage_url}/#/clients/${account.clientId}/settings) is `Post` or `Basic`. Do not set this parameter if your client is not highly trusted (for example, SPA). |
 | `audience` <br/> | The unique identifier of the target API you want to access. |
 | `username` <br/><span class="label label-danger">Required</span> | Resource Owner's identifier. |
 | `password` <br/><span class="label label-danger">Required</span> | Resource Owner's secret. |
 | `scope` | String value of the different scopes the client is asking for. Multiple scopes are separated with whitespace. |
+| `realm` | String value of the realm the user belongs. Set this if you want to add realm support at this grant. For more information on what realms are refer to [Realm Support](/api-auth/grant/password#realm-support). |
 
 
 ### Test this endpoint
@@ -385,21 +386,8 @@ This is the OAuth 2.0 grant that highly trusted apps utilize in order to access 
 ### Remarks
 
 - The scopes issued to the client may differ from the scopes requested. In this case, a `scope` parameter will be included in the response JSON.
+- To add realm support set the `grant_type` to `http://auth0.com/oauth/grant-type/password-realm`, and the `realm` to the realm the user belongs. This maps to a connection in Auth0. For example, if you have configured a database connection for your internal employees and you have named the connection `employees`, then use this value. For more information on how to implement this refer to: [Realm Support](/api-auth/tutorials/password-grant#realm-support).
 
-### Realm support
-
-A extension grant that offers similar functionality with the Resource Owner Password Grant, including the ability to indicate a specific realm, is the `http://auth0.com/oauth/grant-type/password-realm`.
-
-Realms allow you to keep separate user directories and specify which one to use to the token endpoint.
-
-To use this variation you will have to change the following request parameters:
-
-* Set the `grant_type` to `http://auth0.com/oauth/grant-type/password-realm`.
-* Set the new request parameter `realm` to the realm the user belongs. This maps to a connection in Auth0. For example, if you have configured a database connection for your internal employees and you have named the connection `employees`, then use this value.
-
-> **Auth0 Connections as Realms**
-
-> You can configure Auth0 Connections as realms, as long as they support active authentication. This includes [Database](/connections/database), [Passwordless](/connections/passwordless), [Active Directory/LDAP](/connections/enterprise/active-directory), [Windows Azure AD](/connections/enterprise/azure-active-directory) and [ADFS](/connections/enterprise/adfs) connections.
 
 ### More Information
 


### PR DESCRIPTION
* Removed `required` label from `audience` parameter on `/authorize` and `/oauth/token` calls (except when `client_credentials` grant type)
* Added info on realm password grant type