### PR TITLE
Fix typo

### DIFF
--- a/articles/connections/passwordless/_setup-callback.md
+++ b/articles/connections/passwordless/_setup-callback.md
@@ -1,3 +1,3 @@
 #### 4. Configure Callback URL
 
-For security purposes, you must to add <% if(spa){ %>your page's URL<%} else {%>the callback URL<%}%> to the list of **Allowed callback URLs** in your app's [Settings Section](${manage_url}/#/applications) of the Dashboard.
+For security purposes, you must add <% if(spa){ %>your page's URL<%} else {%>the callback URL<%}%> to the list of **Allowed callback URLs** in your app's [Settings Section](${manage_url}/#/applications) of the Dashboard.

--- a/articles/connections/passwordless/_setup-callback.md
+++ b/articles/connections/passwordless/_setup-callback.md
@@ -1,3 +1,3 @@
 #### 4. Configure Callback URL
 
-For security purposes, you must add <% if(spa){ %>your page's URL<%} else {%>the callback URL<%}%> to the list of **Allowed callback URLs** in your app's [Settings Section](${manage_url}/#/applications) of the Dashboard.
+For security purposes, you must add <% if(spa){ %>your page's URL<%} else {%>the callback URL<%}%> to the list of **Allowed callback URLs** in your client's [Settings section](${manage_url}/#/clients) of the Dashboard.


### PR DESCRIPTION
Removed extraneous word from the Passwordless snippet.

https://auth0-docs-content-pr-5033.herokuapp.com/docs/connections/passwordless/regular-web-app-email-code/v8#4-configure-callback-url