### PR TITLE
Correct metadata reference

### DIFF
--- a/articles/multifactor-authentication/user-initiated-mfa.md
+++ b/articles/multifactor-authentication/user-initiated-mfa.md
@@ -41,7 +41,7 @@ function (user, context, callback) {
     var CLIENTS_WITH_MFA = ['{REPLACE_WITH_YOUR_CLIENT_ID}'];
     
     if (CLIENTS_WITH_MFA.indexOf(context.clientID) !== -1) {
-        if (user.user_metadata && user.user_metadata.use_mfa){
+        if (user.app_metadata && user.app_metadata.use_mfa){
 
             context.multifactor = {
                 // required


### PR DESCRIPTION
Per Sandrino: the rule should not use `user_metadata`, but it should use `app_metadata`. using user metadata would allow the user/non-confidential client to change the mfa requirement without approval