### PR TITLE
chore(angular2-login): update for angular v4

### DIFF
--- a/articles/quickstart/spa/angular2/_includes/_login.md
+++ b/articles/quickstart/spa/angular2/_includes/_login.md
@@ -116,15 +116,15 @@ As a workaround, look for an `access_token`, `id_token`, or `error` in the hash 
 ```js
 // app/auth.service.ts
 
-import { Router } from '@angular/router';
+import { Router, NavigationStart } from '@angular/router';
 import 'rxjs/add/operator/filter';
 
 constructor(public router: Router) {
   this
     .router
     .events
-    .filter(event => event.constructor.name === 'NavigationStart')
-    .filter(event => (/access_token|id_token|error/).test(event.url))
+    .filter(event => event instanceof NavigationStart)
+    .filter((event: NavigationStart) => (/access_token|id_token|error/).test(event.url))
     .subscribe(() => {
       this.lock.resumeAuth(window.location.hash, (error, authResult) => {
         if (error) return console.log(error);


### PR DESCRIPTION
Updated the sample to use in Angular v4.0.0, as Event does not have an `url` property.

Change due to:
https://github.com/auth0-samples/auth0-angular-samples/pull/22