### PR TITLE
Fix API Gateway Example

### DIFF
--- a/articles/integrations/aws-api-gateway/part-2.md
+++ b/articles/integrations/aws-api-gateway/part-2.md
@@ -85,7 +85,7 @@ Before you begin, you will need the ARN for your Gateway API:
 
 You'll strip the method name to get the base ARN for the API:
 
-`arn:aws:execute-api:us-east-2:484857107747:97i1dwv0j4/*/`
+`arn:aws:execute-api:us-east-2:484857107747:97i1dwv0j4/*`
 
 The wildcard (`*`) in the ARN above enables permissions to your API for all stages, but you can deploy different stages individually (for example, development, then test, then production).
 


### PR DESCRIPTION
Trailing slash causes the permissions model on Amazon to deny permissions to `/*/`. This was reported at https://auth0.com/forum/t/accessdeniedexception-cors-with-iam-api-gateway-auth/5483

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->