### PR TITLE
Pass 'id_token' to tokenNotExpired function

### DIFF
--- a/articles/quickstart/spa/angular2/_includes/_login.md
+++ b/articles/quickstart/spa/angular2/_includes/_login.md
@@ -43,7 +43,7 @@ export class Auth {
   public authenticated() {
     // Check if there's an unexpired JWT
     // This searches for an item in localStorage with key == 'id_token'
-    return tokenNotExpired();
+    return tokenNotExpired('id_token');
   }
 
   public logout() {


### PR DESCRIPTION
The latest angular2-jwt version uses a default key of 'token' rather than 'id_token' in the tokenNotExpired function.  So this quickstart needs to pass 'id_token' to function properly.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
