### PR TITLE
Added details regarding Lock configuration

### DIFF
--- a/articles/quickstart/native/wpf-winforms/01-login.md
+++ b/articles/quickstart/native/wpf-winforms/01-login.md
@@ -43,7 +43,7 @@ ${snippet(meta.snippets.use)}
 
 ![](/media/articles/native-platforms/wpf-winforms/wpf-winforms-step1.png)
 
-This will load Lock into a web view. If you want to customize Lock you need to enable the [Custom Login Page](https://manage.auth0.com/#/login_page) from your hosted pages. Please refer to [Lock documentation](https://auth0.com/docs/libraries/lock/v10) for available options.
+This will load Lock into a web view. If you want to customize Lock you need to enable the [Custom Login Page](${manage_url}/#/login_page) from your hosted pages. Please refer to [Lock documentation](/libraries/lock) for available options.
 
 ## Accessing the User's Information
 

--- a/articles/quickstart/native/wpf-winforms/01-login.md
+++ b/articles/quickstart/native/wpf-winforms/01-login.md
@@ -43,6 +43,8 @@ ${snippet(meta.snippets.use)}
 
 ![](/media/articles/native-platforms/wpf-winforms/wpf-winforms-step1.png)
 
+This will load Lock into a web view. If you want to customize Lock you need to enable the [Custom Login Page](https://manage.auth0.com/#/login_page) from your hosted pages. Please refer to [Lock documentation](https://auth0.com/docs/libraries/lock/v10) for available options.
+
 ## Accessing the User's Information
 
 The returned login result will indicate whether authentication was successful, and if so contain the tokens and claims of the user.


### PR DESCRIPTION
Users get confused when Lock is mentioned in this sample. Added a note to indicate that Lock is loaded from Auth0 and can be configured in the hosted pages section.
