### PR TITLE
Update docs for pwd and refresh token rules

### DIFF
--- a/articles/api-auth/grant/password.md
+++ b/articles/api-auth/grant/password.md
@@ -29,9 +29,9 @@ For more information on how to implement this extension grant refer to [Executin
 
 ### Rules
 
-Rules will run for the Password Exchange (including the Password Realm extension grant). There are two key differences in the behavior of rules in these flows:
+[Rules](/rules) will run for the Password Exchange (including the Password Realm extension grant). There are two key differences in the behavior of rules in these flows:
 
-- If you try to do a redirect by specifying `context.redirect` in your rule, the authentication flow will return an error.
+- Redirect rules won't work. If you try to do a [redirect](/rules/redirect) by specifying `context.redirect` in your rule, the authentication flow will return an error.
 - If you try to do MFA by specifying `context.multifactor` in your rule, the authentication flow will return an error. MFA support is coming soon, as noted below.
 
 If you wish to execute special logic unique to the Password exchange, you can look at the `context.protocol` property in your rule. If the value is `oauth2-password`, then this is the indication that the rule is running during the password exchange.

--- a/articles/api-auth/grant/password.md
+++ b/articles/api-auth/grant/password.md
@@ -27,6 +27,19 @@ Realms allow you to keep separate user directories and specify which one to use 
 
 For more information on how to implement this extension grant refer to [Executing a Resource Owner Password Grant > Realm Support](/api-auth/tutorials/password-grant#realm-support).
 
+### Rules
+
+Rules will run for the Password Exchange (including the Password Realm extension grant). There are two key differences in the behavior of rules in these flows:
+
+- If you try to do a redirect by specifying `context.redirect` in your rule, the authentication flow will return an error.
+- If you try to do MFA by specifying `context.multifactor` in your rule, the authentication flow will return an error. MFA support is coming soon, as noted below.
+
+If you wish to execute special logic unique to the Password exchange, you can look at the `context.protocol` property in your rule. If the value is `oauth2-password`, then this is the indication that the rule is running during the password exchange.
+
+## MFA Support
+
+MFA support is coming soon.
+
 ## Use Case
 
 - Allow the Client to make calls to the Resource Server on behalf of the Resource Owner

--- a/articles/api-auth/tutorials/password-grant.md
+++ b/articles/api-auth/tutorials/password-grant.md
@@ -5,7 +5,7 @@ description: How to execute a Resource Owner Password Grant
 # Execute the Resource Owner Password Grant
 
 ::: panel-danger Warning
-Support for Rules and Refresh Tokens will be available in a future release.
+Support for Refresh Tokens will be available in a future release.
 :::
 
 ## Configure your tenant for the Resource Owner Password Grant

--- a/articles/migrations/index.md
+++ b/articles/migrations/index.md
@@ -24,6 +24,28 @@ If you need help with the migration, create a ticket in our [Support Center](${e
 ## Current Migrations
 Current migrations are listed below, newest first. For migrations that have already been enabled see [Past Migrations](#past-migrations).
 
+### Password and Refresh Token Exchange Rules Migration Notice
+
+| Severity | Grace Period Start | Mandatory Opt-In|
+| --- | --- | --- |
+| Medium | 2017-02-23 |  2017-05-31 |
+
+As part of Auth0's efforts to improve security, we recently added the ability to execute rules during the OAuth 2.0 Resource Owner Password Grant exchange (the password exchange) and the Refresh Token exchange.
+
+You are using this feature if you are calling the `/oauth/token` endpoint of our Authentication API with `grant_type = “password”` , `grant_type = “http://auth0.com/oauth/grant-type/password-realm”`, or `grant_type = “refresh_token”`.
+
+#### Am I affected by the change?
+
+You could be impacted if you are currently using these exchanges and have Rules defined in Dashboard. In order to ensure a smooth transition, we have disabled the rules execution on these specific exchanges for your tenant. These rules will now execute for all new customers, as well as customers who have not yet used these exchanges.
+
+You can add logic to your rules to alter their behavior for these exchanges by checking the `context.protocol` property:
+`oauth2-password` indicates the password (and password-realm) exchange
+`oauth2-refresh-token` indicates the refresh token exchange
+
+If you would like to enable the new behavior on this tenant for testing before the mandatory opt-in date, login to Dashboard and enable the Migration toggle “Run Rules on Password and Refresh Token Exchanges” toggle in Account Settings -> Advanced. 
+
+If you need help with the migration, create a ticket in our [Support Center](${env.DOMAIN_URL_SUPPORT})
+
 ### Whitelisting IP Address Ranges
 
 | Severity | Grace Period Start | Mandatory Opt-In|

--- a/articles/migrations/index.md
+++ b/articles/migrations/index.md
@@ -32,17 +32,17 @@ Current migrations are listed below, newest first. For migrations that have alre
 
 As part of Auth0's efforts to improve security, we recently added the ability to execute rules during the OAuth 2.0 Resource Owner Password Grant exchange (the password exchange) and the Refresh Token exchange.
 
-You are using this feature if you are calling the `/oauth/token` endpoint of our Authentication API with `grant_type = “password”` , `grant_type = “http://auth0.com/oauth/grant-type/password-realm”`, or `grant_type = “refresh_token”`.
+You are using this feature if you are calling the `/oauth/token` endpoint of our Authentication API with `grant_type = "password"` , `grant_type = "http://auth0.com/oauth/grant-type/password-realm"`, or `grant_type = "refresh_token"`.
 
 #### Am I affected by the change?
 
 You could be impacted if you are currently using these exchanges and have Rules defined in Dashboard. In order to ensure a smooth transition, we have disabled the rules execution on these specific exchanges for your tenant. These rules will now execute for all new customers, as well as customers who have not yet used these exchanges.
 
 You can add logic to your rules to alter their behavior for these exchanges by checking the `context.protocol` property:
-`oauth2-password` indicates the password (and password-realm) exchange
-`oauth2-refresh-token` indicates the refresh token exchange
+- `oauth2-password` indicates the password (and password-realm) exchange
+- `oauth2-refresh-token` indicates the refresh token exchange
 
-If you would like to enable the new behavior on this tenant for testing before the mandatory opt-in date, login to Dashboard and enable the Migration toggle “Run Rules on Password and Refresh Token Exchanges” toggle in Account Settings -> Advanced. 
+If you would like to enable the new behavior on this tenant for testing before the mandatory opt-in date, login to [Dashboard](${manage_url}) and enable the __Run Rules on Password and Refresh Token Exchanges__ toggle in [Account Settings > Advanced](${manage_url}/#/account/advanced).
 
 If you need help with the migration, create a ticket in our [Support Center](${env.DOMAIN_URL_SUPPORT})
 

--- a/articles/rules/context.md
+++ b/articles/rules/context.md
@@ -19,6 +19,8 @@ When creating [Rules](/rules), the following properties are available for the `c
   * `oidc-implicit-profile`: used on mobile devices and single page apps
   * `oauth2-resource-owner`: user/password login typically used on database connections
   * `oauth2-resource-owner-jwt-bearer`: login using a bearer JWT signed with user's private key
+  * `oauth2-password`: login using the password exchange
+  * `oauth2-refresh-token`: refreshing a token using the refresh token exchange
   * `samlp`: SAML protocol used on SaaS apps
   * `wsfed`: WS-Federation used on Microsoft products like Office365
   * `wstrust-usernamemixed`: WS-trust user/password login used on CRM and Office365

--- a/articles/rules/redirect.md
+++ b/articles/rules/redirect.md
@@ -13,7 +13,10 @@ Rules can also be used to programatically redirect users before an authenticatio
 * Forcing users to change passwords.
 
 ::: panel-danger Caution
-Redirect rules won't work for the [Resource Owner endpoint](/api/authentication/reference#resource-owner) or the [Refresh Token exchange](/tokens/preview/refresh-token#rules). You can detect resource owner logins from a rule by checking `context.protocol === 'oauth2-password'`. To detect a Refresh Token exchange, check `context.protocol === 'oauth2-refresh-token'`.
+Redirect rules won't work for the [Resource Owner endpoint](/api/authentication/reference#resource-owner), the [Password exchange](/api-auth/grant/password) or the [Refresh Token exchange](/tokens/preview/refresh-token#rules). You can detect these cases by checking `context.protocol`:
+- For Password exchange: `context.protocol === 'oauth2-password'`
+- For Refresh Token exchange: `context.protocol === 'oauth2-refresh-token'`
+- For Resource Owner logins: `context.protocol === 'oauth2-resource-owner'`
 :::
 
 ## How to implement a redirect

--- a/articles/rules/redirect.md
+++ b/articles/rules/redirect.md
@@ -13,7 +13,7 @@ Rules can also be used to programatically redirect users before an authenticatio
 * Forcing users to change passwords.
 
 ::: panel-danger Caution
-Redirect rules won't work for the [Resource Owner endpoint](/api/authentication/reference#resource-owner) authentication endpoint. You can detect resource owner logins from a rule by checking `context.protocol === 'oauth2-resource-owner'`.
+Redirect rules won't work for the [Resource Owner endpoint](/api/authentication/reference#resource-owner) or the [Refresh Token exchange](/tokens/preview/refresh-token#rules). You can detect resource owner logins from a rule by checking `context.protocol === 'oauth2-password'`. To detect a Refresh Token exchange, check `context.protocol === 'oauth2-refresh-token'`.
 :::
 
 ## How to implement a redirect

--- a/articles/tokens/preview/refresh-token.md
+++ b/articles/tokens/preview/refresh-token.md
@@ -128,10 +128,6 @@ The response will include a new `access_token`, its type, its lifetime (in secon
 You should only ask for a new token if the `access_token` has expired or you want to refresh the claims contained in the `id_token`. For example, it's a bad practice to call the endpoint to get a new `access_token` every time you call an API. There are rate limits in Auth0 that will throttle the amount of requests to this endpoint that can be executed using the same token from the same IP.
 :::
 
-::: panel-warning Refresh tokens and Rules
-Refresh tokens do not run [rules](/rules) at the moment, but we will add support for this in the future.
-:::
-
 
 ## Revoke a Refresh Token
 
@@ -197,12 +193,12 @@ To revoke the user's access to an authorized application, and hence invalidate t
 
 ## Rules
 
-Rules will run for the Refresh Token Exchange. There are two key differences in the behavior of rules in this flow:
+Rules will run for the [Refresh Token Exchange](#use-a-refresh-token). There are two key differences in the behavior of rules in this flow:
 
-- If you try to do a redirect with context.redirect, the authentication flow will return an error.
-- If you try to do MFA by setting context.multifactor, the authentication flow will return an error.
+- If you try to do a [redirect](/rules/redirect) with `context.redirect`, the authentication flow will return an error.
+- If you try to do MFA by setting `context.multifactor`, the authentication flow will return an error.
 
-If you wish to execute special logic unique to the Refresh Token exchange, you can look at the `context.protocol` property in your rule. If the value is `oauth2-refresh-token`, then this is the indication that the rule is running during the Refresh Token exchange.
+If you wish to execute special logic unique to the [Refresh Token Exchange](#use-a-refresh-token), you can look at the `context.protocol` property in your rule. If the value is `oauth2-refresh-token`, then this is the indication that the rule is running during the Refresh Token exchange.
 
 ## SDK Support
 

--- a/articles/tokens/preview/refresh-token.md
+++ b/articles/tokens/preview/refresh-token.md
@@ -195,6 +195,15 @@ To revoke the user's access to an authorized application, and hence invalidate t
 
 ![Revoke a refresh token using the dashboard](/media/articles/tokens/dashboard-revoke-refresh-token.png)
 
+## Rules
+
+Rules will run for the Refresh Token Exchange. There are two key differences in the behavior of rules in this flow:
+
+- If you try to do a redirect with context.redirect, the authentication flow will return an error.
+- If you try to do MFA by setting context.multifactor, the authentication flow will return an error.
+
+If you wish to execute special logic unique to the Refresh Token exchange, you can look at the `context.protocol` property in your rule. If the value is `oauth2-refresh-token`, then this is the indication that the rule is running during the Refresh Token exchange.
+
 ## SDK Support
 
 ### Web Apps


### PR DESCRIPTION
We are adding Rules execution to the Password and Refresh token exchanges. This PR is to update the documentation reflecting these changes and also the migration notice.