### PR TITLE
Update Google Apps SAML configuration

### DIFF
--- a/articles/protocols/saml/saml-apps/index.md
+++ b/articles/protocols/saml/saml-apps/index.md
@@ -16,9 +16,11 @@ description: This page lists SAML Configurations for various SSO integrations in
   "passthroughClaimsWithNoMapping": false,
   "mapUnknownClaimsAsIs": false,
   "mapIdentities": false,
+  "signatureAlgorithm": "rsa-sha256",
+  "digestAlgorithm": "sha256",
   "nameIdentifierFormat": "urn:oasis:names:tc:SAML:2.0:nameid-format:email",
   "nameIdentifierProbes": [
-    "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"
+    "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"
   ],
 }
 ```


### PR DESCRIPTION
Based on recent integration with GApps suite.

Following the requirements specified by Google, the NameID needs to be an email address.
Source: https://support.google.com/a/answer/6330801?hl=en

This changes the identifier format and probe to grab the email as expected.

Also uses sha256 for signature and digest because Google supports the newer hashing algorithm.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
