### PR TITLE
authResult contains idToken

### DIFF
--- a/articles/libraries/lock/v10/api.md
+++ b/articles/libraries/lock/v10/api.md
@@ -187,7 +187,7 @@ Lock will emit events during its lifecycle. The `on` method can be used to liste
 - `unrecoverable_error`: emitted when there is an unrecoverable error, for instance when no connection is available. Has the error as the only argument.
 - `authenticated`: emitted after a successful authentication. Has the authentication result as the only argument. The authentication result contains the token which can be used to get the user's profile or stored to log them in on subsequent checks. 
 
-The `authenticated` event listener has a single argument, an `authResult` object. This object contains the following properties: `accessToken`, `idToken`, `state`, `refreshToken` and `accessTokenPayload`.
+The `authenticated` event listener has a single argument, an `authResult` object. This object contains the following properties: `accessToken`, `idToken`, `state`, `refreshToken` and `idTokenPayload`.
 
 An example use of the `authenticated` event:
 

--- a/articles/libraries/lock/v10/api.md
+++ b/articles/libraries/lock/v10/api.md
@@ -187,7 +187,7 @@ Lock will emit events during its lifecycle. The `on` method can be used to liste
 - `unrecoverable_error`: emitted when there is an unrecoverable error, for instance when no connection is available. Has the error as the only argument.
 - `authenticated`: emitted after a successful authentication. Has the authentication result as the only argument. The authentication result contains the token which can be used to get the user's profile or stored to log them in on subsequent checks. 
 
-The `authenticated` event listener has a single argument, an `authResult` object. This object contains the following properties: `accessToken`, `accessToken`, `state`, `refreshToken` and `accessTokenPayload`.
+The `authenticated` event listener has a single argument, an `authResult` object. This object contains the following properties: `accessToken`, `idToken`, `state`, `refreshToken` and `accessTokenPayload`.
 
 An example use of the `authenticated` event:
 


### PR DESCRIPTION
Was just reading the docs and I really hope the `authResult` contains `idToken`. If it does not I am really confused on how to get the JWT using Lock :)

