### PR TITLE
Pass object literal instead of user ID directly to metadata API functions

### DIFF
--- a/articles/email/custom.md
+++ b/articles/email/custom.md
@@ -43,7 +43,7 @@ function (user, context, callback) {
 
     // Email sent flag persisted in the user's profile.
     user.app_metadata.verification_email_sent = true;
-    auth0.users.updateUserMetadata(user.user_id, user.app_metadata)
+    auth0.users.updateUserMetadata({ id: user.user_id }, user.app_metadata)
       .then(function() {
         callback(null, user, context);
       })

--- a/articles/integrations/office-365-custom-provisioning.md
+++ b/articles/integrations/office-365-custom-provisioning.md
@@ -106,7 +106,7 @@ function (user, context, callback) {
         user.app_metadata.office365_provisioned = true;
         user.app_metadata.office365_upn = context.userPrincipalName;
         user.app_metadata.office365_immutable_id = context.immutableId;
-        auth0.users.updateAppMetadata(user.user_id, user.app_metadata)
+        auth0.users.updateAppMetadata({ id: user.user_id }, user.app_metadata)
         .then(function() {
           // Wait a little bit, it takes some time before the user is created.
           setTimeout(function() {

--- a/articles/link-accounts/suggested-linking.md
+++ b/articles/link-accounts/suggested-linking.md
@@ -165,7 +165,7 @@ function _mergeMetadata(primaryUser, secondaryUser){
   
   return Promise.all([
     auth0.users.updateUserMetadata({ id: primaryUser.user_id }, mergedUserMetadata),
-    auth0.users.updateAppMetadata(primaryUser.user_id, mergedAppMetadata)
+    auth0.users.updateAppMetadata({ id: primaryUser.user_id }, mergedAppMetadata)
   ]).then(result => {
     //save result in primary user in session
     primaryUser.user_metadata = result[0].user_metadata;

--- a/articles/link-accounts/suggested-linking.md
+++ b/articles/link-accounts/suggested-linking.md
@@ -164,7 +164,7 @@ function _mergeMetadata(primaryUser, secondaryUser){
   const mergedAppMetadata = _.merge({}, secondaryUser.app_metadata, primaryUser.app_metadata, customizerCallback);
   
   return Promise.all([
-    auth0.users.updateUserMetadata(primaryUser.user_id, mergedUserMetadata),
+    auth0.users.updateUserMetadata({ id: primaryUser.user_id }, mergedUserMetadata),
     auth0.users.updateAppMetadata(primaryUser.user_id, mergedAppMetadata)
   ]).then(result => {
     //save result in primary user in session

--- a/articles/rules/metadata-in-rules.md
+++ b/articles/rules/metadata-in-rules.md
@@ -102,7 +102,7 @@ function(user, context, callback){
   user.app_metadata.roles.push('administrator');
 
   // persist the app_metadata update
-  auth0.users.updateAppMetadata(user.user_id, user.app_metadata)
+  auth0.users.updateAppMetadata({ id: user.user_id }, user.app_metadata)
     .then(function(){
       callback(null, user, context);
     })
@@ -186,7 +186,7 @@ function(user, context, callback){
   user.app_metadata.roles.push('admin');
 
   // persist the app_metadata update
-  var appMetadataPromise  = auth0.users.updateAppMetadata(user.user_id, user.app_metadata);
+  var appMetadataPromise  = auth0.users.updateAppMetadata({ id: user.user_id }, user.app_metadata);
 
   // persist the user_metadata update
   var userMetadataPromise = auth0.users.updateUserMetadata({ id: user.user_id }, user.user_metadata);
@@ -280,7 +280,7 @@ function(user, context, callback){
   user.app_metadata.roles = null;
 
   // persist the app_metadata update
-  auth0.users.updateAppMetadata(user.user_id, user.app_metadata)
+  auth0.users.updateAppMetadata({ id: user.user_id }, user.app_metadata)
     .then(function(){
       callback(null, user, context);
     })
@@ -322,7 +322,7 @@ function(user, context, callback){
   }
 
   // persist the app_metadata update
-  auth0.users.updateAppMetadata(user.user_id, user.app_metadata)
+  auth0.users.updateAppMetadata({ id: user.user_id }, user.app_metadata)
     .then(function(){
       callback(null, user, context);
     })

--- a/articles/rules/metadata-in-rules.md
+++ b/articles/rules/metadata-in-rules.md
@@ -141,7 +141,7 @@ function(user, context, callback){
   user.user_metadata.preferences.fontSize = 12;
 
   // persist the user_metadata update
-  auth0.users.updateUserMetadata(user.user_id, user.user_metadata)
+  auth0.users.updateUserMetadata({ id: user.user_id }, user.user_metadata)
     .then(function(){
       callback(null, user, context);
     })
@@ -189,7 +189,7 @@ function(user, context, callback){
   var appMetadataPromise  = auth0.users.updateAppMetadata(user.user_id, user.app_metadata);
 
   // persist the user_metadata update
-  var userMetadataPromise = auth0.users.updateUserMetadata(user.user_id, user.user_metadata);
+  var userMetadataPromise = auth0.users.updateUserMetadata({ id: user.user_id }, user.user_metadata);
 
   // using q library to wait for all promises to complete
   q.all([userMetadataPromise, appMetadataPromise])
@@ -363,7 +363,7 @@ function(user, context, callback){
   delete user.user_metadata.preferences.color;
 
   // persist the user_metadata update
-  auth0.users.updateUserMetadata(user.user_id, user.user_metadata)
+  auth0.users.updateUserMetadata({ id: user.user_id }, user.user_metadata)
     .then(function(){
       callback(null, user, context);
     })

--- a/articles/user-profile/user-data-storage.md
+++ b/articles/user-profile/user-data-storage.md
@@ -92,7 +92,7 @@ function (user, context, callback) {
 
     if (plays >= 100 && user.roles.indexOf('playlist_editor') < 0){
       user.app_metadata.roles.push('playlist_editor');
-      auth0.users.updateAppMetadata(user.user_id, user.app_metadata)
+      auth0.users.updateAppMetadata({ id: user.user_id }, user.app_metadata)
         .then(function(){
           callback(null, user, context);
         })
@@ -101,7 +101,7 @@ function (user, context, callback) {
 
     else if (plays < 100 && user.roles.indexOf('playlist_editor') >= 0){
       user.app_metadata.roles = [];
-      auth0.users.updateAppMetadata(user.user_id, user.app_metadata)
+      auth0.users.updateAppMetadata({ id: user.user_id }, user.app_metadata)
         .then(function(){
           callback(null, user, context);
         })

--- a/articles/user-profile/user-data-storage.md
+++ b/articles/user-profile/user-data-storage.md
@@ -153,7 +153,7 @@ function(user, context, callback){
   user.user_metadata = user.user_metadata || {};
   user.user_metadata.displayName = user.user_metadata.displayName || "user";
 
-  auth0.users.updateUserMetadata(user.user_id, user.user_metadata)
+  auth0.users.updateUserMetadata({ id: user.user_id }, user.user_metadata)
     .then(function(){
       callback(null, user, context);
     })


### PR DESCRIPTION
Updated calls to `updateUserMetadata` and `updateAppMetadata` to use object literal instead of passing the ID directly in the call, e.g., `auth0.users.updateUserMetadata({ id: user.user_id }, user.app_metadata)` instead of `auth0.users.updateUserMetadata(user.user_id, user.app_metadata)`.
