### PR TITLE
Add more content on AuthZ extension usage

### DIFF
--- a/articles/architecture-scenarios/application/spa-api/index.md
+++ b/articles/architecture-scenarios/application/spa-api/index.md
@@ -37,6 +37,8 @@ ExampleCo wants to build a flexible solution. At the moment only a SPA is requir
 
 It is required that only authorized users and applications are allowed access to the Timesheets API.
 
+Two kind of users will use this SPA: employees and managers. The employees should be able to read, create and delete their own timesheet entries, while the managers should be able to approve timesheets as well.
+
 <%= include('./_stepnav', {
  next: ["1. Solution Overview", "/architecture-scenarios/application/spa-api/part-1"]
 }) %>

--- a/articles/architecture-scenarios/application/spa-api/index.md
+++ b/articles/architecture-scenarios/application/spa-api/index.md
@@ -9,12 +9,12 @@ toc: true
 
 # SPA + API
 
-In this scenario we will build a Timesheet API for a fictitious company named ExampleCo. The API will allow to add timesheet entries for an employee or a contractor.
+In this scenario, we will build a Timesheet API for a fictitious company named ExampleCo. The API will allow adding timesheet entries for an employee or a contractor.
 
 We will also be building a Single Page Application (SPA) which will be used to log timesheet entries and send them to the centralized timesheet database using the API.
 
 ::: panel TL;DR
