### PR TITLE
Remove unsafe practice from example

### DIFF
--- a/articles/quickstart/backend/python/01-authorization.md
+++ b/articles/quickstart/backend/python/01-authorization.md
@@ -48,6 +48,7 @@ from jose import jwt
 
 auth0_domain = '${account.namespace}'
 api_audience = YOUR_API_AUDIENCE
+algorithms = ["RS256"]
 
 app = Flask(__name__)
 
@@ -110,7 +111,7 @@ def requires_auth(f):
                 payload = jwt.decode(
                     token,
                     rsa_key,
-                    algorithms=unverified_header["alg"],
+                    algorithms=algorithms,
                     audience=API_AUDIENCE,
                     issuer="https://"+AUTH0_DOMAIN+"/"
                 )


### PR DESCRIPTION
Relying on information from the unverified header during verification is an unsafe practice, as described here:
https://auth0.com/blog/critical-vulnerabilities-in-json-web-token-libraries/

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
