### PR TITLE
Change passwordless version alerts

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,4 @@
 // Place your settings in this file to overwrite default and user settings.
 {
-  "editor.wrappingColumn": 0
+
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -751,9 +751,16 @@ The `versioning` object has the following properties:
 
 When a user views an article within a versioned topic, a select will be added after the main title:
 
-![Versioned article Select UI](https://cloud.githubusercontent.com/assets/6318057/25853436/23e93e44-34a3-11e7-8627-1a0364eb9b2c.png)
+![Versioned article Select UI](https://cloud.githubusercontent.com/assets/6318057/25916081/cf14663a-3599-11e7-92ea-c4fbadd45741.png)
 
-It is recommended to add an alert after the version selector for outdated articles.
+If the document is outdated you can add an alert **(after the main title)** using the following HTML structure:
+
+```
+<div class="alert alert-warning version-alert">
+  This document uses an older version of auth0.js. We recommend you to
+  <a href="/libraries/auth0js/v8/migration-guide">upgrade to the latest version</a>.
+</div>
+```
 
 The user can navigate between versions of the topic by selecting a new version from the drop-down box. If an article with the same filename is present in the newly-selected version, the user will navigate to that article. If no article with the same filename is present, they will instead receive a HTTP redirect (302) to the *default article* for that version.
 

--- a/articles/connections/passwordless/_older-version-alert.md
+++ b/articles/connections/passwordless/_older-version-alert.md
@@ -1,0 +1,4 @@
+<div class="alert alert-warning version-alert">
+This document uses an older version of auth0.js. We recommend you to
+<a href="/libraries/auth0js/v8/migration-guide">upgrade to the latest version</a>.
+</div>

--- a/articles/connections/passwordless/regular-web-app-email-code/v7/index.md
+++ b/articles/connections/passwordless/regular-web-app-email-code/v7/index.md
@@ -2,11 +2,9 @@
 title: Using Passwordless Authentication with a one-time code via email on Regular Web Apps
 ---
 
-<div class="alert alert-info">
-This document covers Passwordless Authentication, and uses an older version of auth0.js. If at all possible, we recommend using the newest version of auth0.js instead. You can see a copy of this Passwordless documentation that uses the latest version of auth0.js using the dropdown at the top of this document. If you are interested in upgrading the version of Auth0.js used in your app, take a look at the most recent <a href="/libraries/auth0js/v8/migration-guide">migration guide</a>.
-</div>
-
 # Passwordless Authentication with a one-time code via e-mail on Regular Web Apps
+
+<%= include('../../_older-version-alert' %>
 
 <%= include('../../_introduction-email', { isMobile: false }) %>
 

--- a/articles/connections/passwordless/regular-web-app-email-code/v8/index.md
+++ b/articles/connections/passwordless/regular-web-app-email-code/v8/index.md
@@ -2,10 +2,6 @@
 title: Using Passwordless Authentication with a one-time code via email on Regular Web Apps
 ---
 
-<div class="alert alert-info">
-This document covers Passwordless Authentication, and uses the most up-to-date version of auth0.js - version 8. We recommend using this version, but if you are already using version 7, you can see the Passwordless documentation that uses version 7 using the dropdown at the top of this document. If you are interested in upgrading to use auth0.js v8, take a look at the <a href="/libraries/auth0js/v8/migration-guide">migration guide</a>.
-</div>
-
 # Passwordless Authentication with a one-time code via e-mail on Regular Web Apps
 
 <%= include('../../_introduction-email', { isMobile: false }) %>

--- a/articles/connections/passwordless/regular-web-app-email-link.md
+++ b/articles/connections/passwordless/regular-web-app-email-link.md
@@ -2,11 +2,11 @@
 title: Using Passwordless Authentication with a magic link via email on Regular Web Apps
 ---
 
-<div class="alert alert-info">
+# Passwordless Authentication with a magic link via e-mail on Regular Web Apps
+
+<div class="alert alert-warning version-alert">
 This document covers Passwordless Authentication with Magic Links, and uses the auth0.js v7 SDK. The newest version of auth0.js (v8) does not yet include this functionality.
 </div>
-
-# Passwordless Authentication with a magic link via e-mail on Regular Web Apps
 
 <%= include('./_introduction-email-magic-link') %>
 

--- a/articles/connections/passwordless/regular-web-app-email-link.md
+++ b/articles/connections/passwordless/regular-web-app-email-link.md
@@ -4,7 +4,7 @@ title: Using Passwordless Authentication with a magic link via email on Regular 
 
 # Passwordless Authentication with a magic link via e-mail on Regular Web Apps
 
-<div class="alert alert-warning version-alert">
+<div class="alert alert-warning">
 This document covers Passwordless Authentication with Magic Links, and uses the auth0.js v7 SDK. The newest version of auth0.js (v8) does not yet include this functionality.
 </div>
 

--- a/articles/connections/passwordless/regular-web-app-sms/v7/index.md
+++ b/articles/connections/passwordless/regular-web-app-sms/v7/index.md
@@ -2,11 +2,9 @@
 title: Using Passwordless Authentication in a Regular Web App with SMS
 ---
 
-<div class="alert alert-info">
-This document covers Passwordless Authentication, and uses an older version of auth0.js. If at all possible, we recommend using the newest version of auth0.js instead. You can see a copy of this Passwordless documentation that uses the latest version of auth0.js using the dropdown at the top of this document. If you are interested in upgrading the version of Auth0.js used in your app, take a look at the most recent <a href="/libraries/auth0js/v8/migration-guide">migration guide</a>.
-</div>
-
 # Authenticate users with a one-time code via SMS in a Regular Web App
+
+<%= include('../../_older-version-alert' %>
 
 <%= include('../../_introduction-sms', { isMobile: false }) %>
 

--- a/articles/connections/passwordless/regular-web-app-sms/v8/index.md
+++ b/articles/connections/passwordless/regular-web-app-sms/v8/index.md
@@ -2,10 +2,6 @@
 title: Using Passwordless Authentication in a Regular Web App with SMS
 ---
 
-<div class="alert alert-info">
-This document covers Passwordless Authentication, and uses the most up-to-date version of auth0.js - version 8. We recommend using this version, but if you are already using version 7, you can see the Passwordless documentation that uses version 7 using the dropdown at the top of this document. If you are interested in upgrading to use auth0.js v8, take a look at the <a href="/libraries/auth0js/v8/migration-guide">migration guide</a>.
-</div>
-
 # Authenticate users with a one-time code via SMS in a Regular Web App
 
 <%= include('../../_introduction-sms', { isMobile: false }) %>

--- a/articles/connections/passwordless/spa-email-code/v7/index.md
+++ b/articles/connections/passwordless/spa-email-code/v7/index.md
@@ -2,11 +2,9 @@
 title: Using Passwordless Authentication with a one-time code via email on SPA
 ---
 
-<div class="alert alert-info">
-This document covers Passwordless Authentication, and uses an older version of auth0.js. If at all possible, we recommend using the newest version of auth0.js instead. You can see a copy of this Passwordless documentation that uses the latest version of auth0.js using the dropdown at the top of this document. If you are interested in upgrading the version of Auth0.js used in your app, take a look at the most recent <a href="/libraries/auth0js/v8/migration-guide">migration guide</a>.
-</div>
-
 # Authenticate users with a one-time code via e-mail on SPA
+
+<%= include('../../_older-version-alert' %>
 
 <%= include('../../_introduction-email', { isMobile: false }) %>
 

--- a/articles/connections/passwordless/spa-email-code/v8/index.md
+++ b/articles/connections/passwordless/spa-email-code/v8/index.md
@@ -2,10 +2,6 @@
 title: Using Passwordless Authentication with a one-time code via email on SPA
 ---
 
-<div class="alert alert-info">
-This document covers Passwordless Authentication, and uses the most up-to-date version of auth0.js - version 8. We recommend using this version, but if you are already using version 7, you can see the Passwordless documentation that uses version 7 using the dropdown at the top of this document. If you are interested in upgrading to use auth0.js v8, take a look at the <a href="/libraries/auth0js/v8/migration-guide">migration guide</a>.
-</div>
-
 # Authenticate users with a one-time code via e-mail on SPA
 
 <%= include('../../_introduction-email', { isMobile: false }) %>

--- a/articles/connections/passwordless/spa-email-link.md
+++ b/articles/connections/passwordless/spa-email-link.md
@@ -4,7 +4,7 @@ title: Using Passwordless Authentication with a Magic Link via email on SPA
 
 # Authenticate users with a Magic Link via e-mail on SPA
 
-<div class="alert alert-warning version-alert">
+<div class="alert alert-warning">
 This document covers Passwordless Authentication with Magic Links, and uses the auth0.js v7 SDK. The newest version of auth0.js (v8) does not yet include this functionality.
 </div>
 

--- a/articles/connections/passwordless/spa-email-link.md
+++ b/articles/connections/passwordless/spa-email-link.md
@@ -2,11 +2,11 @@
 title: Using Passwordless Authentication with a Magic Link via email on SPA
 ---
 
-<div class="alert alert-info">
+# Authenticate users with a Magic Link via e-mail on SPA
+
+<div class="alert alert-warning version-alert">
 This document covers Passwordless Authentication with Magic Links, and uses the auth0.js v7 SDK. The newest version of auth0.js (v8) does not yet include this functionality.
 </div>
-
-# Authenticate users with a Magic Link via e-mail on SPA
 
 <%= include('./_introduction-email-magic-link') %>
 

--- a/articles/connections/passwordless/spa-sms/v7/index.md
+++ b/articles/connections/passwordless/spa-sms/v7/index.md
@@ -2,11 +2,9 @@
 title: Using Passwordless Authentication in SPA with SMS
 ---
 
-<div class="alert alert-info">
-This document covers Passwordless Authentication, and uses an older version of auth0.js. If at all possible, we recommend using the newest version of auth0.js instead. You can see a copy of this Passwordless documentation that uses the latest version of auth0.js using the dropdown at the top of this document. If you are interested in upgrading the version of Auth0.js used in your app, take a look at the most recent <a href="/libraries/auth0js/v8/migration-guide">migration guide</a>.
-</div>
-
 # Authenticate Users With a One Time Code via SMS in a SPA
+
+<%= include('../../_older-version-alert' %>
 
 <%= include('../../_introduction-sms', { isMobile: true }) %>
 

--- a/articles/connections/passwordless/spa-sms/v8/index.md
+++ b/articles/connections/passwordless/spa-sms/v8/index.md
@@ -2,10 +2,6 @@
 title: Using Passwordless Authentication in SPA with SMS
 ---
 
-<div class="alert alert-info">
-This document covers Passwordless Authentication, and uses the most up-to-date version of auth0.js - version 8. We recommend using this version, but if you are already using version 7, you can see the Passwordless documentation that uses version 7 using the dropdown at the top of this document. If you are interested in upgrading to use auth0.js v8, take a look at the <a href="/libraries/auth0js/v8/migration-guide">migration guide</a>.
-</div>
-
 # Authenticate Users With a One Time Code via SMS in a SPA
 
 <%= include('../../_introduction-sms', { isMobile: true }) %>

--- a/articles/libraries/lock/_includes/_lock-version-9.md
+++ b/articles/libraries/lock/_includes/_lock-version-9.md
@@ -1,3 +1,3 @@
-<div class="alert alert-warning">
-This document covers an outdated version of Lock - version 9. We recommend using the latest version of the library. To do so select v10 at the dropdown. If you are already using v9 but interested in upgrading, take a look at the <a href="/libraries/lock/v10/migration-guide">Lock 9 to Lock 10 migration guide</a>.
+<div class="alert alert-warning version-alert">
+This document covers an outdated version of Lock. We recommend you to <a href="/libraries/lock/v10/migration-guide">upgrade to v10</a>.
 </div>


### PR DESCRIPTION
- Remove the version alert of latest version (v8) of passwordless docs
- Add older-version-alert include with shorter copy (using the `.version-alert` class) for older docs (v7)
- Change copy and add `.version-alert` class to Lock v9 docs.
- Add info to contributing.md for adding versioning alerts

Before:
![image](https://cloud.githubusercontent.com/assets/6318057/25914115/870e85a6-3593-11e7-9cfa-a44bb25181d3.png)


After:
![image](https://cloud.githubusercontent.com/assets/6318057/25914102/77c52e7e-3593-11e7-9757-b5f153d64e18.png)

It needs the styles of https://github.com/auth0/auth0-docs/pull/1373
