### PR TITLE
Remove deprecation notice (/ro and /tokeninfo endpoints)

### DIFF
--- a/articles/api/authentication/_linking.md
+++ b/articles/api/authentication/_linking.md
@@ -20,7 +20,7 @@ GET https://${account.namespace}/authorize?
 }) %>
 
 ::: panel-danger Deprecation Notice
-This endpoint is deprecated. The [POST /api/v2/users/{id}/identities](/api/management/v2#!/Users/post_identities) should be used instead.
+This endpoint is deprecated for account linking. The [POST /api/v2/users/{id}/identities](/api/management/v2#!/Users/post_identities) should be used instead.
 :::
 
 Call this endpoint when a user wants to link a second authentication method (for example, a user/password database connection, with Facebook).

--- a/articles/api/authentication/_login.md
+++ b/articles/api/authentication/_login.md
@@ -394,10 +394,6 @@ $('.login-dbconn').click(function () {
   "link": "#database-ad-ldap-active-"
 }) %>
 
-::: panel-warning Deprecation Notice
-This endpoint will be deprecated. Customers will be notified and given ample time to migrate once an official deprecation notice is posted. The [POST /oauth/token { grant_type: password }](#resource-owner-password) should be used instead.
-:::
-
 Use this endpoint for API-based (active) authentication. Given the user credentials and the `connection` specified, it will do the authentication on the provider and return a JSON with the `access_token` and `id_token`.
 
 ### Request Parameters

--- a/articles/api/authentication/_passwordless.md
+++ b/articles/api/authentication/_passwordless.md
@@ -218,10 +218,6 @@ auth0.verifySMSCode({
   "link": "#authenticate-user"
 }) %>
 
-::: panel-warning Deprecation Notice
-This endpoint will be deprecated. Customers will be notified and given ample time to migrate once an official deprecation notice is posted. The [POST /oauth/token { grant_type: password }](#resource-owner-password) should be used instead.
-:::
-
 Once you have a verification code, use this endpoint to login the user with their phone number/email and verification code. This is active authentication, so the user must enter the code in your app.
 
 

--- a/articles/api/authentication/_userinfo.md
+++ b/articles/api/authentication/_userinfo.md
@@ -151,10 +151,6 @@ auth0.getProfile(idToken, function (err, profile) {
   "link": "#get-token-info"
 }) %>
 
-::: panel-warning Deprecation Notice
-This endpoint will be deprecated. Customers will be notified and given ample time to migrate once an official deprecation notice is posted. The [GET /userinfo](#get-user-info) endpoint should be used instead to retrieve user information.
-:::
-
 This endpoint validates a JSON Web Token (signature and expiration) and returns the user information associated with the user id `sub` property of the token.
 
 

--- a/articles/api/authentication/api-authz/_resource-owner.md
+++ b/articles/api/authentication/api-authz/_resource-owner.md
@@ -65,10 +65,6 @@ request(options, function (error, response, body) {
   "link": "#resource-owner"
 }) %>
 
-::: panel-warning Deprecation Notice
-This endpoint will be deprecated. Customers will be notified and given ample time to migrate once an official deprecation notice is posted. The `/oauth/token { grant_type: password }` should be used instead.
-:::
-
 Given the user's credentials, this endpoint will authenticate the user with the provider and return a JSON object with the `access_token` and an `id_token`.
 
 


### PR DESCRIPTION
The deprecation notices were removed the `/ro` and `/tokeninfo` endpoints.  

They were causing customers to try to use the new alternatives before the docs were ready, causing a lot of confusion.