### PR TITLE
Remove link to rules repo

### DIFF
--- a/articles/rules/current/index.md
+++ b/articles/rules/current/index.md
@@ -28,10 +28,6 @@ Among many possibilities, Rules can be used to:
 * Enable __multifactor__ authentication, based on context (e.g. last login, IP address of the user, location, etc.).
 * Modify tokens: Change the returned __scopes__ of the `access_token` and/or add claims to it, and to the `id_token`.
 
-::: note
-You can find more examples of common Rules on Github at [auth0/rules](https://github.com/auth0/rules).
-:::
-
 ## Video: Using Rules
 
 Watch this video learn all about rules in just a few minutes.
@@ -51,6 +47,10 @@ A Rule is a function with the following arguments:
 ## Examples
 
 To create a Rule, or try the examples below, go to [New Rule](${manage_url}/#/rules/create) in the Rule Editor on the dashboard.
+
+::: note
+You can find more examples of common Rules on Github at [auth0/rules](https://github.com/auth0/rules).
+:::
 
 ### Hello World
 

--- a/articles/rules/current/index.md
+++ b/articles/rules/current/index.md
@@ -28,6 +28,10 @@ Among many possibilities, Rules can be used to:
 * Enable __multifactor__ authentication, based on context (e.g. last login, IP address of the user, location, etc.).
 * Modify tokens: Change the returned __scopes__ of the `access_token` and/or add claims to it, and to the `id_token`.
 
+::: note
+You can find more examples of common Rules on Github at [auth0/rules](https://github.com/auth0/rules).
+:::
+
 ## Video: Using Rules
 
 Watch this video learn all about rules in just a few minutes.

--- a/articles/rules/legacy/index.md
+++ b/articles/rules/legacy/index.md
@@ -29,10 +29,6 @@ Among many possibilities, Rules can be used to:
 * Enable counters or persist other information. (For information on storing user data, see: [Metadata in Rules](/rules/metadata-in-rules).)
 * Enable __multifactor__ authentication, based on context (e.g. last login, IP address of the user, location, etc.).
 
-::: note
-You can find more examples of common Rules on Github at [auth0/rules](https://github.com/auth0/rules).
-:::
-
 ## Video: Using Rules
 
 Watch this video learn all about rules in just a few minutes.

--- a/articles/rules/legacy/index.md
+++ b/articles/rules/legacy/index.md
@@ -65,10 +65,6 @@ Rules containing shared functions should be placed at the top of the [Rules list
 
 ## Examples
 
-::: note
-You can find more examples of common Rules on Github at [auth0/rules](https://github.com/auth0/rules).
-:::
-
 To create a Rule, or try the examples below, go to [New Rule](${manage_url}/#/rules/create) in the Rule Editor on the dashboard.
 
 ### *Hello World*


### PR DESCRIPTION
Rules repo has been updated to be OIDC conformant, so those examples are not relevant any longer to the legacy implementation