### PR TITLE
fixed golang example: added missing slash / at issuer url

### DIFF
--- a/articles/quickstart/backend/golang/01-authorization.md
+++ b/articles/quickstart/backend/golang/01-authorization.md
@@ -39,7 +39,7 @@ Configure the **checkJwt** middleware to use the remote JWKS for your Auth0 acco
 ```go
 // main.go
 const JWKS_URI = "https://${account.namespace}/.well-known/jwks.json"
-const AUTH0_API_ISSUER = "https://${account.namespace}"
+const AUTH0_API_ISSUER = "https://${account.namespace}/"
 
 var AUTH0_API_AUDIENCE = []string{"${apiIdentifier}"}
 


### PR DESCRIPTION
without the slash, authentication fails with the error "invalid issuer claim (iss)". WIth the slash, it works.
The python example also has the trailing slash.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
