### PR TITLE
Added missing content-type to samples

### DIFF
--- a/articles/tokens/preview/refresh-token.md
+++ b/articles/tokens/preview/refresh-token.md
@@ -94,7 +94,9 @@ To refresh your token, using the `refresh_token` you already got during authoriz
     "url": "https://${account.namespace}/oauth/token",
     "httpVersion": "HTTP/1.1",
     "cookies": [],
-    "headers": [],
+    "headers": [
+      { "name": "Content-Type", "value": "application/json" }
+    ],
     "queryString" : [],
     "postData" : {
       "mimeType": "application/json",
@@ -143,7 +145,9 @@ To revoke a refresh token you can send a `POST` request to `https://${account.na
     "url": "https://${account.namespace}/oauth/revoke",
     "httpVersion": "HTTP/1.1",
     "cookies": [],
-    "headers": [],
+    "headers": [
+      { "name": "Content-Type", "value": "application/json" }
+    ],
     "queryString" : [],
     "postData" : {
       "mimeType": "application/json",


### PR DESCRIPTION
The "Use Refresh Token" and "Revoke a Refresh Token" examples were missing the header  `--header 'content-type: application/json'` in the curl command. As a result the returned value is always "Authentication error". Once the headers are set with the right content-type the sample code works.
