### PR TITLE
Information on scopes for password grant 

### DIFF
--- a/articles/api-auth/grant/password.md
+++ b/articles/api-auth/grant/password.md
@@ -27,6 +27,10 @@ Realms allow you to keep separate user directories and specify which one to use 
 
 For more information on how to implement this extension grant refer to [Executing a Resource Owner Password Grant > Realm Support](/api-auth/tutorials/password-grant#realm-support).
 
+### Scopes
+
+Due to the implied trust in these grants (a user providing his or her password to a client), the `access_token` returned will include all of the available scopes defined for the audience API. A client can request a restricted set of scopes by using the `scope` parameter, or you can restrict the returned scopes by using a [rule](#customizing-the-returned-token).
+
 ### Rules
 
 [Rules](/rules) will run for the Password Exchange (including the Password Realm extension grant). There are two key differences in the behavior of rules in these flows:
@@ -35,6 +39,24 @@ For more information on how to implement this extension grant refer to [Executin
 - If you try to do MFA by specifying `context.multifactor` in your rule, the authentication flow will return an error. MFA support is coming soon, as noted below.
 
 If you wish to execute special logic unique to the Password exchange, you can look at the `context.protocol` property in your rule. If the value is `oauth2-password`, then this is the indication that the rule is running during the password exchange.
+
+#### Customizing the returned token
+
+Inside a rule, you can change the returned scopes of the `access_token` or add claims to it with code like this:
+
+```javascript
+function(user, context, callback) {
+  
+  // add custom claims
+  context.accessToken['http://foo/bar'] = 'value';
+  
+  // change scope
+  context.accessToken.scope = 'scope1 scope2';
+  
+  callback(null, user, context);
+}
+
+```
 
 ## MFA Support
 

--- a/articles/api/authentication/api-authz/_get-token.md
+++ b/articles/api/authentication/api-authz/_get-token.md
@@ -391,6 +391,7 @@ This is the OAuth 2.0 grant that highly trusted apps utilize in order to access 
 ### Remarks
 
 - The scopes issued to the client may differ from the scopes requested. In this case, a `scope` parameter will be included in the response JSON.
+- If you don't request specific scopes, all scopes defined for the audience will be returned due to the implied trust to the client in this grant. You can customize the scopes returned in a rule. For more information, refer to [Calling APIs from Highly Trusted Clients](/api-auth/grant/password).
 - To add realm support set the `grant_type` to `http://auth0.com/oauth/grant-type/password-realm`, and the `realm` to the realm the user belongs. This maps to a connection in Auth0. For example, if you have configured a database connection for your internal employees and you have named the connection `employees`, then use this value. For more information on how to implement this refer to: [Realm Support](/api-auth/tutorials/password-grant#realm-support).
 
 


### PR DESCRIPTION
Information on scopes for resource owner password grant, and how to modify the access token on rules.

