### PR TITLE
Update android QS

### DIFF
--- a/articles/quickstart/native/android/02-custom-login-form.md
+++ b/articles/quickstart/native/android/02-custom-login-form.md
@@ -89,26 +89,26 @@ private void login() {
     Auth0 auth0 = new Auth0(this);
     auth0.setOIDCConformant(true);
     WebAuthProvider.init(auth0)
-                  .withScheme("demo")
-                  .withAudience(String.format("https://%s/userinfo", getString(R.string.com_auth0_domain)))
-                  .withConnection("twitter")
-                  .start(this, new AuthCallback() {
-                      @Override
-                      public void onFailure(@NonNull Dialog dialog) {
-                        // Show error Dialog to user
-                      }
+        .withScheme("demo")
+        .withAudience(String.format("https://%s/userinfo", getString(R.string.com_auth0_domain)))
+        .withConnection("twitter")
+        .start(this, new AuthCallback() {
+            @Override
+            public void onFailure(@NonNull Dialog dialog) {
+                // Show error Dialog to user
+            }
 
-                      @Override
-                      public void onFailure(AuthenticationException exception) {
-                        // Show error to user
-                      }
+            @Override
+            public void onFailure(AuthenticationException exception) {
+                // Show error to user
+            }
 
-                      @Override
-                      public void onSuccess(@NonNull Credentials credentials) {
-                          // Store credentials
-                          // Navigate to your main activity
-                      }
-                });
+            @Override
+            public void onSuccess(@NonNull Credentials credentials) {
+                // Store credentials
+                // Navigate to your main activity
+            }
+    });
 }
 ```
 

--- a/articles/quickstart/native/android/03-session-handling.md
+++ b/articles/quickstart/native/android/03-session-handling.md
@@ -21,7 +21,7 @@ This tutorial shows you how to let users log in and maintain an active session w
 You need the `Credentials` class to handle users' credentials. The class is composed of these elements:
 
 * `accessToken`: Access Token used by the Auth0 API. To learn more, see the [Access Token documentation](/tokens/access-token).
-* `idToken`: Identity token that proves the identity of the user. To learn more, see the [ID Token documentation](/tokens/id-token).
+* `idToken`: Identity Token that proves the identity of the user. To learn more, see the [ID Token documentation](/tokens/id-token).
 * `refreshToken`: Refresh Token that can be used to request new tokens without signing in again. To learn more, see the [Refresh Token documentation](/tokens/refresh-token/current).
 * `tokenType`: The type of tokens issued by the server.
 * `expiresIn`: The number of seconds before the tokens expire.
@@ -52,11 +52,11 @@ WebAuthProvider.init(auth0)
 
 ## Check for Tokens when the Application Starts
 
-::: panel Learn about refresh tokens
+::: panel Learn about Refresh Tokens
 Before you go further with this tutorial, read the [refresh token documentation](/refresh-token).
 It is important that you remember the following:
-* Refresh tokens must be securely saved.
-* Even though refresh tokens cannot expire, they can be revoked.
+* Refresh Tokens must be securely saved.
+* Even though Refresh Tokens cannot expire, they can be revoked.
 * New tokens will have the same scope as was originally requested during the first authentication.
 :::
 

--- a/articles/quickstart/native/android/03-session-handling.md
+++ b/articles/quickstart/native/android/03-session-handling.md
@@ -57,13 +57,13 @@ Before you go further with this tutorial, read the [refresh token documentation]
 It is important that you remember the following:
 * Refresh tokens must be securely saved.
 * Even though refresh tokens cannot expire, they can be revoked.
-* New tokens will never have a different scope than the scope you requested during the first login.
+* New tokens will have the same scope as was originally requested during the first authentication.
 :::
 
 You can simplify the way you handle user sessions using a Credential Manager class, which knows how to securely store, retrieve and renew credentials obtained from Auth0. Two classes are provided in the SDK to help you achieve this. Further read on how they work and their implementation differences is available in the [Saving and Renewing Tokens](/libraries/auth0-android/save-and-refresh-tokens.md) article. For this series of tutorials we're going to use the `SecureCredentialsManager` class as it encrypts the credentials before storing them in a private SharedPreferences file.
 
 
-Create a new instance of the Credentials Manager. When you run the application you'd first check if there are any previous saved credentials, in order to skip the login screen:
+Create a new instance of the Credentials Manager. When you run the application, you should check if there are any previously stored credentials. You can use these credentials to bypass the login screen:
 
 ```java
 // app/src/main/java/com/auth0/samples/LoginActivity.java
@@ -84,13 +84,13 @@ Create a new instance of the Credentials Manager. When you run the application y
 ```
 
 ::: note
-Ideally a single class should have the knowledge of handling credentials, but you can share this instance across activities or create a new one every time is required as long as the Storage strategy persists the data in the same location. Check the `LoginActivity` class to understand how to achieve this in a single class.
+Ideally a single class should manage the handling of credentials. You can share this instance across activities or create a new one every time is required as long as the Storage strategy persists the data in the same location. Check the `LoginActivity` class to understand how to achieve this in a single class.
 :::
 
 
 ## Save the User's Credentials
 
-After a successful login response save the user's credentials on the Credentials Manager. Use the `saveCredentials` method.
+After a successful login response, you can store the user's credentials using the `saveCredentials` method.
 
 ```java
 // app/src/main/java/com/auth0/samples/LoginActivity.java
