### PR TITLE
Change Node.js to JS

### DIFF
--- a/articles/api-auth/tutorials/authorization-code-grant-pkce.md
+++ b/articles/api-auth/tutorials/authorization-code-grant-pkce.md
@@ -24,7 +24,7 @@ First, you need to generate and store a `code_verifier`.
 <div class="code-picker">
   <div class="languages-bar">
     <ul>
-      <li class="active"><a href="#verifier-javascript" data-toggle="tab">Node.js</a></li>
+      <li class="active"><a href="#verifier-javascript" data-toggle="tab">JavaScript</a></li>
       <li><a href="#verifier-java" data-toggle="tab">Java</a></li>
       <li><a href="#verifier-swift" data-toggle="tab">Swift 3</a></li>
       <li><a href="#verifier-objc" data-toggle="tab">Objective-C</a></li>
@@ -78,7 +78,7 @@ Using the `code_verifier`, generate a `code_challenge` that will be sent in the 
 <div class="code-picker">
   <div class="languages-bar">
     <ul>
-      <li class="active"><a href="#challenge-javascript" data-toggle="tab">Node.js</a></li>
+      <li class="active"><a href="#challenge-javascript" data-toggle="tab">JavaScript</a></li>
       <li><a href="#challenge-java" data-toggle="tab">Java</a></li>
       <li><a href="#challenge-swift" data-toggle="tab">Swift 3</a></li>
       <li><a href="#challenge-objc" data-toggle="tab">Objective-C</a></li>

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "*.md": "markdownlint"
   },
   "engines": {
-    "node": "4.5"
+    "node": "6.11.1",
+    "yarn": "1.2.1"
   },
   "devDependencies": {
     "commander": "^2.8.1",


### PR DESCRIPTION
Based on customer feedback, labelling the code samples as `Node.js` is confusing since it seem to imply that this gets executed on the server. But this is should be executed on the client instead.

Have labelled code samples (where possible) as JavaScript instead 