### PR TITLE
Download Button Selector

### DIFF
--- a/articles/_includes/_package.html
+++ b/articles/_includes/_package.html
@@ -16,10 +16,10 @@
     </div>
     <div class="package-buttons">
       <% if (typeof branch !== 'undefined') { %>
-      <a href="/package/v2?org=${org}&repo=${repo}&branch=${branch}&path=${path}&client_id=${account.clientId}" class="btn btn-sm btn-success" rel="nofollow">Download</a>
+      <a href="/package/v2?org=${org}&repo=${repo}&branch=${branch}&path=${path}&client_id=${account.clientId}" class="btn btn-sm btn-success download-package" rel="nofollow">Download</a>
       <a href="https://github.com/${org || 'auth0-samples'}/${repo}/tree/${branch}/${path}" class="github-link" rel="nofollow">Fork on Github</a>
       <% } else { %>
-      <a href="/package/v2?org=${org}&repo=${repo}&path=${path}&client_id=${account.clientId}" class="btn btn-sm btn-success" rel="nofollow">Download</a>
+      <a href="/package/v2?org=${org}&repo=${repo}&path=${path}&client_id=${account.clientId}" class="btn btn-sm btn-success download-package" rel="nofollow">Download</a>
       <a href="https://github.com/${org || 'auth0-samples'}/${repo}/tree/master/${path}" class="github-link" rel="nofollow" target="_top">Fork on Github</a>
       <% } %>
     </div>


### PR DESCRIPTION
Added download-button class to Download Package button for easier distinction between button elements in packages, this specific use case is for jQuery selector on links/buttons within #packages. 

Auth0-Docs PR: https://github.com/auth0/auth0-docs/pull/1435
Fixes https://github.com/auth0/auth0-docs/issues/1424