### PR TITLE
Fixed typo in client-credentials.md page

### DIFF
--- a/articles/api-auth/tutorials/adoption/client-credentials.md
+++ b/articles/api-auth/tutorials/adoption/client-credentials.md
@@ -6,7 +6,7 @@ title: Client Credentials exchange
 
 <%= include('./_about.md') %>
 
-The [Client Credentials exchange](/api-auth/grant/client-credentials) allows clients to authenticate as themselves (i.e. not on behalf of any user) to programatically and securely obtain access to an API.
+The [Client Credentials exchange](/api-auth/grant/client-credentials) allows clients to authenticate as themselves (i.e. not on behalf of any user) to programmatically and securely obtain access to an API.
 This exchange does not exist in the legacy pipeline, but the [Resource Owner Password Credentials exchange](/api-auth/tutorials/adoption/password) can be used to simulate it by creating a "service user".
 We strongly discourage the latter approach in favor of using Client Credentials, since it allows defining fine-grained permissions for each API client.
 


### PR DESCRIPTION
Changed programatically to program**m**atically