### PR TITLE
Update aditional-parameter description

### DIFF
--- a/articles/api/authentication/_login.md
+++ b/articles/api/authentication/_login.md
@@ -63,7 +63,7 @@ Social connections only support browser-based (passive) authentication because m
 | `connection`     | The name of a social identity provider configured to your client, for example `google-oauth2` or `facebook`. If null, it will redirect to the [Auth0 Login Page](https://${account.namespace}/login) and show the Login Widget. |
 | `redirect_uri` <br/><span class="label label-danger">Required</span> | The URL to which Auth0 will redirect the browser after authorization has been granted by the user. |
 | `state` <br/><span class="label label-primary">Recommended</span> | An opaque value the clients adds to the initial request that the authorization server includes when redirecting the back to the client. This value must be used by the client to prevent CSRF attacks. |
-| `additional-parameter` | Use this to send additional parameters to the provider. For example, `access_type=offline` (for Google refresh tokens) , `display=popup` (for Windows Live popup mode). |
+| `*` | Append any additional parameter to the end of your request, and it will be sent to the provider. For example, `access_type=offline` (for Google refresh tokens) , `display=popup` (for Windows Live popup mode). |
 
 ### Test with Authentication API Debugger
 

--- a/articles/api/authentication/_login.md
+++ b/articles/api/authentication/_login.md
@@ -11,7 +11,7 @@ GET https://${account.namespace}/authorize?
   connection=CONNECTION&
   redirect_uri=${account.callback}&
   state=STATE&
-  additional-parameter=ADDITIONAL_PARAMETERS
+  ADDITIONAL_PARAMETERS
 ```
 
 ```javascript
@@ -63,7 +63,7 @@ Social connections only support browser-based (passive) authentication because m
 | `connection`     | The name of a social identity provider configured to your client, for example `google-oauth2` or `facebook`. If null, it will redirect to the [Auth0 Login Page](https://${account.namespace}/login) and show the Login Widget. |
 | `redirect_uri` <br/><span class="label label-danger">Required</span> | The URL to which Auth0 will redirect the browser after authorization has been granted by the user. |
 | `state` <br/><span class="label label-primary">Recommended</span> | An opaque value the clients adds to the initial request that the authorization server includes when redirecting the back to the client. This value must be used by the client to prevent CSRF attacks. |
-| `*` | Append any additional parameter to the end of your request, and it will be sent to the provider. For example, `access_type=offline` (for Google refresh tokens) , `display=popup` (for Windows Live popup mode). |
+| `ADDITIONAL_PARAMETERS` | Append any additional parameter to the end of your request, and it will be sent to the provider. For example, `access_type=offline` (for Google refresh tokens) , `display=popup` (for Windows Live popup mode). |
 
 ### Test with Authentication API Debugger
 


### PR DESCRIPTION
Sometimes, it may be misleading to list `aditional-parameter` as a parameter itself.

In my case I tried to add, for example, `?...aditional-parameter=login_hint=asd@asd.com`, instead of directly adding it to the request as `?...login_hint=asd@asd.com`.

Here's a case that someone had the same misconception: https://community.auth0.com/questions/2984/additional-parameter-on-authorize-does-not-work

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
