### PR TITLE
Fix misleading example

### DIFF
--- a/articles/tutorials/calling-an-external-idp-api.md
+++ b/articles/tutorials/calling-an-external-idp-api.md
@@ -70,7 +70,7 @@ Using the Auth0 access token, call the [Get a User](/api/management/v2#!/Users/g
 ```har
 {
   "method": "GET",
-  "url": "https://${account.namespace}/api/v2/Users/get_users_by_id",
+  "url": "https://${account.namespace}/api/v2/users/:user_id",
   "headers": [
     { "name": "Content-Type", "value": "application/json" }
   ]


### PR DESCRIPTION
The [Calling External API Example](https://auth0.com/docs/tutorials/calling-an-external-idp-api#2-obtain-the-user-profile) has a mis-leading example where it lists /Users/get_user_by_id as an endpoint. This pull-request fixes it.