### PR TITLE
Reference correct file in sample ruby auth doc.

### DIFF
--- a/articles/quickstart/backend/ruby/01-authorization.md
+++ b/articles/quickstart/backend/ruby/01-authorization.md
@@ -113,7 +113,7 @@ To look for a particular `scope` in an `access_token`, provide an array of requi
 In this example the `SCOPES` array for the given key `/restricted_resource` is intersected with the `scopes` contained in the payload of the `access_token` to determine if it contains one or more items from the array.
 
 ```rb
-# lib/jwt/json_web_token.rb
+# lib/server_rs256.rb
 
 SCOPES = {
   '/restricted_resource' => ['read:messages'],


### PR DESCRIPTION
As shown in the [sample project](https://github.com/auth0-community/auth0-ruby-api-samples/blob/master/01-Authorization-RS256/lib/server_rs256.rb), scoping is added to `server_rs256.rb` rather than `json_web_token.rb`

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
