### PR TITLE
Fixed error where "Property 'expectedScopes' does not exist on type '…

### DIFF
--- a/articles/quickstart/spa/angular2/05-authorization.md
+++ b/articles/quickstart/spa/angular2/05-authorization.md
@@ -135,7 +135,7 @@ export class ScopeGuardService implements CanActivate {
 
   canActivate(route: ActivatedRouteSnapshot): boolean {
 
-    const scopes = route.data.expectedScopes;
+    const scopes = (route.data as any).expectedScopes;
 
     if (!this.auth.isAuthenticated() || !this.auth.userHasScopes(scopes)) {
       this.router.navigate(['']);


### PR DESCRIPTION
…{ [name: string]: any; }'."

I kept running into the error that "Property 'expectedScopes' does not exist on type '{ [name: string]: any; }'." when building my angular application. By using as any you can avoid this typescript error.
<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
