### PR TITLE
Update Password Exchange flow description

### DIFF
--- a/articles/api-auth/grant/password.md
+++ b/articles/api-auth/grant/password.md
@@ -6,10 +6,12 @@ description: Describes how to call APIs from highly trusted clients using the Re
 
 <%= include('../../_includes/_pipeline2') %>
 
-Highly trusted applications can use this flow to access APIs. In this case, the end-user is asked to fill in credentials (username/password), typically using an interactive form. This information is later on sent to the client application and Auth0. It is therefore imperative that the client is absolutely trusted with this information. For [client side](/api-auth/grant/implicit) applications and [mobile apps](/api-auth/grant/authorization-code-pkce) we recommend using web flows instead. 
+Highly trusted applications can use this flow to access APIs. In this case, the end-user is asked to fill in credentials (username/password), typically using an interactive form. This information is sent to the backend and from there to Auth0. 
+
+It is imperative that the client is absolutely trusted with this information. For [client side](/api-auth/grant/implicit) applications and [mobile apps](/api-auth/grant/authorization-code-pkce) we recommend using web flows instead. 
 
 ::: note
-  If you need a refresher on the OAuth 2.0 protocol, you can go through our <a href="/protocols/oauth2">OAuth 2.0</a> article.
+If you need a refresher on the OAuth 2.0 protocol, you can go through our <a href="/protocols/oauth2">OAuth 2.0</a> article.
 :::
 
 ## Overview

--- a/articles/api-auth/index.md
+++ b/articles/api-auth/index.md
@@ -124,7 +124,7 @@ Using Auth0, you can easily support different flows in your own APIs without wor
   <li>
     <i class="icon icon-budicon-715"></i><a href="/api-auth/grant/password">Calling APIs from Highly Trusted Clients</a>
     <p>
-      If the application is highly trusted and no other grant can be used, read these docs. In this flow the end-user is asked to fill in credentials (username/password) typically using an interactive form. This information is later on sent to the Client and the Authorization Server. It is therefore imperative that the Client is absolutely trusted with this information.
+      If the application is highly trusted and no other grant can be used, read these docs. In this flow the end-user is asked to fill in credentials (username/password) typically using an interactive form. This information is sent to the backend and from there to Auth0.  It is therefore imperative that the client is absolutely trusted with this information.
     </p>
     <ul>
       <li>

--- a/articles/api-auth/which-oauth-flow-to-use.md
+++ b/articles/api-auth/which-oauth-flow-to-use.md
@@ -36,7 +36,7 @@ If this case matches your needs, then for more information on how this flow work
 
 ## Is the Client absolutely trusted with user credentials?
 
-This decision point may result to suggesting the **Resource Owner Password Credentials Grant**. In this flow the end-user is asked to fill in credentials (username/password) typically using an interactive form. This information is later on sent to the Client and the Authorization Server. It is therefore imperative that the Client is absolutely trusted with this information.
+This decision point may result to suggesting the **Resource Owner Password Credentials Grant**. In this flow the end-user is asked to fill in credentials (username/password) typically using an interactive form. This information is sent to the backend and from there to Auth0. It is therefore imperative that the Client is absolutely trusted with this information.
 
 ## Is the Client a native app or a SPA?
 

--- a/articles/api/authentication/api-authz/_get-token.md
+++ b/articles/api/authentication/api-authz/_get-token.md
@@ -364,7 +364,7 @@ Content-Type: application/json
   "link": "#resource-owner-password"
 }) %>
 
-This is the OAuth 2.0 grant that highly trusted apps utilize in order to access an API. In this flow the end-user is asked to fill in credentials (username/password) typically using an interactive form in the user-agent (browser). This information is later on sent to the client and Auth0. It is therefore imperative that the client is absolutely trusted with this information.
+This is the OAuth 2.0 grant that highly trusted apps utilize in order to access an API. In this flow the end-user is asked to fill in credentials (username/password) typically using an interactive form in the user-agent (browser). This information is sent to the backend and from there to Auth0. It is therefore imperative that the client is absolutely trusted with this information. For [client side](/api-auth/grant/implicit) applications and [mobile apps](/api-auth/grant/authorization-code-pkce) we recommend using web flows instead.
 
 
 ### Request Parameters


### PR DESCRIPTION
The browser itself should never be calling auth0's password exchange endpoint. The exception is where a website puts a password form and submits the form to itself. The website, on the backend, acts as an oauth client and calls auth0 to verify the password.
