### PR TITLE
added Appliance disaster recovery pages to sidebar

### DIFF
--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -634,7 +634,11 @@ appliance:
       - title: Extensions
         url: /appliance/extensions
       - title: Disaster Recovery
-        url: /appliance/geo-ha/disaster-recovery
+        url: /appliance/disaster-recovery
+        children:
+          - title: Roles and Responsibilities
+            url: /appliance/disaster-recovery-raci
+
       - title: Release Notes
         url: https://auth0.com/changelog/appliance
         external: true


### PR DESCRIPTION
/appliance/disaster-recovery and /appliance/disaster-recovery-raci were missing.
Besides, we prefer geo-ha disaster recovery to be accessible only under get-ha node.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
