### PR TITLE
Expand New Relic "Monitoring" Information

### DIFF
--- a/articles/appliance/dashboard/settings.md
+++ b/articles/appliance/dashboard/settings.md
@@ -76,7 +76,7 @@ The Settings page is broken down into the following sections:
 
 ## Monitoring
 
-* **New Relic License Key**: if you use New Relic for monitoring, enter your license key here to monitor your PSaaS Appliance instances.
+* **New Relic License Key**: if you use New Relic for monitoring, enter your license key here to monitor your PSaaS Appliance instances. Once entered, _fatal_ errors will be logged to the "APM" section of New Relic. These will be under the Application "`Auth0 Core`".
 
 ## API Keys
 


### PR DESCRIPTION
Our team were confused about what to expect after entering the New Relic license key.

Following a support ticket with Auth0, it's come to light that only _fatal_ errors are logged to New Relic - under the application `Auth0 Core`.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
