### PR TITLE
Change naming from Deprecated to Legacy

### DIFF
--- a/articles/server-apis/aspnet-core-webapi/04-authentication-rs256-legacy.md
+++ b/articles/server-apis/aspnet-core-webapi/04-authentication-rs256-legacy.md
@@ -8,7 +8,7 @@ budicon: 500
 <%= include('../../_includes/_package', {
   org: 'auth0-samples',
   repo: 'auth0-aspnetcore-webapi-sample',
-  path: '04-Authentication-RS256-Deprecated',
+  path: '04-Authentication-RS256-Legacy',
   requirements: [
     '.NET Core 1.0'
   ]

--- a/articles/server-apis/aspnet-core-webapi/05-authentication-hs256-legacy.md
+++ b/articles/server-apis/aspnet-core-webapi/05-authentication-hs256-legacy.md
@@ -8,7 +8,7 @@ budicon: 500
 <%= include('../../_includes/_package', {
   org: 'auth0-samples',
   repo: 'auth0-aspnetcore-webapi-sample',
-  path: '05-Authentication-HS256-Deprecated',
+  path: '05-Authentication-HS256-Legacy',
   requirements: [
     '.NET Core 1.0'
   ]

--- a/articles/server-apis/aspnet-core-webapi/06-authorization-legacy.md
+++ b/articles/server-apis/aspnet-core-webapi/06-authorization-legacy.md
@@ -7,7 +7,7 @@ budicon: 500
 <%= include('../../_includes/_package', {
   org: 'auth0-samples',
   repo: 'auth0-aspnetcore-webapi-sample',
-  path: '06-Authorization-Deprecated',
+  path: '06-Authorization-Legacy',
   requirements: [
     '.NET Core 1.0'
   ]

--- a/articles/server-apis/aspnet-core-webapi/index.yml
+++ b/articles/server-apis/aspnet-core-webapi/index.yml
@@ -13,6 +13,6 @@ tags:
 snippets:
   dependencies: server-apis/aspnet-core-webapi/dependencies
 articles:
-  - 04-authentication-rs256-deprecated
-  - 05-authentication-hs256-deprecated
-  - 06-authorization-deprecated
+  - 04-authentication-rs256-legacy
+  - 05-authentication-hs256-legacy
+  - 06-authorization-legacy

--- a/articles/server-apis/webapi-owin/04-authentication-rs256-legacy.md
+++ b/articles/server-apis/webapi-owin/04-authentication-rs256-legacy.md
@@ -7,7 +7,7 @@ budicon: 500
 <%= include('../../_includes/_package', {
   org: 'auth0-samples',
   repo: 'auth0-aspnet-owin-webapi-sample',
-  path: '04-Authentication-RS256-Deprecated/WebApi',
+  path: '04-Authentication-RS256-Legacy/WebApi',
   requirements: [
     'Microsoft Visual Studio 2015 Update 3',
     'Microsoft.Owin.Security.ActiveDirectory V3.0.1',

--- a/articles/server-apis/webapi-owin/05-authentication-hs256-legacy.md
+++ b/articles/server-apis/webapi-owin/05-authentication-hs256-legacy.md
@@ -7,7 +7,7 @@ budicon: 500
 <%= include('../../_includes/_package', {
   org: 'auth0-samples',
   repo: 'auth0-aspnet-owin-webapi-sample',
-  path: '05-Authentication-HS256-Deprecated/WebApi',
+  path: '05-Authentication-HS256-Legacy/WebApi',
   requirements: [
     'Microsoft Visual Studio 2015 Update 3',
     'Microsoft.Owin.Security.Jwt NuGet Package V3.0.1',

--- a/articles/server-apis/webapi-owin/06-authorization-legacy.md
+++ b/articles/server-apis/webapi-owin/06-authorization-legacy.md
@@ -7,7 +7,7 @@ budicon: 500
 <%= include('../../_includes/_package', {
   org: 'auth0-samples',
   repo: 'auth0-aspnet-owin-webapi-sample',
-  path: '06-Authorization-Deprecated/WebApi',
+  path: '06-Authorization-Legacy/WebApi',
   requirements: [
     'Microsoft Visual Studio 2015 Update 3',
     'Microsoft.Owin.Security.ActiveDirectory V3.0.1',

--- a/articles/server-apis/webapi-owin/index.yml
+++ b/articles/server-apis/webapi-owin/index.yml
@@ -10,6 +10,6 @@ image: /media/platforms/asp.png
 tags:
   - quickstart
 articles:
-  - 04-authentication-rs256-deprecated
-  - 05-authentication-hs256-deprecated
-  - 06-authorization-deprecated
+  - 04-authentication-rs256-legacy
+  - 05-authentication-hs256-legacy
+  - 06-authorization-legacy

--- a/config/redirect-urls.json
+++ b/config/redirect-urls.json
@@ -1167,5 +1167,29 @@
   {
     "from": "/anomaly-detection/brute-force-protection",
     "to": "/anomaly-detection#brute-force-protection"
+  },
+  {
+    "from": "/quickstart/backend/webapi-owin/04-authentication-rs256-deprecated",
+    "to": "/quickstart/backend/webapi-owin/04-authentication-rs256-legacy"
+  },
+  {
+    "from": "/quickstart/backend/webapi-owin/05-authentication-hs256-deprecated",
+    "to": "/quickstart/backend/webapi-owin/05-authentication-hs256-legacy"
+  },
+  {
+    "from": "/quickstart/backend/webapi-owin/06-authorization-deprecated",
+    "to": "/quickstart/backend/webapi-owin/06-authorization-legacy"
+  },
+  {
+    "from": "/quickstart/backend/aspnet-core-webapi/04-authentication-rs256-deprecated",
+    "to": "/quickstart/backend/aspnet-core-webapi/04-authentication-rs256-legacy"
+  },
+  {
+    "from": "/quickstart/backend/aspnet-core-webapi/05-authentication-hs256-deprecated",
+    "to": "/quickstart/backend/aspnet-core-webapi/05-authentication-hs256-legacy"
+  },
+  {
+    "from": "/quickstart/backend/aspnet-core-webapi/06-authorization-deprecated",
+    "to": "/quickstart/backend/aspnet-core-webapi/06-authorization-legacy"
   }
 ]


### PR DESCRIPTION
Renamed the quickstarts from "Deprecated" to "Legacy"