### PR TITLE
Update use instructions

### DIFF
--- a/articles/hooks/extensibility-points/credentials-exchange.md
+++ b/articles/hooks/extensibility-points/credentials-exchange.md
@@ -6,17 +6,13 @@ beta: true
 
 # Extensibility Point: Credentials Exchange
 
-The `credentials-exchange` extensibility point allows you to change the scopes and add custom claims to the [access tokens](/tokens/access-token) issued by the [Auth0 API's `POST /oauth/token` endpoint](/api/authentication#authorization-code).
+The `credentials-exchange` extensibility point allows you to change the scopes and add custom claims to the [access tokens](/tokens/access-token) issued by the [Auth0 API's `POST /oauth/token` endpoint](/api/authentication#authorization-code) during runtime.
 
 ::: note
 Please see [Calling APIs from a Service](/api-auth/grant/client-credentials) for more information on the Client Credentials Grant.
 :::
 
-## How to Implement This
-
-You can implement a Hook for this extensibility point using either the Dashboard or the Auth0 CLI. For detailed steps refer to [Using Hooks with Client Credentials Grant](/api-auth/tutorials/client-credentials/customize-with-hooks).
-
-### Types of Claims
+## Types of Claims Available
 
 You can add the following as claims to the issued token:
 
@@ -32,7 +28,17 @@ The extensibility point will ignore all other response object properties.
 If you need to configure client secrets and access them within your Hook, you can do so using `context.webtask.secrets.SECRET_NAME`.
 :::
 
-## Starter Code and Parameters
+## How to Implement This
+
+You can implement a [Hook](/hooks#work-with-hooks) using this extensibility point with either the [Dashboard](/hooks/dashboard) or the [Command Line Interface](/hooks/cli). 
+
+For detailed steps on implementing the grant, please refer to [Using Hooks with Client Credentials Grant](/api-auth/tutorials/client-credentials/customize-with-hooks).
+
+### Starter Code and Parameters
+
+After you've created a new Hook that uses the Client Credentials Exchange extensibility point, you can open up the Hook and edit it using the Webtask Editor embedded in the Dashboard. 
+
+The parameters listed in the comment at the top of the code indicate the Auth0 objects (and the parameters within the objects) that can be passed into and used by the Hook's function. For example, the `client` object comes with the following parameters: client name, client ID, the Auth0 tenant name with which the client is associated, and client metadata. 
 
 ```js
 /**
@@ -57,8 +63,11 @@ module.exports = function(client, scope, audience, context, cb) {
 
   cb(null, access_token);
 };
-
 ```
+
+The callback function `cb` at the end of the sample code is used to signal completion and must not be omitted.
+
+#### Response
 
 The default response object every time you run this Hook is as follows:
 
@@ -68,7 +77,32 @@ The default response object every time you run this Hook is as follows:
 }
 ```
 
-### Example: Add Scope to the Access Token
+### Testing Your Hook
+
+::: note
+Executing the code using the Runner requires a save, which means that your original code will be overwritten.
+:::
+
+Once you've modified the sample code with the specific scopes of additional claims you'd like added to your access tokens, you can test your Hook using the Runner. The runner simulates a call to the Hook with the same body/payload that you would get with a Client Credentials Exchange. The following is the sample body that populates the Runner by default (these are the same objects/parameters detailed in the comment at the top of the sample Hook code):
+
+```json
+{
+  "audience": "https://my-tenant.auth0.com/api/v2/",
+  "client": {
+    "id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+    "name": "client-name",
+    "tenant": "my-tenant",
+    "metadata": {
+      "plan": "full"
+    }
+  },
+  "scope": [
+    "read:connections"
+  ]
+}
+```
+
+## Example: Add Scope to the Access Token
 
 This example shows you how to use the Hook to add an additional scope to the scopes already existing on the access token.
 
@@ -101,7 +135,7 @@ Using the [test runner](https://webtask.io/docs/editor/runner), we see that the 
 }
 ```
 
-### Example: Add a Claim to the Access Token
+## Example: Add a Claim to the Access Token
 
 This example show you have to add a namespaced claim and its value to the access token.
 

--- a/articles/hooks/extensibility-points/credentials-exchange.md
+++ b/articles/hooks/extensibility-points/credentials-exchange.md
@@ -1,4 +1,5 @@
 ---
+title: Using the Credentials Exchange Extensibility Point
 description: The credentials-exchange extensibility point for use with Hooks
 toc: true
 beta: true
@@ -36,7 +37,7 @@ For detailed steps on implementing the grant, please refer to [Using Hooks with 
 
 ### Starter Code and Parameters
 
-After you've created a new Hook that uses the Client Credentials Exchange extensibility point, you can open up the Hook and edit it using the Webtask Editor embedded in the Dashboard. 
+After you've created a new Hook that uses the Credentials Exchange extensibility point, you can open up the Hook and edit it using the Webtask Editor embedded in the Dashboard. 
 
 The parameters listed in the comment at the top of the code indicate the Auth0 objects (and the parameters within the objects) that can be passed into and used by the Hook's function. For example, the `client` object comes with the following parameters: client name, client ID, the Auth0 tenant name with which the client is associated, and client metadata. 
 
@@ -83,7 +84,7 @@ The default response object every time you run this Hook is as follows:
 Executing the code using the Runner requires a save, which means that your original code will be overwritten.
 :::
 
-Once you've modified the sample code with the specific scopes of additional claims you'd like added to your access tokens, you can test your Hook using the Runner. The runner simulates a call to the Hook with the same body/payload that you would get with a Client Credentials Exchange. The following is the sample body that populates the Runner by default (these are the same objects/parameters detailed in the comment at the top of the sample Hook code):
+Once you've modified the sample code with the specific scopes of additional claims you'd like added to your access tokens, you can test your Hook using the Runner. The runner simulates a call to the Hook with the same body/payload that you would get with a Credentials Exchange. The following is the sample body that populates the Runner by default (these are the same objects/parameters detailed in the comment at the top of the sample Hook code):
 
 ```json
 {

--- a/articles/hooks/extensibility-points/index.md
+++ b/articles/hooks/extensibility-points/index.md
@@ -6,7 +6,7 @@ beta: true
 
 # Extensibility Points
 
-The following is a list of available extensibility points:
+Hooks allow you to customize the behavior of Auth0 with Node.js code. They are essentially [Webtask](https://webtask.io), but [Hooks](/hooks#work-with-hooks) are executed only against selected extensibility points, which are the serverless option that's analagous to the webhooks that come with a server. The following is a list of currently available extensibility points:
 
 - [Credentials Exchange](/hooks/extensibility-points/credentials-exchange): change the scopes and add custom claims to the tokens issued by the Auth0 API's `POST /oauth/token` endpoint
 - [Pre-User Registration](/hooks/extensibility-points/pre-user-registration): prevent user registration and add custom metadata to a newly-created user

--- a/articles/hooks/extensibility-points/post-user-registration.md
+++ b/articles/hooks/extensibility-points/post-user-registration.md
@@ -1,6 +1,8 @@
 ---
+title: Using the Post-User Registration Extensibility Point
 description: The post-user-registration extensibility point for use with Hooks
 beta: true
+toc: true
 ---
 
 # Extensibility Point: Post-User Registration

--- a/articles/hooks/extensibility-points/post-user-registration.md
+++ b/articles/hooks/extensibility-points/post-user-registration.md
@@ -5,14 +5,22 @@ beta: true
 
 # Extensibility Point: Post-User Registration
 
-For [Database Connections](/connections/database), the `post-user-registration` extensibility point allows you to implement custom actions that execute after a new user registers and is added to the database. Hooks associated with the `post-user-registration` extensibility point execute asynchronously from the actions that are a part of the Auth0 authentication process.
+For [Database Connections](/connections/database), the `post-user-registration` extensibility point allows you to implement custom actions that execute after a new user registers and is added to the database. [Hooks](/hooks#work-with-hooks) associated with the `post-user-registration` extensibility point execute asynchronously from the actions that are a part of the Auth0 authentication process.
 
 This allows you to implement scenarios including (but not limited to):
 
 * Sending notifications to Slack or via e-mail about the user's new account;
 * Creating a new user record in a CRM system.
 
-## Starter Code and Parameters
+## How to Implement This
+
+You can implement a [Hook](/hooks#work-with-hooks) using this extensibility point with either the [Dashboard](/hooks/dashboard) or the [Command Line Interface](/hooks/cli). 
+
+### Starter Code and Parameters
+
+After you've created a new Hook that uses the Post-User Registration extensibility point, you can open up the Hook and edit it using the Webtask Editor embedded in the Dashboard. 
+
+The parameters listed in the comment at the top of the code indicate the Auth0 objects (and the parameters within the objects) that can be passed into and used by the Hook's function. For example, the `client` object comes with the following parameters: client name, client ID, the Auth0 tenant name with which the client is associated, and client metadata. 
 
 ```js
 /**
@@ -41,11 +49,48 @@ module.exports = function (user, context, cb) {
 };
 ```
 
-:::panel-warning Response Object
+The callback function `cb` at the end of the sample code is used to signal completion and must not be omitted (even though the extensibility point ignores response objects).
+
+#### Response
+
 The Post-User Registration extensibility point ignores any response object.
+
+### Testing Your Hook
+
+::: note
+Executing the code using the Runner requires a save, which means that your original code will be overwritten.
 :::
 
-### Example: Integrate with Slack
+Once you've modified the sample code with the specific scopes of additional claims you'd like added to your access tokens, you can test your Hook using the Runner. The runner simulates a call to the Hook with the appropriate user information body/payload. The following is the sample body that populates the Runner by default (these are the same objects/parameters detailed in the comment at the top of the sample Hook code):
+
+```json
+{
+  "user": {
+    "tenant": "my-tenant",
+    "username": "user1",
+    "email": "user1@foo.com",
+    "emailVerified": true,
+    "phoneNumber": "1-000-000-0000",
+    "phoneNumberVerified": true,
+    "user_metadata": {
+      "hobby": "surfing"
+    },
+    "app_metadata": {
+      "plan": "full"
+    }
+  },
+  "context": {
+    "requestLanguage": "en-us",
+    "connection": {
+      "id": "con_xxxxxxxxxxxxxxxx",
+      "name": "Username-Password-Authentication",
+      "tenant": "my-tenant"
+    }
+  }
+}
+```
+
+## Example: Integrate with Slack
 
 ```js
 module.exports = function (user, context, cb) {

--- a/articles/hooks/extensibility-points/pre-user-registration.md
+++ b/articles/hooks/extensibility-points/pre-user-registration.md
@@ -1,5 +1,7 @@
 ---
+title: Using the Pre-User Registration Extensibility Point
 description: The pre-user-registration extensibility point for use with Hooks
+toc: true
 beta: true
 ---
 

--- a/articles/hooks/extensibility-points/pre-user-registration.md
+++ b/articles/hooks/extensibility-points/pre-user-registration.md
@@ -14,7 +14,15 @@ This allows you to implement scenarios including (but not limited to):
 * Setting conditional `app_metadata` or `user_metadata` on users that do not yet exist;
 * Preventing (blacklisting) the use of personal email domains.
 
+## How to Implement This
+
+You can implement a [Hook](/hooks#work-with-hooks) using this extensibility point with either the [Dashboard](/hooks/dashboard) or the [Command Line Interface](/hooks/cli). 
+
 ## Starter Code and Parameters
+
+After you've created a new Hook that uses the Pre-User Registration extensibility point, you can open up the Hook and edit it using the Webtask Editor embedded in the Dashboard. 
+
+The parameters listed in the comment at the top of the code indicate the Auth0 objects (and the parameters within the objects) that can be passed into and used by the Hook's function. For example, the `client` object comes with the following parameters: client name, client ID, the Auth0 tenant name with which the client is associated, and client metadata. 
 
 ```js
 /**
@@ -50,6 +58,10 @@ module.exports = function (user, context, cb) {
 };
 ```
 
+The callback function `cb` at the end of the sample code is used to signal completion and must not be omitted.
+
+#### Response
+
 The default response object every time the Hook runs is as follows:
 
 ```json
@@ -63,12 +75,50 @@ The default response object every time the Hook runs is as follows:
 
 If you specify `app_metadata` and `user_metadata` in the response object, Auth0 adds this information to the new user.
 
+::: note
 Metadata property names must not:
 
 * Start with the `$` character;
 * Contain the `.` character.
+:::
 
-### Example: Add Metadata to New Users
+### Testing Your Hook
+
+::: note
+Executing the code using the Runner requires a save, which means that your original code will be overwritten.
+:::
+
+Once you've modified the sample code with the specific scopes of additional claims you'd like added to your access tokens, you can test your Hook using the Runner. The runner simulates a call to the Hook with the appropriate user information body/payload. The following is the sample body that populates the Runner by default (these are the same objects/parameters detailed in the comment at the top of the sample Hook code):
+
+```json
+{
+  "user": {
+    "tenant": "my-tenant",
+    "username": "user1",
+    "password": "xxxxxxx",
+    "email": "user1@foo.com",
+    "emailVerified": false,
+    "phoneNumber": "1-000-000-0000",
+    "phoneNumberVerified": false,
+    "user_metadata": {
+      "hobby": "surfing"
+    },
+    "app_metadata": {
+      "plan": "full"
+    }
+  },
+  "context": {
+    "requestLanguage": "en-us",
+    "connection": {
+      "id": "con_xxxxxxxxxxxxxxxx",
+      "name": "Username-Password-Authentication",
+      "tenant": "my-tenant"
+    }
+  }
+}
+```
+
+## Example: Add Metadata to New Users
 
 ```js
 module.exports = function (user, context, cb) {
@@ -99,7 +149,7 @@ Using the [test runner](https://webtask.io/docs/editor/runner), we see that the 
 }
 ```
 
-### Allow Signups for Users with Whitelisted Email Domains
+## Allow Signups for Users with Whitelisted Email Domains
 
 ```js
 module.exports = function (user, context, cb) {

--- a/articles/hooks/extensibility-points/pre-user-registration.md
+++ b/articles/hooks/extensibility-points/pre-user-registration.md
@@ -78,10 +78,7 @@ The default response object every time the Hook runs is as follows:
 If you specify `app_metadata` and `user_metadata` in the response object, Auth0 adds this information to the new user.
 
 ::: note
-Metadata property names must not:
-
-* Start with the `$` character;
-* Contain the `.` character.
+Metadata property names must not start with the `$` character or contain the `.` character.
 :::
 
 ### Testing Your Hook


### PR DESCRIPTION
Updating extensibility point docs so that they aren't without context if you land directly on them instead of coming through the Hooks pages.

Trello: https://trello.com/c/e8ge6bCH/1758-extensibility-point-pre

* https://auth0-docs-content-pr-4995.herokuapp.com/docs/hooks/extensibility-points/credentials-exchange
* https://auth0-docs-content-pr-4995.herokuapp.com/docs/hooks/extensibility-points/pre-user-registration
* https://auth0-docs-content-pr-4995.herokuapp.com/docs/hooks/extensibility-points/post-user-registration