### PR TITLE
Add note about IdPs that return access_token

### DIFF
--- a/articles/tutorials/calling-an-external-idp-api.md
+++ b/articles/tutorials/calling-an-external-idp-api.md
@@ -74,6 +74,10 @@ Replace these values:
 
 Within the user's `identities` array, there will be an `access_token` that you can extract and use to make calls to the IdP's API: `user.identities[0].access_token`.
 
+::: note
+The `access_token` is only returned from the BitBucket, Google (OAuth 2.0), OAuth 2.0, SharePoint and Azure AD Identity Providers. For more information refer to the [Identity Provider Access Tokens](https://auth0.com/docs/tokens/idp#renewing-the-token) documentation.
+:::
+
 In most cases, the user will only have one identity, but if you have used the [account linking feature](/link-accounts), there may be more.
 
 In this sample response we can see that our user had only one identity: `google-oauth2`.

--- a/articles/tutorials/calling-an-external-idp-api.md
+++ b/articles/tutorials/calling-an-external-idp-api.md
@@ -75,7 +75,7 @@ Replace these values:
 Within the user's `identities` array, there will be an `access_token` that you can extract and use to make calls to the IdP's API: `user.identities[0].access_token`.
 
 ::: note
-The `access_token` is only returned from the BitBucket, Google (OAuth 2.0), OAuth 2.0, SharePoint and Azure AD Identity Providers. For more information refer to the [Identity Provider Access Tokens](https://auth0.com/docs/tokens/idp#renewing-the-token) documentation.
+The `access_token` is only returned from the following Identity Providers: BitBucket, Google (OAuth 2.0), OAuth 2.0, SharePoint, Azure AD. For more information, refer to [Identity Provider Access Tokens](https://auth0.com/docs/tokens/idp#renewing-the-token).
 :::
 
 In most cases, the user will only have one identity, but if you have used the [account linking feature](/link-accounts), there may be more.


### PR DESCRIPTION
Added note based on customer feedback.

Updated doc:
https://auth0-docs-content-pr-4372.herokuapp.com/docs/tutorials/calling-an-external-idp-api#3-extract-the-idp-access-token