### PR TITLE
Incorrect Example Parameter for webAuth.parseHash

### DIFF
--- a/articles/libraries/auth0js/v8/index.md
+++ b/articles/libraries/auth0js/v8/index.md
@@ -294,7 +294,7 @@ The contents of the authResult object returned by `parseHash` depend upon which 
 | `idToken` |  An id token JWT containing user profile information |
 
 ```js
-webAuth.parseHash(window.location.hash, function(err, authResult) {
+webAuth.parseHash({ hash: window.location.hash }, function(err, authResult) {
   if (err) {
     return console.log(err);
   }


### PR DESCRIPTION
In order for the hash parameter to be properly passed to the webAuth.parseHash method, it needs to be represented as an options object instead of a simple string pass.  Digging into the library seems to show that the original method never truly got passed as the hash value and the default window.location.hash was being used instead of the provided parameter.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
