### PR TITLE
Enhance guidance for multiple DB connections

### DIFF
--- a/articles/tutorials/using-auth0-with-multi-tenant-apps.md
+++ b/articles/tutorials/using-auth0-with-multi-tenant-apps.md
@@ -1,5 +1,6 @@
 ---
 description: This articles lists several existing multi-tenant applications and describes their implementations.
+toc: true
 ---
 
 # Using Auth0 with Multi-tenant Apps
@@ -12,7 +13,7 @@ Here are some examples of existing multi-tenant applications and descriptions of
 
 ## Slack
 
-### Authentication:
+### Authentication
 
 * Slack implements a login screen that asks for an email.
 * The email is then mapped to a Slack account:  `https://{account}.slack.com`.
@@ -21,7 +22,7 @@ Here are some examples of existing multi-tenant applications and descriptions of
 
 ![](/media/articles/saas/saas-01.png)
 
-### Authorization:
+### Authorization
 
 * With Slack, a user can belong to multiple teams or organizations. Each team can be considered a __tenant__.
 * You can switch from one team to another through an option in Slack.
@@ -54,7 +55,7 @@ The `User Profile` below captures the intent of the requirements described above
 
 ## Dropbox
 
-### Authentication:
+### Authentication
 
 * Dropbox asks for an email. If there is an organization with a domain that matches the email suffix, Dropbox will hide the password textbox and display a __Single Sign On Enabled__ message on the login screen.
 * When the user clicks on __Continue__, they will be redirected to the configured identity provider.
@@ -62,7 +63,7 @@ The `User Profile` below captures the intent of the requirements described above
 
 ![](/media/articles/saas/saas-03.png)
 
-### Authorization:
+### Authorization
 
 * Once a user is authenticated, they are granted access to the files they own and those that were shared with them.
 * Users are granted access to their personal account and to any organizations they belong to.
@@ -94,7 +95,7 @@ Storing all of the folders that the user has access to as part of the user profi
 
 ## Auth0
 
-### Authentication:
+### Authentication
 
 * Auth0 has a single [Dashboard](${manage_url}) for all tenants.
 * Auth0 supports Google, GitHub, Live and user/password authentication.
@@ -103,7 +104,7 @@ Storing all of the folders that the user has access to as part of the user profi
 
 ![](/media/articles/saas/saas-05.png)
 
-### Authorization:
+### Authorization
 
 * A user can belong to multiple tenants and have different permissions on each (__user foo__ can be an __admin__ on __tenant bar__ and a __regular user__ of __tenant xyz__).
 * This is implemented by assigning a `user_id` property to an **account-level** entity if the user has access to everything or an **app-level** entity if the user has only app level permission.
@@ -142,7 +143,7 @@ A typical modern SaaS multi-tenant app has these features:
 
 ### One database connection or many
 
-A single database connection is often sufficient. Whether or not a user has access to a certain tenant can be handled with [metadata](/api/v1#!#put--api-users--user_id--metadata) instead of separate database connections. You can easily find users that have specific metadata values via our [user search API](https://auth0.com/docs/api/management/v2/user-search). For example, to fetch all users that belong to the `company1` tenant per the example give earlier, you could use this Lucene query:
+A single database connection is often sufficient. Whether or not a user has access to a certain tenant can be handled with [metadata](/metadata) instead of separate database connections. You can easily find users that have specific metadata values via our [user search API](/api/management/v2/user-search). For example, to fetch all users that belong to the `company1` tenant per the example give earlier, you could use this Lucene query:
 
 ```
 _exists_:app_metadata.permissions.company1
@@ -150,11 +151,15 @@ _exists_:app_metadata.permissions.company1
 
 There are a few cases where storing users in multiple database connections might make sense:
 
-1. If you need to isolate a set of users (e.g. staging vs. prod environment), it may make sense to use different database connections. However, we recommend you use [separate Auth0 tenants](https://auth0.com/docs/dev-lifecycle/setting-up-env) for this instead.
-2. If your **tenant A** and **tenant B** only contain username/password users but **tenant C** uses an enterprise connection for its users (eg. Active Directory or SAML), then you might want separate database connections for **tenant A** and **tenant B**, but again, you could just use one database connection for both and use the metadata approach instead. In fact, you may have some tenants with a mixture of both database and enterprise (or even social) connections. Metadata provides a consistent way to categorize your users without the added complexity of multiple database connections.
-3. If your tenants have different connetion-level requirements. The best example is if they have different password policy requirements. So **tenant A** only requires the **Fair** password policy where **tenant B** requires the **Excellent** password policy and maybe a specific password history. Since these are settings at the connection level you would require multiple database connections to accomplish this.
+- If you need to isolate a set of users (e.g. staging vs. prod environment), it may make sense to use different database connections. However, we recommend you use [separate Auth0 tenants](https://auth0.com/docs/dev-lifecycle/setting-up-env) for this instead.
 
-> WARNING: If you do decide to employ multiple database connections, be aware that there is currently a limit to how many _enabled_ database connections that Lock will support for a single client. Therefore we advise if you have multiple database connections _and_ you use Lock in your application, that you actually create _separate_ Auth0 clients for each of your tenants. Many would argue that multi-tenant SaaS applications should treat each tenant as separate applications anyway, even if it's the same physical application hosting all of them.
+- If your **tenant A** and **tenant B** only contain username/password users but **tenant C** uses an enterprise connection for its users (eg. Active Directory or SAML), then you might want separate database connections for **tenant A** and **tenant B**, but again, you could just use one database connection for both and use the metadata approach instead. In fact, you may have some tenants with a mixture of both database and enterprise (or even social) connections. Metadata provides a consistent way to categorize your users without the added complexity of multiple database connections.
+
+- If your tenants have different connetion-level requirements. The best example is if they have different password policy requirements. So **tenant A** only requires the **Fair** password policy where **tenant B** requires the **Excellent** password policy and maybe a specific password history. Since these are settings at the connection level you would require multiple database connections to accomplish this.
+
+::: panel-warning Warning
+If you do decide to employ multiple database connections, be aware that there is currently a limit to how many _enabled_ database connections that Lock will support for a single client. Therefore we advise if you have multiple database connections _and_ you use Lock in your application, that you actually create _separate_ Auth0 clients for each of your tenants. Many would argue that multi-tenant SaaS applications should treat each tenant as separate applications anyway, even if it's the same physical application hosting all of them.
+:::
 
 ### A single Auth0 account for all tenants
 


### PR DESCRIPTION
There currently is a limit with Lock today where it will only support the first 50 enabled database connections for a given client. This is because Lock loads connection metadata from the Auth0 CDN and to avoid those files from becoming ridiculously large, a limit was employed. Customers should be aware of this and consider the one client per tenant approach described in the WARNING included in this PR.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
