### PR TITLE
Update reference to correct sample

### DIFF
--- a/articles/sso/current/index.md
+++ b/articles/sso/current/index.md
@@ -71,12 +71,10 @@ Whenever you need to determine the user's SSO status, you'll need to check the f
 
 If you don't have a valid `accessToken`, the user is *not* logged in. However, they may be logged in via SSO to another associated application -- you can determine if this is the case or not by calling the `renewAuth` method of the auth0.js library, which will attempt to silently authenticate the user within an iframe. Whether the authentication is successful or not indicates whether the user has an active SSO cookie.
 
-For more detailed information on how to implement this, please refer to the following:
-
-* [Client-Side SSO (Single Page Apps)](/sso/current/single-page-apps-sso)
+For more detailed information on how to implement this, please refer to [Client-Side SSO (Single Page Apps)](/sso/current/single-page-apps-sso).
 
 ::: note
-Please see the [Auth0 OIDC SSO Sample](https://github.com/auth0-samples/oidc-sso-sample) repo for an example of how to implement OIDC-compliant SSO.
+The [Auth0 OIDC SSO Sample](https://github.com/auth0-samples/oidc-sso-sample) repo is an example of how to implement OIDC-compliant SSO.
 :::
 
 ### Length of SSO Sessions

--- a/articles/sso/current/index.md
+++ b/articles/sso/current/index.md
@@ -71,7 +71,7 @@ For more detailed information on how to implement this, please refer to the foll
 * [Client-Side SSO (Single Page Apps)](/sso/current/single-page-apps-sso)
 
 ::: note
-Please see the [Auth0 OIDC SSO Sample](https://github.com/auth0-samples/oidc-sso-sample) repo for an example of OIDC-compliance SSO.
+Please see the [Auth0 OIDC SSO Sample](https://github.com/auth0-samples/oidc-sso-sample) repo for an example of how to implement OIDC-compliant SSO.
 
 ### Length of SSO Sessions
 

--- a/articles/sso/current/index.md
+++ b/articles/sso/current/index.md
@@ -71,8 +71,7 @@ For more detailed information on how to implement this, please refer to the foll
 * [Client-Side SSO (Single Page Apps)](/sso/current/single-page-apps-sso)
 
 ::: note
-Please see the [Auth0 SSO Sample](https://github.com/auth0/auth0-sso-sample) repo for an example of SSO with both Single Page Apps and Regular Web Apps.
-:::
+Please see the [Auth0 OIDC SSO Sample](https://github.com/auth0-samples/oidc-sso-sample) repo for an example of OIDC-compliance SSO.
 
 ### Length of SSO Sessions
 

--- a/articles/sso/current/index.md
+++ b/articles/sso/current/index.md
@@ -64,7 +64,7 @@ Alternatively you can also set the Client's SSO flag using the [Auth0 Management
 
 ### Checking the User's SSO Status from the Client
 
-You'll need to check two things to determine if the user is logged in or not:
+Whenever you need to determine the user's SSO status, you'll need to check the following:
 
 * The Auth0 `accessToken`, which is used to access the desired resource
 * The `expirationDate` on the `accessToken`, which is calculated using the `expires_in` response parameter after successful authentication on the part of the user

--- a/articles/sso/current/index.md
+++ b/articles/sso/current/index.md
@@ -62,9 +62,14 @@ Near the bottom of the **Settings** page, toggle **Use Auth0 instead of the IdP 
 
 Alternatively you can also set the Client's SSO flag using the [Auth0 Management API](/api/management/v2#!/Clients/patch_clients_by_id).
 
-Once you have set the SSO flag for your Client, you must add logic to your application to check the user's SSO status. Checking the user's SSO status can only be done via JavaScript by making use of the `getSSOData()` function in the [auth0.js library](/libraries/auth0js#sso).
+### Checking the User's SSO Status from the Client
 
-The result of this function will indicate whether an SSO cookie is present, and if so it will return the SSO data of the user which can then subsequently be used to log the user in silently without even displaying Lock.
+You'll need to check two things to determine if the user is logged in or not:
+
+* The Auth0 `accessToken`, which is used to access the desired resource
+* The `expirationDate` on the `accessToken`, which is calculated using the `expires_in` response parameter after successful authentication on the part of the user
+
+If you don't have a valid `accessToken`, the user is *not* logged in. However, they may be logged in via SSO to another associated application -- you can determine if this is the case or not by calling the `renewAuth` method of the auth0.js library, which will attempt to silently authenticate the user within an iframe. Whether the authentication is successful or not indicates whether the user has an active SSO cookie.
 
 For more detailed information on how to implement this, please refer to the following:
 
@@ -72,6 +77,7 @@ For more detailed information on how to implement this, please refer to the foll
 
 ::: note
 Please see the [Auth0 OIDC SSO Sample](https://github.com/auth0-samples/oidc-sso-sample) repo for an example of how to implement OIDC-compliant SSO.
+:::
 
 ### Length of SSO Sessions
 


### PR DESCRIPTION
Found one reference on the `current` SSO docs pointing to legacy samples, so I updated the link.

https://auth0-docs-content-pr-5150.herokuapp.com/docs/sso/current#checking-the-user-s-sso-status-from-the-client