### PR TITLE
Add clarification on userinfo and RS256

### DIFF
--- a/articles/api-auth/tutorials/adoption/api-tokens.md
+++ b/articles/api-auth/tutorials/adoption/api-tokens.md
@@ -77,7 +77,7 @@ the token does not contain any information about the user itself besides
 their ID (`sub` claim), it only contains authorization information about
 which actions the client is allowed to perform at the API (scope). Since
 in many cases it’s desirable to retrieve additional user information at
-the API, this token is also valid for calling the /userinfo API, which
+the API, this token is also valid for calling the /userinfo API (provided that the API for which the `access_token` is issued, uses `RS256` as signing algorithm), which
 will return the user’s profile information.
 
 [Note that the `scope` parameter has a different behavior than in the legacy pipeline](/api-auth/tutorials/adoption/scope-custom-claims).

--- a/articles/api-auth/tutorials/adoption/api-tokens.md
+++ b/articles/api-auth/tutorials/adoption/api-tokens.md
@@ -43,7 +43,7 @@ of example tokens which conform to the OIDC specification:
 
 The above is an ID token, which is meant for **authenticating** the user
 to the **client**. Note that the audience (aud claim) of the token is
-set to the client’s identifier, which means that only this specific
+set to the client's identifier, which means that only this specific
 client should consume this token.
 
 The ID token can be thought of as no more than a performance
@@ -52,7 +52,7 @@ without making additional network requests after authentication has
 completed. It should not be used to obtain access to any resources or
 make authorization decisions.
 