@@ -115,12 +115,12 @@ private final AuthCallback webCallback = new AuthCallback() {
 ```
 
 ::: note
-The Storage implementation given to the Credentials Manager in the seed project uses a SharedPreferences file to store the user credentials in [Private mode](https://developer.android.com/reference/android/content/Context.html#MODE_PRIVATE). Change this behavior by implementing a custom Storage. 
+A Storage defines how data is going to be persisted in the device. The Storage implementation given to the Credentials Manager in the seed project uses a SharedPreferences file to store the user credentials in [Private mode](https://developer.android.com/reference/android/content/Context.html#MODE_PRIVATE). You can modify this behavior by implementing a custom Storage. 
 :::
 
 ## Recover the User's Credentials
 
-Retrieving the credentials from the Credentials Manager is an async process, as credentials may have expired and require to be refreshed. This renewing process is done automatically by the Credentials Manager as long as a valid Refresh Token is currently stored. A `CredentialsManagerException` exception will raise if the credentials have expired and the network request to refresh them has failed.
+Retrieving the credentials from the Credentials Manager is an async process, as credentials may have expired and require to be refreshed. This renewing process is done automatically by the Credentials Manager as long as a valid Refresh Token is currently stored. A `CredentialsManagerException` exception will be raised if the credentials cannot be renewed.
 
 ```java
 // app/src/main/java/com/auth0/samples/LoginActivity.java
@@ -169,5 +169,5 @@ protected void onCreate(Bundle savedInstanceState) {
 ```
 
 ::: note
-If you are not using our Credentials Manager classes, depending on the way you store users' credentials you delete them differently. 
+If you are not using our Credentials Manager classes, you are responsible for ensuring that the user's credentials have been removed.
 :::

--- a/articles/quickstart/native/android/03-session-handling.md
+++ b/articles/quickstart/native/android/03-session-handling.md
@@ -44,10 +44,10 @@ Before you launch the login process, make sure you get a valid Refresh Token in 
 Auth0 auth0 = new Auth0(this);
 auth0.setOIDCConformant(true);
 WebAuthProvider.init(auth0)
-                .withScheme("demo")
-                .withAudience(String.format("https://%s/userinfo", getString(R.string.com_auth0_domain)))
-                .withScope("openid offline_access")
-                .start(LoginActivity.this, webCallback);
+    .withScheme("demo")
+    .withAudience(String.format("https://%s/userinfo", getString(R.string.com_auth0_domain)))
+    .withScope("openid offline_access")
+    .start(LoginActivity.this, webCallback);
 ```
 
 ## Check for Tokens when the Application Starts
@@ -69,7 +69,8 @@ Create a new instance of the Credentials Manager. When you run the application, 
 // app/src/main/java/com/auth0/samples/LoginActivity.java
   Auth0 auth0 = new Auth0(this);
   auth0.setOIDCConformant(true);
-  SecureCredentialsManager credentialsManager = new SecureCredentialsManager(this, new AuthenticationAPIClient(auth0), new SharedPreferencesStorage(this));
+  AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
+  SecureCredentialsManager credentialsManager = new SecureCredentialsManager(this, client, new SharedPreferencesStorage(this));
 
   // Check if the activity was launched after a logout
   if (getIntent().getBooleanExtra(KEY_CLEAR_CREDENTIALS, false)) {
@@ -108,8 +109,8 @@ private final AuthCallback webCallback = new AuthCallback() {
 
     @Override
     public void onSuccess(@NonNull Credentials credentials) {
+        //user successfully authenticated
         credentialsManager.saveCredentials(credentials);
-        //...
     }
 };
 ```

--- a/articles/quickstart/native/android/03-session-handling.md
+++ b/articles/quickstart/native/android/03-session-handling.md
@@ -50,13 +50,38 @@ WebAuthProvider.init(auth0)
                 .start(LoginActivity.this, callback);
 ```
 
+## Check for Tokens when the Application Starts
+
+::: panel Learn about refresh tokens
+Before you go further with this tutorial, read the [refresh token documentation](/refresh-token).
+It is important that you remember the following:
+* Refresh tokens must be securely saved.
+* Even though refresh tokens cannot expire, they can be revoked.
+* New tokens will never have a different scope than the scope you requested during the first login.
+:::
+
+You can simplify the way you handle user sessions using a Credential Manager class, which knows how to securely store, retrieve and renew credentials obtained from Auth0. Two classes are provided in the SDK to help you achieve this. Further read on how they work and their implementation differences is available in the [Saving and Renewing Tokens](/libraries/auth0-android/save-and-refresh-tokens.md) article. For this series of tutorials we're going to use the `SecureCredentialsManager` class as it encrypts the credentials before storing them in a private SharedPreferences file.
+
+
+Create a new instance of the Credentials Manager. The instance can be shared across activities or a new one can be created anytime needed as long as the Storage strategy persists the data in the same location. When you run the application you'd first check if there are any previous saved credentials, in order to skip the login screen:
+
+```java
+// app/src/main/java/com/auth0/samples/LoginActivity.java
+  Auth0 auth0 = new Auth0(this);
+  auth0.setOIDCConformant(true);
+  SecureCredentialsManager credentialsManager = new SecureCredentialsManager(this, new AuthenticationAPIClient(auth0), new SharedPreferencesStorage(this));
+
+  if (credentialsManager.hasValidCredentials()) {
+    // Try to make an automatic login
+  } else {
+    // Prompt Login screen.
+  }
+```
+
+
 ## Save the User's Credentials
 
-Save the user's credentials obtained in the login success response.
-
-::: warning
-Make sure you use a secure method.
-:::
+After a successful login response save the user's credentials on the Credentials Manager. Use the `saveCredentials` method.
 
 ```java
 // app/src/main/java/com/auth0/samples/LoginActivity.java
@@ -74,122 +99,48 @@ private final AuthCallback callback = new AuthCallback() {
 
     @Override
     public void onSuccess(@NonNull Credentials credentials) {
-        saveCredentials(credentials);
+        credentialsManager.saveCredentials(credentials);
         //...
     }
 };
 ```
 
 ::: note
-User credentials are stored in [Private mode](https://developer.android.com/reference/android/content/Context.html#MODE_PRIVATE) in the seed project in the `SharedPreferences` file. You can achieve this with the `CredentialsManager` class. For details, check the implementation in the project code. There are better and more secure ways to store tokens, but we will not cover them in this tutorial.
+The Storage implementation given to the Credentials Manager in the seed project uses a SharedPreferences file to store the user credentials in [Private mode](https://developer.android.com/reference/android/content/Context.html#MODE_PRIVATE). Change this behavior by implementing a custom Storage. 
 :::
 
-## Check for Tokens when the Application Starts
+## Recover the User's Credentials
 
-To save your users the effort of logging in every time they open your app, use their Access Tokens. You can check for the Access Token when a user starts the app. If you find the token, you can automatically log the user in and direct them straight to your app's main flow.  
-
-
-```java
-// app/src/main/java/com/auth0/samples/LoginActivity.java
-
-String accessToken = CredentialsManager.getCredentials(this).getAccessToken();
-if (accessToken == null) {
-  // Prompt Login screen.
-} else {
-  // Try to make an automatic login
-}
-```
-
-## Validate the Existing Token
-
-If the Access Token exists, the next step is to check if it is valid. 
-You can choose between two options: 
-* Save the time when the user receives a new pair of credentials. When you need to use the Access Token, check how many seconds have passed since the user got the token. When the number exceeds the number specified in the `expiresIn` value, the token is no longer valid. 
-* Call the Auth0 Authentication API and check the response.
-
-::: note 
-This tutorial shows you how to call the Auth0 Authentication API with the `/userinfo` endpoint.
-:::
-
-
-```java
-// app/src/main/java/com/auth0/samples/LoginActivity.java
-
-AuthenticationAPIClient aClient = new AuthenticationAPIClient(auth0);
-aClient.userInfo(accessToken)
-        .start(new BaseCallback<UserProfile, AuthenticationException>() {
-            @Override
-            public void onSuccess(final UserProfile payload) {
-                //Navigate to the next activity
-            }
-
-            @Override
-            public void onFailure(AuthenticationException error) {
-                //Delete current credentials and try again
-            }
-        });
-```
-
-You need to decide how to deal with an invalid token. Typically, you can choose between two options: 
-* Ask the user to re-enter their credentials.
-* Use a Refresh Token to get a new valid Access Token.
-
-::: note
-This tutorial shows how to use a Refresh Token. If you want users to re-enter their credentials, clear the stored data and prompt the login screen.
-:::
-
-## Refresh the User's Session
-
-::: panel Learn about Refresh Tokens
-Before you go further with this tutorial, read the [Refresh Token documentation](/refresh-token).
-It is important that you remember the following:
-* Refresh Tokens must be securely saved.
-* Even though Refresh Tokens cannot expire, they can be revoked. 
-* New tokens will never have a different scope than the scope you requested during the first login.
-:::
-
-Create an `AuthenticationAPIClient` instance:
+Retrieving the credentials from the Credentials Manager is an async process, as credentials may have expired and require to be refreshed. This renewing process is done automatically by the Credentials Manager as long as a valid Refresh Token is currently stored. A `CredentialsManagerException` exception will raise if the credentials have expired and no valid Refresh Token was found.
 
 ```java
 // app/src/main/java/com/auth0/samples/MainActivity.java
 
-AuthenticationAPIClient aClient = new AuthenticationAPIClient(auth0);
+credentialsManager.getCredentials(new BaseCallback<Credentials, CredentialsManagerException>() {
+    @Override
+    public void onSuccess(Credentials credentials) {
+        // use credentials
+    }
+
+    @Override
+    public void onFailure(CredentialsManagerException error) {
+        // Credentials could not be refreshed. Log in again
+    }
+});
 ```
 
-Use the Refresh Token to get new credentials:
-
-```java
-// app/src/main/java/com/auth0/samples/MainActivity.java
-
-String refreshToken = CredentialsManager.getCredentials(this).getRefreshToken();
-aClient.renewAuth(refreshToken)
-      .start(new BaseCallback<Credentials, AuthenticationException>() {
-
-          @Override
-          public void onSuccess(Credentials payload) {
-            String accessToken = payload.getAccessToken(); // New Access Token
-            String idToken = payload.getIdToken(); // New ID Token
-            //Save the new values
-          }
-
-          @Override
-          public void onFailure(AuthenticationException error) {
-            //show error
-          }
-      });
-```
 
 ## Log the User Out
 
-To log the user out, you must remove their credentials and navigate them to the login screen.
+To log the user out, you remove their credentials and navigate them to the login screen. 
 
-For example, you can do the following:
+When using a Credentials Manager, you do that calling `clearCredentials`.
 
 ```java
 // app/src/main/java/com/auth0/samples/MainActivity.java
 
 private void logout() {
-  CredentialsManager.deleteCredentials(this);
+  credentialsManager.clearCredentials();
   startActivity(new Intent(this, LoginActivity.class));
   finish();
 }
@@ -198,9 +149,3 @@ private void logout() {
 ::: note
 Depending on the way you store users' credentials, you delete them differently. 
 :::
-
-## Optional: Encapsulate Session Handling
-
-You can simplify the way you handle user sessions by storing token-related information and processes in a class. The class separates the logic for handling user sessions from the activity. 
-
-We recommend that you download the sample project from this tutorial and look at its implementation. Focus on the `CredentialsManager` class, which manages session handling, obtains user credentials from the `SharedPreferences` file and saves them.

--- a/articles/quickstart/native/android/04-user-profile.md
+++ b/articles/quickstart/native/android/04-user-profile.md
@@ -44,7 +44,7 @@ The profile obtained this way is OIDC-conformant. Depending on the [scopes](/sco
 2. Get the user's full profile using the [Management API](/api/management/v2#!/Users). This step is explained next:
 
 
-Create an instance of the Users API client using the id token. The snippet below makes use of the Credentials Manager to retrieve the credentials that you saved in the log in step. This client is used to request the users' profile data.
+Create an instance of the Users API client using the id token that you saved in the log in step. In the snippet bellow we obtain it from the extras that the LoginActivity class has passed when starting this activity. The API client is used to request the users' profile data.
 
 ```java
 // app/src/main/java/com/auth0/samples/activities/MainActivity.java
@@ -52,21 +52,8 @@ Create an instance of the Users API client using the id token. The snippet below
 Auth0 auth0 = new Auth0(this);
 auth0.setOIDCConformant(true);
 
-SecureCredentialsManager credentialsManager = new SecureCredentialsManager(this, new AuthenticationAPIClient(auth0), new SharedPreferencesStorage(this));
-credentialsManager.getCredentials(new BaseCallback<Credentials, CredentialsManagerException>() {
-
-    @Override
-    public void onSuccess(Credentials credentials) {
-        String idToken = credentials.getIdToken();
-        UsersAPIClient usersClient = new UsersAPIClient(auth0, idToken);
-        //...
-    }
-
-    @Override
-    public void onFailure(CredentialsManagerException error) {
-        //Credentials expired. Log in again
-    }
-});
+String idToken = getIntent().getStringExtra(LoginActivity.KEY_ID_TOKEN);
+UsersAPIClient usersClient = new UsersAPIClient(auth0, idToken);
 ```
 
 ::: note

--- a/articles/quickstart/native/android/04-user-profile.md
+++ b/articles/quickstart/native/android/04-user-profile.md
@@ -44,7 +44,7 @@ The profile obtained this way is OIDC-conformant. Depending on the [scopes](/sco
 2. Get the user's full profile using the [Management API](/api/management/v2#!/Users). This step is explained next:
 
 
-Create an instance of the Users API client using the id token that you saved in the log in step. In the snippet bellow we obtain it from the extras that the LoginActivity class has passed when starting this activity. The API client is used to request the users' profile data.
+Create an instance of the Users API client using the id token that you saved in the log in step. In the snippet bellow we obtain it from the extras that the LoginActivity class has passed when starting this activity. The API client is used to request the user's profile data.
 
 ```java
 // app/src/main/java/com/auth0/samples/activities/MainActivity.java

--- a/articles/quickstart/native/android/04-user-profile.md
+++ b/articles/quickstart/native/android/04-user-profile.md
@@ -51,9 +51,9 @@ The profile obtained this way is OIDC-conformant. Depending on the [scopes](/sco
 2. Get the user's full profile using the [Management API](/api/management/v2#!/Users). Since fields such as [user_metadata](#additional-information) are not part of the OIDC specification you need to obtain the full profile to read them. This step is explained next:
 
 
-Create an instance of the Users API client using the access token that you saved in the log in step. This access token can be used to authorize requests since you've requested the Management API audience and the corresponding user entity scopes in the login step. In the snippet bellow we obtain the token from the extras that the LoginActivity class has passed when starting this activity. The API client is used to request the user's profile data.
+Create an instance of the Users API client using the Access Token that you saved in the log in step. This Access Token can be used to authorize requests since you've requested the Management API audience and the corresponding user entity scopes in the login step. In the snippet bellow we obtain the token from the extras that the LoginActivity class has passed when starting this activity. The API client is used to request the user's profile data.
 
-Create now an instance of the Authentication API client. This time is used to call the userinfo endpoint and retrieve the id of the user to whom the token was issued.
+Create now an instance of the Authentication API client. This time is used to call the userinfo endpoint and retrieve the ID of the user to whom the token was issued.
 
 ```java
 // app/src/main/java/com/auth0/samples/activities/MainActivity.java
@@ -99,7 +99,7 @@ authenticationAPIClient.userInfo(accessToken)
 
         @Override
         public void onFailure(AuthenticationException error) {
-          // Show error
+            // Show error
         }
     });
 ```

--- a/articles/quickstart/native/android/04-user-profile.md
+++ b/articles/quickstart/native/android/04-user-profile.md
@@ -24,16 +24,23 @@ This tutorial shows you how to get and modify the user's profile data with Auth0
 Before you continue with this tutorial, make sure that you have completed the [Login](/quickstart/native/android/00-login) and [Session Handling](/quickstart/native/android/03-session-handling) tutorials. To call the API clients, you need a valid Access Token and ID Token.
 :::
 
-Before launching the login process, you need to make sure you get a valid profile from the authorization server. To do that, ask for the `openid profile email` scope. Find the snippet in which you initialize the `WebAuthProvider` class. To that snippet, add the line `withScope("openid profile email")`.
+Before launching the login process, you need to make sure the authorization server allows you to read and edit the current user profile. To do that, ask for the `openid profile email read:current_user update:current_user_metadata` scope and the Management API audience, which happens to include the User Info audience as well. Find the snippet in which you initialize the `WebAuthProvider` class. To that snippet, add the line `withScope("openid profile email read:current_user update:current_user_metadata")` and `withAudience(String.format("https://%s/api/v2/", getString(R.string.com_auth0_domain)))`.
 
 ```java
+// app/src/main/java/com/auth0/samples/activities/LoginActivity.java
+
 Auth0 auth0 = new Auth0(this);
 auth0.setOIDCConformant(true);
 WebAuthProvider.init(auth0)
-                .withScheme("demo")
-                .withScope("openid profile email")
-                .start(this, callback);
+    .withScheme("demo")
+    .withAudience(String.format("https://%s/api/v2/", getString(R.string.com_auth0_domain)))
+    .withScope("openid profile email read:current_user update:current_user_metadata")
+    .start(this, callback);
 ```
+
+::: note
+Note that the Management API audience value ends in `/` in constrast to the User Info audience. 
+:::
 
 ## Request User Data
 
@@ -41,10 +48,12 @@ WebAuthProvider.init(auth0)
 To get the user's information:
 1. Use the user's access token to call the `userInfo` method in the `AuthenticationAPIClient` client instance.
 The profile obtained this way is OIDC-conformant. Depending on the [scopes](/scopes/current) you requested when logging in, the profile contains different information. The result will never contain fields outside the OIDC specification.
-2. Get the user's full profile using the [Management API](/api/management/v2#!/Users). This step is explained next:
+2. Get the user's full profile using the [Management API](/api/management/v2#!/Users). Since fields such as [user_metadata](#additional-information) are not part of the OIDC specification you need to obtain the full profile to read them. This step is explained next:
 
 
-Create an instance of the Users API client using the id token that you saved in the log in step. In the snippet bellow we obtain it from the extras that the LoginActivity class has passed when starting this activity. The API client is used to request the user's profile data.
+Create an instance of the Users API client using the access token that you saved in the log in step. This access token can be used to authorize requests since you've requested the Management API audience and the corresponding user entity scopes in the login step. In the snippet bellow we obtain the token from the extras that the LoginActivity class has passed when starting this activity. The API client is used to request the user's profile data.
+
+Create now an instance of the Authentication API client. This time is used to call the userinfo endpoint and retrieve the id of the user to whom the token was issued.
 
 ```java
 // app/src/main/java/com/auth0/samples/activities/MainActivity.java
@@ -52,8 +61,9 @@ Create an instance of the Users API client using the id token that you saved in 
 Auth0 auth0 = new Auth0(this);
 auth0.setOIDCConformant(true);
 
-String idToken = getIntent().getStringExtra(LoginActivity.KEY_ID_TOKEN);
-UsersAPIClient usersClient = new UsersAPIClient(auth0, idToken);
+String accessToken = getIntent().getStringExtra(LoginActivity.KEY_ACCESS_TOKEN);
+UsersAPIClient usersClient = new UsersAPIClient(auth0, accessToken);
+AuthenticationAPIClient authenticationAPIClient = new AuthenticationAPIClient(auth0);
 ```
 
 ::: note
@@ -61,36 +71,44 @@ Do not hardcode the Auth0 `domain` and `clientId` values when creating the Auth0
 :::
 
 
-To get the user's information:
+To get the user's profile:
 1. Use the user's Access Token to call the `userInfo` method in the `AuthenticationAPIClient` client instance.
 You get an instance of the `UserProfile` profile. The profile is OIDC-conformant. Depending on the on the [scopes](/scopes/current) you requested, the profile contains different information. 
-2. To get the user's full profile, use the [Management API](/api/management/v2#!/Users).
-
-
-Use the User ID to call `getProfile` on the Users API client and obtain the full user profile. Use the received data to update the layout.
+2. To get the user's full profile, use the [Management API](/api/management/v2#!/Users). Use the user ID obtained in previous step to call `getProfile` on the Users API client and obtain the full user profile. Use the received data to update the layout.
 
 ```java
 // app/src/main/java/com/auth0/samples/activities/MainActivity.java
 
-usersClient.getProfile(getUserId(idToken))
-  .start(new BaseCallback<UserProfile, ManagementException>() {
-      @Override
-      public void onSuccess(UserProfile profile) {
-        // Display the user profile
-      }
+authenticationAPIClient.userInfo(accessToken)
+    .start(new BaseCallback<UserProfile, AuthenticationException>() {
+        @Override
+        public void onSuccess(UserProfile userinfo) {
+            usersClient.getProfile(userinfo.getId())
+                .start(new BaseCallback<UserProfile, ManagementException>() {
+                    @Override
+                    public void onSuccess(UserProfile profile) {
+                      // Display the user profile        
+                    }
 
-      @Override
-      public void onFailure(ManagementException error) {
-        // Show error
-      }
-  });
+                    @Override
+                    public void onFailure(ManagementException error) {
+                      // Show error                            
+                    }
+                });
+        }
+
+        @Override
+        public void onFailure(AuthenticationException error) {
+          // Show error
+        }
+    });
 ```
 
 ## Access the Data Inside the Received Profile
 
 ### Default information
 
-At this point, you already have access to the `UserProfile` instance.
+At this point, you already have access to the full version of the `UserProfile` instance.
 You can use this data wherever you need it.
 
 Some examples are:
@@ -145,15 +163,14 @@ Map<String, Object> userMetadata = new HashMap<>();
 userMetadata.put("country", "USA");
 ```
 
-Update the information with the User API client:
+Update the information with the Users API client created before:
 
 ```java
 // app/src/main/java/com/auth0/samples/activities/MainActivity.java
 
-UsersAPIClient usersClient = new UsersAPIClient(auth0, idToken);
 usersClient.updateMetadata(userInfo.getId(), userMetadata).start(new BaseCallback<UserProfile, ManagementException>() {
   @Override
-  public void onSuccess(final UserProfile profile) {
+  public void onSuccess(UserProfile profile) {
     // As receive the updated profile here
     // You can react to this, and show the information to the user.
   }

--- a/articles/quickstart/native/android/04-user-profile.md
+++ b/articles/quickstart/native/android/04-user-profile.md
@@ -37,7 +37,14 @@ WebAuthProvider.init(auth0)
 
 ## Request User Data
 
-Create instances of the API clients. You will use them to request the users' profile data.
+
+To get the user's information:
+1. Use the user's access token to call the `userInfo` method in the `AuthenticationAPIClient` client instance.
+The profile obtained this way is OIDC-conformant. Depending on the [scopes](/scopes/current) you requested when logging in, the profile contains different information. The result will never contain fields outside the OIDC specification.
+2. Get the user's full profile using the [Management API](/api/management/v2#!/Users). This step is explained next:
+
+
+Create an instance of the Users API client using the id token. The snippet below makes use of the Credentials Manager to retrieve the credentials that you saved in the log in step. This client is used to request the users' profile data.
 
 ```java
 // app/src/main/java/com/auth0/samples/activities/MainActivity.java
@@ -45,59 +52,51 @@ Create instances of the API clients. You will use them to request the users' pro
 Auth0 auth0 = new Auth0(this);
 auth0.setOIDCConformant(true);
 
-String idToken = CredentialsManager.getCredentials(this).getIdToken();
-UsersAPIClient usersClient = new UsersAPIClient(auth0, idToken);
-AuthenticationAPIClient authClient = new AuthenticationAPIClient(auth0);
+SecureCredentialsManager credentialsManager = new SecureCredentialsManager(this, new AuthenticationAPIClient(auth0), new SharedPreferencesStorage(this));
+credentialsManager.getCredentials(new BaseCallback<Credentials, CredentialsManagerException>() {
+
+    @Override
+    public void onSuccess(Credentials credentials) {
+        String idToken = credentials.getIdToken();
+        UsersAPIClient usersClient = new UsersAPIClient(auth0, idToken);
+        //...
+    }
+
+    @Override
+    public void onFailure(CredentialsManagerException error) {
+        //Credentials expired. Log in again
+    }
+});
 ```
 
 ::: note
-Do not hardcode the Auth0 `domain` and `clientId` values. We recommend you add them to the `strings.xml` file.
+Do not hardcode the Auth0 `domain` and `clientId` values when creating the Auth0 instance. We recommend you add them to the `strings.xml` file.
 :::
+
 
 To get the user's information:
 1. Use the user's Access Token to call the `userInfo` method in the `AuthenticationAPIClient` client instance.
 You get an instance of the `UserProfile` profile. The profile is OIDC-conformant. Depending on the on the [scopes](/scopes/current) you requested, the profile contains different information. 
 2. To get the user's full profile, use the [Management API](/api/management/v2#!/Users).
 
-```java
-// app/src/main/java/com/auth0/samples/activities/MainActivity.java
 
-String accessToken = CredentialsManager.getCredentials(this).getAccessToken();
-authenticationClient.userInfo(accessToken)
-    .start(new BaseCallback<UserProfile, AuthenticationException>() {
-
-        @Override
-        public void onSuccess(final UserProfile userInfo) {
-            String userId = userInfo.getId();
-            // fetch the full user profile
-        }
-
-        @Override
-        public void onFailure(AuthenticationException error) {
-            //show error
-        }
-    });
-```
-
-When you get the `sub` value, call the [Management API](https://auth0.com/docs/api/management/v2#!/Users).
-
-Use the `UsersAPIClient` client and the user's ID to get the full user profile.
+Use the User ID to call `getProfile` on the Users API client and obtain the full user profile. Use the received data to update the layout.
 
 ```java
 // app/src/main/java/com/auth0/samples/activities/MainActivity.java
 
-usersClient.getProfile(userId)
-        .start(new BaseCallback<UserProfile, ManagementException>() {
-            @Override
-            public void onSuccess(UserProfile profile) {
-                // Display the user profile
-            }
+usersClient.getProfile(getUserId(idToken))
+  .start(new BaseCallback<UserProfile, ManagementException>() {
+      @Override
+      public void onSuccess(UserProfile profile) {
+        // Display the user profile
+      }
 
-            @Override
-            public void onFailure(ManagementException error) {
-                //show error
-            }
-        });
+      @Override
+      public void onFailure(ManagementException error) {
+        // Show error
+      }
+  });
 ```
 
 ## Access the Data Inside the Received Profile
@@ -116,10 +115,10 @@ profile.getPictureURL();
 ```
 
 ::: panel Modifying the UI
-You cannot modify the UI inside the `onSuccess()` method because the method works in a second thread. To solve this issue, you can choose between three options:
-* Persist the data
-* Create a task in the UI thread
-* Create a handler to receive the information
+You cannot modify the UI inside the callback methods as they run in a different thread. To solve this issue you can choose between three options:
+* Persist the data and then retrieve it
+* Create a task in the UI thread and run it. i.e. using the `Activity#runOnUiThread` method.
+* Create a `Handler` to post the information
 :::
 
 ### Additional information
@@ -140,7 +139,7 @@ You can choose the key names and value types for subscripting the `user_metadata
 
 #### B. App metadata
 
-The `appMetadata` map contains fields that are usually added with a [Rule](/rule) or a [Hook](/hooks). For native platforms, this information is read-only.
+The `appMetadata` map contains fields that are usually added with a [Rule](/rules) or a [Hook](/hooks). For native platforms, this information is read-only.
 
 ::: note
 To learn more about metadata, see the [metadata documentation](/metadata).
@@ -152,19 +151,18 @@ The `extraInfo` map contains additional values that are stored in Auth0 but not 
 
 ## Update the User's Profile
 
-You can only update the user metadata. To do this, create a `Map<String, Object>` object and add the new metadata:
+You can only update the user metadata. To do this, create a `Map<String, Object>` object and add the information you want to store.
 
 ```java
 Map<String, Object> userMetadata = new HashMap<>();
 userMetadata.put("country", "USA");
 ```
 
-Update the information with the `UsersAPIClient` client:
+Update the information with the User API client:
 
 ```java
 // app/src/main/java/com/auth0/samples/activities/MainActivity.java
 
-String idToken = CredentialsManager.getCredentials(this).getIdToken();
 UsersAPIClient usersClient = new UsersAPIClient(auth0, idToken);
 usersClient.updateMetadata(userInfo.getId(), userMetadata).start(new BaseCallback<UserProfile, ManagementException>() {
   @Override
@@ -179,3 +177,8 @@ usersClient.updateMetadata(userInfo.getId(), userMetadata).start(new BaseCallbac
   }
 });
 ```
+
+
+::: note
+A call to `updateMetadata` will replace any previous user metadata stored in Auth0. Remember to copy the old values that you wish to maintain. 
+::: 

--- a/articles/quickstart/native/android/05-linking-accounts.md
+++ b/articles/quickstart/native/android/05-linking-accounts.md
@@ -54,7 +54,7 @@ Note that the Management API audience value ends in `/` in constrast to the User
 
 Your users may want to link their other accounts to the account they are logged in to.
 
-To achieve this, you need to store the user ID for the logged user in the Intent, along with the id token and access token provided by the LoginActivity at launch, which are already available in the intent extras. 
+To achieve this, you need to store the user ID for the logged user in the Intent, along with the ID Token and Access Token provided by the LoginActivity at launch, which are already available in the intent extras. 
 
 ```java
 // app/src/main/java/com/auth0/samples/activities/MainActivity.java

--- a/articles/quickstart/native/android/06-calling-apis.md
+++ b/articles/quickstart/native/android/06-calling-apis.md
@@ -46,25 +46,24 @@ private void login() {
     Auth0 auth0 = new Auth0(this);
     auth0.setOIDCConformant(true);
     WebAuthProvider.init(auth0)
-                  .withScheme("demo")
-                  .withAudience(API_IDENTIFIER)
-                  .start(LoginActivity.this, new AuthCallback() {
-                      @Override
-                      public void onFailure(@NonNull Dialog dialog) {
-                        // Show error Dialog to user
-                      }
+        .withScheme("demo")
+        .withAudience(API_IDENTIFIER)
+        .start(LoginActivity.this, new AuthCallback() {
+            @Override
+            public void onFailure(@NonNull Dialog dialog) {
+                // Show error Dialog to user
+            }
 
-                      @Override
-                      public void onFailure(AuthenticationException exception) {
-                        // Show error to user
-                      }
+            @Override
+            public void onFailure(AuthenticationException exception) {
+                // Show error to user
+            }
 
-                      @Override
-                      public void onSuccess(@NonNull Credentials credentials) {
-                          // Store credentials
-                          // Navigate to your main activity
-                      }
-                });
+            @Override
+            public void onSuccess(@NonNull Credentials credentials) {
+                // Verify tokens and Store credentials
+            }
+    });
 }
 ```
 

--- a/articles/quickstart/native/android/07-authorization.md
+++ b/articles/quickstart/native/android/07-authorization.md
@@ -60,18 +60,30 @@ The rule can be customized to grant the user different roles other than the ones
 
 Once the user credentials had been obtained (as explained in the [Login](/quickstart/native/android/00-login) tutorial), save them to access them at any time.
 
-The ID Token is a [JSON Web Token](/jwt) that holds several claims, like the one with the roles set on this tutorial. Use a *JWT decoding library* like [this one](https://github.com/auth0/JWTDecode.Android) to obtain the roles and perform the access control.
+The claims added to the Id Token via a Rule are included in the userinfo endpoint response. Use the Access Token to call this endpoint and obtain the user roles.
 
 ```java
 // app/src/main/java/com/auth0/samples/activities/MainActivity.java
-JWT idToken = new JWT(CredentialsManager.getCredentials(this).getIdToken());
-final List<String> roles = idToken.getClaim("https://access.control/roles").asList(String.class);
 
-if (!roles.contains("admin")) {
-  // User is not authorized
-} else {
-  // User is authorized  
-}
+authenticationClient.userInfo(accessToken)
+  .start(new BaseCallback<UserProfile, AuthenticationException>() {
+      @Override
+      public void onSuccess(UserProfile userInfo) {
+        //Obtain the claim from the "extra info" of the user info
+        List<String> roles = userInfo.getExtraInfo().containsKey("https://access.control/roles") ? (List<String>) userInfo.getExtraInfo().get("https://access.control/roles") : Collections.<String>emptyList();
+        
+        if (!roles.contains("admin")) {
+          // User is not authorized
+        } else {
+          // User is authorized  
+        }
+      }
+
+      @Override
+      public void onFailure(AuthenticationException error) {
+          // Show error
+      }
+  });
 ```
 
 ## Restrict Content Based On Access Level

--- a/articles/quickstart/native/android/07-authorization.md
+++ b/articles/quickstart/native/android/07-authorization.md
@@ -60,7 +60,7 @@ The rule can be customized to grant the user different roles other than the ones
 
 Once the user credentials had been obtained (as explained in the [Login](/quickstart/native/android/00-login) tutorial), save them to access them at any time.
 
-The claims added to the Id Token via a Rule are included in the userinfo endpoint response. Use the Access Token to call this endpoint and obtain the user roles.
+The claims added to the ID Token via a Rule are included in the userinfo endpoint response. Use the Access Token to call this endpoint and obtain the user roles.
 
 ```java
 // app/src/main/java/com/auth0/samples/activities/MainActivity.java

--- a/articles/quickstart/native/android/_includes/_api_authz.md
+++ b/articles/quickstart/native/android/_includes/_api_authz.md
@@ -69,11 +69,11 @@ Next, you need to use the `WebAuthProvider` to initiate the authentication and a
 ```java
 public void startAuth() {
     WebAuthProvider.init(account)
-            .withConnection("Username-Password-Authentication")
-            .withScope("openid profile {API_SCOPES}")
-            .withAudience("${apiIdentifier}")
-            .withScheme("demo")
-            .start(MainActivity.this, authCallback);
+        .withConnection("Username-Password-Authentication")
+        .withScope("openid profile {API_SCOPES}")
+        .withAudience("${apiIdentifier}")
+        .withScheme("demo")
+        .start(MainActivity.this, authCallback);
 }
 
 private AuthCallback authCallback = new AuthCallback() {
@@ -117,9 +117,9 @@ Use the `access_token` to invoke your Resource Server (API). In this example we 
 
 ```java
 HttpResponse<String> response = Unirest.get("https://someapi.com/api")
-  .header("content-type", "application/json")
-  .header("Authorization", "Bearer {ACCESS_TOKEN}")
-  .asString();
+    .header("content-type", "application/json")
+    .header("Authorization", "Bearer {ACCESS_TOKEN}")
+    .asString();
 ```
 
 The Resource Server (API) should be configured to verify the JWT and any claims contained within it. Because the Resource Server is utilizing the RS256 signature method, tokens are signed using Auth0's private key for your account. Verification is done using the corresponding public key, which can be found at the following standard [JWKS (JSON Web Key set)](https://self-issued.info/docs/draft-ietf-jose-json-web-key.html) URL: [https://${account.namespace}/.well-known/jwks.json]. You can use any [recommended JWT library](https://jwt.io) to validate the standard claims returned in the token. These details are outside the scope of this quickstart tutorial. More information can be found [in our documentation](https://auth0.com/docs/api-auth/config/asking-for-access-tokens).

--- a/articles/quickstart/native/android/_includes/_lock_login.md
+++ b/articles/quickstart/native/android/_includes/_lock_login.md
@@ -10,10 +10,10 @@ To ensure Open ID Connect compliant responses you must either request an `audien
 protected void onCreate(Bundle savedInstanceState) {
     Auth0 auth0 = new Auth0(this);
     lock = Lock.newBuilder(auth0, callback)
-                    .withScheme("demo")
-                    .withAudience(String.format("https://%s/userinfo", getString(R.string.com_auth0_domain)))
-                    // Add parameters to the Lock Builder
-                    .build(this);
+        .withScheme("demo")
+        .withAudience(String.format("https://%s/userinfo", getString(R.string.com_auth0_domain)))
+        // Add parameters to the Lock Builder
+        .build(this);
 }
 ```
 

--- a/articles/quickstart/native/android/_includes/_login.md
+++ b/articles/quickstart/native/android/_includes/_login.md
@@ -28,34 +28,32 @@ You need to make sure you get a response compliant with the OpenID Connect proto
 To turn on the **OIDC conformant** switch, in your [Client Settings](${manage_url}/#/applications/${account.clientId}/settings), click on **Show Advanced Settings** > **OAuth**.
 :::
 
-After you call the `WebAuthProvider#start` function, the browser launches and shows the **Lock** widget. Once the user authenticates, the callback URL is called. The callback URL contains the final result of the authentication process. 
+After you call the `WebAuthProvider#start` function, the browser launches and shows the **Lock** widget. Once the user authenticates, the callback URL is called. The callback URL contains the final result of the authentication process.
 
 ```java
 // app/src/main/java/com/auth0/samples/MainActivity.java
 
 private void login() {
-    Auth0 auth0 = new Auth0(this);
-    auth0.setOIDCConformant(true);
     WebAuthProvider.init(auth0)
-                  .withScheme("demo")
-                  .withAudience(String.format("https://%s/userinfo", getString(R.string.com_auth0_domain)))
-                  .start(MainActivity.this, new AuthCallback() {
-                      @Override
-                      public void onFailure(@NonNull Dialog dialog) {
-                        // Show error Dialog to user
-                      }
+        .withScheme("demo")
+        .withAudience(String.format("https://%s/userinfo", getString(R.string.com_auth0_domain)))
+        .start(MainActivity.this, new AuthCallback() {
+            @Override
+            public void onFailure(@NonNull Dialog dialog) {
+               // Show error Dialog to user
+            }
 
-                      @Override
-                      public void onFailure(AuthenticationException exception) {
-                        // Show error to user
-                      }
+            @Override
+            public void onFailure(AuthenticationException exception) {
+               // Show error to user
+            }
 
-                      @Override
-                      public void onSuccess(@NonNull Credentials credentials) {
-                          // Store credentials
-                          // Navigate to your main activity
-                      }
-                });
+            @Override
+            public void onSuccess(@NonNull Credentials credentials) {
+               // Store credentials
+               // Navigate to your main activity
+            }
+    });
 }
 ```
 
@@ -74,7 +72,7 @@ Replace `YOUR_APP_PACKAGE_NAME` with your application's package name, available 
 After authentication, the browser redirects the user to your application with the authentication result. The SDK captures the result and parses it. 
 
 ::: note
-You do not need to declare a specific `intent-filter` for your activity, because you have defined the manifest placeholders with your Auth0 **Domain** and **Scheme** values.
+You do not need to declare a specific `intent-filter` for your activity, because you have defined the manifest placeholders with your Auth0 **Domain** and **Scheme** values and the library will handle the redirection for you.
 :::
 
 The `AndroidManifest.xml` file should look like this:


### PR DESCRIPTION
This PR:

- Use secure `CredentialsManager` to handle credentials
- Call /userinfo to obtain the profile data required given an access token, since we don't verify the id_tokens locally in our SDKs yet.
- Create instances of the `UsersAPIClient` using an access token instead of an id token. 