### PR TITLE
Switch ASP.NET Core to master branches of sample repos

### DIFF
--- a/articles/quickstart/backend/aspnet-core-webapi/v2/01-authorization.md
+++ b/articles/quickstart/backend/aspnet-core-webapi/v2/01-authorization.md
@@ -7,7 +7,7 @@ budicon: 500
 
 <%= include('../../../../_includes/_package', {
   org: 'auth0-samples',
-  branch: 'v2',
+  branch: 'master',
   repo: 'auth0-aspnetcore-webapi-samples',
   path: 'Quickstart/01-Authorization',
   requirements: [

--- a/articles/quickstart/webapp/aspnet-core/v2/01-login.md
+++ b/articles/quickstart/webapp/aspnet-core/v2/01-login.md
@@ -8,7 +8,7 @@ budicon: 448
   org: 'auth0-samples',
   repo: 'auth0-aspnetcore-mvc-samples',
   path: 'Quickstart/01-Login',
-  branch: 'v2',
+  branch: 'master',
   requirements: [
     '.NET Core SDK 2.0',
     '.NET Core 2.0',

--- a/articles/quickstart/webapp/aspnet-core/v2/02-login-custom.md
+++ b/articles/quickstart/webapp/aspnet-core/v2/02-login-custom.md
@@ -8,7 +8,7 @@ budicon: 448
   org: 'auth0-samples',
   repo: 'auth0-aspnetcore-mvc-samples',
   path: 'Quickstart/02-Login-Custom',
-  branch: 'v2',
+  branch: 'master',
   requirements: [
     '.NET Core SDK 2.0',
     '.NET Core 2.0',

--- a/articles/quickstart/webapp/aspnet-core/v2/03-storing-tokens.md
+++ b/articles/quickstart/webapp/aspnet-core/v2/03-storing-tokens.md
@@ -8,7 +8,7 @@ budicon: 280
   org: 'auth0-samples',
   repo: 'auth0-aspnetcore-mvc-samples',
   path: 'Quickstart/03-Storing-Tokens',
-  branch: 'v2',
+  branch: 'master',
   requirements: [
     '.NET Core SDK 2.0',
     '.NET Core 2.0',

--- a/articles/quickstart/webapp/aspnet-core/v2/04-user-profile.md
+++ b/articles/quickstart/webapp/aspnet-core/v2/04-user-profile.md
@@ -8,7 +8,7 @@ budicon: 292
   org: 'auth0-samples',
   repo: 'auth0-aspnetcore-mvc-samples',
   path: 'Quickstart/04-User-Profile',
-  branch: 'v2',
+  branch: 'master',
   requirements: [
     '.NET Core SDK 2.0',
     '.NET Core 2.0',

--- a/articles/quickstart/webapp/aspnet-core/v2/05-authorization.md
+++ b/articles/quickstart/webapp/aspnet-core/v2/05-authorization.md
@@ -8,7 +8,7 @@ budicon: 546
   org: 'auth0-samples',
   repo: 'auth0-aspnetcore-mvc-samples',
   path: 'Quickstart/05-Authorization',
-  branch: 'v2',
+  branch: 'master',
   requirements: [
     '.NET Core SDK 2.0',
     '.NET Core 2.0',


### PR DESCRIPTION
I merged the `V2` branch of the ASP.NET Core samples repositories into the `master` branch, and plan to delete the `V2` branch.

This is PR is to ensure that the quickstarts point to the `master` branch.

* https://auth0-docs-content-pr-5049.herokuapp.com/docs/quickstart/webapp/aspnet-core/
* https://auth0-docs-content-pr-5049.herokuapp.com/docs/quickstart/backend/aspnet-core-webapi