### PR TITLE
Allowed Origins (CORS) is required for COA

### DIFF
--- a/articles/cross-origin-authentication/index.md
+++ b/articles/cross-origin-authentication/index.md
@@ -29,11 +29,12 @@ This limitation is another reason why the more practical solution, where possibl
 
 Configuring your client for cross-origin authentication is a process that requires a few steps:
 
-1. In the [client settings](${manage_url}/#/applications/${account.clientId}/settings) for your application, click **Show Advanced Settings** > **OAuth** and find the **Cross Origin Authentication Mode** switch. Ensure that the switch is in the on position.
-1. Also ensure that the **OIDC Conformant** switch is toggled on in the same settings panel.
+1. In the [Client Settings](${manage_url}/#/clients/${account.clientId}/settings) for your application, click **Show Advanced Settings** > **OAuth** and find the **Cross Origin Authentication Mode** switch. Ensure that the switch is in the on position.
+1. Εnsure that the **OIDC Conformant** switch is toggled on in the same settings panel.
   ![Cross-Origin Authentication switch](/media/articles/cross-origin-authentication/cross-origin-settings.png)
+1. Ensure that the **Allowed Origins (CORS)** field is set to the domain making the request. You can find this field in the [Client Settings](${manage_url}/#/clients/${account.clientId}/settings).
 1. Ensure that your application is using [Lock](/libraries/lock) version 10.22 or higher, or [Auth0.js](/libraries/auth0js) version 8.7 or higher.
-1. If you are using Lock, make sure that you are using the [oidcconformant](/libraries/lock/v10/customization#oidcconformant-boolean-) option.
+1. If you are using Lock 10, make sure that you are using the [oidcconformant](/libraries/lock/v10/customization#oidcconformant-boolean-) option.
 1. Third-party cookies do not work in some browsers. To handle these cases, you will need to author a page which uses **auth0.js** to act as a fallback for the cross-origin transaction. More information on setting up this page is provided below.
 
 ::: note


### PR DESCRIPTION
Cross Origin Authentication requires the `Allowed Origins (CORS)` field set, pointing to the domain making the request.

