### PR TITLE
Mentioned required parameters when executing `passwordlessVerify` met…

### DIFF
--- a/articles/libraries/auth0js/index.md
+++ b/articles/libraries/auth0js/index.md
@@ -208,6 +208,7 @@ In addition, _one_ of the two following options must be sent:
 * `phoneNumber`: a string containing the user's phone number, to which the code or link was delivered via SMS
 * `email`: a string containing the user's email, to which the code or link was delivered via email
 
+Additionally the values `redirectUri` and `responseType: 'token'` must be specified as options when initialising `WebAuth`.
 
 ```js
 webAuth.passwordlessVerify({

--- a/articles/libraries/auth0js/index.md
+++ b/articles/libraries/auth0js/index.md
@@ -208,7 +208,7 @@ In addition, _one_ of the two following options must be sent:
 * `phoneNumber`: a string containing the user's phone number, to which the code or link was delivered via SMS
 * `email`: a string containing the user's email, to which the code or link was delivered via email
 
-Additionally the values `redirectUri` and `responseType: 'token'` must be specified as options when initialising `WebAuth`.
+Note that in order to use `passwordlessVerify`, the options `redirectUri `and `responseType: 'token' `must be specified when first initializing WebAuth.
 
 ```js
 webAuth.passwordlessVerify({


### PR DESCRIPTION
Mentioned that the properties `redirectUri` and `responseType` must be set when initialising `WebAuth` when calling the password less verify method `passwordlessVerify`.

If one of the properties is missing you either get the message `invalid_request: Missing required parameter: response_type` or `server_error: Unable to issue redirect for OAuth 2.0 transaction` which is not clear for the consumer of the library.
