### PR TITLE
Bump the composer version for auth0/login

### DIFF
--- a/snippets/server-platforms/laravel/dependencies.md
+++ b/snippets/server-platforms/laravel/dependencies.md
@@ -1,1 +1,1 @@
-To install this plugin run `composer require auth0/login:"~4.0"`
+To install this plugin run `composer require auth0/login:"~5.0"`


### PR DESCRIPTION
Installing 4.0 with Laravel Spark failed as it used firebase/php-jwt v3.0.0 but Spark requires 4.0+

This is fixed by using "~5.0"

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
