### PR TITLE
Made some corrections to Apache quickstart

### DIFF
--- a/articles/quickstart/webapp/apache/01-login.md
+++ b/articles/quickstart/webapp/apache/01-login.md
@@ -22,7 +22,7 @@ Once you've installed it, you just need to enable it for Apache (If you are usin
 
 ${snippet(meta.snippets.dependencies)}
 
-## Configure the Module with your Auth0 Account Information
+## Configure the Module with Your Auth0 Account Information
 
 Now you should get a new configuration file under the `/etc/apache2/mods-available` folder, where Apache modules are normally installed (On Windows you need to use `/apache/conf/httpd.conf` file).
 

--- a/snippets/server-platforms/apache/setup.md
+++ b/snippets/server-platforms/apache/setup.md
@@ -7,11 +7,7 @@ OIDCScope "openid name email"
 OIDCRedirectURI https://your_apache_server/your_path/redirect_uri/
 OIDCCryptoPassphrase <passwordToEncryptTheSessionInformationOnTheCookie>
 
-SSLEngine on
-SSLCertificateFile /home/your_cert.crt
-SSLCertificateKeyFile /home/your_key.key
-
-<Location /your_path/>
+<Location /your_path>
    AuthType openid-connect
    Require valid-user
    LogLevel debug

--- a/snippets/server-platforms/apache/use.md
+++ b/snippets/server-platforms/apache/use.md
@@ -1,5 +1,5 @@
 ```xml
-<Location /example/>
+<Location /example>
    AuthType openid-connect
    #Require valid-user
    Require claim folder:example


### PR DESCRIPTION
Removed the SSL directives as they aren't directly related to configuration of the module and belong in the `VirtualHost` blocks instead. Also corrected the case of one of the headings.