-For comparison, let’s look at the contents of an access token that could
+For comparison, let's look at the contents of an access token that could
 be returned in the same authentication flow:
 
 ```json
@@ -76,9 +76,7 @@ that clients should not care about the contents of this token. Note that
 the token does not contain any information about the user itself besides
 their ID (`sub` claim), it only contains authorization information about
 which actions the client is allowed to perform at the API (scope). Since
-in many cases it’s desirable to retrieve additional user information at
-the API, this token is also valid for calling the /userinfo API (provided that the API for which the `access_token` is issued, uses `RS256` as signing algorithm), which
-will return the user’s profile information.
+in many cases it's desirable to retrieve additional user information, this token is also valid for calling the [/userinfo API](/api/authentication#get-user-info) (provided that the API for which the `access_token` is issued, uses `RS256` as signing algorithm), which will return the user's profile information.
 
 [Note that the `scope` parameter has a different behavior than in the legacy pipeline](/api-auth/tutorials/adoption/scope-custom-claims).
 It determines the permissions that an authorized client should have for

--- a/articles/api-auth/tutorials/adoption/authorization-code.md
+++ b/articles/api-auth/tutorials/adoption/authorization-code.md
@@ -116,7 +116,7 @@ Pragma: no-cache
     "id_token": "eyJ..."
 }</code></pre>
         <ul>
-            <li>The returned access token is valid for calling the <a href="/api/authentication#get-user-info">/userinfo endpoint</a> (provided that the API specified by the `audience` param uses `RS256` as signing algorithm) and optionally the resource server specified by the <code>audience</code> parameter.</li>
+            <li>The returned access token is valid for calling the <a href="/api/authentication#get-user-info">/userinfo endpoint</a> (provided that the API specified by the <code>audience</code> param uses <code>RS256</code> as signing algorithm) and optionally the resource server specified by the <code>audience</code> parameter.</li>
             <li>A refresh token will be returned only if the <code>offline_access</code> scope was granted.</li>
         </ul>
     </div>
@@ -193,7 +193,7 @@ Pragma: no-cache
     "scope": "openid email"
 }</code></pre>
         <ul>
-            <li>The returned access token is a JWT valid for calling the <a href="/api/authentication#get-user-info">/userinfo endpoint</a> (provided that the API specified by the `audience` param uses `RS256` as signing algorithm) as well as the resource server specified by the <code>audience</code> parameter.</li>
+            <li>The returned access token is a JWT valid for calling the <a href="/api/authentication#get-user-info">/userinfo endpoint</a> (provided that the API specified by the <code>audience</code> param uses <code>RS256</code> as signing algorithm) as well as the resource server specified by the <code>audience</code> parameter.</li>
             <li>Note that an opaque access token could still be returned if /userinfo is the only specified audience.</li>
         </ul>
     </div>

--- a/articles/api-auth/tutorials/adoption/authorization-code.md
+++ b/articles/api-auth/tutorials/adoption/authorization-code.md
@@ -116,7 +116,7 @@ Pragma: no-cache
     "id_token": "eyJ..."
 }</code></pre>
         <ul>
-            <li>The returned access token is valid for calling the <a href="/api/authentication#get-user-info">/userinfo endpoint</a> and optionally the resource server specified by the <code>audience</code> parameter.</li>
+            <li>The returned access token is valid for calling the <a href="/api/authentication#get-user-info">/userinfo endpoint</a> (provided that the API specified by the `audience` param uses `RS256` as signing algorithm) and optionally the resource server specified by the <code>audience</code> parameter.</li>
             <li>A refresh token will be returned only if the <code>offline_access</code> scope was granted.</li>
         </ul>
     </div>
@@ -193,7 +193,7 @@ Pragma: no-cache
     "scope": "openid email"
 }</code></pre>
         <ul>
-            <li>The returned access token is a JWT valid for calling the <a href="/api/authentication#get-user-info">/userinfo endpoint</a> as well as the resource server specified by the <code>audience</code> parameter.</li>
+            <li>The returned access token is a JWT valid for calling the <a href="/api/authentication#get-user-info">/userinfo endpoint</a> (provided that the API specified by the `audience` param uses `RS256` as signing algorithm) as well as the resource server specified by the <code>audience</code> parameter.</li>
             <li>Note that an opaque access token could still be returned if /userinfo is the only specified audience.</li>
         </ul>
     </div>

--- a/articles/api-auth/tutorials/adoption/implicit.md
+++ b/articles/api-auth/tutorials/adoption/implicit.md
@@ -84,7 +84,7 @@ Location: https://app.example.com/#
     &id_token=eyJ...
     &token_type=Bearer</code></pre>
     <ul>
-        <li>The returned access token is valid for calling the <a href="/api/authentication#get-user-info">/userinfo endpoint</a> (provided that the API specified by the `audience` param uses `RS256` as signing algorithm) and optionally the resource server specified by the <code>audience</code> parameter.</li>
+        <li>The returned access token is valid for calling the <a href="/api/authentication#get-user-info">/userinfo endpoint</a> (provided that the API specified by the <code>audience</code> param uses <code>RS256</code> as signing algorithm) and optionally the resource server specified by the <code>audience</code> parameter.</li>
         <li>If using <code>response_type=id_token</code>, Auth0 will only return an ID token.</li>
         <li>Refresh tokens are not allowed in the implicit grant. <a href="/api-auth/tutorials/silent-authentication">Use <code>prompt=none</code> instead</a>.</li>
     </ul>
@@ -165,7 +165,7 @@ Location: https://app.example.com/#
     "scope": "openid email"
 }</code></pre>
         <ul>
-            <li>The returned access token is a JWT valid for calling the <a href="/api/authentication#get-user-info">/userinfo endpoint</a>(provided that the API specified by the `audience` param uses `RS256` as signing algorithm) as well as the resource server specified by the <code>audience</code> parameter.</li>
+            <li>The returned access token is a JWT valid for calling the <a href="/api/authentication#get-user-info">/userinfo endpoint</a>(provided that the API specified by the <code>audience</code> param uses <code>RS256</code> as signing algorithm) as well as the resource server specified by the <code>audience</code> parameter.</li>
             <li>Note that an opaque access token could still be returned if /userinfo is the only specified audience.</li>
         </ul>
     </div>

--- a/articles/api-auth/tutorials/adoption/implicit.md
+++ b/articles/api-auth/tutorials/adoption/implicit.md
@@ -71,7 +71,7 @@ Location: https://app.example.com/#
     &refresh_token=8xLOxBtZp8
     &token_type=Bearer</code></pre>
     <ul>
-        <li>The returned access token is only valid for calling the <a href="/api/authentication#get-user-info">/userinfo endpoint</a>.</li>
+        <li>The returned access token is valid for calling the <a href="/api/authentication#get-user-info">/userinfo endpoint</a>.</li>
         <li>A refresh token will be returned only if a <code>device</code> parameter was passed and the <code>offline_access</code> scope was requested.</li>
     </ul>
     </div>
@@ -84,7 +84,7 @@ Location: https://app.example.com/#
     &id_token=eyJ...
     &token_type=Bearer</code></pre>
     <ul>
-        <li>The returned access token is valid for calling the <a href="/api/authentication#get-user-info">/userinfo endpoint</a> and optionally the resource server specified by the <code>audience</code> parameter.</li>
+        <li>The returned access token is valid for calling the <a href="/api/authentication#get-user-info">/userinfo endpoint</a> (provided that the API specified by the `audience` param uses `RS256` as signing algorithm) and optionally the resource server specified by the <code>audience</code> parameter.</li>
         <li>If using <code>response_type=id_token</code>, Auth0 will only return an ID token.</li>
         <li>Refresh tokens are not allowed in the implicit grant. <a href="/api-auth/tutorials/silent-authentication">Use <code>prompt=none</code> instead</a>.</li>
     </ul>
@@ -165,7 +165,7 @@ Location: https://app.example.com/#
     "scope": "openid email"
 }</code></pre>
         <ul>
-            <li>The returned access token is a JWT valid for calling the <a href="/api/authentication#get-user-info">/userinfo endpoint</a> as well as the resource server specified by the <code>audience</code> parameter.</li>
+            <li>The returned access token is a JWT valid for calling the <a href="/api/authentication#get-user-info">/userinfo endpoint</a>(provided that the API specified by the `audience` param uses `RS256` as signing algorithm) as well as the resource server specified by the <code>audience</code> parameter.</li>
             <li>Note that an opaque access token could still be returned if /userinfo is the only specified audience.</li>
         </ul>
     </div>

--- a/articles/api-auth/tutorials/adoption/password.md
+++ b/articles/api-auth/tutorials/adoption/password.md
@@ -100,7 +100,7 @@ Pragma: no-cache
     "id_token": "eyJ..."
 }</code></pre>
     <ul>
-        <li>The returned access token is valid for calling the <a href="/api/authentication#get-user-info">/userinfo endpoint</a> and optionally the resource server specified by the <code>audience</code> parameter.</li>
+        <li>The returned access token is valid for calling the <a href="/api/authentication#get-user-info">/userinfo endpoint</a> (provided that the API specified by the `audience` param uses `RS256` as signing algorithm) and optionally the resource server specified by the <code>audience</code> parameter.</li>
         <li>The ID token will be forcibly signed using RS256 if requested by a <a href="/api-auth/client-types">public client</a>.</li>
         <li>A refresh token will be returned only if the <code>offline_access</code> scope was granted.</li>
     </ul>
@@ -180,7 +180,7 @@ Pragma: no-cache
     "scope": "openid email"
 }</code></pre>
         <ul>
-            <li>The returned access token is a JWT valid for calling the <a href="/api/authentication#get-user-info">/userinfo endpoint</a> as well as the resource server specified by the <code>audience</code> parameter.</li>
+            <li>The returned access token is a JWT valid for calling the <a href="/api/authentication#get-user-info">/userinfo endpoint</a> (provided that the API specified by the `audience` param uses `RS256` as signing algorithm) as well as the resource server specified by the <code>audience</code> parameter.</li>
             <li>Note that an opaque access token could still be returned if /userinfo is the only specified audience.</li>
         </ul>
     </div>

--- a/articles/api-auth/tutorials/adoption/password.md
+++ b/articles/api-auth/tutorials/adoption/password.md
@@ -100,7 +100,7 @@ Pragma: no-cache
     "id_token": "eyJ..."
 }</code></pre>
     <ul>
-        <li>The returned access token is valid for calling the <a href="/api/authentication#get-user-info">/userinfo endpoint</a> (provided that the API specified by the `audience` param uses `RS256` as signing algorithm) and optionally the resource server specified by the <code>audience</code> parameter.</li>
+        <li>The returned access token is valid for calling the <a href="/api/authentication#get-user-info">/userinfo endpoint</a> (provided that the API specified by the <code>audience</code> param uses <code>RS256</code> as signing algorithm) and optionally the resource server specified by the <code>audience</code> parameter.</li>
         <li>The ID token will be forcibly signed using RS256 if requested by a <a href="/api-auth/client-types">public client</a>.</li>
         <li>A refresh token will be returned only if the <code>offline_access</code> scope was granted.</li>
     </ul>
@@ -180,7 +180,7 @@ Pragma: no-cache
     "scope": "openid email"
 }</code></pre>
         <ul>
-            <li>The returned access token is a JWT valid for calling the <a href="/api/authentication#get-user-info">/userinfo endpoint</a> (provided that the API specified by the `audience` param uses `RS256` as signing algorithm) as well as the resource server specified by the <code>audience</code> parameter.</li>
+            <li>The returned access token is a JWT valid for calling the <a href="/api/authentication#get-user-info">/userinfo endpoint</a> (provided that the API specified by the <code>audience</code> param uses <code>RS256</code> as signing algorithm) as well as the resource server specified by the <code>audience</code> parameter.</li>
             <li>Note that an opaque access token could still be returned if /userinfo is the only specified audience.</li>
         </ul>
     </div>

--- a/articles/architecture-scenarios/application/mobile-api.md
+++ b/articles/architecture-scenarios/application/mobile-api.md
@@ -16,7 +16,7 @@ When a user logs in, Auth0 will return to the application an `access_token`, an 
 
 - The `access_token` is used to securely call the API on behalf of the user.
 
-- The `id_token` is consumed only by the client and contains user profile data. Alternatively the user profile can be obtained by calling the `/userinfo` endpoint in the Auth0 Authentication API with the `access_token`.
+- The `id_token` is consumed only by the client and contains user profile data. Alternatively the user profile can be obtained by calling the `/userinfo` endpoint in the Auth0 Authentication API with the `access_token` (provided that the API for which the `access_token` is issued, uses `RS256` as signing algorithm).
 
 - The `refresh_token` can be used in order to obtain a new `access_token` whenever a previous one expires. Note that a `refresh_token` will only be present in the response if you included the `offline_access` scope and enabled **Allow Offline Access** for your API in the [Dashboard](${manage_url}).
 

--- a/articles/architecture-scenarios/application/spa-api.md
+++ b/articles/architecture-scenarios/application/spa-api.md
@@ -16,7 +16,7 @@ When a user logs in, Auth0 will return to the application an `access_token` and 
 
 - The `access_token` is used to securely call the API on behalf of the user.
 
-- The `id_token` is consumed only by the client and contains user profile data. Alternatively the user profile can be obtained by calling the `/userinfo` endpoint in the Auth0 Authentication API with the `access_token`. In order for this to work `openid` should be granted as a scope.
+- The `id_token` is consumed only by the client and contains user profile data. Alternatively the user profile can be obtained by calling the `/userinfo` endpoint in the Auth0 Authentication API with the `access_token`. In order for this to work `openid` should be granted as a scope and the API, for which the `access_token` is issued, should use `RS256` as signing algorithm.
 
 The application will usually store the information about the user's session (i.e. whether they are logged in, their tokens, user profile data, and so forth) inside some sort of storage such a Local Storage.
 


### PR DESCRIPTION
If the API uses `RS256` as the signing algorithm, the `access_token` will also include `/userinfo` as a valid audience. You can use this `access_token` to invoke the [/userinfo endpoint](/api/authentication#get-user-info) and retrieve the user's claims.