### PR TITLE
Add instructions on finding Azure AD for Office 365 account

### DIFF
--- a/articles/connections/enterprise/azure-active-directory/v2/index.md
+++ b/articles/connections/enterprise/azure-active-directory/v2/index.md
@@ -23,11 +23,22 @@ There are different scenarios in which you might want to integrate with Microsof
 
 * You want to let users coming from other companies' Azure ADs into your application. You may set up those external directories manually as different connections, or [create a multi-tenant application that accepts new directories dynamically](/tutorials/building-multi-tenant-saas-applications-with-azure-active-directory).
 
-If you plan on allowing users to login using a Microsoft Azure Active Directory account, either from your company or from external directories, you must register your application through the Microsoft Azure portal. If you don't have a Microsoft Azure account, you can [signup](https://azure.microsoft.com/en-us/free) for free. You can access the Azure management portal from your Microsoft service, or visit [https://manage.windowsazure.com](https://manage.windowsazure.com) and sign in to Azure using the global administrator account that was used to create the Office 365 organization.
+If you plan on allowing users to log in using a Microsoft Azure Active Directory account, either from your company or from external directories, you must register your application through the Microsoft Azure portal. If you don't have a Microsoft Azure account, you can [signup](https://azure.microsoft.com/en-us/free) for free.
+
+You can access the Azure management portal from your Microsoft service, or visit [https://manage.windowsazure.com](https://manage.windowsazure.com) and sign in to Azure using the global administrator account used to create the Office 365 organization.
 
 ::: note
 There is no way to create an application that integrates with Microsoft Azure AD without having **your own** Microsoft Azure AD instance.
 :::
+
+If you have an Office 365 account, you can use the account's Azure AD instance instead of creating a new one. To find your Office 365 account's Azure AD instance:
+
+1. [Sign in](https://portal.office.com) to Office 365.
+2. Navigate to the [Office 365 Admin Center](https://portal.office.com/adminportal/home#/homepage).
+3. Open the **Admin centers** menu drawer located in the left menu.
+4. Click on **Azure AD**.
+
+This will bring you to the admin center of the Azure AD instance backing your Office 365 account.
 
 ## 1. Create a new application
 


### PR DESCRIPTION
Add instructions on finding the Azure AD which backs an Office 365 account, and clarify that creating a new Azure AD is not required (if you already have an Office 365 account).

Perhaps this blurb should be in a panel? Or a subsection?

[Connect your app to Microsoft Azure Active Directory](https://auth0-docs-content-pr-5154.herokuapp.com/docs/connections/enterprise/azure-active-directory/v2)