### PR TITLE
Fix curl example for password exchange in /oauth/token

### DIFF
--- a/articles/api/authentication/api-authz/_get-token.md
+++ b/articles/api/authentication/api-authz/_get-token.md
@@ -313,7 +313,7 @@ Content-Type: 'application/json'
 
 ```shell
 curl --request POST \
-  --url '${account.namespace}/oauth/token' \
+  --url 'https://${account.namespace}/oauth/token' \
   --header 'content-type: application/json' \
   --data '{"grant_type":"password", "username":"USERNAME", "password":"PASSWORD", "audience":"API_IDENTIFIER", "scope":"SCOPE", "client_id": "${account.clientId}", "client_secret": "${account.clientSecret}"
  }'


### PR DESCRIPTION
Added missing `https://` to curl example for *Resource Owner Password* grant in `/oauh/token` endpoint.

Without this fix the command will not work unless the user figure out that the `https://` is missing in the url.