### PR TITLE
Add note on supported email template attributes

### DIFF
--- a/articles/email/liquid-syntax.md
+++ b/articles/email/liquid-syntax.md
@@ -24,6 +24,10 @@ There are two types of markup in Liquid: **output** and **tag**.
 
 `Hello {{ name }}!`
 
+::: note
+For more information on supported output attributes and their usage, see [Customizing Your Emails](/email/templates).
+:::
+
 You can further customize the appearance of the output by using filters, which are simple methods. For example, the `upcase` filter will convert the text which is passed to the filter to upper case:
 
 `Hello {{ name | upcase }}!`

--- a/articles/email/templates.md
+++ b/articles/email/templates.md
@@ -4,7 +4,7 @@ description: The Emails section of the Auth0 dashboard allows you to customize y
 
 # Customizing Your Emails
 
-::: panel-warning Email Setup
+::: warning
 You must setup your own email provider using a [third-party service](/email/providers) ([Amazon SES](https://aws.amazon.com/ses/), [Mandrill](https://www.mandrill.com/signup/) or [SendGrid](https://sendgrid.com/pricing)) or a [custom provider](/email/custom) to be able to customize your emails.
 :::
 


### PR DESCRIPTION
Added a link to the doc listing supported email template attributes.

Perhaps it'd better to add a table like the one found under [Liquid Markup: Output](https://auth0.com/docs/email/liquid-syntax#liquid-markup-output) for output filters.

[Liquid Syntax in Email Templates](/docs/email/liquid-syntax)