### PR TITLE
Rename ASP.NET Quickstarts

### DIFF
--- a/articles/server-apis/aspnet-webapi/index.yml
+++ b/articles/server-apis/aspnet-webapi/index.yml
@@ -1,4 +1,4 @@
-title: ASP.NET Web API
+title: ASP.NET Web API (System.Web)
 alias:
   - webapi
   - asp.net webapi

--- a/articles/server-platforms/aspnet/index.yml
+++ b/articles/server-platforms/aspnet/index.yml
@@ -1,4 +1,4 @@
-title: ASP.NET
+title: ASP.NET (System.Web)
 image: /media/platforms/asp.png
 tags:
   - quickstart


### PR DESCRIPTION
Renaming the ASP.NET Quickstarts to make it clearer that it is using the older System.Web model