### PR TITLE
Fix Auth API Debugger link

### DIFF
--- a/articles/_includes/_test-this-endpoint.md
+++ b/articles/_includes/_test-this-endpoint.md
@@ -3,15 +3,20 @@ You can use our **Authentication API Debugger** extension to test this endpoint.
 Click on **Install Debugger** to go to the article that explains how (you only have to do this once).
 
 <%
-  var urlUS = 'https://' + account.tenant + '.us.webtask.io/auth0-authentication-api-debugger';
-  var urlEU = 'https://' + account.tenant + '.eu.webtask.io/auth0-authentication-api-debugger';
-  var urlAU = 'https://' + account.tenant + '.au.webtask.io/auth0-authentication-api-debugger';
+  var tenantWithLoc = account.namespace.slice(0, account.namespace.length - 10);
+%>
+
+<%
+  if(tenantWithLoc.indexOf('.') !== -1){
+    var debugURL = 'https://' + tenantWithLoc + '.webtask.io/auth0-authentication-api-debugger';
+  } else {
+    var debugURL = 'https://' + tenantWithLoc + '.us.webtask.io/auth0-authentication-api-debugger';
+  }
 %>
 
 <div class="test-endpoint-box">
   <a href="/extensions/authentication-api-debugger" class="btn btn-primary" target="_blank">Install Debugger</a>
 </div>
 
-**If you have already installed the extension, skip to the Authentication API Debugger.**
+**If you have already installed the extension, skip to the <a href="${debugURL}" target="_blank">Authentication API Debugger</a>.**
 
-The link varies according to your tenant's region: <a href="${urlUS}" target="_blank">US West</a>, <a href="${urlEU}" target="_blank">Europe Central</a> or <a href="${urlAU}" target="_blank">Australia</a>.


### PR DESCRIPTION
@mpaktiti I think your original code was correct, except for one small oversight. The code was:

```
var tenantWithLoc = account.namespace.slice(0, account.namespace.length - 10);

if(tenantWithLoc.indexOf('.') !== -1){
  var debugURL = 'https://' + account.tenant + '.webtask.io/auth0-authentication-api-debugger';
} else {
  var debugURL = 'https://' + account.tenant + '.us.webtask.io/auth0-authentication-api-debugger';
}
```

So you strip the `.auth0.com` and store it in the `tenantWithLoc`. The you check in `tenantWithLoc` whether there is a `.` so you know whether we are sitting with `jerrie.au` or just `jerrie` (in which case it is `us` domain).


But then when you build up the `debugURL` you use the `account.tenant` which never contains the domain. So for example, for the `jerrie.au` case above, the `tenant.domain` will only return `jerrie`. This results in a wrong URL being built for the non-`us` cases.

You should be using `tenantWithLoc` when building up the `debugURL` variable, e.g.

```
var tenantWithLoc = account.namespace.slice(0, account.namespace.length - 10);

if(tenantWithLoc.indexOf('.') !== -1){
  var debugURL = 'https://' + tenantWithLoc + '.webtask.io/auth0-authentication-api-debugger';
} else {
  var debugURL = 'https://' + tenantWithLoc + '.us.webtask.io/auth0-authentication-api-debugger';
}
```

I believe this will fix it

https://auth0-docs-content-pr-5050.herokuapp.com/docs/api/authentication

Not sure how we test this though, without pushing it into production ;)
