### PR TITLE
SAML endpoint reference confusing

### DIFF
--- a/articles/integrations/aws/aws-api-setup.md
+++ b/articles/integrations/aws/aws-api-setup.md
@@ -19,7 +19,7 @@ Set the following parameters:
 | - | - |
 | Provider Type | The type of provider. Set as `SAML` |
 | Provider Name | A descriptive name for the provider, such as `auth0SamlProvider` |
-| Metadata Document | Upload the file containing the Auth0 metadata you downloaded in the previous step here. |
+| Metadata Document | Upload the file containing the Auth0 metadata, found in client settings->advanced settings->endpoints->SAML Metadata URL |
 
 ![](/media/articles/integrations/aws/aws-configure-provider.png)
 

--- a/articles/integrations/aws/aws-api-setup.md
+++ b/articles/integrations/aws/aws-api-setup.md
@@ -19,7 +19,7 @@ Set the following parameters:
 | - | - |
 | Provider Type | The type of provider. Set as `SAML` |
 | Provider Name | A descriptive name for the provider, such as `auth0SamlProvider` |
-| Metadata Document | Upload the file containing the Auth0 metadata, found in client settings->advanced settings->endpoints->SAML Metadata URL |
+| Metadata Document | Upload the file containing the Auth0 metadata, found in **Dashboard > Clients > client Settings > Advanced Settings > Endpoints > SAML Metadata URL** |
 
 ![](/media/articles/integrations/aws/aws-configure-provider.png)
 


### PR DESCRIPTION
I believe this once was a multi-step tutorial.  The reference to use the metadata from the previous step is confusing if the user doesn't have much experience with the Auth0 platform.  This data is found in the client advanced settings under the end points tab, in a field labeled SAML Metadata URL.

Updated the ref in the table to give slight guidance on where to find the saml settings.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