-* Auth0 provides API Authentication and Authorizaion as a means to secure access to API endpoints (see [API Authentication and Authorization](/architecture-scenarios/application/spa-api/part-1#api-authentication-and-authorization))
+* Auth0 provides API Authentication and Authorization as a means to secure access to API endpoints (see [API Authentication and Authorization](/architecture-scenarios/application/spa-api/part-1#api-authentication-and-authorization))
 * For authorizing a user of a SPA, Auth0 supports the Implicit Grant (see [Implicit Grant](/architecture-scenarios/application/spa-api/part-1#implicit-grant))
 * Both the SPA and the API must be configured in the Auth0 Dashboard (see [Auth0 Configuration](/architecture-scenarios/application/spa-api/part-2#auth0-configuration))
 * User Permissions can be enforced using the Authorization Extension (see [Configure the Authorization Extension](/architecture-scenarios/application/spa-api/part-2#configure-the-authorization-extension))
@@ -27,17 +27,17 @@ We will also be building a Single Page Application (SPA) which will be used to l
 
 ## The Premise
 
-ExampleCo is a consulting startup company. Currently they have approximately 100 employees and they also outsource several activities to external contractors. All employees and external contractors are required to fill in their timesheets every week.
+ExampleCo is a consulting startup company. Currently, they have approximately 100 employees and they also outsource several activities to external contractors. All employees and external contractors are required to fill in their timesheets every week.
 
 The company has built a timesheets application, a scenario we covered in [Single Sign-On for Regular Web Apps](/architecture-scenarios/application/web-app-sso). The internal employees use this web app to fill in their timesheets but the company wants to replace it with a SPA. The app will be used to log timesheet entries and send the data to the centralized timesheet database using the API. The app will also allow managers to approve timesheet entries.
 
 ## Goals & Requirements
 
-ExampleCo wants to build a flexible solution. At the moment only a SPA is required to capture timesheet entries but in the future the company plans on launching more clients, like a mobile app to accommodate their sales teams. Hence the company has decided to develop a single Timesheets API which will be used to log time not only by this server process, but by all future clients as well. They want to put in place a security architecture that is flexible enough to accommodate this. ExampleCo wants to ensure that a large part of the code and business logic for the application can be shared across the different client applications.
+ExampleCo wants to build a flexible solution. At the moment only a SPA is required to capture timesheet entries but in the future, the company plans on launching more clients, like a mobile app to accommodate their sales teams. Hence the company has decided to develop a single Timesheets API which will be used to log time not only by this server process but by all future clients as well. They want to put in place a security architecture that is flexible enough to accommodate this. ExampleCo wants to ensure that a large part of the code and business logic for the application can be shared across the different client applications.
 
 It is required that only authorized users and applications are allowed access to the Timesheets API.
 
-Two kind of users will use this SPA: employees and managers. The employees should be able to read, create and delete their own timesheet entries, while the managers should be able to approve timesheets as well.
+Two kinds of users will use this SPA: employees and managers. The employees should be able to read, create and delete their own timesheet entries, while the managers should be able to approve timesheets as well.
 
 <%= include('./_stepnav', {
  next: ["1. Solution Overview", "/architecture-scenarios/application/spa-api/part-1"]

--- a/articles/architecture-scenarios/application/spa-api/part-1.md
+++ b/articles/architecture-scenarios/application/spa-api/part-1.md
@@ -72,9 +72,14 @@ Once the user authenticates, the client app receives the `id_token` and `access_
 
 ## Authorization Extension
 
-The [Auth0 Authorization Extension](/extensions/authorization-extension) allows you to provide authorization support in your application, by assigning Roles, Groups and Permissions to Users. 
+The [Auth0 Authorization Extension](/extensions/authorization-extension) allows you to configure Roles, Groups and Permissions, and assign them to Users.
 
-The Authorization Extension creates a [Rule](/rules) which will augment the [User profile](/rules/current#rule-syntax) during the authentication flow with the Roles, Groups and Permissions assigned to the user. You can then use this information to ensure that the `access_token` issued to a user only contains scopes which are allowed according to the permissions defined in the Authorization Extension.
+- The Permissions are actions that someone can do. For ExampleCo's business needs, we will configure four Permissions: read, create, delete and approve timesheets.
+- The Roles are collections of Permissions. ExampleCo's timesheets app, will be used by two kind of users (employees and managers), with different permissions each, so we will configure two Roles: employee and manager.
+
+Since this covers our business case we will not create any Groups.
+
+The Authorization Extension will create a [Rule](/rules) which will read the Roles, Groups and Permissions assigned to a user and add this information to the [User profile](/rules/current#rule-syntax) during the authentication flow. We can use this information to ensure that the `access_token` issued to a user only contains scopes which are allowed. We can later on proceed to customizing our app, like disabling the Approve Timesheets functionality if the user does not have the required permission to do so.
 
 <%= include('./_stepnav', {
  prev: ["Introduction", "/architecture-scenarios/application/spa-api"], next: ["2. Auth0 Configuration", "/architecture-scenarios/application/spa-api/part-2"]

--- a/articles/architecture-scenarios/application/spa-api/part-1.md
+++ b/articles/architecture-scenarios/application/spa-api/part-1.md
@@ -1,9 +1,9 @@
 ---
-description: Solutions Overview for the SPA + API architecture scenario
+description: Solution Overview for the SPA + API architecture scenario
 toc: true
 ---
 
-# SPA + API: Solutions Overview
+# SPA + API: Solution Overview
 
 In order to ensure that only authorized users and applications are allowed access to the Timesheets API, ExampleCo has decided to make use of the [OAuth 2.0 authorization framework](https://tools.ietf.org/html/rfc6749). The framework provides the flexibility the company wants since the different grants can allow them to easily authorize the various types of application which need to communicate with the Timesheets API.
 
@@ -13,7 +13,7 @@ An API is a way to expose functionality of your application to other application
 
 An API endpoint can be secured or not. In our case, since the timesheets are sensitive information that affect reviews and payments, it is important to ensure that only authorized users and applications can call the endpoints on our API. When a client application wants to access protected endpoints on an API it needs to present an access token as proof that it has the required permissions for making the call to the endpoint.
 
-An access token is obtained by authenticating the user with an Authorization Server and the user can then in turn authorize the application to access the API on their behalf.
+An access token is obtained by authenticating the user with an Authorization Server and the user can then, in turn, authorize the application to access the API on their behalf.
 
 ::: panel What is an Access Token?
 An access token (also referred to as `access_token`) is an opaque string representing an authorization issued to the client. It may denote an identifier used to retrieve the authorization information or may self-contain the authorization information (for example, the user's identity, permissions, and so forth) in a verifiable manner.
@@ -21,11 +21,11 @@ An access token (also referred to as `access_token`) is an opaque string represe
 It is quite common for access tokens to be implemented as [JSON Web Tokens](/jwt). For more information on Auth0 Access Tokens refer to [Access Token](/tokens/access-token).
 :::
 
-An API can enforce fine grained control over who can access the various endpoints exposed by the API. These permissions are expressed as scopes.
+An API can enforce fine-grained control over who can access the various endpoints exposed by the API. These permissions are expressed as scopes.
 
 When a user authorizes a client application, the application can also indicate which permissions it requires. The user is then allowed to review and grant these permissions. These permissions are then included in the access token as part of the `scope` claim.
 
-Subsequently when the client passes along the access token when making requests to the API, the API can inspect the `scope` claim to ensure that the required permissions were granted in order to call the particular API endpoint.
+Subsequently, when the client passes along the access token when making requests to the API, the API can inspect the `scope` claim to ensure that the required permissions were granted in order to call the particular API endpoint.
 
 ::: panel What are Scopes?
 Each access token may include a list of the permissions that have been granted to the client. When a client authenticates with Auth0, it will specify the list of scopes (or permissions) it is requesting. If those scopes are authorized, then the access token will contain a list of authorized scopes.
@@ -64,22 +64,22 @@ Once the user authenticates, the client app receives the `id_token` and `access_
 
 1. The app initiates the flow and redirects the browser to Auth0 (specifically to the [/authorize endpoint](/api/authentication#implicit-grant)), so the user can authenticate.
 
-1. Auth0 authenticates the user. The first time the user goes through this flow, and if the client is a third party client, a consent page will be shown where the permissions, that will be given to the Client, are listed (for example: post messages, list contacts, and so forth).
+1. Auth0 authenticates the user. The first time the user goes through this flow, and if the client is a third party client, a consent page will be shown where the permissions, that will be given to the Client, are listed (for example, post messages, list contacts, and so forth).
 
-1. Auth0 redirects the user to the app with an `access_token` (and optionally a `id_token`) in the hash fragment of the URI. The app can now extract the tokens from the hash fragment.
+1. Auth0 redirects the user to the app with an `access_token` (and optionally an `id_token`) in the hash fragment of the URI. The app can now extract the tokens from the hash fragment.
 
 1. The app can use the `access_token` to call the API on behalf of the user.
 
 ## Authorization Extension
 
-The [Auth0 Authorization Extension](/extensions/authorization-extension) allows you to configure Roles, Groups and Permissions, and assign them to Users.
+The [Auth0 Authorization Extension](/extensions/authorization-extension) allows you to configure Roles, Groups, and Permissions, and assign them to Users.
 
 - The Permissions are actions that someone can do. For ExampleCo's business needs, we will configure four Permissions: read, create, delete and approve timesheets.
-- The Roles are collections of Permissions. ExampleCo's timesheets app, will be used by two kind of users (employees and managers), with different permissions each, so we will configure two Roles: employee and manager.
+- The Roles are collections of Permissions. ExampleCo's timesheets app will be used by two kinds of users (employees and managers), with different permissions each, so we will configure two Roles: employee and manager.
 
 Since this covers our business case we will not create any Groups.
 
-The Authorization Extension will create a [Rule](/rules) which will read the Roles, Groups and Permissions assigned to a user and add this information to the [User profile](/rules/current#rule-syntax) during the authentication flow. We can use this information to ensure that the `access_token` issued to a user only contains scopes which are allowed. We can later on proceed to customizing our app, like disabling the Approve Timesheets functionality if the user does not have the required permission to do so.
+The Authorization Extension will create a [Rule](/rules) which will read the Roles, Groups, and Permissions assigned to a user and add this information to the [User profile](/rules/current#rule-syntax) during the authentication flow. We can use this information to ensure that the `access_token` issued to a user only contains scopes which are allowed. We can later on proceed to customize our app, like disabling the Approve Timesheets functionality if the user does not have the required permission to do so.
 
 <%= include('./_stepnav', {
  prev: ["Introduction", "/architecture-scenarios/application/spa-api"], next: ["2. Auth0 Configuration", "/architecture-scenarios/application/spa-api/part-2"]

--- a/articles/architecture-scenarios/application/spa-api/part-2.md
+++ b/articles/architecture-scenarios/application/spa-api/part-2.md
@@ -26,7 +26,7 @@ Fill in the required information and click the **Create** button.
 When you create an API you have to select the algorithm your tokens will be signed with. The signature is used to verify that the sender of the JWT is who it says it is and to ensure that the message wasn't changed along the way.
 
 ::: note
-The signature is part of a JWT. If you are not familiar with the JWT structure please refer to: [JSON Web Tokens (JWTs) in Auth0](/jwt#what-is-the-json-web-token-structure-).
+The signature is part of a JWT. If you are not familiar with the JWT structure please refer to [JSON Web Tokens (JWTs) in Auth0](/jwt#what-is-the-json-web-token-structure-).
 :::
 
 To create the signature part you have to take the encoded header, the encoded payload, a secret, the algorithm specified in the header, and sign that. That algorithm, which is part of the JWT header, is the one you select for your API: `HS256` or `RS256`.
@@ -42,20 +42,26 @@ The most secure practice, and our recommendation, is to use __RS256__. Some of t
 - With RS256 you can implement key rotation without having to re-deploy the API with the new secret.
 
 ::: note
-For a more detailed overview of the JWT signing algorithms refer to: [JSON Web Token (JWT) Signing Algorithms Overview](https://auth0.com/blog/json-web-token-signing-algorithms-overview/).
+For a more detailed overview of the JWT signing algorithms refer to [JSON Web Token (JWT) Signing Algorithms Overview](https://auth0.com/blog/json-web-token-signing-algorithms-overview/).
 :::
 
 ## Configure the Scopes
 
 Once the client has been created you will need to configure the Scopes which clients can request during authorization.
 
-In the settings for your API, go to the **Scopes** tab. In this section you can add all four of the scopes which was discussed before, namely `read:timesheets`, `create:timesheets`, `delete:timesheets`, `approve:timesheets`.
+In the settings for your API, go to the **Scopes** tab. In this section you can add the scopes for our business case: `read:timesheets`, `create:timesheets`, `delete:timesheets`, and `approve:timesheets`.
 
 ![Add Scopes](/media/articles/architecture-scenarios/spa-api/add-scopes.png)
 
 ## Create the Client
 
-There are four client types in Auth0: __Native__ (used by mobile or desktop apps), __Single Page Web Applications__, __Regular Web Applications__ and __Non Interactive Clients__ (used by CLIs, Daemons, or services running on your backend). For this scenario we want to create a new Client for our SPA, hence we will use Single Page Application as the client type.
+There are four client types in Auth0: 
+- __Native__ (used by mobile or desktop apps), 
+- __Single Page Web Applications__, 
+- __Regular Web Applications__ and 
+- __Non Interactive Clients__ (used by CLIs, Daemons, or services running on your backend). 
+
+For this scenario we want to create a new Client for our SPA, hence we will use Single Page Application as the client type.
 
 To create a new Client, navigate to the [dashboard](${manage_url}) and click on the [Clients](${manage_url}/#/clients}) menu option on the left. Click the __+ Create Client__ button.
 
@@ -73,7 +79,13 @@ You will need to ensure that the Authorization Extension is installed for your t
 
 ### Define Permissions 
 
-You will need to define Permissions which correlates with the scopes you have already defined. In the Authorization Extension, click the _Permissions_ tab, and then click on the **Create Permission** button. In the dialog, capture the details for each permission. Ensure that the name of the permission is exactly the same as the corresponding scope:
+You will now define the required Permissions, according to the scopes you have already defined: `read:timesheets`, `create:timesheets`, `delete:timesheets`, and `approve:timesheets`.
+
+In the Authorization Extension, click the **Permissions** tab, and then click on the **Create Permission** button. 
+
+In the dialog, capture the details for each permission. 
+
+Ensure that the name of the permission is exactly the same as the corresponding scope:
 
 ![Create Permission](/media/articles/architecture-scenarios/spa-api/create-permission.png)
 
@@ -83,27 +95,37 @@ Proceed to create the permissions for all the remaining scopes:
 
 ### Define Roles
 
-Head over to the _Roles_ tab and create 2 Roles. Click the **Create Role** button and select the **Timesheets SPA** application. Give the Role a name and description of Employee, and select the `delete:timesheets`, `create:timesheets` and `read:timesheets` permissons. Click on **Save**.
+Next let's configure the two Roles: employee and manager.
+
+Head over to the **Roles** tab, click the **Create Role** button, and select the **Timesheets SPA** application. 
+
+Set the **Name** and **Description** to `Employee`, and select the `delete:timesheets`, `create:timesheets` and `read:timesheets` permissons. Click on **Save**.
 
 ![Create Employee Role](/media/articles/architecture-scenarios/spa-api/create-employee-role.png)
 
-Next, follow the same process to create a **Manager** role, and ensure that you have selected all the permissions:
+Next, follow the same process to create a `Manager` role, and ensure that you have selected all the permissions.
 
 ![Create Manager Role](/media/articles/architecture-scenarios/spa-api/create-manager-role.png)
 
 ### Assign Users to Roles
 
-You will need to assign all users to either the Manager or the User role. You can do this by going to the _Users_ tab in the Authorization Extension and selecting a user. On the user information screen, go to the _Roles_ tab. You can add a role to the user by clicking the **Add Role to User** button, and selecting the approproate role for the user.
+You need to assign all users to either the `Manager` or the `Employee` role. 
+
+You can do this by going to the **Users** tab in the Authorization Extension and selecting a user. 
+
+On the user information screen, go to the **Roles** tab. Click **Add Role to User**, and select the appropriate role.
 
 ![Add User to Role](/media/articles/architecture-scenarios/spa-api/add-user-role.png)
 
 ### Configuring the Authorization Extension
 
-You will also need to ensure that the Rule for the Authorization Extension is published. You can do this by clicking on your user avatar in to top right of the Authorization Extension, and selecting the **Configuration** option:
+You will also need to ensure that the Rule for the Authorization Extension is published. 
 
-![Navigate to COnfiguration](/media/articles/architecture-scenarios/spa-api/select-configuration.png)
+To do so, click on your user avatar in the top right of the Authorization Extension, and select **Configuration**.
 
-Ensure that you have enabled **Permissions** and then click the **Publish Rule** button:
+![Navigate to Configuration](/media/articles/architecture-scenarios/spa-api/select-configuration.png)
+
+Make sure that **Permissions** are enabled and then click **Publish Rule**.
 
 ![Pulish Rule](/media/articles/architecture-scenarios/spa-api/publish-rule.png)
 
@@ -111,7 +133,7 @@ Ensure that you have enabled **Permissions** and then click the **Publish Rule**
 
 The final step in this process is to create a Rule which will validate that the scopes contained in an `access_token` is valid based on the permissions assigned to the user. Any scopes which are not valid for a user should be removed from the `access_token`.
 
-In your Auth0 Dashboard, go to the _Rules_ tab. You should see the Rule created by the Authorization Extension:
+In your Auth0 Dashboard, go to the **Rules** tab. You should see the Rule created by the Authorization Extension:
 
 ![Rules](/media/articles/architecture-scenarios/spa-api/rules-1.png)
 


### PR DESCRIPTION
Add some more content to support the usage of the Authorization Extension for user permissions, and better clarify how its configuration maps to scopes.

https://trello.com/c/zTjBhyHt/1683-clarify-scopes-roles-groups-oauth2-vs-authz-extension