### PR TITLE
Add missing information about Allowed Logout URL

### DIFF
--- a/articles/quickstart/webapp/aspnet-core/_includes/_setup.md
+++ b/articles/quickstart/webapp/aspnet-core/_includes/_setup.md
@@ -6,6 +6,10 @@ You will need to add this URL to the list of Allowed URLs for your application. 
 
 If you deploy your application to a different URL you will also need to ensure to add that URL to the **Allowed Callback URLs**. For ASP.NET Core this URL will take the format `http://YOUR_APPLICATION_URL/signin-auth0`  
 
+## Configure Allowed Logout URLs
+
+To return back to your application after logging out, add the url to the list of Allowed Logout URLs in format `http://YOUR_APPLICATION_URL/optional_path`. This URL gets used in the `returnTo` parameter in the Logout URL.
+
 ## Configure JSON Web Token Signature Algorithm
 
 The ASP.NET Core OpenID Connect (OIDC) middleware which will be used to authenticate the user, requires that the JSON Web Token (JWT) be signed with an asymmetric key. To configure this go to the settings for your application in the Auth0 Dashboard, scroll down and click on **Show Advanced Settings**. Go to the **OAuth** tab and set the **JsonWebToken Signature Algorithm** to **RS256**.


### PR DESCRIPTION
When following this tutorial https://auth0.com/docs/quickstart/webapp/aspnet-core/v2/01-login the application I built did not logout properly due to returnTo parameter not being allowed for logout. I found solution here: https://auth0.com/docs/logout#set-the-allowed-logout-urls-at-the-client-level and thought that we could prevent users from facing this issue when following the .NET core MVC tutorial

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
