### PR TITLE
Minor library fixes

### DIFF
--- a/articles/libraries/auth0js/v8/migration-guide.md
+++ b/articles/libraries/auth0js/v8/migration-guide.md
@@ -188,7 +188,7 @@ Remember that if the token is being validated anywhere else, changes might be ne
 
 ### Manually Parsing Hashes
 
-If you would rather manually parse hashes, to avoid the `parseHash` method since it only works with RS256, feel free to take a look at [this example](https://github.com/auth0/auth0.js/blob/master/src/web-auth/index.js#L97) or [this one](https://github.com/auth0/auth0.js/blob/master/src/helper/qs.js#L10) to help you get started.
+If you would rather manually parse hashes, to avoid the `parseHash` method since it only works with RS256, feel free to take a look at [what parseHash is doing](https://github.com/auth0/auth0.js/blob/master/src/web-auth/index.js) to help you get started replicating that.
 
 ## Refreshing Tokens
 

--- a/articles/libraries/lock/v10/configuration.md
+++ b/articles/libraries/lock/v10/configuration.md
@@ -17,7 +17,7 @@ var lock = new Auth0Lock('clientID', 'account.auth0.com', options);
 
 | Option | Description |
 | --- | --- |
-| [allowAutoComplete](#allowautocomplete-boolean-) | Whether or not to allow autocomplete in the widget |
+| [allowAutocomplete](#allowautocomplete-boolean-) | Whether or not to allow autocomplete in the widget |
 | [allowedConnections](#allowedconnections-array-) | limit the client connections shown in Lock to a particular set |
 | [allowShowPassword](#allowshowpassword-boolean-) | Whether to allow the user to show password as typing |
 | [autoclose](#autoclose-boolean-) | Whether or not Lock auto closes after a login |
@@ -98,13 +98,13 @@ var lock = new Auth0Lock('clientID', 'account.auth0.com', options);
 
 ## Display Options
 
-### allowAutoComplete {Boolean}
+### allowAutocomplete {Boolean}
 
 Determines whether or not the email or username inputs will allow autocomplete (`<input autocomplete />`). Defaults to `false`.
 
 ```js
 var options = {
-  allowAutoComplete: true
+  allowAutocomplete: true
 };
 ```
 


### PR DESCRIPTION
Docs-Request

- `allowAutoComplete` is not the name of the option as represented in the code - no capital C.
- Bad links in Auth0.js for replicating their own manual parsing. One goes to the wrong line in the `index.js` for auth0.js; the other goes to 404. Removed both links altogether and just linking to the file `index.js` - better to recommend they CMD+F than to constantly be pointing to the wrong line number as the file changes.
