### PR TITLE
Plugin install command correction

### DIFF
--- a/articles/quickstart/native/ionic2/01-login.md
+++ b/articles/quickstart/native/ionic2/01-login.md
@@ -63,13 +63,13 @@ ${snippet(meta.snippets.cordova)}
 You must install the `SafariViewController` plugin from Cordova to be able to show the Login popup. The seed project already has this plugin added, but if you are adding Auth0 to your own application you need to run the following command:
 
 ```bash
-ionic cordova plugin add cordova-plugin-safariviewcontroller
+ionic plugin add cordova-plugin-safariviewcontroller
 ```
 
 You'll also need to install the `CustomURLScheme` from Cordova to handle redirects properly. The seed project has it already, but if you're adding Auth0 to your own project, you'll need to run this command (replace `YOUR_PACKAGE_ID` with your app identifier):
 
 ```bash
-ionic cordova plugin add cordova-plugin-customurlscheme --variable URL_SCHEME={YOUR_PACKAGE_ID} --variable ANDROID_SCHEME={YOUR_PACKAGE_ID} --variable ANDROID_HOST=${account.namespace} --variable ANDROID_PATHPREFIX=/cordova/{YOUR_PACKAGE_ID}/callback
+ionic plugin add cordova-plugin-customurlscheme --variable URL_SCHEME={YOUR_PACKAGE_ID} --variable ANDROID_SCHEME={YOUR_PACKAGE_ID} --variable ANDROID_HOST=${account.namespace} --variable ANDROID_PATHPREFIX=/cordova/{YOUR_PACKAGE_ID}/callback
 ```
 
 ## Create an Authentication Service and Configure Auth0


### PR DESCRIPTION
**First Change** 
The listed commands to install included both ionic and cordova in same statement. i.e. `ionic cordova plugin add ...`

Was
```bash
ionic cordova plugin add cordova-plugin-safariviewcontroller
```

Now

```bash
ionic plugin add cordova-plugin-safariviewcontroller
```

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
