### PR TITLE
Fix broken ${manage_url} links

### DIFF
--- a/articles/api/management/v2/tokens.md
+++ b/articles/api/management/v2/tokens.md
@@ -165,7 +165,7 @@ That's it! You are done!
 This python script gets a Management API v2 access token, uses it to call the [Get all clients](/api/management/v2#!/Clients/get_clients) endpoint, and prints the response in the console.
 
 Before you run it make sure that the following variables hold valid values:
-- `AUDIENCE`: The __Identifier__ of the `Auth0 Management API`. You can find it at the [Settings tab of the API](https://${manage_url}/#/apis).
+- `AUDIENCE`: The __Identifier__ of the `Auth0 Management API`. You can find it at the [Settings tab of the API](${manage_url}/#/apis).
 - `DOMAIN`: The __Domain__ of the Non Interactive Client you created at [this step](#1-create-a-client).
 - `CLIENT_ID`: The __Client ID__ of the Non Interactive Client you created at [this step](#1-create-a-client).
 - `CLIENT_SECRET`: The __Client Secret__ of the Non Interactive Client you created at [this step](#1-create-a-client).

--- a/articles/appliance/dashboard/settings.md
+++ b/articles/appliance/dashboard/settings.md
@@ -55,7 +55,7 @@ The Settings page is broken down into the following sections:
 
 ## SMTP Server
 
-* **Send Mails From**: *Deprecated.* The email address used in the "From" field typically comes from that provided on your [custom email template](https://${manage_url}/#/emails);
+* **Send Mails From**: *Deprecated.* The email address used in the "From" field typically comes from that provided on your [custom email template](${manage_url}/#/emails);
 * **SMTP Server**: the name of your SMTP server;
 * **SMTP Port**: the port through which you access your SMTP server;
 * **SMTP User**: the username to log in to your SMTP server;

--- a/articles/extensions/loggly.md
+++ b/articles/extensions/loggly.md
@@ -14,7 +14,7 @@ To install and configure this extension, click on the __Auth0 Logs to Loggly__ b
 At this point you should set the following configuration variables:
 
 - __Schedule__: The frequency with which logs should be exported.
-- __Auth0_Domain__: The domain of your Auth0 client. You can find this information at the [__Settings__ view of your client](https://${manage_url}/#/applications/${account.clientId}/settings).
+- __Auth0_Domain__: The domain of your Auth0 client. You can find this information at the [__Settings__ view of your client](${manage_url}/#/applications/${account.clientId}/settings).
 - __Auth0_Global_Client_ID__: The Global Client ID of your Auth0 client.
 - __Auth0_Global_Client_Secret__: The Global Client Secret of your Auth0 client.
 


### PR DESCRIPTION
Noticed a broken link when reading https://auth0.com/docs/api/management/v2/tokens, fixed the same issue in a couple of other locations