### PR TITLE
Rate limiting is now on by default for Appliance

### DIFF
--- a/articles/policies/rate-limits.md
+++ b/articles/policies/rate-limits.md
@@ -75,7 +75,7 @@ The following rate limits apply:
 
 The aforementioned rate limits include calls made via [Rules](/rules).
 
-Note, that the limit is set by tenant and not by endpoint, and that it does not apply to [Private Instance deployments](/appliance).
+Note, that the limit is set by tenant and not by endpoint.
 
 The following Auth0 Management API endpoints return rate limit-related headers. For additional information about these endpoints, please consult the [Management API explorer](/api/management/v2).
 


### PR DESCRIPTION
See PR https://github.com/auth0/auth0-start/commit/70f3b2fa1dfed1c3ffc9ee10a1d7f94ec2dcd266

This was updated a long time ago but the docs were never updated.

