### PR TITLE
Lock 11 - docs changes

### DIFF
--- a/articles/connector/kerberos.md
+++ b/articles/connector/kerberos.md
@@ -48,10 +48,10 @@ On the other hand, when users are not in the corporate network (e.g.: at a custo
 ## Auto-login with Lock
 
 ::: warning
-Windows Authentication works for Lock up to version 10.
+Detecting IP ranges in an Active Directory/LDAP connection and using those ranges with Lock to allow integrated Windows Authentication is a feature which works up through Lock 10, but is disabled in Lock 11.
 :::
 
-When an application is using the Login Page hosted by Auth0 (typicaly used for SAML/WS-Federation protocols and SSO Integrations) the Lock will show a button which allows users to authenticate using "Windows Authentication". If they don't want to use this they can continue and have the Lock show all other available connections.
+When an application is using Lock within the Login Page hosted by Auth0 (typically used for SAML/WS-Federation protocols and SSO Integrations) the Lock will show a button which allows users to authenticate using "Windows Authentication". If they don't want to use this they can continue and have the Lock show all other available connections.
 
 In some cases the requirement could be to automatically sign in the user if Kerberos is possible (based on the IP-address of the end user). The following changes can be added to the Auth0 Login Page (or to your own page hosting the Lock) to automatically sign in the user if Kerberos is possible:
 

--- a/articles/connector/kerberos.md
+++ b/articles/connector/kerberos.md
@@ -47,6 +47,10 @@ On the other hand, when users are not in the corporate network (e.g.: at a custo
 
 ## Auto-login with Lock
 
+::: warning
+Windows Authentication works for Lock up to version 10.
+:::
+
 When an application is using the Login Page hosted by Auth0 (typicaly used for SAML/WS-Federation protocols and SSO Integrations) the Lock will show a button which allows users to authenticate using "Windows Authentication". If they don't want to use this they can continue and have the Lock show all other available connections.
 
 In some cases the requirement could be to automatically sign in the user if Kerberos is possible (based on the IP-address of the end user). The following changes can be added to the Auth0 Login Page (or to your own page hosting the Lock) to automatically sign in the user if Kerberos is possible:

--- a/articles/connector/kerberos.md
+++ b/articles/connector/kerberos.md
@@ -1,39 +1,33 @@
 ---
-description: Explains Kerberos Support with Auth0, how to configure it, the flow, and auto-login with Lock.
+description: Explains AD/LDAP Federation Support with Auth0, how to configure it, the flow, and auto-login with Lock.
 toc: true
 ---
 
-# Kerberos Support
+# Federating with Active Directory through the AD/LDAP Connector
 
-Kerberos is a security protocol used by Active Directory which is based on tickets and can provide nearly invisible authentication to users on domain-joined machines. This allows users to use resources in the corporate network (eg: SharePoint, Dynamics CRM, Web Applications) without having to enter their credentials for each application.
-
-The AD/LDAP connector supports Kerberos to make it easer for your users to authenticate when they are on a domain-joined machine within the corporate network.
+The AD/LDAP connector makes it easy for your users to authenticate when they are on a domain-joined machine within the corporate network.
 
 ## Configuration
 
-To activate Kerberos on an Active Directory, simply enable the option in the dashboard.
+To activate this feature for Active Directory/LDAP, simply enable the option in the dashboard.
 
 ![](/media/articles/connector/kerberos/connector-kerberos-configuration.png)
 
-After enabling Kerberos you'll also be able to configure the **IP Ranges**. When users originate from these IP address ranges this information will be exposed in the **SSO endpoint** which means client-side SDKs like **auth0.js** and the **Lock** will be able to detect Kerberos support and allow Integrated Windows Authentication.
+After enabling it, you'll also be able to configure the **IP Ranges**. When users originate from these IP address ranges Auth0 will be able to redirect to the AD/LDAP identity provider and leverage their native authentication mechanisms.
+
+The IP addresses are configured using the [CIDR-notation](http://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing). Note that these should be ranges that are visible by Auth0. If Auth0 is deployed on-premises you'll typically enter internal IP address ranges of your users.
 
 ::: note
 We recommend restarting the Windows Service that hosts the AD Connector every time this setting is changed. This way, changes will take effect immediately.
 :::
 
-The IP addresses are configured using the [CIDR-notation](http://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing). Note that these should be ranges that are visible by Auth0. If Auth0 is deployed on-premises you'll typically enter internal IP address ranges of your users.
-
 When Auth0 is running in the cloud, it won't be able to see your user's internal IP address. In that case you'd configure the public facing/WAN IP address(es) of your company.
-
-::: panel Kerberos and IP Ranges
-Normally the step above is not necessary. When Kerberos is enabled, Auth0 server will assume all requests coming from that IP address are originating from your intranet. For normal use then, simply turn Kerberos on and then leave the IP configurations empty. If your intranet spans multiple networks and those are different from where the connector is installed, then it is important to define it here.
-:::
 
 ## Flow
 
-Depending on the location of the user the authentication flow will be different when Kerberos is enabled. Let's take Fabrikam as an example. Since Fabrikam uses the SaaS version of Auth0 they configured their Public IP Address (`24.12.34.56/32`) in the connection.
+Depending on the location of the user the authentication flow will be different when IP ranges are set. Let's take Fabrikam as an example. Since Fabrikam uses the SaaS version of Auth0 they configured their Public IP Address (`24.12.34.56/32`) in the connection.
 
-Users connecting from within the building will all originate from `24.12.34.56` (as configured on the connection). When they authenticate, the users can follow the Kerberos flow and have a seamless SSO experience.
+Users connecting from within the building will all originate from `24.12.34.56` (as configured on the connection). When they authenticate, the users can follow the AD/LDAP native flow and have a seamless SSO experience.
 
 ::: note
 For this to work, the network must allow the users to connect to the AD/LDAP Connector on the port configured in the `config.json` file. In [highly available](/connector/high-availability) deployments of the connector, the address users will be connecting to is the network load balancer in front of all connectors instances.
@@ -48,7 +42,7 @@ On the other hand, when users are not in the corporate network (e.g.: at a custo
 ## Auto-login with Lock
 
 ::: warning
-Detecting IP ranges in an Active Directory/LDAP connection and using those ranges with Lock to allow integrated Windows Authentication is a feature which works up through Lock 10, but is disabled in Lock 11.
+Detecting IP ranges in an Active Directory/LDAP connection and using those ranges with Lock to allow integrated Windows Authentication is a feature which works in Lock 10  but is disabled in Lock 11.
 :::
 
 When an application is using Lock within the Login Page hosted by Auth0 (typically used for SAML/WS-Federation protocols and SSO Integrations) the Lock will show a button which allows users to authenticate using "Windows Authentication". If they don't want to use this they can continue and have the Lock show all other available connections.

--- a/articles/sso/current/single-page-apps.md
+++ b/articles/sso/current/single-page-apps.md
@@ -172,7 +172,7 @@ setInterval(function() {
   // if the token is not in local storage, there is nothing to check (i.e. the user is already logged out)
   if (!localStorage.getItem('userToken')) return;
 
-  auth0.getSSOData(function (err, data) {
+  auth0.checkSession(function (err, data) {
     // if there is still a session, do nothing
     if (err || (data && data.sso)) return;
 

--- a/articles/sso/current/single-page-apps.md
+++ b/articles/sso/current/single-page-apps.md
@@ -173,14 +173,12 @@ setInterval(function() {
   if (!localStorage.getItem('userToken')) return;
 
   auth0.checkSession(function (err, data) {
-    // if there is still a session, do nothing
-    if (err || (data && data.sso)) return;
-
-    // if we get here, it means there is no session on Auth0,
-    // then remove the token and redirect to #login
-    localStorage.removeItem('userToken');
-    window.location.href = '#login'
-
+    if (err) { 
+      // if we get here, it means there is no session on Auth0,
+      // then remove the token and redirect to #login
+      localStorage.removeItem('userToken');
+      window.location.href = '#login';
+    }
   });
 }, 5000)
 ```


### PR DESCRIPTION
- [x] [Kerberos Support](https://auth0.com/docs/connector/kerberos#auto-login-with-lock): Add warning about this not working with Lock 11

- [x] [Kerberos Support](https://auth0.com/docs/connector/kerberos#auto-login-with-lock): Remove references to Kerberos (?)

- [x] [Client-Side SSO on Single Page Applications](https://auth0.com/docs/sso/current/single-page-apps-sso#single-logout): Remove references to `getSSOData` (use `checkSession`). **WAITING FOR ENGINEERING**