### PR TITLE
Add info about SMS failure log for Guardian

### DIFF
--- a/articles/multifactor-authentication/guardian/admin-guide.md
+++ b/articles/multifactor-authentication/guardian/admin-guide.md
@@ -129,6 +129,7 @@ Here are all the possible events related to MFA:
 | `gd_update_device_account` | When a device account is updated |
 | `gd_send_pn` | When a push notification is sent |
 | `gd_send_sms` | When a SMS is sent |
+| `gd_sms_failure` | When a SMS failed to be sent. It usually means a configuration mistake for Twilio provider. You can check the provider error message and code as part of the details. |
 | `gd_start_auth` | Start second factor authentication  |
 | `gd_start_enroll` | Second factor auth enrollment is started |
 | `gd_module_switch` | When changing feature config |

--- a/articles/multifactor-authentication/guardian/dev-guide.md
+++ b/articles/multifactor-authentication/guardian/dev-guide.md
@@ -112,6 +112,7 @@ Here are all the possible events related to MFA:
 | `gd_update_device_account` | When a device account is updated |
 | `gd_send_pn` | When a push notification is sent |
 | `gd_send_sms` | When a SMS is sent |
+| `gd_sms_failure` | When a SMS failed to be sent. It usually means a configuration mistake for Twilio provider. You can check the provider error message and code as part of the details. |
 | `gd_start_auth` | Start second factor authentication  |
 | `gd_start_enroll` | Second factor auth enrollment is started |
 | `gd_module_switch` | When changing feature config |


### PR DESCRIPTION
Adds info about the new logs we are adding for when sms delivery fails.

Related PR: https://github.com/auth0/auth0-mfa-api/pull/362