### PR TITLE
Remove Auth API steps from Web API quickstarts

### DIFF
--- a/articles/server-apis/aspnet-core-webapi/04-authentication-rs256-deprecated.md
+++ b/articles/server-apis/aspnet-core-webapi/04-authentication-rs256-deprecated.md
@@ -1,5 +1,5 @@
 ---
-title: Authentication (Deprecated)
+title: Authentication
 name: Shows how to secure your API using the standard JWT middeware
 description: Shows how to secure your API using the standard JWT middeware.
 budicon: 500

--- a/articles/server-apis/aspnet-core-webapi/05-authentication-hs256-deprecated.md
+++ b/articles/server-apis/aspnet-core-webapi/05-authentication-hs256-deprecated.md
@@ -1,5 +1,5 @@
 ---
-title: Authentication - HS256 (Deprecated)
+title: Authentication (HS256)
 name: Shows how to secure your API using the standard JWT middeware
 description: Shows how to secure your API using the standard JWT middeware
 budicon: 500

--- a/articles/server-apis/aspnet-core-webapi/06-authorization-deprecated.md
+++ b/articles/server-apis/aspnet-core-webapi/06-authorization-deprecated.md
@@ -1,5 +1,5 @@
 ---
-title: Authorization (Deprecated)
+title: Authorization
 description: This tutorial will show you how assign roles to your users, and use those claims to authorize or deny a user to access certain API endpoints.
 budicon: 500
 ---

--- a/articles/server-apis/aspnet-core-webapi/index.yml
+++ b/articles/server-apis/aspnet-core-webapi/index.yml
@@ -13,10 +13,6 @@ tags:
 snippets:
   dependencies: server-apis/aspnet-core-webapi/dependencies
 articles:
-  - 00-intro
-  - 01-authentication
-  - 02-authorization
-  - 03-authentication-hs256
   - 04-authentication-rs256-deprecated
   - 05-authentication-hs256-deprecated
   - 06-authorization-deprecated

--- a/articles/server-apis/webapi-owin/04-authentication-rs256-deprecated.md
+++ b/articles/server-apis/webapi-owin/04-authentication-rs256-deprecated.md
@@ -1,5 +1,5 @@
 ---
-title: Authentication (Deprecated)
+title: Authentication
 name: Shows how to secure your API using the standard JWT middeware
 budicon: 500
 ---

--- a/articles/server-apis/webapi-owin/05-authentication-hs256-deprecated.md
+++ b/articles/server-apis/webapi-owin/05-authentication-hs256-deprecated.md
@@ -1,5 +1,5 @@
 ---
-title: Authentication - HS256 (Deprecated)
+title: Authentication (HS256)
 name: Shows how to secure your API using the standard JWT middeware
 budicon: 500
 ---

--- a/articles/server-apis/webapi-owin/06-authorization-deprecated.md
+++ b/articles/server-apis/webapi-owin/06-authorization-deprecated.md
@@ -1,5 +1,5 @@
 ---
-title: Authorization (Deprecated)
+title: Authorization
 description: This tutorial will show you how assign roles to your users, and use those claims to authorize or deny a user to access certain API endpoints.
 budicon: 500
 ---

--- a/articles/server-apis/webapi-owin/index.yml
+++ b/articles/server-apis/webapi-owin/index.yml
@@ -10,10 +10,6 @@ image: /media/platforms/asp.png
 tags:
   - quickstart
 articles:
-  - 00-intro
-  - 01-authentication
-  - 02-authorization
-  - 03-authentication-hs256
   - 04-authentication-rs256-deprecated
   - 05-authentication-hs256-deprecated
   - 06-authorization-deprecated


### PR DESCRIPTION
DSE requested that we remove the Authentication API based steps from the API quickstarts and only display the `id_token` based ones as it was causing customer confusion because the Authentication API stuff is not yet available to everyone