### PR TITLE
Update tenant settings cURL call to post p2 merge

### DIFF
--- a/articles/api-auth/dynamic-client-registration.md
+++ b/articles/api-auth/dynamic-client-registration.md
@@ -44,11 +44,9 @@ Auth0 supports Open Dynamic Registration, which means that if you enable this fe
 
 ### Update tenant settings
 
-In order to enable the feature, you need to set to `true` the following flags at your tenant's settings:
-- `enable_dynamic_client_registration`: Enables the feature.
-- `enable_pipeline2`: Enables the underlying pipeline that is a required dependency.
+In order to enable the feature, you need to set the `enable_dynamic_client_registration` flag to `true` in your tenant's settings.
 
-You can update these flags using the [Update tenant settings endpoint](/api/management/v2#!/Tenants/patch_settings).
+You can update this flag using the [Update tenant settings endpoint](/api/management/v2#!/Tenants/patch_settings).
 
 ```har
 {
@@ -61,7 +59,7 @@ You can update these flags using the [Update tenant settings endpoint](/api/mana
   ],
   "postData": {
       "mimeType": "application/json",
-      "text" : "{ \"enable_pipeline2\": true, \"enable_dynamic_client_registration\": true }"
+      "text" : "{ \"flags\": { \"enable_dynamic_client_registration\": true } }"
   }
 }
 ```


### PR DESCRIPTION
Since we're now post-p2 merge we don't need to set the `enable_pipeline2` flag. Also, the `enable_dynamic_client_registration` property needs to live inside of a `flags` object in the request. I think this was a typo in the original version of this doc.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
