### PR TITLE
Changes in lock section

### DIFF
--- a/articles/libraries/lock/v10/api.md
+++ b/articles/libraries/lock/v10/api.md
@@ -4,7 +4,7 @@ toc: true
 description: Details on the Lock V10 API.
 ---
 
-# API
+# Lock: API Reference
 
 Lock has many methods, features, and configurable options. This reference is designed to direct you to the ones that you need, and discuss how to use them. Click below to go straight the method you're looking for, or just browse! If you're looking for information about events emitted by Lock, they're listed under the [on()](#on-event-callback-) method section!
 

--- a/articles/libraries/lock/v10/api.md
+++ b/articles/libraries/lock/v10/api.md
@@ -4,8 +4,6 @@ toc: true
 description: Details on the Lock V10 API.
 ---
 
-<%= include('../_includes/_lock-version') %>
-
 # API
 
 Lock has many methods, features, and configurable options. This reference is designed to direct you to the ones that you need, and discuss how to use them. Click below to go straight the method you're looking for, or just browse! If you're looking for information about events emitted by Lock, they're listed under the [on()](#on-event-callback-) method section!

--- a/articles/libraries/lock/v10/auth0js.md
+++ b/articles/libraries/lock/v10/auth0js.md
@@ -3,8 +3,6 @@ section: libraries
 description: How to use Lock V10 with auth0.js
 ---
 
-<%= include('../_includes/_lock-version') %>
-
 # Using Lock With auth0.js
 
 By nature, Lock and the Auth0.js SDK are very different things. Lock provides a UI that is customizable, to an extent, with behavior that is customizable, to an extent. It is an easily deployed, easily used interface for Auth0 authentication in custom applications. For simple uses, Lock is all that is necessary, sometimes. However, if more customization is requiredin an application's signup, authentication, and user management process, then functionality from the SDK can be used alongside Lock to meet those needs.

--- a/articles/libraries/lock/v10/customization.md
+++ b/articles/libraries/lock/v10/customization.md
@@ -4,7 +4,7 @@ toc: true
 description: Lock 10 has many configurable options that allow you to change the behavior, appearance, and connectivity of the Lock widget - this resource provides the details on those options for you!
 ---
 
-# Lock: Configurable Options
+# Lock: Configuration Options
 
 The **Auth0Lock** can be configured through the `options` parameter sent to the constructor. These options can alter the way that the Lock widget behaves, how it deals with connections, additional signup fields that you require for your project, the language and text values, colors, and images on the widget, and many more. Take a look at the index below if you know what you are looking for, or browse the options for more details.
 

--- a/articles/libraries/lock/v10/customization.md
+++ b/articles/libraries/lock/v10/customization.md
@@ -4,8 +4,6 @@ toc: true
 description: Lock 10 has many configurable options that allow you to change the behavior, appearance, and connectivity of the Lock widget - this resource provides the details on those options for you!
 ---
 
-<%= include('../_includes/_lock-version') %>
-
 # Lock: Configurable Options
 
 The **Auth0Lock** can be configured through the `options` parameter sent to the constructor. These options can alter the way that the Lock widget behaves, how it deals with connections, additional signup fields that you require for your project, the language and text values, colors, and images on the widget, and many more. Take a look at the index below if you know what you are looking for, or browse the options for more details.

--- a/articles/libraries/lock/v10/customizing-error-messages.md
+++ b/articles/libraries/lock/v10/customizing-error-messages.md
@@ -3,8 +3,6 @@ section: libraries
 description: Customizing error messages with Lock 10
 ---
 
