### PR TITLE
Correct state usage

### DIFF
--- a/articles/email/spa-redirect.md
+++ b/articles/email/spa-redirect.md
@@ -27,17 +27,17 @@ However, SPA frameworks (such as Angular) typically expect URLs in the `scheme|a
 
 For example, with the above URL, the app will be routed to `/` instead of `/#/register`.
 
-## Using state 
+## Using a Query String Parameter 
 
-To work around this limitation of SPA frameworks, it is recommended to use a server-side callback URL as the **redirect To** URL with a `state` parameter that preserves the SPA app route for the redirect. Once in this server-side URL, simply redirect to the SPA route saved in `state` parameter along with rest of the query string.
+To work around this limitation of SPA frameworks, it is recommended to use a server-side callback URL as the **redirect To** URL with a `route` parameter that preserves the SPA app route for the redirect. Once in this server-side URL, simply redirect to the SPA route saved in the `route` parameter along with rest of the query string.
 
-1. Add a server-side URL as the **redirect To** URL with a `state` parameter that records the SPA route for the redirect.
+1. Add a server-side URL as the **redirect To** URL with a `route` parameter that records the SPA route for the redirect.
 
 ```text
-http://localhost:3001/register?state=register
+http://localhost:3001/register?route=register
 ```
 
-1. Next, create a server-side route controller that reads the `state` and other parameters from the URL and redirects to the SPA route specified in `state` parameter. Remember to append the other parameters received from Auth0.
+1. Next, create a server-side route controller that reads the `route` and other parameters from the URL and redirects to the SPA route specified in `route` parameter. Remember to append the other parameters received from Auth0.
 
 ```js
 var express = require('express');
@@ -45,10 +45,10 @@ var router = express.Router();
 var qs = require('qs'); // to read query string params and stringify them
 
 router.get('/register', function(req, res, next) {
-  var state = req.query.state; // retrieve the state param that contains the SPA client side route user needs to be redirected to.
+  var route = req.query.route; // retrieve the route param that contains the SPA client side route user needs to be redirected to.
 
-  delete req.query.state; // remove it from query params.
-  res.redirect('http://localhost:3000/#/' + state + '?' +  qs.stringify(req.query)); // Send a 302 redirect for the expected route
+  delete req.query.route; // remove it from query params.
+  res.redirect('http://localhost:3000/#/' + route + '?' +  qs.stringify(req.query)); // Send a 302 redirect for the expected route
 });
 
 module.exports = router;

--- a/articles/email/spa-redirect.md
+++ b/articles/email/spa-redirect.md
@@ -37,7 +37,7 @@ To work around this limitation of SPA frameworks, it is recommended to use a ser
 http://localhost:3001/register?route=register
 ```
 
-1. Next, create a server-side route controller that reads the `route` and other parameters from the URL and redirects to the SPA route specified in `route` parameter. Remember to append the other parameters received from Auth0.
+2. Next, create a server-side route controller that reads the `route` and other parameters from the URL and redirects to the SPA route specified in `route` parameter. Remember to append the other parameters received from Auth0.
 
 ```js
 var express = require('express');

--- a/articles/tutorials/redirecting-users.md
+++ b/articles/tutorials/redirecting-users.md
@@ -1,33 +1,17 @@
 ---
 description: How to handle returning users after authentication.
 ---
-
 # Redirect Users After Login
 
-To make your login process as easy-to-use and seamless as possible, you'll need provide Auth0 with explicit information on redirecting users back to your application after authentication.
+To make your login process as easy-to-use and seamless as possible, you'll need to keep track of where you want to route users inside your application once Auth0  redirects users back to your application after authentication.
 
-When implementing Auth0, please note that the `redirect_uri` field is actually used as a callback URL. Auth0 invokes callback URLs after the authentication process and are where your application gets routed. Because callback URLs can be manipulated by unauthorized parties, Auth0 recognizes only whitelisted URLs set in the `Allowed Callback URLs` field of a [Client's Settings](${manage_url}/#/clients/${account.clientId}/settings) as valid.
+When implementing Auth0, please note that the `redirect_uri` field is used as a callback URL. Auth0 invokes callback URLs after the authentication process and are where your application gets routed. Because callback URLs can be manipulated by unauthorized parties, Auth0 recognizes only whitelisted URLs set in the `Allowed Callback URLs` field of a [Client's Settings](${manage_url}/#/clients/${account.clientId}/settings) as valid.
 
 The callback URL is not necessarily the same URL to which you want users redirected after authentication.
 
 ## Redirect Users to a Non-Callback URL
 
 If you want to redirect authenticated users to a URL that is *not* the callback URL, you can do so using one of the following methods.
-
-### Store the Desired URL in the `state` Parameter
-
-The [`state` parameter](/protocols/oauth-state) is one of the supported Auth0 [Authentication Parameters](/libraries/lock/v10/sending-authentication-parameters). You can use this field to hold multiple values such as a JSON object that holds the URL you want to bring the user to.
-
-```
-state = {
-   "auth0_authorize": "xyzABC123",
-   "return_url": "https://yoursite.com/home"
-}
-```
-
-To send the `state` parameter, [add it to the `options` object](/libraries/lock/v10/sending-authentication-parameters). For additonal information on where to modify `options`, please see the doc on [Getting Started with Lock](/libraries/lock/v10#start-using-lock).
-
-After a successful request, you can used the `return_url` encapsulated in the returned `state` value to redirect users to the appropriate URL.
 
 ### Store the Desired URL in Web Storage
 


### PR DESCRIPTION
Removed incorrect usage of `state` parameter from `articles/tutorials/redirecting-users.md`
https://auth0-docs-content-pr-4475.herokuapp.com/docs/tutorials/redirecting-users

For `articles/email/spa-redirect.md`, it was not using the actual `state` parameter which is used in the OAuth/OIDC flow. But after talking with @hzalaz I renamed this one so as to avoid confusion with the OAuth/OIDC `state` parameter
https://auth0-docs-content-pr-4475.herokuapp.com/docs/email/spa-redirect
