### PR TITLE
Update part-3.md

### DIFF
--- a/articles/integrations/aws-api-gateway/custom-authorizers/part-3.md
+++ b/articles/integrations/aws-api-gateway/custom-authorizers/part-3.md
@@ -228,7 +228,7 @@ Set the following parameters:
 | **Lambda function** | `jwtRsaCustomAuthorizer` |
 | **Authorizer name** | `jwt-rsa-custom-authorizer` |
 | **Execution role** | The IAM Role ARN you copied above |
-| **Identity token source** | `method.request.header.Authorization` |
+| **Identity token source** | `Authorization` |
 | **Token validation expression** | `^Bearer [-0-9a-zA-z\.]*$` |
 | **Result TTL in seconds** | `3600` |
 


### PR DESCRIPTION
change `method.request.header.Authorization` to just plain `Authorization` in Token Source, API Gateway fails to invoke custom authorizer if method.request.header is specified

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
