### PR TITLE
Why you should always use access tokens to secure an API

### DIFF
--- a/articles/api-auth/index.html
+++ b/articles/api-auth/index.html
@@ -134,4 +134,10 @@ title: API Authorization
       Frequently Asked Questions on API Authentication and Authorization .
     </p>
   </li>
+  <li>
+    <i class="icon icon-budicon-715"></i><a href="/api-auth/why-use-access-tokens-to-secure-apis">Why you should always use access tokens to secure an API</a>
+    <p>
+      Learn about the differences between Αccess Τoken and ID Τoken and why the later should never be used to secure an API.
+    </p>
+  </li>
 </ul>

--- a/articles/api-auth/why-use-access-tokens-to-secure-apis.md
+++ b/articles/api-auth/why-use-access-tokens-to-secure-apis.md
@@ -1,0 +1,16 @@
+---
+title: Why you should always use access tokens to secure an API
+description: Explains the differences between access token and ID token and why the later should never be used to secure an API.
+---
+
+# Why you should always use access tokens to secure an API
+
+There is much confussion on the Web as to the differences between the OpenID Connect and OAuth 2.0 specifications, and their respective tokens. As a result many developers publish insecure applications, compromising their users security. The contradicting implementations between identity providers do not help either.
+
+This article is an attempt to clear what is what and convince you that you should always use an access token to secure an API, and never an ID token.
+
+## Two complementary specifications
+
+OpenID Connect is used for __user authentication__. It enables you to verify the identity of a user and get some basic profile information.
+
+OAuth 2.0 is used to __grant authorization__. It enables you to 

--- a/articles/api-auth/why-use-access-tokens-to-secure-apis.md
+++ b/articles/api-auth/why-use-access-tokens-to-secure-apis.md
@@ -39,6 +39,52 @@ Now that we saw what these tokens can be used for, let's see what they cannot be
 
 - __An `id_token` should not be used for API access__. Each token contains information on the intended audience (recipient). According to the OpenID Connect specification, the audience (claim `aud`) of each `id_token` must be the `client_id` of the client making the authentication request. If it isn't you shouldn't trust the token. An API, on the other hand, expects a token with the audience set to the API's unique identifier. So unless you are in control of both the client and the API, sending an `id_token` to an API will not work.
 
+## Compare Tokens
+
+To better understand what we just read, let's look at the contents of example tokens.
+
+The (decoded) contents of an `id_token` look like the following:
+
+```json
+{
+  "iss": "http://${account.namespace}/",
+  "sub": "auth0|123456",
+  "aud": "${account.clientId}",
+  "exp": 1311281970,
+  "iat": 1311280970,
+  "name": "Jane Doe",
+  "given_name": "Jane",
+  "family_name": "Doe",
+  "gender": "female",
+  "birthdate": "0000-10-31",
+  "email": "janedoe@example.com",
+  "picture": "http://example.com/janedoe/me.jpg"
+}
+```
+
+This token is meant for __authenticating the user to the client__. Note that the audience (`aud` claim) of the token is set to the client's identifier, which means that only this specific client should consume this token.
+
+For comparison, let's look at the contents of an `access_token`:
+
+```json
+{
+  "iss": "https://${account.namespace}/",
+  "sub": "auth0|123456",
+  "aud": [
+    "my-api-identifier",
+    "https://${account.namespace}/userinfo"
+  ],
+  "azp": "${account.clientId}",
+  "exp": 1489179954,
+  "iat": 1489143954,
+  "scope": "openid profile email address phone read:appointments email"
+}
+```
+
+This token is meant for __authorizing the user to the API__. As such, it is completely opaque to clients, meaning that clients should not care about the contents of this token. Note that the token does not contain any information about the user itself besides their ID (`sub` claim), it only contains authorization information about which actions the client is allowed to perform at the API (`scope` claim). 
+
+Since in many cases it is desirable to retrieve additional user information at the API, this token is also valid for calling the `/userinfo` API, which will return the user's profile information. So the intented audience (`aud` claim) of the token is either the API (`my-api-identifier`) or the `/userinfo` endpoint (`https://${account.namespace}/userinfo`).
+
 ## Keep reading
 
 <i class="notification-icon icon-budicon-345"></i>&nbsp;[Access Token](/tokens/access-token)<br/>

