### PR TITLE
Update 01-authorization.md

### DIFF
--- a/articles/quickstart/backend/nodejs/01-authorization.md
+++ b/articles/quickstart/backend/nodejs/01-authorization.md
@@ -59,7 +59,7 @@ const checkJwt = jwt({
   }),
 
   // Validate the audience and the issuer.
-  audience: '${apiIdentifier}',
+  aud: '${apiIdentifier}',
   issuer: `https://${account.namespace}/`,
   algorithms: ['RS256']
 });


### PR DESCRIPTION
The block of code for the jwt method actually needs to have the key `aud` instead of `audience` for it to function properly.

I've attempted 3 times to re-do this PR to avoid the change on line 96. Not sure why it keeps getting pulled in.