### PR TITLE
Add notes on using Hooks only w/ DB Connections

### DIFF
--- a/articles/hooks/index.md
+++ b/articles/hooks/index.md
@@ -16,7 +16,7 @@ beta: true
 
 ## What are Hooks?
 
-Hooks allow you to customize the behavior of Auth0 using Node.js code that is executed against extensibility points (which are comparable to webhooks that come with a server). Hooks allow you modularity when configuring your Auth0 implementation, and extend the functionality of base Auth0 features.
+When using [Database Connections](/connections/database), Hooks allow you to customize the behavior of Auth0 using Node.js code that is executed against extensibility points (which are comparable to webhooks that come with a server). Hooks allow you modularity when configuring your Auth0 implementation, and extend the functionality of base Auth0 features.
 
 ### Hooks vs. Rules
 

--- a/articles/hooks/overview.md
+++ b/articles/hooks/overview.md
@@ -10,7 +10,7 @@ beta: true
 
 Hooks, which will eventually replace [Rules](/rules), allow you to extend the Auth0 platform with custom code.
 
-Hooks are Webtasks associated with specific extensibility points of the Auth0 platform. Auth0 invokes the Hooks at runtime to execute your custom logic.
+Hooks are Webtasks associated with specific extensibility points of the Auth0 platform. When using [Database Connections](/connections/database), Auth0 invokes the Hooks at runtime to execute your custom logic.
 
 You can manage your Hooks using:
 


### PR DESCRIPTION
Currently, you can only use Hooks w/ DB connections:

* https://auth0-docs-content-pr-5067.herokuapp.com/docs/hooks
* https://auth0-docs-content-pr-5067.herokuapp.com/docs/hooks/overview