### PR TITLE
Fixed callback_path in Rails OmniAuth middleware

### DIFF
--- a/snippets/server-platforms/rails/setup.md
+++ b/snippets/server-platforms/rails/setup.md
@@ -5,7 +5,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
     '${account.clientId}',
     '${account.clientSecret}',
     '${account.namespace}',
-    callback_path: "/auth/auth0/callback"
+    callback_path: "/auth/oauth2/callback"
   )
 end
 ```


### PR DESCRIPTION
I updated the path to match the `/auth/oauth2/callback` paths used in the rest of the Rails docs. When using the old path (`/auth/auth0/callback`), OmniAuth does not work and does not include `omniauth.auth` information in the request.

Apologies: I did not submit this to the Heroku review.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
