### PR TITLE
Remove suggestion for generating own JWT

### DIFF
--- a/articles/dev-lifecycle/local-testing-and-development.md
+++ b/articles/dev-lifecycle/local-testing-and-development.md
@@ -1,7 +1,6 @@
 ---
 description: How to develop and test Auth0 applications.
 ---
-
 # Work with Auth0 Locally
 
  In most cases, authenticating users through Auth0 requires an Internet connection. However, you can still develop and test apps that use Auth0 locally. In some cases, you might not need access to an Internet connection.
@@ -16,11 +15,9 @@ Because [JSON Web Tokens (JWT)](/jwt) are stateless (that is, the app that consu
 
 You can obtain JWTs for testing using any of the following methods:
 
-1. Manually [generate a JWT](https://jwt.io#libraries-io) with the needed data, and sign it with your [Auth0 client secret](${manage_url}/#/clients/${account.clientId}/settings). Omit the `exp` claim from a token; most JWT libraries will interpret it as a token which never expires (it's possible some libraries might reject a perpetual token). **This method doesn't require Internet access.**
+1. Create a test user for a database [connection](/identityproviders), and programatically log this user in. Essentially, you are using the recommended process for [calling an API using a highly-trusted client](/api-auth/grant/password). For detailed implementation instructions, see [Execute the Resource Owner Password Grant](/api-auth/tutorials/password-grant).
 
-2. Create a test user for a database [connection](/identityproviders), and programatically log this user in. Essentially, you are using the recommended process for [calling an API using a highly-trusted client](/api-auth/grant/password). For detailed implementation instructions, see [Execute the Resource Owner Password Grant](/api-auth/tutorials/password-grant).
-
-3. Use a browser bot (e.g. Selenium) to play the role of a user, log in and retrieve a JWT. While this approach may take some effort to develop and maintain, it will allow you to test any [redirection rules](/rules/redirect) or [MFA prompts](/multifactor-authentication) that you have configured.
+2. Use a browser bot (e.g. Selenium) to play the role of a user, log in and retrieve a JWT. While this approach may take some effort to develop and maintain, it will allow you to test any [redirection rules](/rules/redirect) or [MFA prompts](/multifactor-authentication) that you have configured.
 
 ## Use Sessions with Server-Side Applications
 


### PR DESCRIPTION
Since we now use RS256 users cannot generate their own JWT for local testing since they do not have access to the Private Key to sign the tokens. Removed this suggestion

https://auth0-docs-content-pr-4600.herokuapp.com/docs/dev-lifecycle/local-testing-and-development#use-json-web-tokens-jwt-with-client-side-applications