### PR TITLE
update to professional services navigation

### DIFF
--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -401,9 +401,6 @@ articles:
       - title: "Performance and Scalability"
         url: "/services/performance-scalability"
 
-      - title: "Geo High Availability"
-        url: "/services/geo-ha"
-
       - title: "Scenario guidance"
         url: "/services/scenario-guidance"
 
@@ -421,9 +418,6 @@ articles:
 
       - title: "Auth0 Advanced Topics"
         url: "/services/auth0-advanced"
-
-      - title: "Private SaaS Introduction"
-        url: "/services/private-saas-introduction"
 
       - title: "Private SaaS Management Workshop"
         url: "/services/private-saas-management"


### PR DESCRIPTION
removed /services/private-saas-introduction and /services/geo-ha from the navigation tree

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
