### PR TITLE
Fix syntax error in 01-authorization.md

### DIFF
--- a/articles/quickstart/backend/ruby/01-authorization.md
+++ b/articles/quickstart/backend/ruby/01-authorization.md
@@ -45,10 +45,10 @@ class JsonWebToken
     JWT.decode(token, nil,
                true, # Verify the signature of this token
                algorithm: 'RS256',
-               iss: 'https://${account.namespace}/'
+               iss: 'https://${account.namespace}/',
                verify_iss: true,
                # auth0_api_audience is the identifier for the API set up in the Auth0 dashboard
-               aud: auth0_api_audience
+               aud: auth0_api_audience,
                verify_aud: true) do |header|
       jwks_hash[header['kid']]
     end


### PR DESCRIPTION
It was missing some commas in a hash definition! Fixed now 💪 

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
