### PR TITLE
Update auth0.js github repo URL

### DIFF
--- a/articles/libraries/auth0js/v8/index.md
+++ b/articles/libraries/auth0js/v8/index.md
@@ -8,7 +8,7 @@ description: How to install, initialize and use auth0.js v8
 Auth0.js is a client-side library for Auth0. Using auth0.js in your web apps makes it easier to do authentication and authorization with Auth0 in your web apps.
 
 ::: note
-Check out the [Auth0.js repository](https://github.com/auth0/auth0.js) on GitHub.
+Check out the [Auth0.js repository](https://github.com/auth0/auth0.js/tree/v8) on GitHub.
 :::
 
 ## Ready-to-go example


### PR DESCRIPTION
v9 beta has been released so `master` now points there. I updated the v8 note to point to [auth0.js v8 branch](https://github.com/auth0/auth0.js/tree/v8)