### PR TITLE
Correct Error Code for "Account Blocked"

### DIFF
--- a/articles/libraries/error-messages.md
+++ b/articles/libraries/error-messages.md
@@ -16,7 +16,7 @@ You may encounter one or more of the following messages when signing up:
 
 In the case of a failed login, the errors can be one of the following:
 
-* **unauthorized**: the user you are attempting to sign up with is blocked.
+* **unauthorized**: the user you are attempting to sign in with is blocked.
 * **too_many_attempts**: too many attempts to sign in have been made and the account was blocked.
 * **mfa_required**: the user must provide the multifactor authentication (MFA) code to authenticate;
 * **mfa_registration_required**: the administrator has required multifactor authentication (MFA), but the user has not enrolled;

--- a/articles/libraries/error-messages.md
+++ b/articles/libraries/error-messages.md
@@ -16,7 +16,7 @@ You may encounter one or more of the following messages when signing up:
 
 In the case of a failed login, the errors can be one of the following:
 
-* **user is blocked**: the user you are attempting to sign up with is blocked.
+* **unauthorized**: the user you are attempting to sign up with is blocked.
 * **too_many_attempts**: too many attempts to sign in have been made and the account was blocked.
 * **mfa_required**: the user must provide the multifactor authentication (MFA) code to authenticate;
 * **mfa_registration_required**: the administrator has required multifactor authentication (MFA), but the user has not enrolled;


### PR DESCRIPTION
After looking at the format of the `error` message for "Account Blocked" `user is blocked` (i.e. the spaces) I thought I would test this:

1. Log in to Management UI.
1. Block a User.
1. Go to Appropriate Connection for User.
1. "Try Connection" - Log In.
1. Observe the Response

```json
{
  "error": "unauthorized",
  "error_description": "user is blocked"
}
```

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
