### PR TITLE
fix fork in github btn for quickstarts inside manage frame

### DIFF
--- a/articles/_includes/_package.html
+++ b/articles/_includes/_package.html
@@ -20,7 +20,7 @@
       <a href="https://github.com/${org || 'auth0-samples'}/${repo}/tree/${branch}/${path}" class="github-link" rel="nofollow">Fork on Github</a>
       <% } else { %>
       <a href="/package/v2?org=${org}&repo=${repo}&path=${path}&client_id=${account.clientId}" class="btn btn-sm btn-success" rel="nofollow">Download</a>
-      <a href="https://github.com/${org || 'auth0-samples'}/${repo}/tree/master/${path}" class="github-link" rel="nofollow">Fork on Github</a>
+      <a href="https://github.com/${org || 'auth0-samples'}/${repo}/tree/master/${path}" class="github-link" rel="nofollow" target="_top">Fork on Github</a>
       <% } %>
     </div>
   </div>


### PR DESCRIPTION
Still need to fix all other links in the quickstarts. But at least this will make the Fork in Github btn work when the quickstart is embedded in manage.

Fixes https://github.com/auth0/auth0-docs/issues/1346