### PR TITLE
SAML Index Clean Up

### DIFF
--- a/articles/protocols/saml/index.html
+++ b/articles/protocols/saml/index.html
@@ -119,10 +119,4 @@ title: SAML
       </li>
     </ul>
   </li>
-  <li>
-    <i class="icon icon-budicon-715"></i><a href="/protocols/saml/idp-initiated-sso">IdP-Initiated SSO</a>
-    <p>
-      This article explains how to set up Identity Provider initiated Single Sign On.
-    </p>
-  </li>
 </ul>

--- a/articles/protocols/saml/index.html
+++ b/articles/protocols/saml/index.html
@@ -56,41 +56,6 @@ title: SAML
     </ul>
   </li>
   <li>
-    <i class="icon icon-budicon-715"></i><a href="/samlp">Configure a SAML Identity Provider Connection</a>
-    <p>
-      How to configure a SAML Identity Provider Connection
-    </p>
-  </li>
-  <li>
-    <i class="icon icon-budicon-715"></i><a href="/saml-idp-generic">Auth0 as Identity Provider</a>
-    <p>
-      How to configure Auth0 to serve as an Identity Provider in a SAML federation.
-    </p>
-    <ul>
-      <li>
-        <i class="icon icon-budicon-695"></i><a href="/protocols/saml/saml-idp-eloqua">Configure Auth0 as IdP for Oracle Eloqua</a>
-      </li>
-    </ul>
-  </li>
-  <li>
-    <i class="icon icon-budicon-715"></i><a href="/saml-sp-generic">Auth0 as Service Provider</a>
-    <p>
-      How to configure Auth0 to serve as a Service Provider in a SAML federation.
-    </p>
-  </li>
-  <li>
-    <i class="icon icon-budicon-715"></i><a href="/samlsso-auth0-to-auth0">SAML SSO with Auth0 as Service Provider and as an Identity Provider</a>
-    <p>
-      Learn how to use SAML SSO with Auth0 as both the Service Provider and Identity Provider, using two Auth0 accounts, allowing you to test your Auth0 SAML without configuring another provider to do so!
-    </p>
-  </li>
-  <li>
-    <i class="icon icon-budicon-715"></i><a href="/samlp">SAML Identity Provider Configuration</a>
-    <p>
-      How to configure a SAML Identity Provider.
-    </p>
-  </li>
-  <li>
     <i class="icon icon-budicon-715"></i><a href="/samlp-providers">List of SAML-P Identity Providers</a>
     <p>
       List of Identity Provider services known to support the SAML protocol.


### PR DESCRIPTION
@mpaktiti This is in response to your concerns about duplicate docs in the SAML index. I looked at the docs, and while the ones you brought attention to are similar, they aren't identical (as a matter of fact, the new docs I wrote reference the existing ones). However, I do agree that they're confusing, so I removed them from the index. If the user needs them, they will see the appropriate links in the new config guide.