### PR TITLE
Removing state param description for authorize

### DIFF
--- a/articles/libraries/auth0js/v8/index.md
+++ b/articles/libraries/auth0js/v8/index.md
@@ -94,7 +94,6 @@ The `authorize()` method can be used for logging in users via the [Hosted Login 
 | `scope` | required | (String) The scopes which you want to request authorization for. These must be separated by a space. You can request any of the standard OIDC scopes about users, such as `profile` and `email`, custom claims that must [conform to a namespaced format](/api-auth/tutorials/adoption/scope-custom-claims), or any scopes supported by the target API (for example, `read:contacts`). Include `offline_access` to get a refresh token. |
 | `responseType` | required | (String) The value must be `'token'` or `'code'`. It defaults to `'token'`, unless a `redirectUri` is provided, then it defaults to `'code'`. |
 | `clientID` | optional | (String)  Your Auth0 client ID. |
-| `state` | recommended | (String)  An opaque value the client adds to the initial request that Auth0 includes when redirecting back to the client. This value must be used by the client to prevent CSRF attacks. |
 | `redirectUri` | optional | (String) The URL to which Auth0 will redirect the browser after authorization has been granted for the user. |
 
 For hosted login, one must call the `authorize()` method.


### PR DESCRIPTION
The `state` param here is copied from `authorize` endpoint but is unnecessary to note for the SDK.
