### PR TITLE
Rename APIs section

### DIFF
--- a/config/sections.yml
+++ b/config/sections.yml
@@ -13,7 +13,7 @@
 #   url: "/sdks"
 
 - id: "apis"
-  title: "APIs"
+  title: "Auth0 APIs"
   url: "/api/info"
 
 - id: "quickstarts"


### PR DESCRIPTION
As informed by DSE, customers often mistake this section for their own APIs. Renaming to make it more clear.