### PR TITLE
Ensure correct configuration for all .NET OIDC Client quickstarts

### DIFF
--- a/articles/quickstart/native/_includes/_dotnet-oidc-client-configuration.md
+++ b/articles/quickstart/native/_includes/_dotnet-oidc-client-configuration.md
@@ -1,0 +1,16 @@
+## Ensuring Your Client is Configured Correctly
+
+Before using the Auth0 OIDC Client, you will need to ensure that you have set the __JsonWebToken Signature Algorithm__ to `RS256` and have enabled the __OIDC Conformant__ switch for your Client:
+
+1. Go to [Dashboard > Clients](https://manage.auth0.com/#/clients)
+1. Select your Client
+1. Go to __Settings__
+1. Click on __Show Advanced Settings__
+1. Click on the __OAuth__ tab in Advanced Settings
+1. Change the __JsonWebToken Signature Algorithm__ to `RS256`
+1. Ensure that the __OIDC Conformant__ switch is enabled
+1. Click __Save Changes__
+
+::: warning
+Please note that altering the signing algorithm for your client will immediately change the way your user's tokens are signed. This means that if you have already implemented JWT verification for your client somewhere, your tokens will not be verifiable until you update the logic to account for the new signing algorithm.
+:::

--- a/articles/quickstart/native/_includes/_dotnet-oidc-client-configuration.md
+++ b/articles/quickstart/native/_includes/_dotnet-oidc-client-configuration.md
@@ -1,4 +1,4 @@
-## Ensuring Your Client is Configured Correctly
+## Ensure Your Client is Configured Correctly
 
 Before using the Auth0 OIDC Client, you will need to ensure that you have set the __JsonWebToken Signature Algorithm__ to `RS256` and have enabled the __OIDC Conformant__ switch for your Client:
 

--- a/articles/quickstart/native/windows-uwp-csharp/01-login.md
+++ b/articles/quickstart/native/windows-uwp-csharp/01-login.md
@@ -18,6 +18,8 @@ budicon: 448
 
 This tutorial explains how to integrate the Auth0 OIDC Client with a Windows UWP (Universal Windows Platform) C# application. The NuGet package `Auth0.OidcClient.UWP` helps you authenticate users with any [Auth0 supported identity provider](/identityproviders).
 
+<%= include('../includes/_dotnet-oidc-client-configuration') %>
+
 ## Install the Auth0.OidcClient.UWP NuGet Package
 
 Use the NuGet Package Manager Console (Tools -> NuGet Package Manager -> Package Manager Console) to install the `Auth0.OidcClient.UWP` package, running the command:

--- a/articles/quickstart/native/windows-uwp-csharp/01-login.md
+++ b/articles/quickstart/native/windows-uwp-csharp/01-login.md
@@ -18,7 +18,7 @@ budicon: 448
 
 This tutorial explains how to integrate the Auth0 OIDC Client with a Windows UWP (Universal Windows Platform) C# application. The NuGet package `Auth0.OidcClient.UWP` helps you authenticate users with any [Auth0 supported identity provider](/identityproviders).
 
-<%= include('../includes/_dotnet-oidc-client-configuration') %>
+<%= include('../_includes/_dotnet-oidc-client-configuration') %>
 
 ## Install the Auth0.OidcClient.UWP NuGet Package
 

--- a/articles/quickstart/native/wpf-winforms/01-login.md
+++ b/articles/quickstart/native/wpf-winforms/01-login.md
@@ -17,6 +17,8 @@ budicon: 448
 
 This tutorial explains how to integrate Auth0 with a WPF or Windows Forms application. The `Auth0.OidcClient.WPF` or `Auth0.OidcClient.WinForms` NuGet packages helps you authenticate users with any [Auth0 supported identity provider](/identityproviders).
 
+<%= include('../includes/_dotnet-oidc-client-configuration') %>
+
 ## Install Auth0.OidcClient.WPF or Auth0.OidcClient.WinForms NuGet Package
 
 Use the NuGet Package Manager (Tools -> Library Package Manager -> Package Manager Console) to install the `Auth0.OidcClient.WPF` or `Auth0.OidcClient.WinForms` package, depending on whether you are building a WPF or Windows Forms application:

--- a/articles/quickstart/native/wpf-winforms/01-login.md
+++ b/articles/quickstart/native/wpf-winforms/01-login.md
@@ -17,7 +17,7 @@ budicon: 448
 
 This tutorial explains how to integrate Auth0 with a WPF or Windows Forms application. The `Auth0.OidcClient.WPF` or `Auth0.OidcClient.WinForms` NuGet packages helps you authenticate users with any [Auth0 supported identity provider](/identityproviders).
 
-<%= include('../includes/_dotnet-oidc-client-configuration') %>
+<%= include('../_includes/_dotnet-oidc-client-configuration') %>
 
 ## Install Auth0.OidcClient.WPF or Auth0.OidcClient.WinForms NuGet Package
 

--- a/articles/quickstart/native/xamarin/01-login.md
+++ b/articles/quickstart/native/xamarin/01-login.md
@@ -19,23 +19,7 @@ budicon: 448
 
 This tutorial explains how to integrate the Auth0 OIDC Client with a Xamarin application.
 
-## Switching token signature algorithm to RS256
-
-The Auth0 OIDC Client requires that the __JsonWebToken Signature Algorithm__ for your client is set to `RS256`.
-
-::: warning
-Please note that altering the signing algorithm for your client will immediately change the way your user's tokens are signed. This means that if you have already implemented JWT verification for your client somewhere, your tokens will not be verifiable until you update the logic to account for the new signing algorithm.
-:::
-
-To switch from HS256 to RS256 for a specific client, follow these instructions:
-1. Go to [Dashboard > Clients](https://manage.auth0.com/#/clients)
-1. Select your client
-1. Go to _Settings_
-1. Click on __Show Advanced Settings__
-1. Click on the _OAuth_ tab in Advanced Settings
-1. Change the __JsonWebToken Signature Algorithm__ to `RS256`
-
-Remember that if the token is being validated anywhere else, changes might be needed there as well in order to comply.
+<%= include('../includes/_dotnet-oidc-client-configuration') %>
 
 ## Install the Auth0.OidcClient.Android NuGet Package
 

--- a/articles/quickstart/native/xamarin/01-login.md
+++ b/articles/quickstart/native/xamarin/01-login.md
@@ -19,7 +19,7 @@ budicon: 448
 
 This tutorial explains how to integrate the Auth0 OIDC Client with a Xamarin application.
 
-<%= include('../includes/_dotnet-oidc-client-configuration') %>
+<%= include('../_includes/_dotnet-oidc-client-configuration') %>
 
 ## Install the Auth0.OidcClient.Android NuGet Package
 


### PR DESCRIPTION
Ensure that the section on how to configure the client correctly is in all the Auth0 OIDC Client related quickstarts, as this has been tripping up some users:

* https://auth0-docs-content-pr-4493.herokuapp.com/docs/quickstart/native/windows-uwp-csharp
* https://auth0-docs-content-pr-4493.herokuapp.com/docs/quickstart/native/wpf-winforms
* https://auth0-docs-content-pr-4493.herokuapp.com/docs/quickstart/native/xamarin