--- a/articles/api-auth/why-use-access-tokens-to-secure-apis.md
+++ b/articles/api-auth/why-use-access-tokens-to-secure-apis.md
@@ -39,12 +39,11 @@ Now that we saw what these tokens can be used for, let's see what they cannot be
 
 - __An `id_token` should not be used for API access__. Each token contains information on the intended audience (recipient). According to the OpenID Connect specification, the audience (claim `aud`) of each `id_token` must be the `client_id` of the client making the authentication request. If it isn't you shouldn't trust the token. An API, on the other hand, expects a token with the audience set to the API's unique identifier. So unless you are in control of both the client and the API, sending an `id_token` to an API will not work.
 
-## More information
+## Keep reading
 
-- [Access Token](/tokens/access-token)
-
-- [ID Token](/tokens/id-token)
-
-- [The problem with OAuth for Authentication](http://www.thread-safe.com/2012/01/problem-with-oauth-for-authentication.html)
-
-- [User Authentication with OAuth 2.0](https://oauth.net/articles/authentication/)
+<i class="notification-icon icon-budicon-345"></i>&nbsp;[Access Token](/tokens/access-token)
+<i class="notification-icon icon-budicon-345"></i>&nbsp;[ID Token](/tokens/id-token)
+<i class="notification-icon icon-budicon-345"></i>&nbsp;[The problem with OAuth for Authentication](http://www.thread-safe.com/2012/01/problem-with-oauth-for-authentication.html)
+<i class="notification-icon icon-budicon-345"></i>&nbsp;[User Authentication with OAuth 2.0](https://oauth.net/articles/authentication/)
+<i class="notification-icon icon-budicon-345"></i>&nbsp;[OAuth 2.0 Overview](/protocols/oauth2)
+<i class="notification-icon icon-budicon-345"></i>&nbsp;[OpenID Connect Overview](/protocols/oidc)

--- a/articles/api-auth/why-use-access-tokens-to-secure-apis.md
+++ b/articles/api-auth/why-use-access-tokens-to-secure-apis.md
@@ -5,7 +5,7 @@ description: Explains the differences between access token and ID token and why 
 
 # Why you should always use access tokens to secure an API
 
-There is much confusion on the Web as to the differences between the OpenID Connect and OAuth 2.0 specifications, and their respective tokens. As a result many developers publish insecure applications, compromising their users security. The contradicting implementations between identity providers do not help either.
+There is much confusion on the Web about the differences between the OpenID Connect and OAuth 2.0 specifications, and their respective tokens. As a result many developers publish insecure applications, compromising their users security. The contradicting implementations between identity providers do not help either.
 
 This article is an attempt to clear what is what and explain why you should always use an access token to secure an API, and never an ID token.
 
@@ -29,7 +29,7 @@ The `id_token` is a JWT and is meant for the client only. In the example we used
 You must never use the info in an `id_token` unless you have validated it! For more information refer to: [How to validate an ID token](/tokens/id-token#how-to-validate-an-id-token). For a list of libraries you can use to verify a JWT refer to [JWT.io](https://jwt.io/).
 :::
 
-The `access_token` can be any type of token (not necessarily a JWT) and is meant for the resource/API. Its purpose is to inform the API that the bearer of this token has been authorized to access the API and perform specific actions (as specified by the `scope` that has been granted). In the example we used earlier, after you authenticate, and provide your consent that the to-do application can have read/write access to your calendar, an `access_token` is sent from Google to the to-do application. Each time the to-do application wants to access your Google Calendar it will make a request to the Google Calendar API, using this `access_token` in an HTTP `Authorization` header.
+The `access_token` can be any type of token (not necessarily a JWT) and is meant for the API. Its purpose is to inform the API that the bearer of this token has been authorized to access the API and perform specific actions (as specified by the `scope` that has been granted). In the example we used earlier, after you authenticate, and provide your consent that the to-do application can have read/write access to your calendar, an `access_token` is sent from Google to the to-do application. Each time the to-do application wants to access your Google Calendar it will make a request to the Google Calendar API, using this `access_token` in an HTTP `Authorization` header.
 
 ## How NOT to use each token
 

--- a/articles/api-auth/why-use-access-tokens-to-secure-apis.md
+++ b/articles/api-auth/why-use-access-tokens-to-secure-apis.md
@@ -11,11 +11,13 @@ This article is an attempt to clear what is what and explain why you should alwa
 
 ## Two complementary specifications
 
-OpenID Connect is used for __user authentication__. It enables you, the user, to verify your identity and give some basic profile information, without sharing your credentials.
+OAuth 2.0 is used to __grant authorization__. It enables you to authorize the Web App A to access your information from Web App B, without sharing your credentials. It was built with _only_ authorization in mind and doesn't include any authentication mechanisms (in other words, it doesn't give the Authorization Server any way of verifying who the user is). 
 
-OAuth 2.0 is used to __grant authorization__. It enables you to authorize the Web App A to access your information from Web App B, without sharing your credentials.
+OpenID Connect builds on OAuth 2.0. It enables you, the user, to verify your identity and give some basic profile information, without sharing your credentials.
 
 An example is a to-do application, that lets you log in using your Google account, and can push your to-do items as calendar entries, at your Google Calendar. The part where you authenticate your identity is implemented via OpenID Connect, while the part where you authorize the to-do application to modify your calendar by adding entries, is implemented via OAuth 2.0.
+
+> OpenID Connect is about who someone is. OAuth 2.0 is about what they are allowed to do.
 
 You may noticed the _"without sharing your credentials"_ part, at our definitions of the two specifications earlier. What you do share in both cases, is tokens.
 
@@ -23,7 +25,7 @@ OpenID Connect issues an identity token, known as `id_token`, while OAuth 2.0 is
 
 ## How to use each token
 
-The `id_token` is a JWT and is meant for the client only. In the example we used earlier, when you authenticate using Google, an `id_token` is sent from Google to the to-do application, that says who you are. The to-do application can parse the token's contents and use this information, like your name and your profile picture, to customize the user experience.
+The `id_token` is a [JWT](/jwt) and is meant for the client only. In the example we used earlier, when you authenticate using Google, an `id_token` is sent from Google to the to-do application, that says who you are. The to-do application can parse [the token's contents](https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims) and use this information, like your name and your profile picture, to customize the user experience.
 
 ::: panel-warning Security warning
 You must never use the info in an `id_token` unless you have validated it! For more information refer to: [How to validate an ID token](/tokens/id-token#how-to-validate-an-id-token). For a list of libraries you can use to verify a JWT refer to [JWT.io](https://jwt.io/).
@@ -31,13 +33,17 @@ You must never use the info in an `id_token` unless you have validated it! For m
 
 The `access_token` can be any type of token (not necessarily a JWT) and is meant for the API. Its purpose is to inform the API that the bearer of this token has been authorized to access the API and perform specific actions (as specified by the `scope` that has been granted). In the example we used earlier, after you authenticate, and provide your consent that the to-do application can have read/write access to your calendar, an `access_token` is sent from Google to the to-do application. Each time the to-do application wants to access your Google Calendar it will make a request to the Google Calendar API, using this `access_token` in an HTTP `Authorization` header.
 
+<div class="alert alert-info">
+  Access Tokens should be treated as opaque strings by clients. They are only meant for the API. Your Client should not attempt to decode them or depend on a particular <code>access_token</code> format.
+</div>
+
 ## How NOT to use each token
 
 Now that we saw what these tokens can be used for, let's see what they cannot be used for.
 
-- __An `access_token` should not be used for authentication__. The reason for that is that it holds no information about the user. It cannot tell us if the user has authenticated and when. That's why OAuth 2.0 cannot be used for authentication. Instead, OpenID Connect works on top of OAuth 2.0 and provides user authentication.
+- __An `access_token` cannot be used for authentication__. It holds no information about the user. It cannot tell us if the user has authenticated and when.
 
-- __An `id_token` should not be used for API access__. Each token contains information on the intended audience (recipient). According to the OpenID Connect specification, the audience (claim `aud`) of each `id_token` must be the `client_id` of the client making the authentication request. If it isn't you shouldn't trust the token. An API, on the other hand, expects a token with the audience set to the API's unique identifier. So unless you are in control of both the client and the API, sending an `id_token` to an API will not work.
+- __An `id_token` cannot be used for API access__. Each token contains information on the intended audience (recipient). According to the OpenID Connect specification, the audience (claim `aud`) of each `id_token` must be the `client_id` of the client making the authentication request. If it isn't you shouldn't trust the token. An API, on the other hand, expects a token with the audience set to the API's unique identifier. So unless you are in control of both the client and the API, sending an `id_token` to an API will not work. Furthermore, the `id_token` is signed with a secret that is known to the client (since it is issued to a particular client). This means that if an API were to accept such token, it would have no way of knowing if the client has modified the token (to add more scopes) and then signed it again.
 
 ## Compare Tokens
 
@@ -81,7 +87,7 @@ For comparison, let's look at the contents of an `access_token`:
 }
 ```
 
-This token is meant for __authorizing the user to the API__. As such, it is completely opaque to clients, meaning that clients should not care about the contents of this token. Note that the token does not contain any information about the user itself besides their ID (`sub` claim), it only contains authorization information about which actions the client is allowed to perform at the API (`scope` claim). 
+This token is meant for __authorizing the user to the API__. As such, it is completely opaque to clients, meaning that a client should not care about the contents of this token, decode it or depend on a particular token format. Note that the token does not contain any information about the user itself besides their ID (`sub` claim), it only contains authorization information about which actions the client is allowed to perform at the API (`scope` claim). 
 
 Since in many cases it is desirable to retrieve additional user information at the API, this token is also valid for calling the `/userinfo` API, which will return the user's profile information. So the intented audience (`aud` claim) of the token is either the API (`my-api-identifier`) or the `/userinfo` endpoint (`https://${account.namespace}/userinfo`).
 

--- a/articles/api-auth/why-use-access-tokens-to-secure-apis.md
+++ b/articles/api-auth/why-use-access-tokens-to-secure-apis.md
@@ -41,9 +41,9 @@ Now that we saw what these tokens can be used for, let's see what they cannot be
 
 ## Keep reading
 
-<i class="notification-icon icon-budicon-345"></i>&nbsp;[Access Token](/tokens/access-token)
-<i class="notification-icon icon-budicon-345"></i>&nbsp;[ID Token](/tokens/id-token)
-<i class="notification-icon icon-budicon-345"></i>&nbsp;[The problem with OAuth for Authentication](http://www.thread-safe.com/2012/01/problem-with-oauth-for-authentication.html)
-<i class="notification-icon icon-budicon-345"></i>&nbsp;[User Authentication with OAuth 2.0](https://oauth.net/articles/authentication/)
-<i class="notification-icon icon-budicon-345"></i>&nbsp;[OAuth 2.0 Overview](/protocols/oauth2)
-<i class="notification-icon icon-budicon-345"></i>&nbsp;[OpenID Connect Overview](/protocols/oidc)
+<i class="notification-icon icon-budicon-345"></i>&nbsp;[Access Token](/tokens/access-token)<br/>
+<i class="notification-icon icon-budicon-345"></i>&nbsp;[ID Token](/tokens/id-token)<br/>
+<i class="notification-icon icon-budicon-345"></i>&nbsp;[The problem with OAuth for Authentication](http://www.thread-safe.com/2012/01/problem-with-oauth-for-authentication.html)<br/>
+<i class="notification-icon icon-budicon-345"></i>&nbsp;[User Authentication with OAuth 2.0](https://oauth.net/articles/authentication/)<br/>
+<i class="notification-icon icon-budicon-345"></i>&nbsp;[OAuth 2.0 Overview](/protocols/oauth2)<br/>
+<i class="notification-icon icon-budicon-345"></i>&nbsp;[OpenID Connect Overview](/protocols/oidc)<br/>

--- a/articles/api-auth/why-use-access-tokens-to-secure-apis.md
+++ b/articles/api-auth/why-use-access-tokens-to-secure-apis.md
@@ -5,12 +5,46 @@ description: Explains the differences between access token and ID token and why 
 
 # Why you should always use access tokens to secure an API
 
-There is much confussion on the Web as to the differences between the OpenID Connect and OAuth 2.0 specifications, and their respective tokens. As a result many developers publish insecure applications, compromising their users security. The contradicting implementations between identity providers do not help either.
+There is much confusion on the Web as to the differences between the OpenID Connect and OAuth 2.0 specifications, and their respective tokens. As a result many developers publish insecure applications, compromising their users security. The contradicting implementations between identity providers do not help either.
 
-This article is an attempt to clear what is what and convince you that you should always use an access token to secure an API, and never an ID token.
+This article is an attempt to clear what is what and explain why you should always use an access token to secure an API, and never an ID token.
 
 ## Two complementary specifications
 
-OpenID Connect is used for __user authentication__. It enables you to verify the identity of a user and get some basic profile information.
+OpenID Connect is used for __user authentication__. It enables you, the user, to verify your identity and give some basic profile information, without sharing your credentials.
 
-OAuth 2.0 is used to __grant authorization__. It enables you to 
+OAuth 2.0 is used to __grant authorization__. It enables you to authorize the Web App A to access your information from Web App B, without sharing your credentials.
+
+An example is a to-do application, that lets you log in using your Google account, and can push your to-do items as calendar entries, at your Google Calendar. The part where you authenticate your identity is implemented via OpenID Connect, while the part where you authorize the to-do application to modify your calendar by adding entries, is implemented via OAuth 2.0.
+
+You may noticed the _"without sharing your credentials"_ part, at our definitions of the two specifications earlier. What you do share in both cases, is tokens.
+
+OpenID Connect issues an identity token, known as `id_token`, while OAuth 2.0 issues an `access_token`.
+
+## How to use each token
+
+The `id_token` is a JWT and is meant for the client only. In the example we used earlier, when you authenticate using Google, an `id_token` is sent from Google to the to-do application, that says who you are. The to-do application can parse the token's contents and use this information, like your name and your profile picture, to customize the user experience.
+
+::: panel-warning Security warning
+You must never use the info in an `id_token` unless you have validated it! For more information refer to: [How to validate an ID token](/tokens/id-token#how-to-validate-an-id-token). For a list of libraries you can use to verify a JWT refer to [JWT.io](https://jwt.io/).
+:::
+
+The `access_token` can be any type of token (not necessarily a JWT) and is meant for the resource/API. Its purpose is to inform the API that the bearer of this token has been authorized to access the API and perform specific actions (as specified by the `scope` that has been granted). In the example we used earlier, after you authenticate, and provide your consent that the to-do application can have read/write access to your calendar, an `access_token` is sent from Google to the to-do application. Each time the to-do application wants to access your Google Calendar it will make a request to the Google Calendar API, using this `access_token` in an HTTP `Authorization` header.
+
+## How NOT to use each token
+
+Now that we saw what these tokens can be used for, let's see what they cannot be used for.
+
+- __An `access_token` should not be used for authentication__. The reason for that is that holds no information about the user. It cannot tell us if the user has authenticated and when. That's why OAuth 2.0 cannot be used for authentication. Instead, OpenID Connect works on top of OAuth 2.0 and provides user authentication.
+
+- __An `id_token` should not be used for API access__. Each token contains information on the intended audience (recipient). According to the OpenID Connect specification, the audience (claim `aud`) of each `id_token` must be the `client_id` of the client making the authentication request. If it isn't you shouldn't trust the token. An API, on the other hand, expects a token with the audience set to the API's unique identifier. So unless you are in control of both the client and the API, sending an `id_token` to an API will not work.
+
+## More information
+
+- [Access Token](/tokens/access-token)
+
+- [ID Token](/tokens/id-token)
+
+- [The problem with OAuth for Authentication](http://www.thread-safe.com/2012/01/problem-with-oauth-for-authentication.html)
+
+- [User Authentication with OAuth 2.0](https://oauth.net/articles/authentication/)

--- a/articles/api-auth/why-use-access-tokens-to-secure-apis.md
+++ b/articles/api-auth/why-use-access-tokens-to-secure-apis.md
@@ -35,7 +35,7 @@ The `access_token` can be any type of token (not necessarily a JWT) and is meant
 
 Now that we saw what these tokens can be used for, let's see what they cannot be used for.
 
-- __An `access_token` should not be used for authentication__. The reason for that is that holds no information about the user. It cannot tell us if the user has authenticated and when. That's why OAuth 2.0 cannot be used for authentication. Instead, OpenID Connect works on top of OAuth 2.0 and provides user authentication.
+- __An `access_token` should not be used for authentication__. The reason for that is that it holds no information about the user. It cannot tell us if the user has authenticated and when. That's why OAuth 2.0 cannot be used for authentication. Instead, OpenID Connect works on top of OAuth 2.0 and provides user authentication.
 
 - __An `id_token` should not be used for API access__. Each token contains information on the intended audience (recipient). According to the OpenID Connect specification, the audience (claim `aud`) of each `id_token` must be the `client_id` of the client making the authentication request. If it isn't you shouldn't trust the token. An API, on the other hand, expects a token with the audience set to the API's unique identifier. So unless you are in control of both the client and the API, sending an `id_token` to an API will not work.
 


### PR DESCRIPTION
New p2 doc