### PR TITLE
Remove trailing quotation in auth0 parameters.

### DIFF
--- a/articles/quickstart/native/android/_includes/_credentials.md
+++ b/articles/quickstart/native/android/_includes/_credentials.md
@@ -4,8 +4,8 @@ You will require the **Client ID** and **Domain** for your client application. T
 
 ```xml
 <resources>
-    <string name="com_auth0_client_id">${account.clientId}"</string>
-    <string name="com_auth0_domain">${account.namespace}"</string>
+    <string name="com_auth0_client_id">${account.clientId}</string>
+    <string name="com_auth0_domain">${account.namespace}</string>
 </resources>
 ```
 


### PR DESCRIPTION
When the web page renders with the user's local clientId and domain, the trailing quotation mark remains. If copied into the resource file in Android, the application will successfully run, but the auth0 server will not recognize the clientId because of the trailing quotation mark. This is misleading, and I believe it's a mistake.
