### PR TITLE
Fix typo on Okta doc

### DIFF
--- a/articles/protocols/saml/identity-providers/okta.md
+++ b/articles/protocols/saml/identity-providers/okta.md
@@ -49,7 +49,7 @@ You will also need to add the following *Attribute Statement*:
 
 * **Name**: email
 * **Name format** (optional): Unspecified
-* **Value**: <%= "${user.email}" %>"
+* **Value**: <%= "${user.email}" %>
 
 At this point, you can click **Preview the SAML Assertion** to generate XML you can use to verify that your provided settings are correct.
 


### PR DESCRIPTION
https://auth0-docs-content-pr-4814.herokuapp.com/docs/protocols/saml/identity-providers/okta