### PR TITLE
Add auth0.com as domain and comment about userinfo

### DIFF
--- a/articles/api-auth/tutorials/adoption/scope-custom-claims.md
+++ b/articles/api-auth/tutorials/adoption/scope-custom-claims.md
@@ -69,6 +69,8 @@ This follows a [recommendation from the OIDC specification](https://openid.net/s
 
 If you need to add custom claims to the access token, the same applies but using `context.accessToken` instead.
 
+Please note that adding custom claims to id tokens trough this method will also let you obtain them when calling the `/userinfo` endpoint. However, rules run when the user is authenticating, not when `/userinfo` is called.
+
 ## Further reading
 
 <%= include('./_index.md') %>

--- a/articles/api-auth/tutorials/adoption/scope-custom-claims.md
+++ b/articles/api-auth/tutorials/adoption/scope-custom-claims.md
@@ -62,7 +62,7 @@ function (user, context, callback) {
 Any non-Auth0 HTTP or HTTPS URL can be used as a namespace identifier, and any number of namespaces can be used. The namespace URL does not have to point to an actual resource, it’s only used as an identifier and will not be called by Auth0. 
 
 ::: warning
-`webtask.io` and `webtask.run` are Auth0 domains and therefore cannot be used as a namespace identifier.
+`auth0.com`, `webtask.io` and `webtask.run` are Auth0 domains and therefore cannot be used as a namespace identifier.
 :::
 
 This follows a [recommendation from the OIDC specification](https://openid.net/specs/openid-connect-core-1_0.html#AdditionalClaims) stating that custom claim identifiers should be collision-resistant. While this is not mandatory according to the specification, Auth0 will always enforce namespacing when performing OIDC-conformant login flows, meaning that any non-namespaced claims will be silently excluded from tokens.


### PR DESCRIPTION
I know that this is redundant, but perhaps seeing `auth0.com` can be useful in helping customers find this faster, what do you think?
<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
