### PR TITLE
Custom DB / users import: document new data validations

### DIFF
--- a/articles/connections/database/migrating.md
+++ b/articles/connections/database/migrating.md
@@ -59,7 +59,7 @@ You can enable these validations for a connection using the [Update a connection
   "queryString": [],
   "postData": {
     "mimeType": "application/json",
-    "text": "{ \"options\": { \"strategy_version\": 2 } }"
+    "text": "{ \"options\": { \"strategy_version\": 2, \"nextOptionParam\": \"...\" } }"
   },
   "headersSize": -1,
   "bodySize": -1,
@@ -68,7 +68,7 @@ You can enable these validations for a connection using the [Update a connection
 ```
 
 - You should replace `{connection-id}` with the Id of the custom database connection you want to update. If you don't know it, you can use the [Get all connections endpoint](/api/management/v2#!/Connections/get_connections) to find it.
-- The parameter that enables the validations is the `"strategy_version": 2`. However, when you update `options`, the whole object is overridden, so all the parameters should be present. You can use the [Get a connection endpoint](/api/management/v2#!/Connections/get_connections_by_id) to get the whole object.
+- The parameter that enables the validations is the `"strategy_version": 2`. However, when you update `options`, the whole object is overridden, so all the parameters should be present. You can use the [Get a connection endpoint](/api/management/v2#!/Connections/get_connections_by_id) to get the whole object. Replace the `"nextOptionParam": "..."` placeholder with the list of parameters you get.
 - To access any Management APIv2 endpoint you need an Access Token (which you should set at the `{access-token}` placeholder of the `Authorization` header). For information on how to get one refer to [The Auth0 Management APIv2 Token](/api/management/v2/tokens).
 
 ## Enable Automatic Migration

--- a/articles/connections/database/migrating.md
+++ b/articles/connections/database/migrating.md
@@ -2,6 +2,7 @@
 title: Migrate Users to Auth0
 description: Auth0 supports automatic migration of users to Auth0 from a custom database connection. This feature adds your users to the Auth0 database as each person logs in and avoids asking your users to reset their passwords due to migration.
 crews: crew-2
+toc: true
 ---
 # Migrate Users to Auth0
 
@@ -58,14 +59,7 @@ You can enable these validations for a connection using the [Update a connection
   "queryString": [],
   "postData": {
     "mimeType": "application/json",
-    "text": "{\"options\": {
-      \"strategy_version\": 2,
-      \"validation\": \"object\",
-      \"passwordPolicy\": \"\",
-      \"password_history\": \"object\",
-      \"password_no_personal_info\": \"object\",
-      \"password_dictionary\": \"object\"
-    }}"
+    "text": "{ \"options\": { \"strategy_version\": 2 } }"
   },
   "headersSize": -1,
   "bodySize": -1,

--- a/articles/connections/database/migrating.md
+++ b/articles/connections/database/migrating.md
@@ -61,15 +61,14 @@ You can enable these validations for a connection using the [Update a connection
   "queryString": [],
   "postData": {
     "mimeType": "application/json",
-    "text": "{\"email\": \"jane.doe@example.com\", \"user_metadata\": {\"hobby\": \"surfing\"}, \"app_metadata\": {\"plan\": \"full\"}}"
     "text": "\"options\": {
-    \"strategy_version\": 2,
-    \"validation\": "object",
-    \"passwordPolicy\": "",
-    \"password_history\": "object",
-    \"password_no_personal_info\": "object",
-    \"password_dictionary\": "object"
-  }"
+      \"strategy_version\": 2,
+      \"validation\": \"object\",
+      \"passwordPolicy\": \"\",
+      \"password_history\": \"object\",
+      \"password_no_personal_info\": \"object\",
+      \"password_dictionary\": \"object\"
+    }"
   },
   "headersSize": -1,
   "bodySize": -1,

--- a/articles/connections/database/migrating.md
+++ b/articles/connections/database/migrating.md
@@ -51,24 +51,21 @@ You can enable these validations for a connection using the [Update a connection
   "url": "https://${account.namespace}/api/v2/connections/{connection-id}",
   "httpVersion": "HTTP/1.1",
   "cookies": [],
-  "headers": [{
-    "name": "Authorization",
-    "value": "Bearer {access-token}"
-  }, {
-    "name": "Content-Type",
-    "value": "application/json"
-  }],
+  "headers": [
+    { "name": "Authorization", "value": "Bearer {access-token}" }, 
+    { "name": "Content-Type", "value": "application/json"}
+  ],
   "queryString": [],
   "postData": {
     "mimeType": "application/json",
-    "text": "\"options\": {
+    "text": "{\"options\": {
       \"strategy_version\": 2,
       \"validation\": \"object\",
       \"passwordPolicy\": \"\",
       \"password_history\": \"object\",
       \"password_no_personal_info\": \"object\",
       \"password_dictionary\": \"object\"
-    }"
+    }}"
   },
   "headersSize": -1,
   "bodySize": -1,

--- a/articles/connections/database/migrating.md
+++ b/articles/connections/database/migrating.md
@@ -67,8 +67,8 @@ You can enable these validations for a connection using the [Update a connection
 }
 ```
 
-- You should replace `{connection-id}` with the Id of the custom database connection you want to update. If you don't know it, you can use the [Get all connections endpoint](/api/management/v2#!/Connections/get_connections) to find it.
 - The parameter that enables the validations is the `"strategy_version": 2`. However, when you update `options`, the whole object is overridden, so all the parameters should be present. You can use the [Get a connection endpoint](/api/management/v2#!/Connections/get_connections_by_id) to get the whole object. Replace the `"nextOptionParam": "..."` placeholder with the list of parameters you get.
+- You should replace `{connection-id}` with the Id of the custom database connection you want to update. If you don't know it, you can use the [Get all connections endpoint](/api/management/v2#!/Connections/get_connections) to find it.
 - To access any Management APIv2 endpoint you need an Access Token (which you should set at the `{access-token}` placeholder of the `Authorization` header). For information on how to get one refer to [The Auth0 Management APIv2 Token](/api/management/v2/tokens).
 
 ## Enable Automatic Migration

--- a/articles/connections/database/migrating.md
+++ b/articles/connections/database/migrating.md
@@ -1,22 +1,18 @@
 ---
-title: Migrating Users to Auth0
+title: Migrate Users to Auth0
 description: Auth0 supports automatic migration of users to Auth0 from a custom database connection. This feature adds your users to the Auth0 database as each person logs in and avoids asking your users to reset their passwords due to migration.
 crews: crew-2
 ---
 # Migrate Users to Auth0
 
-Auth0 supports automatic migration of users from a Custom Database Connection to Auth0. By activating this feature, your users are moved to Auth0 the first time they log in after you set up the integration. Your users are not asked to reset their password as a result of the migration.
+Auth0 supports automatic migration of users from a [custom database connection](/connections/database/custom-db) to Auth0. By activating this feature, your users are moved to Auth0 the first time they log in after you set up the integration. Your users are not asked to reset their password as a result of the migration.
 
 ::: panel Feature availability
+- Only **Developer**, **Developer Pro**, and **Enterprise** subscription plans include the database migration feature.
+- Only **Enterprise** subscription plans include the ability to connect to an existing store or database via JavaScript running on Auth0's servers for every authentication request.
 
-Only **Developer**, **Developer Pro**, and **Enterprise** subscription plans include the database migration feature.
-
-Only **Enterprise** subscription plans include the ability to connect to an existing store or database via JavaScript running on Auth0's servers for every authentication request.
-
-[Click here](https://auth0.com/pricing) to learn more about Auth0 pricing plans.
+For more information refer to [Auth0 pricing plans](https://auth0.com/pricing).
 :::
-
-You can read more about database connections and the the options for using several user stores at [Database Identity Providers](/connections/database).
 
 ## The Migration Process
 
@@ -24,13 +20,66 @@ When a user authenticates via a custom database connection marked for import to 
 
 ![Migration Diagram](/media/articles/connections/database/migrating-diagram.png)
 
-Auth0 authenticates migrated users against the Auth0 database. If the user has not been migrated, Auth0 executes your custom login script and, upon successfully log in, adds the user to the Auth0 database. Subsequent logins results in the user's credentials retrieved from Auth0, *not* your custom database.
+Auth0 authenticates migrated users against the Auth0 database.
 
-New users are automatically added to the Auth0 database..
+If the user has not been migrated, Auth0 executes your custom login script and, upon successfully log in, adds the user to the Auth0 database.
+
+Subsequent logins result in the user's credentials retrieved from Auth0, **NOT** your custom database.
+
+New users are automatically added to the Auth0 database.
 
 ::: note
 Auth0 can only assist users in the Auth0 database with password reset.
 :::
+
+## Enable Data Validation
+
+There are certain validations that Auth0 can run before adding the user to the Auth0 database:
+
+- The email must be set and unique
+- If the connection requires a username (i.e. the **Requires Username** toggle is enabled at the connection's settings), then one must be set
+- If a username is set, then it must be unique
+- The email format must be valid
+
+Additionally, both the email and the username will be converted to lowercase before they are stored.
+
+You can enable these validations for a connection using the [Update a connection endpoint](/api/management/v2#!/Connections/patch_connections_by_id) of the Management APIv2.
+
+```har
+{
+  "method": "PATCH",
+  "url": "https://${account.namespace}/api/v2/connections/{connection-id}",
+  "httpVersion": "HTTP/1.1",
+  "cookies": [],
+  "headers": [{
+    "name": "Authorization",
+    "value": "Bearer {access-token}"
+  }, {
+    "name": "Content-Type",
+    "value": "application/json"
+  }],
+  "queryString": [],
+  "postData": {
+    "mimeType": "application/json",
+    "text": "{\"email\": \"jane.doe@example.com\", \"user_metadata\": {\"hobby\": \"surfing\"}, \"app_metadata\": {\"plan\": \"full\"}}"
+    "text": "\"options\": {
+    \"strategy_version\": 2,
+    \"validation\": "object",
+    \"passwordPolicy\": "",
+    \"password_history\": "object",
+    \"password_no_personal_info\": "object",
+    \"password_dictionary\": "object"
+  }"
+  },
+  "headersSize": -1,
+  "bodySize": -1,
+  "comment": ""
+}
+```
+
+- You should replace `{connection-id}` with the Id of the custom database connection you want to update. If you don't know it, you can use the [Get all connections endpoint](/api/management/v2#!/Connections/get_connections) to find it.
+- The parameter that enables the validations is the `"strategy_version": 2`. However, when you update `options`, the whole object is overridden, so all the parameters should be present. You can use the [Get a connection endpoint](/api/management/v2#!/Connections/get_connections_by_id) to get the whole object.
+- To access any Management APIv2 endpoint you need an Access Token (which you should set at the `{access-token}` placeholder of the `Authorization` header). For information on how to get one refer to [The Auth0 Management APIv2 Token](/api/management/v2/tokens).
 
 ## Enable Automatic Migration
 


### PR DESCRIPTION
Document new (optional) data validations when importing users from custom databases https://github.com/auth0/auth0-users/pull/908

This is enabled with `strategy_version=2` https://github.com/auth0/auth0-users/pull/912/files