### PR TITLE
prevent_sign_ups appears to be a typo

### DIFF
--- a/articles/extensions/account-link.md
+++ b/articles/extensions/account-link.md
@@ -33,7 +33,7 @@ If it is not already enabled, toggle the **Customize Login Page** to enable the 
 Toward the bottom of the object configuring the Lock widget, add the following line (after the `closable` setting works well):
 
 ```text
-allowSignUp: !config.extraParams.prevent_sign_ups,
+allowSignUp: !config.extraParams.prevent_sign_up,
 ```
 
 ![Updating the Hosted Page](/media/articles/extensions/account-link/hosted-page-code.png)


### PR DESCRIPTION
It looks like `prevent_sign_up` is the param that is actually passed into the uri, not `prevent_sign_ups`.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
