### PR TITLE
Fixes to hooks examples

### DIFF
--- a/articles/hooks/extensibility-points/post-user-registration.md
+++ b/articles/hooks/extensibility-points/post-user-registration.md
@@ -97,7 +97,7 @@ Once you've modified the sample code with the specific scopes of additional clai
 ```js
 module.exports = function (user, context, cb) {
 
-  // Get your Slack's hook URL from https://slack.com/services/10525858050
+  // Read more about incoming webhooks at https://api.slack.com/incoming-webhooks
   var SLACK_HOOK = 'YOUR SLACK HOOK URL';
 
   // Post the new user's name and email address to the selected channel
@@ -111,6 +111,6 @@ module.exports = function (user, context, cb) {
   });
 
   // Return immediately; the request to the Slack API will continue on the sandbox
-  cb(null, user, context);
+  cb();
 };
 ```

--- a/articles/hooks/extensibility-points/pre-user-registration.md
+++ b/articles/hooks/extensibility-points/pre-user-registration.md
@@ -165,7 +165,7 @@ module.exports = function (user, context, cb) {
   });
 
   if (!userHasAccess) {  
-    return cb('You may not sign up with an email address using your current domain.');
+    return cb('Email domain not allowed');
   }
 
   const response = { user };


### PR DESCRIPTION
Fixes the following:
* The error message in pre-reg hook doesn't match with message in code
* Misleading Slack URL in post-reg hook example
* `cb()` function in post-reg hooks don't take any arguments, but the
code in example does

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
