### PR TITLE
Prepare custom authorization > wrong audience info

### DIFF
--- a/articles/integrations/aws-api-gateway/custom-authorizers/part-3.md
+++ b/articles/integrations/aws-api-gateway/custom-authorizers/part-3.md
@@ -28,13 +28,13 @@ You can [download a sample custom authorizer](https://github.com/auth0-samples/j
 | - | - |
 | **`TOKEN_ISSUER`** | The issuer of the token. If Auth0 is the token issuer, use `https://${account.namespace}` |
 | **`JWKS_URI`** | The URL of the JWKS endpoint. If Auth0 is the token issuer, use `https://${account.namespace}/.well-known/jwks.json` |
-| **`AUDIENCE`** | The ID of the Auth0 client you're using with this integration. See [Client Settings](/clients/client-settings) for information on finding your Client ID |
+| **`AUDIENCE`** | The audience value is the same thing as your API Identifier for the specific API in your APIs section. |
 
 As an example, the text of your .env file should look something like this when complete:
 
 ```text
 JWKS_URI=https://${account.namespace}/.well-known/jwks.json
-AUDIENCE=hVG7...3QA1q
+AUDIENCE=http://myApiIdentifier
 TOKEN_ISSUER=https://${account.namespace}/
 ```
 


### PR DESCRIPTION
Says to use Client ID, should be api identifier instead
This is correctly explained on the readme.md from the github linked previously on the same page

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
