### PR TITLE
Auth0.js parameter updates

### DIFF
--- a/articles/libraries/auth0js/v8/index.md
+++ b/articles/libraries/auth0js/v8/index.md
@@ -91,10 +91,11 @@ The `authorize()` method can be used for logging in users via the [Hosted Login 
 | **Parameter** | **Required** | **Description** |
 | --- | --- | --- |
 | `audience` | optional | (String)  The default audience to be used for requesting API access. |
-| `scope` | required | (String) The scopes which you want to request authorization for. These must be separated by a space. You can request any of the standard OIDC scopes about users, such as `profile` and `email`, custom claims that must [conform to a namespaced format](/api-auth/tutorials/adoption/scope-custom-claims), or any scopes supported by the target API (for example, `read:contacts`). Include `offline_access` to get a refresh token. |
-| `responseType` | required | (String) It can be any space separated list of the values `code`, `token`, `id_token`.  It defaults to `'token'`, unless a `redirectUri` is provided, then it defaults to `'code'`. |
+| `scope` | optional | (String) The scopes which you want to request authorization for. These must be separated by a space. You can request any of the standard OIDC scopes about users, such as `profile` and `email`, custom claims that must [conform to a namespaced format](/api-auth/tutorials/adoption/scope-custom-claims), or any scopes supported by the target API (for example, `read:contacts`). Include `offline_access` to get a refresh token. |
+| `responseType` | optional | (String) It can be any space separated list of the values `code`, `token`, `id_token`.  It defaults to `'token'`, unless a `redirectUri` is provided, then it defaults to `'code'`. |
 | `clientID` | optional | (String)  Your Auth0 client ID. |
 | `redirectUri` | optional | (String) The URL to which Auth0 will redirect the browser after authorization has been granted for the user. |
+| `leeway` | optional | (Integer) Add leeway for clock skew to JWT expiration times. |
 
 For hosted login, one must call the `authorize()` method.
 
@@ -103,8 +104,6 @@ webAuth.authorize({
   //Any additional options can go here
 });
 ```
-
-If `authorize()` is called without any parameters, it will use those which were set when `webAuth` was instantiated. The first required parameter, `client_id`, will be thus passed to `authorize()`. The second required parameter is `response_type`, and this will either be acquired from the same place, or, if it was never set, default to `token` in most cases.
 
 For social logins, the `connection` parameter will need to be specified:
 

--- a/articles/libraries/auth0js/v8/index.md
+++ b/articles/libraries/auth0js/v8/index.md
@@ -86,7 +86,7 @@ You can choose a method for login based on the type of auth you need in your app
 
 ### webAuth.authorize()
 
-The `authorize()` method can be used for logging in users via the [Hosted Login Page](/libraries/auth0js#hosted-login-page), or via social connections, as exhibited in the examples below. This method invokes the [/authorize endpoint](/api/authentication?javascript#social) of the Authentication API, and can take a variety of parameters via the `options` object.
+The `authorize()` method can be used for logging in users via the [Hosted Login Page](/hosted-pages/login), or via social connections, as exhibited in the examples below. This method invokes the [/authorize endpoint](/api/authentication?javascript#social) of the Authentication API, and can take a variety of parameters via the `options` object.
 
 | **Parameter** | **Required** | **Description** |
 | --- | --- | --- |
@@ -96,6 +96,10 @@ The `authorize()` method can be used for logging in users via the [Hosted Login 
 | `clientID` | optional | (String)  Your Auth0 client ID. |
 | `redirectUri` | optional | (String) The URL to which Auth0 will redirect the browser after authorization has been granted for the user. |
 | `leeway` | optional | (Integer) Add leeway for clock skew to JWT expiration times. |
+
+::: note
+Because of clock skew issues, you may occasionally encounter the error `The token was issued in the future`. The `leeway` parameter can be used to allow a few seconds of leeway to JWT expiration times, to prevent that from occuring.
+:::
 
 For hosted login, one must call the `authorize()` method.
 

--- a/articles/libraries/auth0js/v8/migration-guide.md
+++ b/articles/libraries/auth0js/v8/migration-guide.md
@@ -57,7 +57,7 @@ The `login` method of version 7 was divided into several different methods in ve
 
 ### webAuth.authorize()
 
-The `authorize` method can be used for logging in users via the [Hosted Login Page](/libraries/auth0js#hosted-login-page), or via social connections, as exhibited below.
+The `authorize` method can be used for logging in users via the [Hosted Login Page](/hosted-pages/login), or via social connections, as exhibited below.
 
 For hosted login, one must call the authorize endpoint
 


### PR DESCRIPTION
Feedback from a customer noted that we have required parameters in `authorize()` - wrongly so, they're required by the `authorize` endpoint, not as parameters to the auth0.js method (if they're not provided, the SDK defaults them). Also made some suggestions about the below paragraph, which just needed removed.

Lastly, separate request to document `leeway` parameter + explain what error might cause you to need to set a `leeway` to start with.