### PR TITLE
Revert "Fix Auth API Debugger link"

### DIFF
--- a/articles/_includes/_test-this-endpoint.md
+++ b/articles/_includes/_test-this-endpoint.md
@@ -3,20 +3,15 @@ You can use our **Authentication API Debugger** extension to test this endpoint.
 Click on **Install Debugger** to go to the article that explains how (you only have to do this once).
 
 <%
-  var tenantWithLoc = account.namespace.slice(0, account.namespace.length - 10);
-%>
-
-<%
-  if(tenantWithLoc.indexOf('.') !== -1){
-    var debugURL = 'https://' + tenantWithLoc + '.webtask.io/auth0-authentication-api-debugger';
-  } else {
-    var debugURL = 'https://' + tenantWithLoc + '.us.webtask.io/auth0-authentication-api-debugger';
-  }
+  var urlUS = 'https://' + account.tenant + '.us.webtask.io/auth0-authentication-api-debugger';
+  var urlEU = 'https://' + account.tenant + '.eu.webtask.io/auth0-authentication-api-debugger';
+  var urlAU = 'https://' + account.tenant + '.au.webtask.io/auth0-authentication-api-debugger';
 %>
 
 <div class="test-endpoint-box">
   <a href="/extensions/authentication-api-debugger" class="btn btn-primary" target="_blank">Install Debugger</a>
 </div>
 
-**If you have already installed the extension, skip to the <a href="${debugURL}" target="_blank">Authentication API Debugger</a>.**
+**If you have already installed the extension, skip to the Authentication API Debugger.**
 
+The link varies according to your tenant's region: <a href="${urlUS}" target="_blank">US West</a>, <a href="${urlEU}" target="_blank">Europe Central</a> or <a href="${urlAU}" target="_blank">Australia</a>.


### PR DESCRIPTION
Revert that API Debugger URL fix - which did not fix anything :(

https://auth0-docs-content-pr-5063.herokuapp.com/docs/api/authentication