### PR TITLE
Fix token renewal by explicitly setting postMessageOrigin in renewAuth

### DIFF
--- a/articles/quickstart/spa/angular2/05-token-renewal.md
+++ b/articles/quickstart/spa/angular2/05-token-renewal.md
@@ -31,7 +31,8 @@ public renewToken() {
   this.auth0.renewAuth({
     audience: '${apiIdentifier}',
     redirectUri: 'http://localhost:3001/silent',
-    usePostMessage: true
+    usePostMessage: true,
+    postMessageOrigin: 'http://localhost:3001'
   }, (err, result) => {
     if (err) {
       console.log(err);


### PR DESCRIPTION
The Angular quickstart token renewal step is not working out of the box due to the `postMessageOrigin` option not being provided and the fact that the silent handler is served from a different origin than the application itself.

This PR adds the missing option; a similar PR was added to the associated quickstart sample, see:

https://github.com/auth0-samples/auth0-angular-samples/pull/70
