### PR TITLE
Update 03-user-sessions.md

### DIFF
--- a/articles/native-platforms/ios-swift/03-user-sessions.md
+++ b/articles/native-platforms/ios-swift/03-user-sessions.md
@@ -61,7 +61,9 @@ Once the user has logged in, you get a `Credentials` object, as follows:
 Lock
     .classic()
     .withOptions {
-        $0.oidcConformant = true
+        // TODO Use OIDC once refreshToken fixed
+        $0.oidcConformant = false
+        $0.parameters = ["device":"UNIQUE_ID"]
         $0.scope = "openid profile"
     }
     .onAuth { credentials in


### PR DESCRIPTION
Update based on sample.

It seem there is a bug in SDK... It won't work using `oidcConformant = true`....

It was really frustrating to try it and not having it working until I did this fix.
The base `Lock.classic().onAuth {}` work but the later call `Auth0.authentication().userInfo(token: token).start()...` will fail with a unknown error... (even if the API call seem to succeed)

https://github.com/auth0-samples/auth0-ios-swift-v2-sample/blob/master/03-User-Sessions/Auth0Sample/HomeViewController.swift#L49-L52

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->