### PR TITLE
Remove reference to access token

### DIFF
--- a/articles/integrations/aws-api-gateway/custom-authorizers/part-4.md
+++ b/articles/integrations/aws-api-gateway/custom-authorizers/part-4.md
@@ -47,7 +47,7 @@ You can test your deployment by making a `GET` call to the **Invoke URL** you co
 ```har
 {
     "method": "GET",
-    "url": "https://YOUR_INVOKE_URL/pets",
+    "url": "https://YOUR_INVOKE_URL/pets"
 }
 ```
 

--- a/articles/integrations/aws-api-gateway/custom-authorizers/part-4.md
+++ b/articles/integrations/aws-api-gateway/custom-authorizers/part-4.md
@@ -48,10 +48,6 @@ You can test your deployment by making a `GET` call to the **Invoke URL** you co
 {
     "method": "GET",
     "url": "https://YOUR_INVOKE_URL/pets",
-    "headers": [{
-        "name": "Authorization",
-        "value": "Bearer TOKEN"
-    }]
 }
 ```
 


### PR DESCRIPTION
Remove inclusion of access token in GET snippet.

https://trello.com/c/PpCdE8DL

https://auth0-docs-content-pr-5412.herokuapp.com/docs/integrations/aws-api-gateway/custom-authorizers/part-4