### PR TITLE
missing Reply URL configuration after step 4.

### DIFF
--- a/articles/connections/enterprise/azure-active-directory.md
+++ b/articles/connections/enterprise/azure-active-directory.md
@@ -92,7 +92,13 @@ Click on **Save** and the key will be displayed. **Make sure to copy the value o
 
 ![Creating a Key](/media/articles/connections/enterprise/azure-active-directory/azure-ad-4-2b.png)
 
-## 5. Copy the Client ID and Client Secret to Auth0
+## 5 Configure Reply URLs for you Azure AD Application.
+Next you need to ensure that your **Auth0** tenant url is listed in allowed reply urls for the created application.
+Navigate to Azure AD -> Apps registrations -> Your app -> Setttings -> Reply URLs and add callback url of your Auth0 account to the list of allowed urls. It has the following format `https://<accountname>.<region>.auth0.com/login/callback` (`region` part is omitted if Auth0 account has been created in US region.
+
+Without this step, Azure AD administrator can't *give consent* to your app (Step .6) - App consent page will end up with a "Bad request" error. Fine print in the footer of this error page can be used to identify the exact tenant name and missing callback url.
+
+## 6. Copy the Client ID and Client Secret to Auth0
 
 Login to your [Auth0 Dashboard](${manage_url}), and select the **Connections > Enterprise** menu option. Select **Windows Azure AD**. In the **Configuration** tab you will configure global settings, including data about the app registration you just created in Auth0.
 
@@ -108,7 +114,7 @@ For the **Client Secret** use the value that was shown for the key when you crea
 
 Click **SAVE** when you have finished.
 
-## 6. Create Connections
+## 7. Create Connections
 
 After configuring the global settings that link Auth0 to the app registration in Azure AD, you will create one or more connections. Go to [Connections->Enterprise](${manage_url}/#/connections/enterprise) and click on the **CREATE NEW** button next to **Microsoft Azure AD**.
 


### PR DESCRIPTION
Added it as Step 5. 
Was configuring new app from scratch and stuck on  giving consent to Azure AD app (Step 7 now). Then discovered that app is misconfigured ( on the app creation step I put my web app url for login, but not account.auth9.com/login/callback

Reluctant to make screenshots on my company portal, so feel free to reject this pr and make a proper one with nice screenshots. on how to navigate to Reply URLs. 

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
