### PR TITLE
Fixed Delegated Admin Filter Hook docs

### DIFF
--- a/articles/extensions/delegated-admin/hooks.md
+++ b/articles/extensions/delegated-admin/hooks.md
@@ -123,7 +123,7 @@ function(ctx, callback) {
   }
 
   // Return the lucene query.
-  return callback(null, 'app_metadata.department:"' + department + '"');
+  return callback(null, 'app_metadata.department = "' + department + '"');
 }
 ```
 


### PR DESCRIPTION
Search syntax fails with colon syntax and has to use equals syntax.

I didn't go through wordy for this, but can if needed.