### PR TITLE
Fix Content-Type

### DIFF
--- a/articles/api/authentication/_change-password.md
+++ b/articles/api/authentication/_change-password.md
@@ -4,7 +4,7 @@
 
 ```http
 POST https://${account.namespace}/dbconnections/change_password
-Content-Type: 'application/json'
+Content-Type: application/json
 {
   "client_id": "${account.clientId}",
   "email": "EMAIL",

--- a/articles/api/authentication/_impersonation.md
+++ b/articles/api/authentication/_impersonation.md
@@ -4,7 +4,7 @@
 
 ```http
 POST https://${account.namespace}/users/{user_id}/impersonate
-Content-Type:   'application/json'
+Content-Type:   application/json
 Authorization:  'Bearer {ACCESS_TOKEN}'
 {
   protocol: "PROTOCOL",

--- a/articles/api/authentication/_linking.md
+++ b/articles/api/authentication/_linking.md
@@ -58,7 +58,7 @@ This endpoint will trigger the login flow to link an existing account with a new
 
 ```http
 POST https://${account.namespace}/login/unlink
-Content-Type: 'application/json'
+Content-Type: application/json
 {
   "access_token": "LOGGED_IN_USER_ACCESS_TOKEN", // Primary identity access_token
   "user_id": "LINKED_USER_ID" // (provider|id)

--- a/articles/api/authentication/_passwordless.md
+++ b/articles/api/authentication/_passwordless.md
@@ -10,7 +10,7 @@ Passwordless connections do not require the user to remember a password. Instead
 
 ```http
 POST https://${account.namespace}/passwordless/start
-Content-Type: 'application/json'
+Content-Type: application/json
 {
   "client_id": "${account.clientId}",
   "connection": "email|sms",
@@ -124,7 +124,7 @@ For the complete error code reference for this endpoint refer to [Errors > POST 
 
 ```http
 POST https://${account.namespace}/oauth/ro
-Content-Type: 'application/json'
+Content-Type: application/json
 {
   "client_id": "${account.clientId}",
   "connection": "email|sms",

--- a/articles/api/authentication/_sign-up.md
+++ b/articles/api/authentication/_sign-up.md
@@ -4,7 +4,7 @@
 
 ```http
 POST https://${account.namespace}/dbconnections/signup
-Content-Type: 'application/json'
+Content-Type: application/json
 {
   "client_id": "${account.clientId}",
   "email": "EMAIL",

--- a/articles/api/authentication/api-authz/_get-token.md
+++ b/articles/api/authentication/api-authz/_get-token.md
@@ -15,7 +15,7 @@ Note that the only OAuth 2.0 flows that can retrieve a refresh token are:
 
 ```http
 POST https://${account.namespace}/oauth/token
-Content-Type: 'application/json'
+Content-Type: application/json
 {
   "grant_type": "authorization_code",
   "client_id": "${account.clientId}",
@@ -118,7 +118,7 @@ If you have just executed the [Authorization Code Grant](#authorization-code-gra
 
 ```http
 POST https://${account.namespace}/oauth/token
-Content-Type: 'application/json'
+Content-Type: application/json
 {
   "grant_type": "authorization_code",
   "client_id": "${account.clientId}",
@@ -211,7 +211,7 @@ If you have just executed the [Authorization Code Grant (PKCE)](#authorization-c
 
 ```http
 POST https://${account.namespace}/oauth/token
-Content-Type: 'application/json'
+Content-Type: application/json
 {
   audience: "API_IDENTIFIER",
   grant_type: "client_credentials",
@@ -302,7 +302,7 @@ This is the OAuth 2.0 grant that server processes utilize in order to access an 
 
 ```http
 POST https://${account.namespace}/oauth/token
-Content-Type: 'application/json'
+Content-Type: application/json
 {
   "grant_type": "password",
   "username": "USERNAME",
@@ -422,7 +422,7 @@ Next, you have to verify the MFA, using the `/oauth/token` endpoint and the chal
 
 ```http
 POST https://${account.namespace}/mfa/challenge
-Content-Type: 'application/json'
+Content-Type: application/json
 {
   "client_id": "${account.clientId}",
   "client_secret": "${account.clientSecret}",
@@ -525,7 +525,7 @@ For details on the supported challenge types refer to [Multifactor Authenticatio
 
 ```http
 POST https://${account.namespace}/oauth/token
-Content-Type: 'application/json'
+Content-Type: application/json
 {
   "client_id": "${account.clientId}",
   "client_secret": "${account.clientSecret}",
@@ -600,7 +600,7 @@ To verify MFA using an OTP code your app must prompt the user to get the OTP cod
 
 ```http
 POST https://${account.namespace}/oauth/token
-Content-Type: 'application/json'
+Content-Type: application/json
 {
   "client_id": "${account.clientId}",
   "client_secret": "${account.clientSecret}",
@@ -705,7 +705,7 @@ When the challenge response includes a `binding_method: prompt` your app needs t
 
 ```http
 POST https://${account.namespace}/oauth/token
-Content-Type: 'application/json'
+Content-Type: application/json
 {
   "client_id": "${account.clientId}",
   "client_secret": "${account.clientSecret}",
@@ -782,7 +782,7 @@ To verify MFA using a recovery code your app must prompt the user for the recove
 
 ```http
 POST https://${account.namespace}/oauth/token
-Content-Type: 'application/json'
+Content-Type: application/json
 {
   "grant_type": "refresh_token",
   "client_id": "${account.clientId}",
@@ -865,4 +865,4 @@ Use this endpoint to refresh an access token, using the refresh token you got du
 
 ### More Information
 
-- [Refresh Token](/tokens/preview/refresh-token)
+- [Refresh Token](/tokens/refresh-token)

--- a/articles/api/authentication/api-authz/_revoke-refersh-token.md
+++ b/articles/api/authentication/api-authz/_revoke-refersh-token.md
@@ -4,7 +4,7 @@
 
 ```http
 POST https://${account.namespace}/oauth/revoke
-Content-Type: 'application/json'
+Content-Type: application/json
 {
   "client_id": "${account.clientId}",
   "client_secret": "${account.clientSecret}",

--- a/articles/api/authentication/legacy/_delegation.md
+++ b/articles/api/authentication/legacy/_delegation.md
@@ -6,7 +6,7 @@
 
 ```http
 POST https://${account.namespace}/delegation
-Content-Type: 'application/json'
+Content-Type: application/json
 {
   "client_id": "${account.clientId}",
   "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",

--- a/articles/api/authentication/legacy/_login.md
+++ b/articles/api/authentication/legacy/_login.md
@@ -8,7 +8,7 @@
 
 ```http
 POST https://${account.namespace}/oauth/access_token
-Content-Type: 'application/json'
+Content-Type: application/json
 {
   "client_id": "${account.clientId}",
   "access_token": "ACCESS_TOKEN",
@@ -107,7 +107,7 @@ For the complete error code reference for this endpoint refer to [Errors > POST 
 
 ```http
 POST https://${account.namespace}/oauth/ro
-Content-Type: 'application/json'
+Content-Type: application/json
 {
   "client_id": "${account.clientId}",
   "username": "USERNAME",

--- a/articles/api/authentication/legacy/_resource-owner.md
+++ b/articles/api/authentication/legacy/_resource-owner.md
@@ -4,7 +4,7 @@
 
 ```http
 POST https://${account.namespace}/oauth/ro
-Content-Type: 'application/json'
+Content-Type: application/json
 {
   "client_id": "${account.clientId}",
   "connection": "CONNECTION",

--- a/articles/api/authentication/legacy/_userinfo.md
+++ b/articles/api/authentication/legacy/_userinfo.md
@@ -6,7 +6,7 @@
 
 ```http
 POST https://${account.namespace}/tokeninfo
-Content-Type: 'application/json'
+Content-Type: application/json
 {
   "id_token": "ID_TOKEN"
 }


### PR DESCRIPTION
Some endpoints of the Authentication API explorer, show the raw HTTP example calls with:

`Content-Type: 'application/json'`

however, the correct would be (without the single quotes):

`Content-Type: application/json`