### PR TITLE
Update rate limits doc

### DIFF
--- a/articles/policies/rate-limits.md
+++ b/articles/policies/rate-limits.md
@@ -181,7 +181,7 @@ The following Auth0 Management API endpoints return rate limit-related headers. 
 The following Auth0 Authentication API endpoints return rate limit-related headers.
 
 :::note
-Rate limits are not yet enabled for all endpoints, as the rate limits for some endpoints will only be enabled at a future date. This is indicated by the <div class="label label-primary">Enabled</div> and <div class="label label-warning">Not Enabled</div> labels.
+Rate limits are not yet enabled for all endpoints, and rate limits for some endpoints will only be enabled at a future date. This is indicated by the **Enabled** column.
 :::
 
 <table class="table">

--- a/articles/policies/rate-limits.md
+++ b/articles/policies/rate-limits.md
@@ -180,8 +180,11 @@ The following Auth0 Management API endpoints return rate limit-related headers. 
 
 The following Auth0 Authentication API endpoints return rate limit-related headers:
 
-| Endpoint | Scope | GET | POST |
-| - | - | - | - |
-| User Profile | Per User ID (GET), Per IP (POST) | /userinfo | /tokeninfo |
-| Delegated Authentication | Per User ID per IP | | /delegation |
-| Database and Active Directory / LDAP Authentication | Per User ID Per IP | | /dbconnections/change_password |
+| Endpoint | Path | Scope |
+| - | - | - |
+| Get Token | /oauth/token |  |
+| Cross-Origin Authentication | /co/authenticate | |
+| Authenticate User | /oauth/ro | |
+| Delegation | /delegation | |
+| Login | /authorize | |
+| Login (DB Connection) | /usernamepassword/login | |

--- a/articles/policies/rate-limits.md
+++ b/articles/policies/rate-limits.md
@@ -32,13 +32,7 @@ For some API endpoints, the rate limits are defined per bucket, so the origins o
 
 ## Exceeding the Rate Limit
 
