### PR TITLE
Java code for Creating code challenge is not correct

### DIFF
--- a/articles/api-auth/tutorials/authorization-code-grant-pkce.md
+++ b/articles/api-auth/tutorials/authorization-code-grant-pkce.md
@@ -96,10 +96,11 @@ var challenge = base64URLEncode(sha256(verifier));</code></pre>
     <div id="challenge-java" class="tab-pane">
       <pre>
 <code class="java hljs">byte[] bytes = verifier.getBytes("US-ASCII");
-MessageDigest md = MessageDigest.getInstance("SHA-256");
-md.update(bytes, 0, bytes.length);
-byte[] digest = md.digest();
-String challenge = Base64.encodeToString(digest, Base64.URL_SAFE | Base64.NO_WRAP | Base64.NO_PADDING);</code></pre>
+  MessageDigest md = MessageDigest.getInstance("SHA-256");
+  md.update(bytes, 0, bytes.length);
+  byte[] digest = md.digest();
+  Base64.Encoder encoder = Base64.getUrlEncoder().withoutPadding();
+  String challenge = encoder.encodeToString(digest);</code></pre>
     </div>
     <div id="challenge-swift" class="tab-pane">
       <pre>


### PR DESCRIPTION
The JAVA code that is used in the document is not actually JAVA but android code.  Base64.URL_SAFE | Base64.NO_WRAP | Base64.NO_PADDING is not standard Java code.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
