### PR TITLE
Remove rule MD026

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -13,7 +13,6 @@
   "MD023": true,
   "MD024": true,
   "MD025": true,
-  "MD026": true,
   "MD027": true,
   "MD031": true,
   "MD034": true,


### PR DESCRIPTION
Disable rule [MD026 - Trailing punctuation in header](https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md026).