### PR TITLE
Replace instances of app with client

### DIFF
--- a/articles/api/authentication/_logout.md
+++ b/articles/api/authentication/_logout.md
@@ -40,7 +40,7 @@ curl --request GET \
 }) %>
 
 Use this endpoint to logout a user. If you want to navigate the user to a specific URL after the logout, set that URL at the `returnTo` parameter. The URL should be included in any the appropriate `Allowed Logout URLs` list:
-- If the `client_id` parameter is included, the `returnTo` URL must be listed in the `Allowed Logout URLs` set at the client level (see [Setting Allowed Logout URLs at the App Level](/logout#set-the-allowed-logout-urls-at-the-app-level)).
+- If the `client_id` parameter is included, the `returnTo` URL must be listed in the `Allowed Logout URLs` set at the client level (see [Setting Allowed Logout URLs at the App Level](/logout#set-the-allowed-logout-urls-at-the-client-level)).
 - If the `client_id` parameter is NOT included, the `returnTo` URL must be listed in the `Allowed Logout URLs` set at the tenant level (see [Setting Allowed Logout URLs at the Tenant Level](/logout#set-the-allowed-logout-urls-at-the-tenant-level)).
 
 

--- a/articles/logout/index.md
+++ b/articles/logout/index.md
@@ -5,23 +5,22 @@ toc: true
 
 # Logout
 
-## Overview
+When you're implementing the logout functionality for your app, there are typically three sessions layers you need to consider:
 
-When you are implementing the logout functionality of your app there are typically three layers of sessions you need to consider:
+- __Application Session__: The first is the session inside your application. Though your application uses Auth0 to authenticate users, you'll still need to track that the user has logged in to your application. In a regular web application, this is achieved by storing information inside a cookie. You need to log out the user from your application by clearing their session.
 
-- __Application Session__: The first is the session inside the application. Even though your application uses Auth0 to authenticate users, you will still need to track that the user has logged in to your application. In a normal web application this is achieved by storing information inside a cookie. You need to log out the user from your application, by clearing their session.
+- __Auth0 session__: Auth0 also keep a session for the user and stores their information inside a cookie. The next time a user is redirected to the Auth0 Lock screen, the user's information will be remembered. To log out a user from Auth0, you need to clear the single sign-on (SSO) cookie.
 
-- __Auth0 session__: Next, Auth0 will also keep a session and store the user's information inside a cookie. The next time a user is redirected to the Auth0 Lock screen, the user's information will be remembered. In order to log out a user from Auth0 you need to clear the single sign-on (SSO) cookie.
+- __Identity Provider session__: The last layer is the Identity Provider, such as Facebook or Google. When users attempt to sign in with any of these providers and they are already signed into the provider, they will not be prompted again to sign in. They may simply be asked to give permissions to share their information with Auth0 and in turn, your application.
 
-- __Identity Provider session__: The last layer is the Identity Provider, for example Facebook or Google. When you allow users to sign in with any of these providers, and they are already signed into the provider, they will not be prompted to sign in. They may simply be required to give permissions to share their information with Auth0 and in turn your application.
-
-This document explains how to log out a user from the Auth0 session and optionally from the Identity Provider session. Keep in mind though that you should handle also the Application Session in your app!
+This document explains how to log out a user from the Auth0 session and (optionally) from the Identity Provider session. Remember that you should handle the Application Session in your app!
 
 ## Log Out a User
 
-The [logout endpoint](/api/authentication?javascript#logout) in Auth0 can work in two ways:
+The [logout endpoint](/api/authentication?javascript#logout) in Auth0 works in one of two ways:
+
 - Clear the SSO cookie in Auth0
-- Clear the SSO cookie in Auth0 and sign out from the IdP (for example, ADFS or Google)
+- Clear the SSO cookie in Auth0 and sign out the user from the IdP (such as ADFS or Google)
 
 To force a logout, redirect the user to the following URL:
 
@@ -31,7 +30,7 @@ https://${account.namespace}/v2/logout
 
 Redirecting the user to this URL clears all single sign-on cookies set by Auth0 for the user.
 
-Although this is not common practice, you can force the user to also log out of their identity provider. To do this add a `federated` querystring parameter to the logout URL:
+Although this is not common practice, you can also force the user to log out of their identity provider. To do this, add a `federated` querystring parameter to the logout URL:
 
 ```text
 https://${account.namespace}/v2/logout?federated
@@ -59,21 +58,21 @@ The following identity providers support federated logout:
 * Yammer
 
 ::: panel-warning Clear your application session
-The Auth0 [logout endpoint](/api/authentication?javascript#logout) logs you out from Auth0, and optionally from your identity provider. It does not log you out of your application! This is something that you should implement on your side. You need to log out the user from your application, by clearing their session. You might find [this video](/videos/session-and-cookies) helpful.
+The Auth0 [logout endpoint](/api/authentication?javascript#logout) logs you out from Auth0, and (optionally) from your identity provider. It does *not* log you out of your application! This is something that you must implement on your side. You need to log out the user from your application by clearing their session. You might find [this video](/videos/session-and-cookies) helpful.
 :::
 
 
 ## Redirect Users After Logout
 
-To redirect a user after logout, add a `returnTo` querystring parameter with the target URL as the value. It is suggested that you URL Encode the target URL being passed in, for example to redirect the user to `http://www.example.com`, you can make the following request:
+To redirect a user after logout, add a `returnTo` querystring parameter with the target URL as the value. We suggest that you encode the target URL being passed in -- for example, to redirect the user to `http://www.example.com` after logout, you can make the following request:
 
 ```text
 https://${account.namespace}/v2/logout?returnTo=http%3A%2F%2Fwww.example.com
 ```
 
-You will need to add the non URL Encoded `returnTo` URL (i.e. for these examples it is `http://www.example.com`) as an **Allowed Logout URLs** in one of two places:
+You will need to add the non-encoded `returnTo` URL (for these examples, it is `http://www.example.com`) as an **Allowed Logout URLs** in one of two places:
 
-* For logout requests that do not include the `client_id` parameter, for example:
+* For logout requests that do not include the `client_id` parameter, such as:
 
     ```text
     https://${account.namespace}/v2/logout?returnTo=http%3A%2F%2Fwww.example.com
@@ -81,14 +80,13 @@ You will need to add the non URL Encoded `returnTo` URL (i.e. for these examples
 
   you must add the `returnTo` URL (i.e. `http://www.example.com`) to the **Allowed Logout URLs** list in the [Advanced tab of your Tenant Settings](${manage_url}/#/tenant/advanced). See [Set the Allowed Logout URLs at the Tenant Level](#set-the-allowed-logout-urls-at-the-tenant-level) for more information.
 
-* For logout requests that include the `client_id` parameter, for example:
+* For logout requests that include the `client_id` parameter, such as:
 
     ```text
     https://${account.namespace}/v2/logout?returnTo=http%3A%2F%2Fwww.example.com&client_id=CLIENT_ID
     ```
 
   you must add the `returnTo` URL (i.e. `http://www.example.com`) to the **Allowed Logout URLs** list in the **Settings** tab of your Auth0 app that is associated with the specified `CLIENT_ID`. See [Set the Allowed Logout URLs at the App Level](#set-the-allowed-logout-urls-at-the-app-level) for more information.
-
 
 ### Set the Allowed Logout URLs at the Tenant Level
 
@@ -101,12 +99,11 @@ When providing the URL list, you can:
 * Specify multiple, valid, comma-separated URLs
 * Use `*` as a wildcard for subdomains (e.g. `http://*.example.com`)
 
+### Set the Allowed Logout URLs at the Client Level
 
-### Set the Allowed Logout URLs at the App Level
+To redirect the user after they log out from a specific client, you must add the URL used in the `returnTo` parameter of the redirect URL to the **Allowed Logout URLs** list in the **Settings** tab of your Auth0 client that is associated with the `CLIENT_ID` parameter.
 
-To redirect the user after they log out from a specific app, you must add the URL used in the `returnTo` parameter of the redirect URL to the **Allowed Logout URLs** list in the **Settings** tab of your Auth0 app that is associated with the `CLIENT_ID` parameter.
-
-![Application level logout screen](/media/articles/logout/client-level-logout.png)
+![Client level logout screen](/media/articles/logout/client-level-logout.png)
 
 When providing the URL list, you can:
 
@@ -114,33 +111,32 @@ When providing the URL list, you can:
 * Use `*` as a wildcard for subdomains (e.g. `http://*.example.com`)
 
 ::: note
-In order to avoid validation errors, make sure that you do include the protocol part of the URL. For example, setting the value to `*.example.com` will result in a validation error, you should use `http://*.example.com` instead.
+In order to avoid validation errors, make sure that you include the protocol part of the URL. For example, setting the value to `*.example.com` will result in a validation error, so you should use `http://*.example.com` instead.
 :::
 
 #### Limitations
 
-* The validation of URLs provided as values to the `returnTo` parameter, the querystring and hash information provided as part of the URL are not taken into account.
+* The validation of URLs provided as values to the `returnTo` parameter, the querystring, and hash information provided as part of the URL are not taken into account.
 
-* The `returnTo` parameter does not function for all social providers. Please check your social provider's settings to ensure that they will accept the `redirectTo` parameter.
+* The `returnTo` parameter does not work with all social providers. Please check your social provider's settings to ensure that they will accept the `redirectTo` parameter.
 
-* The URLs provided to the **Allowed Logout URLs** list are case-sensitive, so the URL used for logouts must match the case of the logout URL configured on the dashboard. Note, that the scheme and host parts, are case-insensitive. For example, in `http://www.Example.Com/FooHoo.html`, the `http://www.Example.Com` is case-insensitive, while the `FooHoo.html` is case-sensitive.
+* The URLs provided to the **Allowed Logout URLs** list are case-sensitive, so the URL used for logouts must match the case of the logout URL configured on the dashboard. Note, that the scheme and host parts, however, are case insensitive. For example, if your URL is `http://www.Example.Com/FooHoo.html`, the `http://www.Example.Com` portion is case insensitive, while the `FooHoo.html` portion is case sensitive.
 
 ::: note
-If you are working with social identity providers such as Google or Facebook, you must set your `Client ID` and `Secret` for these providers in the [Dashboard](${manage_url}) for the logout to function.
+If you are working with social identity providers such as Google or Facebook, you must set your `Client ID` and `Secret` for these providers in the [Dashboard](${manage_url}) for the logout to function properly.
 :::
 
 #### Facebook Users
 
 If you are using Facebook, please be aware of the additional requirements when triggering a logout.
 
-Also make sure to encode the `returnTo` parameter.
+You will also need to encode the `returnTo` parameter.
 
 ```text
 https://${account.namespace}/v2/logout?federated&
       returnTo=https%3A%2F%2F${account.namespace}%2Flogout%3FreturnTo%3Dhttp%3A%2F%2Fwww.example.com
       &access_token=[facebook access_token]
 ```
-
 
 ### Supported Providers
 
@@ -175,12 +171,11 @@ Auth0 supports use of the [`logout` endpoint](/api/authentication?javascript#log
 - Yahoo
 - Yammer
 
-
 ## SAML Logout
 
-To logout users from an external SAML identity provider, a [SAML logout URL](/saml-sp-generic#1-obtain-information-from-idp) must be configured in the SAML connection settings.
+To logout users from an external SAML identity provider, you must configure a [SAML logout URL](/saml-sp-generic#1-obtain-information-from-idp) in the SAML connection settings.
 
-If a logout URL is not configured, Auth0 will use the __SAML login URL__.
+If you don't configure a logout URL, Auth0 will use the __SAML login URL__.
 
 To log out a user from both Auth0 and their SAML identity provider, they must be redirected to the [logout endpoint](/api/authentication?javascript#logout) with a URL that includes the `federated` querystring parameter as [described above](#log-out-a-user).
 


### PR DESCRIPTION
The logout doc still referred to app instead of client (I also made minor edits to the doc).

https://auth0-docs-content-pr-5011.herokuapp.com/docs/logout#set-the-allowed-logout-urls-at-the-client-level