### PR TITLE
Use the auth0 object thats created, not the Classtype

### DIFF
--- a/articles/libraries/auth0-android/index.md
+++ b/articles/libraries/auth0-android/index.md
@@ -45,7 +45,7 @@ Method one is to simply create an instance of `Auth0` with your client informati
 
 ```java
 Auth0 account = new Auth0("${account.clientId}", "${account.namespace}");
-auth0.setOIDCConformant(true);
+account.setOIDCConformant(true);
 ```
 
 ### 2) Client information read from XML
@@ -64,7 +64,7 @@ And then create your new Auth0 instance by passing an Android Context:
 
 ```java
 Auth0 account = new Auth0(context);
-auth0.setOIDCConformant(true);
+account.setOIDCConformant(true);
 ```
 
 ## Using the Authentication API


### PR DESCRIPTION
When setting setOIDCConformant it states to use an object called "auth0" when it should be the Auth0 object thats created called "account"
