### PR TITLE
Grammar fix in local-testing-and-dev

### DIFF
--- a/articles/dev-lifecycle/local-testing-and-development.md
+++ b/articles/dev-lifecycle/local-testing-and-development.md
@@ -20,7 +20,7 @@ You can obtain JWTs for testing using any of the following methods:
 
 2. Create a test user for a database [connection](/identityproviders), and programatically log this user in. Essentially, you are using the recommended process for [calling an API using a highly-trusted client](/api-auth/grant/password). For detailed implementation instructions, see [Execute the Resource Owner Password Grant](/api-auth/tutorials/password-grant).
 
-3. Use a browser bot (e.g. Selenium) to play the role of a user, log in and retrieve a JWT. While this is approach may take some effort to develop and maintain, it will allow you to test any [redirection rules](/rules/redirect) or [MFA prompts](/multifactor-authentication) that you have configured.
+3. Use a browser bot (e.g. Selenium) to play the role of a user, log in and retrieve a JWT. While this approach may take some effort to develop and maintain, it will allow you to test any [redirection rules](/rules/redirect) or [MFA prompts](/multifactor-authentication) that you have configured.
 
 ## Use Sessions with Server-Side Applications
 


### PR DESCRIPTION
The word 'is' is unnecessary in this sentence.