### PR TITLE
Moving "accessing state from rules" from Lock v9 doc to state doc

### DIFF
--- a/articles/libraries/lock/v9/sending-authentication-parameters.md
+++ b/articles/libraries/lock/v9/sending-authentication-parameters.md
@@ -69,11 +69,3 @@ The values for each scope are not transformed in any way. They must match exactl
 The `state` parameter is an arbitrary state value that will be mantained across redirects. It is useful to mitigate [CSRF attacks](http://en.wikipedia.org/wiki/Cross-site_request_forgery) and for any contextual information (such as a return url) that you might need after the authentication process is finished.
 
 [Click here to learn more about how to send/receive the state parameter.](/protocols/oauth-state)
-
-#### Getting the `state` value in a rule
-
-If you need to access the `state` parameter within a rule you must take in consideration that, depending on the type of connection used, it might come either in the body of the request or in the query string, so you should do:
-
-```js
-var state = context.request.query.state || context.request.body.state;.
-```

--- a/articles/protocols/oauth2/oauth-state.md
+++ b/articles/protocols/oauth2/oauth-state.md
@@ -58,6 +58,15 @@ if(decodedString == auth0-authorize) {
 	// Request Denied
 }
 ```
+
+### Getting the `state` value in a rule
+
+If you need to access the `state` value within a rule you must take in consideration that, depending on the type of connection used, it might come either in the body of the request or in the query string. Keeping that in mind, it can be accessed using the following:
+
+```js
+var state = context.request.query.state || context.request.body.state;
+```
+
 ## Keep reading
 
 ::: next-steps


### PR DESCRIPTION
Realized this section does not in any way belong in the Lock v9 docs, while dealing with this feedback card: https://trello.com/c/Kt5S5fCv

Old location at bottom of https://auth0-docs-content-pr-5232.herokuapp.com/docs/libraries/lock/v9/sending-authentication-parameters

New location at bottom of https://auth0-docs-content-pr-5232.herokuapp.com/docs/protocols/oauth2/oauth-state