### PR TITLE
API changes and JSON compatibility

### DIFF
--- a/articles/connections/adding-generic-oauth1-connection.md
+++ b/articles/connections/adding-generic-oauth1-connection.md
@@ -10,9 +10,10 @@ To create an arbitrary __OAuth1__ connection, you use __[Auth0's Connections API
 This example would create a custom Twitter connection:
 
 ```bash
-curl -H "Content-Type: application/json"
+curl -X POST
+     -H "Content-Type: application/json"
      -H 'Authorization: Bearer YOUR_GLOBAL_CLIENT_ACCESS_TOKEN'
-     -d @twitter.json https://${account.namespace}/api/connections
+     -d @twitter.json https://${account.namespace}/api/v2/connections
 ```
 
 ```json
@@ -22,9 +23,9 @@ curl -H "Content-Type: application/json"
   "options": {
     "client_id": "YOUR_TWITTER_CLIENT_ID",
     "client_secret": "YOUR_TWITTER_CLIENT_SECRET",
-    "requestTokenURL": 'https://api.twitter.com/oauth/request_token',
-    "accessTokenURL": 'https://api.twitter.com/oauth/access_token',
-    "userAuthorizationURL": 'https://api.twitter.com/oauth/authenticate',
+    "requestTokenURL": "https://api.twitter.com/oauth/request_token",
+    "accessTokenURL": "https://api.twitter.com/oauth/access_token",
+    "userAuthorizationURL": "https://api.twitter.com/oauth/authenticate",
     "scripts": {
       "fetchUserProfile": "function (token, tokenSecret, ctx, cb) {var OAuth = new require('oauth').OAuth;var oauth = new OAuth(ctx.requestTokenURL,ctx.accessTokenURL,ctx.client_id,ctx.client_secret,'1.0',null,'HMAC-SHA1');oauth.get('https://api.twitter.com/1.1/users/show.json?user_id=' + ctx.user_id,token,tokenSecret,function(e, b, r) {if (e) return cb(e);if (r.statusCode !== 200) return cb(new Error('StatusCode: ' + r.statusCode));cb(null, JSON.parse(b));});}"
     }

--- a/articles/connections/adding-generic-oauth1-connection.md
+++ b/articles/connections/adding-generic-oauth1-connection.md
@@ -1,4 +1,5 @@
 ---
+title: Adding a generic OAuth1 Authorization Server to Auth0
 description: How to add a generic Oauth1 Authorization Server to Auth0.
 ---
 # Adding a generic OAuth1 Authorization Server to Auth0
@@ -12,9 +13,13 @@ This example would create a custom Twitter connection:
 ```bash
 curl -X POST
      -H "Content-Type: application/json"
-     -H 'Authorization: Bearer YOUR_GLOBAL_CLIENT_ACCESS_TOKEN'
+     -H 'Authorization: Bearer YOUR_MANAGEMENT_API_TOKEN'
      -d @twitter.json https://${account.namespace}/api/v2/connections
 ```
+
+:::note
+Replace `YOUR_MANAGEMENT_API_TOKEN` with a valid token. For info on how to get one, see [The Auth0 Management APIv2 Token](/api/management/v2/tokens).
+:::
 
 ```json
 {


### PR DESCRIPTION
I couldn't get it to work the v1 API, but when changing the URL to use the v2 endpoint (and specifying the method to be POST) it worked. Also, JSON is supposed to use double quotes instead of single quotes.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
