### PR TITLE
Added description for config value GITLAB_URL

### DIFF
--- a/articles/extensions/gitlab-deploy.md
+++ b/articles/extensions/gitlab-deploy.md
@@ -17,6 +17,7 @@ Set the following configuration variables:
 
 * **GITLAB_REPOSITORY**: The name of your GitLab repository.
 * **GITLAB_BRANCH**: The branch of your GitLab repository your extension should monitor.
+* **GITLAB_URL**: The url of your GitLab instance, in case of gitlab.com use `https://gitlab.com`
 * **GITLAB_TOKEN**: The personal access token to your GitLab repository for this account. For details on how to configure one refer to [Configure a GitLab Token](configure-a-gitlab-token).
 * **SLACK_INCOMING_WEBHOOK**: The URL used to integrate with Slack to deliver notifications.
 


### PR DESCRIPTION
As of Gitlab version `2.3` the config value `GITLAB_URL` is added to support private instances.

This version is not yet available, will remove `do-not-merge` label when available.