### PR TITLE
Remove phrase qualifier from wildcard examples

### DIFF
--- a/articles/api/management/v2/user-search.md
+++ b/articles/api/management/v2/user-search.md
@@ -100,11 +100,11 @@ Search all users whose name _is_ exactly "john":
 
 Search for all user names starting with "john"
 
-`name:"john*"`
+`name:john*`
 
 Search for user names that start with "john" and end with "smith"
 
-`name:"john*smith"`
+`name:john*smith`
 
 ### Search by email
 


### PR DESCRIPTION
The samples included for wildcard searching were using double quotes(") which qualifies the search as a phrase and disables wildcards by default
