### PR TITLE
Fixed a typo (you referred to 'class' instead of 'id').

### DIFF
--- a/articles/quickstart/spa/vanillajs/_includes/_centralized_login.md
+++ b/articles/quickstart/spa/vanillajs/_includes/_centralized_login.md
@@ -31,7 +31,7 @@ window.addEventListener('load', function() {
 ```
 
 ::: note
-**Checkpoint:** Try adding a `button` with a class of `btn-login` to your app. This will call the `authorize` method from auth0.js so you can see the login page.
+**Checkpoint:** Try adding a `button` with the id `btn-login` to your app. This will call the `authorize` method from auth0.js so you can see the login page.
 :::
 
 ![hosted login](/media/articles/web/hosted-login.png)


### PR DESCRIPTION
Fixed a typo (you referred to 'class' instead of 'id').

I guess the change also needs to be applied to articles/quickstart/spa/jquery/_includes/_centralized_login.md

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
