### PR TITLE
Fix terminal commands for easier copying

### DIFF
--- a/articles/connector/install-other-platforms.md
+++ b/articles/connector/install-other-platforms.md
@@ -19,17 +19,17 @@ For most platforms, you will need to run the required commands with root privile
 
 2. Expand the <a class="download-github" href=""></a> package and install its dependencies:
 
-    ```text
-    > mkdir /opt/auth0-adldap
-    > tar -xzf /tmp/adldap.tar.gz -C /opt/auth0-adldap --strip-components=1
-    > cd /opt/auth0-adldap
-    > npm install
+    ```bash
+    mkdir /opt/auth0-adldap
+    tar -xzf /tmp/adldap.tar.gz -C /opt/auth0-adldap --strip-components=1
+    cd /opt/auth0-adldap
+    npm install
     ```
 
 3. Start your server.
 
-    ```text
-    > node server.js
+    ```bash
+    node server.js
     ```
 
     When prompted for the ticket number, enter the full ticket URL from the **Settings** tab of the **Setup AD/LDAP connector** screen in the Auth0 Management Dashboard:


### PR DESCRIPTION
Minor fix to some terminal commands for easier copy/pasting.

[Install the AD/LDAP Connector on Non-Microsoft Platforms](https://auth0-docs-content-pr-5075.herokuapp.com/docs/connector/install-other-platforms)