-<%= include('../_includes/_lock-version') %>
-
 # Lock: Customizing Error Messages
 
 You can customize the error messages that will be displayed in certain situations by providing a [languageDictionary option](/libraries/lock/v10/customization#languagedictionary-object-). A full listing of available `languageDictionary` fields to customize can be found in the GitHub repository's [English Dictionary file for Lock 10](https://github.com/auth0/lock/blob/master/src/i18n/en.js). Below is an example of some customized error messages:

--- a/articles/libraries/lock/v10/i18n.md
+++ b/articles/libraries/lock/v10/i18n.md
@@ -3,8 +3,6 @@ section: libraries
 description: Lock 10 supports multiple languages, and allows for the addition of other custom language files, as well as for customizing the values of specific pieces of text that are displayed in the Lock widget.
 ---
 
-<%= include('../_includes/_lock-version') %>
-
 # Lock: Internationalization
 
 You can change the language of Lock by using the `language` configuration option. This will pull the corresponding language file from the `i18n` directory in Lock. Take a look at that [i18n directory](https://github.com/auth0/lock/blob/master/src/i18n/) for a current list of provided languages.

--- a/articles/libraries/lock/v10/index.md
+++ b/articles/libraries/lock/v10/index.md
@@ -6,8 +6,6 @@ description: A widget that provides a frictionless login and signup experience f
 img: media/articles/libraries/lock-web.png
 ---
 
-<%= include('../_includes/_lock-version') %>
-
 # Lock 10 for Web
 
 You're looking at the documentation for the _easiest_ way of securing your website and mobile apps!

--- a/articles/libraries/lock/v10/migration-guide.md
+++ b/articles/libraries/lock/v10/migration-guide.md
@@ -4,8 +4,6 @@ toc: true
 description: Lock 9 to Lock 10 Migration Guide
 ---
 
-<%= include('../_includes/_lock-version') %>
-
 # Lock 9 to Lock 10 Migration Guide
 
 The following instructions assume you are migrating from **Lock 9** to the latest **Lock 10**. If you are upgrading from a preview release of Lock 10, please refer to the [preview changes](#upgrading-from-preview-releases). Otherwise, read on!

--- a/articles/libraries/lock/v10/new-features.md
+++ b/articles/libraries/lock/v10/new-features.md
@@ -3,8 +3,6 @@ section: libraries
 description: Describes the new features with Lock V10.
 ---
 
-<%= include('../_includes/_lock-version') %>
-
 # New Features in Lock 10
 
 ## Custom Sign Up Fields

--- a/articles/libraries/lock/v10/popup-mode.md
+++ b/articles/libraries/lock/v10/popup-mode.md
@@ -3,8 +3,6 @@ section: libraries
 description: Details about Popup Mode with Lock V10.
 ---
 
-<%= include('../_includes/_lock-version') %>
-
 # Popup Mode
 
 ## The Default: Redirect Mode

--- a/articles/libraries/lock/v10/sending-authentication-parameters.md
+++ b/articles/libraries/lock/v10/sending-authentication-parameters.md
@@ -3,8 +3,6 @@ section: libraries
 description: Lock V10 documentation on setting authentication parameters.
 ---
 
-<%= include('../_includes/_lock-version') %>
-
 # Lock: Authentication Parameters
 
 You can send parameters when starting a login by adding them to the options object. The example below adds a `state` parameter with a value equal to `'foo'`.

--- a/articles/libraries/lock/v10/ui-customization.md
+++ b/articles/libraries/lock/v10/ui-customization.md
@@ -3,7 +3,7 @@ section: libraries
 description: Customizing the appearance of your Lock widget can be important for branding and a cohesive UI, and this resource highlights the ways in which you can do so while implementing Lock in your project.
 ---
 
-# Customizing the Look and Feel of Lock 10
+# Lock: UI Customization
 
 You can customize the appearance of your Lock widget in a few different ways. The best and safest way to do so is with the provided JavaScript options.
 

--- a/articles/libraries/lock/v10/ui-customization.md
+++ b/articles/libraries/lock/v10/ui-customization.md
@@ -3,8 +3,6 @@ section: libraries
 description: Customizing the appearance of your Lock widget can be important for branding and a cohesive UI, and this resource highlights the ways in which you can do so while implementing Lock in your project.
 ---
 
-<%= include('../_includes/_lock-version') %>
-
 # Customizing the Look and Feel of Lock 10
 
 You can customize the appearance of your Lock widget in a few different ways. The best and safest way to do so is with the provided JavaScript options.

--- a/articles/libraries/lock/v9/authentication-modes.md
+++ b/articles/libraries/lock/v9/authentication-modes.md
@@ -3,9 +3,9 @@ section: libraries
 description: Lock V9 doc on the different types of authentication modes.
 ---
 
-<%= include('../_includes/_lock-version-9') %>
-
 # Lock: Authentication Modes
+
+<%= include('../_includes/_lock-version-9') %>
 
 After Auth0 Lock is opened, you can choose any of the Identity Providers (IdP) that Auth0 has, to Login. Depending on how the IdP Web/App is openned, a different authentication mode is used.
 

--- a/articles/libraries/lock/v9/customization.md
+++ b/articles/libraries/lock/v9/customization.md
@@ -3,9 +3,10 @@ section: libraries
 description: How to configure user options with Lock V9
 ---
 
+# Lock: User configurable options
+
 <%= include('../_includes/_lock-version-9') %>
 
-## Lock: User configurable options
 The **Auth0Lock** can be customized through the `options` parameter sent to the `.show()` methods.
 
 ```js

--- a/articles/libraries/lock/v9/customizing-error-messages.md
+++ b/articles/libraries/lock/v9/customizing-error-messages.md
@@ -3,9 +3,9 @@ section: libraries
 description: Customizing error messages with Lock V9
 ---
 
-<%= include('../_includes/_lock-version-9') %>
-
 # Lock: Customizing Error Messages
+
+<%= include('../_includes/_lock-version-9') %>
 
 You can customize the error messages that will be displayed on certain situations by providing a [dict option](/libraries/lock/v9/customization#dict-object) at the [customization options](/libraries/lock/v9/customization). A full listing of available `dict` fields to customize can be found in the GitHub repository's [English Dictionary file for Lock 9](https://github.com/auth0/lock/blob/v9/i18n/en.json). Below is an example of some customized error messages:
 

--- a/articles/libraries/lock/v9/display-modes.md
+++ b/articles/libraries/lock/v9/display-modes.md
@@ -3,9 +3,9 @@ section: libraries
 description: Lock V9 document on the display modes, overlay and embedded mode
 ---
 
-<%= include('../_includes/_lock-version-9') %>
-
 # Lock: Display Modes
+
+<%= include('../_includes/_lock-version-9') %>
 
 You can display Lock embedded or as a modal dialog with an overlay
 

--- a/articles/libraries/lock/v9/events.md
+++ b/articles/libraries/lock/v9/events.md
@@ -3,9 +3,9 @@ section: libraries
 description: Lock V9 API syntax
 ---
 
-<%= include('../_includes/_lock-version-9') %>
-
 ## Lock: API syntax
+
+<%= include('../_includes/_lock-version-9') %>
 
 ```js
 var lock = new Auth0Lock(clientID, domain).

--- a/articles/libraries/lock/v9/i18n.md
+++ b/articles/libraries/lock/v9/i18n.md
@@ -3,9 +3,9 @@ section: libraries
 description: Lock V9 internationalization 
 ---
 
-<%= include('../_includes/_lock-version-9') %>
-
 # Lock: Internationalization
+
+<%= include('../_includes/_lock-version-9') %>
 
 You can call instantiate the widget with the `dict` option:
 

--- a/articles/libraries/lock/v9/index.md
+++ b/articles/libraries/lock/v9/index.md
@@ -5,9 +5,9 @@ title: Lock 9 for Web
 toc: true
 ---
 
-<%= include('../_includes/_lock-version-9') %>
-
 # Lock 9 for Web
+
+<%= include('../_includes/_lock-version-9') %>
 
 ![Lock Image](/media/articles/libraries/lock/v9/lock-landing.png)
 

--- a/articles/libraries/lock/v9/initialization.md
+++ b/articles/libraries/lock/v9/initialization.md
@@ -3,9 +3,9 @@ section: libraries
 description: Lock V9 guide to initialization.
 ---
 
-<%= include('../_includes/_lock-version-9') %>
-
 # Lock: Initialization
+
+<%= include('../_includes/_lock-version-9') %>
 
 ```javascript
 // Initialize with clientID and domain

--- a/articles/libraries/lock/v9/migration-guide.md
+++ b/articles/libraries/lock/v9/migration-guide.md
@@ -3,9 +3,9 @@ section: libraries
 description: Guide to migrate from Auth0 Widget to Auth0 Lock.
 ---
 
-<%= include('../_includes/_lock-version-9') %>
-
 # Lock: Migration Guide
+
+<%= include('../_includes/_lock-version-9') %>
 
 This guide will walk you through the needed changes to migrate from **Auth0Widget** to **Auth0Lock**.
 

--- a/articles/libraries/lock/v9/selecting-the-connection-for-multiple-logins.md
+++ b/articles/libraries/lock/v9/selecting-the-connection-for-multiple-logins.md
@@ -3,9 +3,9 @@ section: libraries
 description: Describes different options for selecting the connection in Auth0 when there are multiple login options for Lock v9.
 ---
 
-<%= include('../_includes/_lock-version-9') %>
-
 # Selecting the connection in Auth0 for multiple login options
+
+<%= include('../_includes/_lock-version-9') %>
 
 Auth0 allows you to offer your users multiple ways of authenticating. This is especially important with SaaS, multitenant apps in which a single app is used by many different organizations, each one potentially using different systems: LDAP, Active Directory, Google Apps, or username/password stores.
 

--- a/articles/libraries/lock/v9/sending-authentication-parameters.md
+++ b/articles/libraries/lock/v9/sending-authentication-parameters.md
@@ -3,9 +3,9 @@ section: libraries
 description: Supported parameters that can be used with Lock V9.
 ---
 
-<%= include('../_includes/_lock-version-9') %>
-
 # Lock: Authentication Parameters
+
+<%= include('../_includes/_lock-version-9') %>
 
 You can send parameters when starting a login by adding them to the options object. The example below adds a `state` parameter with a value equal to `'foo'`.
 

--- a/articles/libraries/lock/v9/types-of-applications.md
+++ b/articles/libraries/lock/v9/types-of-applications.md
@@ -3,9 +3,9 @@ section: libraries
 description: Explains the types of applications that can be used with Lock.
 ---
 
-<%= include('../_includes/_lock-version-9') %>
-
 # Lock: Types of applications
+
+<%= include('../_includes/_lock-version-9') %>
 
 You can use Auth0 Lock with both Single Page Apps and with Regular WebApps. In this section we'll learn how to use it with each of them.
 

--- a/articles/libraries/lock/v9/ui-customization.md
+++ b/articles/libraries/lock/v9/ui-customization.md
@@ -3,9 +3,9 @@ section: libraries
 description: Customizing how Lock with CSS and Javascript
 ---
 
-<%= include('../_includes/_lock-version-9') %>
-
 # Lock: Customize the look and feel
+
+<%= include('../_includes/_lock-version-9') %>
 
 You can apply your own styles to the elements of the Lock.
 

--- a/articles/libraries/lock/v9/using-a-refresh-token.md
+++ b/articles/libraries/lock/v9/using-a-refresh-token.md
@@ -3,9 +3,9 @@ section: libraries
 description: Getting and using a refresh token with Lock.
 ---
 
-<%= include('../_includes/_lock-version-9') %>
-
 # Lock: Refresh tokens
+
+<%= include('../_includes/_lock-version-9') %>
 
 Mostly when building mobile apps, we want to show the signin page only once and then leave the user logged in forever. For those cases, it makes sense to have a `refreshToken`. A `refreshToken` lets us get a new `id_token` (`JWT`) anytime we want.
 


### PR DESCRIPTION
- Remove the alerts from all Lock v10 articles (there is no need to alert the user that he is seeing the latest version). Only keep alerts for older versions.
- Move all alerts below the main title
- Make Lock section titles more consistent (add `Lock:` at the beginning, change titles)