-If you exceed the provided rate limit for a given API endpoint, you will receive the [429 Too Many Requests](http://tools.ietf.org/html/rfc6585#section-4) response with the following message:
-
-```text
-{
-    "message": "Too many requests. Check the X-RateLimit-Limit, X-RateLimit-Remaining and X-RateLimit-Reset headers."
-}
-```
+If you exceed the provided rate limit for a given API endpoint, you will receive a response with [HTTP Status Code 429 (Too Many Requests)](http://tools.ietf.org/html/rfc6585#section-4). You can refer to the [HTTP Response Headers](#http-response-headers) for more information on the rate limits applicable to that endpoint.
 
 Actions such as rapidly updating configuration settings, aggressive polling, or making highy concurrent API calls may result in your app being rate limited.
 
@@ -46,11 +40,11 @@ If your app triggers the rate limit, please refrain from making additional reque
 
 ## HTTP Response Headers
 
-API requests to selected [Authentication](/api/authentication) or [Management API](/api/management/v2) endpoints will return HTTP Response Headers that provide relevant data on where you are at for a given rate limit. If you receive a rate limit-related response header, it will include numeric information detailing your status.
+API requests to selected [Authentication](/api/authentication) or [Management API](/api/management/v2) endpoints will return HTTP Response Headers that provide relevant data on the current status of your rate limits for that endpoint. If you receive a rate limit-related response header, it will include numeric information detailing your status.
 
-* **X-RateLimit-Limit**: Request limit
-* **X-RateLimit-Remaining**: Requests available for the current time frame
-* **X-RateLimit-Reset**: Time until the rate limit resets (in UTC [epoch seconds](https://en.wikipedia.org/wiki/Unix_time))
+* **X-RateLimit-Limit**: The maximum number of requests available in the current time frame.
+* **X-RateLimit-Remaining**: The number of remaining requests in the current time frame.
+* **X-RateLimit-Reset**: A [UNIX timestamp](https://en.wikipedia.org/wiki/Unix_time) of the expected time when the rate limit will reset.
 
 ## Endpoints with Rate Limits
 

--- a/articles/policies/rate-limits.md
+++ b/articles/policies/rate-limits.md
@@ -178,13 +178,115 @@ The following Auth0 Management API endpoints return rate limit-related headers. 
 
 ### Authentication API
 
-The following Auth0 Authentication API endpoints return rate limit-related headers:
+The following Auth0 Authentication API endpoints return rate limit-related headers.
 
-| Endpoint | Path | Scope |
-| - | - | - |
-| Get Token | /oauth/token |  |
-| Cross-Origin Authentication | /co/authenticate | |
-| Authenticate User | /oauth/ro | |
-| Delegation | /delegation | |
-| Login | /authorize | |
-| Login (DB Connection) | /usernamepassword/login | |
+:::note
+Rate limits are not yet enabled for all endpoints, as the rate limits for some endpoints will only be enabled at a future date. This is indicated by the <div class="label label-primary">Enabled</div> and <div class="label label-warning">Not Enabled</div> labels.
+:::
+
+<table class="table">
+  <tr>
+      <th><strong>Endpoint</strong></th>
+      <th><strong>Path</strong></th>
+      <th><strong>Limited By</strong></th>
+      <th><strong>Affected Tenants</strong></th>
+      <th><strong>Enabled</strong></th>
+  </tr>
+  <tr>
+    <td rowspan="2">User Profile</td>
+    <td>/tokeninfo (legacy)</td>
+    <td>IP</td>
+    <td>All</td>
+    <td><div class="label label-primary">Enabled</div></td>
+  </tr>
+  <tr>
+    <td>/userinfo</td>
+    <td>User ID</td>
+    <td>All</td>
+    <td><div class="label label-primary">Enabled</div></td>
+  </tr>
+  <tr>
+    <td rowspan="3">Delegated Authentication (legacy)</td>
+    <td rowspan="3">/delegation</td>
+    <td>User ID and IP</td>
+    <td>All</td>
+    <td><div class="label label-primary">Enabled</div></td>
+  </tr>
+  <tr>
+    <td>(any request)</td>
+    <td>Free</td>
+    <td><div class="label label-warning">Not Enabled</div></td>
+  </tr>
+  <tr>
+    <td>IP</td>
+    <td>Paid</td>
+    <td><div class="label label-warning">Not Enabled</div></td>
+  </tr>
+  <tr>
+    <td>Change Password</td>
+    <td>/dbconnections/change_password</td>
+    <td>User ID and IP</td>
+    <td>All</td>
+    <td><div class="label label-primary">Enabled</div></td>
+  </tr>
+  <tr>
+    <td rowspan="2">Get Token</td>
+    <td rowspan="2">/oauth/token</td>
+    <td>(any request)</td>
+    <td>Free</td>
+    <td><div class="label label-warning">Not Enabled</div></td>
+  </tr>
+  <tr>
+    <td>IP</td>
+    <td>Paid</td>
+    <td><div class="label label-warning">Not Enabled</div></td>
+  </tr>
+  <tr>
+    <td rowspan="2">Cross Origin Authentication</td>
+    <td rowspan="2">/co/authenticate</td>
+    <td>(any request)</td>
+    <td>Free</td>
+    <td><div class="label label-warning">Not Enabled</div></td>
+  </tr>
+  <tr>
+    <td>IP</td>
+    <td>Paid</td>
+    <td><div class="label label-warning">Not Enabled</div></td>
+  </tr>
+  <tr>
+    <td rowspan="2">Authentication</td>
+    <td rowspan="2">/usernamepassword/login</td>
+    <td>(any request)</td>
+    <td>Free</td>
+    <td><div class="label label-warning">Not Enabled</div></td>
+  </tr>
+  <tr>
+    <td>IP</td>
+    <td>Paid</td>
+    <td><div class="label label-warning">Not Enabled</div></td>
+  </tr>
+  <tr>
+    <td rowspan="2">Resource Owner (legacy)</td>
+    <td rowspan="2">/oauth/ro</td>
+    <td>(any request)</td>
+    <td>Free</td>
+    <td><div class="label label-warning">Not Enabled</div></td>
+  </tr>
+  <tr>
+    <td>IP</td>
+    <td>Paid</td>
+    <td><div class="label label-warning">Not Enabled</div></td>
+  </tr>
+  <tr>
+    <td rowspan="2">Json Web Token Keys</td>
+    <td rowspan="2">/.well-known/jwks.json</td>
+    <td>(any request)</td>
+    <td>Free</td>
+    <td><div class="label label-warning">Not Enabled</div></td>
+  </tr>
+  <tr>
+    <td>IP</td>
+    <td>Paid</td>
+    <td><div class="label label-warning">Not Enabled</div></td>
+  </tr>
+</table>

--- a/articles/policies/rate-limits.md
+++ b/articles/policies/rate-limits.md
@@ -180,113 +180,96 @@ The following Auth0 Management API endpoints return rate limit-related headers. 
 
 The following Auth0 Authentication API endpoints return rate limit-related headers.
 
-:::note
-Rate limits are not yet enabled for all endpoints, and rate limits for some endpoints will only be enabled at a future date. This is indicated by the **Enabled** column.
-:::
-
 <table class="table">
   <tr>
       <th><strong>Endpoint</strong></th>
       <th><strong>Path</strong></th>
       <th><strong>Limited By</strong></th>
       <th><strong>Affected Tenants</strong></th>
-      <th><strong>Enabled</strong></th>
   </tr>
   <tr>
     <td rowspan="2">User Profile</td>
     <td>/tokeninfo (legacy)</td>
     <td>IP</td>
     <td>All</td>
-    <td><div class="label label-primary">Enabled</div></td>
   </tr>
   <tr>
     <td>/userinfo</td>
     <td>User ID</td>
     <td>All</td>
-    <td><div class="label label-primary">Enabled</div></td>
   </tr>
   <tr>
     <td rowspan="3">Delegated Authentication (legacy)</td>
     <td rowspan="3">/delegation</td>
     <td>User ID and IP</td>
     <td>All</td>
-    <td><div class="label label-primary">Enabled</div></td>
   </tr>
   <tr>
     <td>(any request)</td>
-    <td>Free</td>
-    <td><div class="label label-warning">Not Enabled</div></td>
+    <td>Free (*)</td>
   </tr>
   <tr>
     <td>IP</td>
     <td>Paid</td>
-    <td><div class="label label-warning">Not Enabled</div></td>
   </tr>
   <tr>
     <td>Change Password</td>
     <td>/dbconnections/change_password</td>
     <td>User ID and IP</td>
     <td>All</td>
-    <td><div class="label label-primary">Enabled</div></td>
   </tr>
   <tr>
     <td rowspan="2">Get Token</td>
     <td rowspan="2">/oauth/token</td>
     <td>(any request)</td>
     <td>Free</td>
-    <td><div class="label label-warning">Not Enabled</div></td>
   </tr>
   <tr>
     <td>IP</td>
     <td>Paid</td>
-    <td><div class="label label-warning">Not Enabled</div></td>
   </tr>
   <tr>
     <td rowspan="2">Cross Origin Authentication</td>
     <td rowspan="2">/co/authenticate</td>
     <td>(any request)</td>
     <td>Free</td>
-    <td><div class="label label-warning">Not Enabled</div></td>
   </tr>
   <tr>
     <td>IP</td>
     <td>Paid</td>
-    <td><div class="label label-warning">Not Enabled</div></td>
   </tr>
   <tr>
     <td rowspan="2">Authentication</td>
     <td rowspan="2">/usernamepassword/login</td>
     <td>(any request)</td>
     <td>Free</td>
-    <td><div class="label label-warning">Not Enabled</div></td>
   </tr>
   <tr>
     <td>IP</td>
     <td>Paid</td>
-    <td><div class="label label-warning">Not Enabled</div></td>
   </tr>
   <tr>
     <td rowspan="2">Resource Owner (legacy)</td>
     <td rowspan="2">/oauth/ro</td>
     <td>(any request)</td>
     <td>Free</td>
-    <td><div class="label label-warning">Not Enabled</div></td>
   </tr>
   <tr>
     <td>IP</td>
     <td>Paid</td>
-    <td><div class="label label-warning">Not Enabled</div></td>
   </tr>
   <tr>
     <td rowspan="2">Json Web Token Keys</td>
     <td rowspan="2">/.well-known/jwks.json</td>
     <td>(any request)</td>
     <td>Free</td>
-    <td><div class="label label-warning">Not Enabled</div></td>
   </tr>
   <tr>
     <td>IP</td>
     <td>Paid</td>
-    <td><div class="label label-warning">Not Enabled</div></td>
   </tr>
 </table>
+
+:::note
+(*) In all instances above, **Free** includes tenants on the Free plan, as well as the non-production tenants of enterprise customers. 
+:::


### PR DESCRIPTION
* https://auth0-docs-content-pr-5160.herokuapp.com/docs/policies/rate-limits

Due the changes about rate limiting we will need to modify these docs: https://auth0.com/docs/policies/rate-limits
(RFC: https://docs.google.com/document/d/11kJhSXHFWV4CGdV49RcwOTIZ4LgVJRhv6WlzvyKi4Js)

Some input:
- The document says about “this is the response you will get”, that’s wrong, since different endpoints could return different responses, I’d like to mention there that the customer should trust on the status code and the headers.
- The table format (columns) for authentication api could be re-thought