### PR TITLE
Auth0.Android - creation of subpages to better organize content

### DIFF
--- a/articles/libraries/auth0-android/configuration.md
+++ b/articles/libraries/auth0-android/configuration.md
@@ -5,6 +5,8 @@ description: How to configure Auth0.Android to meet your application's needs
 ---
 # Auth0.Android Configuration Options
 
+Auth0.Android can be configured with a variety of options, listed below.
+
 ## withConnection
 
 The `withConnection` option allows you to specify a connection that you wish to authenticate with.

--- a/articles/libraries/auth0-android/configuration.md
+++ b/articles/libraries/auth0-android/configuration.md
@@ -1,12 +1,11 @@
-```java
-WebAuthProvider.init(account)
-                .withAudience("https://${account.namespace}/userinfo")
-                .start(this, authCallback);
-```
+---
+section: libraries
+toc: true
+description: How to configure Auth0.Android to meet your application's needs
+---
+# Auth0.Android Configuration Options
 
-The authentication result will be delivered to the callback.
-
-### Authenticate with a specific Auth0 connection
+## withConnection
 
 The `withConnection` option allows you to specify a connection that you wish to authenticate with.
 
@@ -16,11 +15,11 @@ WebAuthProvider.init(account)
                 .start(this, authCallback);
 ```
 
-### Authenticate using a code grant with PKCE
+## useCodeGrant
 
 Code grant is the default mode, and will always be used unless calling `useCodeGrant` with `false`, or unless the device doesn't support the signing/hashing algorithms.
 
-Before you can use `Code Grant` in Android, make sure to go to your [client's section](${manage_url}/#/applications) in dashboard and check in the Settings that `Client Type` is `Native`.
+Before you can use `Code Grant` in Android, make sure to go to your [Dashboard](${manage_url}/#/clients) and check in the client's settings that `Client Type` is `Native`.
 
 ```java
 WebAuthProvider.init(account)
@@ -28,7 +27,7 @@ WebAuthProvider.init(account)
                 .start(this, authCallback);
 ```
 
-### Authenticate using a specific scope
+## withScope
 
 Using scopes can allow you to return specific claims for specific fields in your request. Adding parameters to `withScope` will allow you to add more scopes. You should read our [documentation on scopes](/scopes) for further details about them.
 
@@ -42,9 +41,9 @@ WebAuthProvider.init(account)
 Note that the default scope used is `openid`
 :::
 
-### Authenticate using specific connection scopes
+## withConnectionScope
 
-There may be times when you need to authenticate with particular connection scopes, or permissions, from the Authentication Provider in question. Auth0 has [documentation on setting up connection scopes for external Authentication Providers](/tutorials/adding-scopes-for-an-external-idp), but if you need specific access for a particular situation in your app, you can do so by passing parameters to `withConnectionScope`. A full listing of available parameters can be found in that connection's settings in your dashboard, or from the Authentication Providers's documentation. The scope requested here is added on top of the ones specified in the Dashboard's Connection settings.
+There may be times when you need to authenticate with particular connection scopes, or permissions, from the Authentication Provider in question. Auth0 has [documentation on setting up connection scopes for external Authentication Providers](/tutorials/adding-scopes-for-an-external-idp). However, if you need specific access for a particular situation in your app you can do so by passing parameters to `withConnectionScope`. A full listing of available parameters can be found in that connection's settings in your [Dashboard](${manage_url}), or from the Authentication Providers's documentation. The scope requested here is added on top of the ones specified in the connection's settings in the Dashboard.
 
 ```java
 WebAuthProvider.init(account)
@@ -52,7 +51,7 @@ WebAuthProvider.init(account)
                 .start(this, authCallback);
 ```
 
-### Authenticate using custom authentication parameters
+## withParameters
 
 To send additional parameters on the authentication, use `withParameters`:
 
@@ -64,9 +63,9 @@ WebAuthProvider.init(account)
                 .start(this, authCallback);
 ```
 
-### Use a custom scheme for the Redirect URI
+## withScheme
 
-If you're not using Android "App Links" or you just want to use a different scheme for the _redirect uri_ then use `withScheme`. Note that you'll need to update the `auth0Scheme` Manifest Placeholder in the `app/build.gradle` file and the whitelisted Callback URL in the dashboard to match the chosen scheme:
+If you are not using Android "App Links" or you want to use a different scheme for the redirect URI, then use `withScheme`. Note that you'll need to update the `auth0Scheme` Manifest Placeholder in the `app/build.gradle` file and the whitelisted **Allowed Callback URLs** on the [Dashboard](${manage_url}) in the Client's settings to match the chosen scheme.
 
 ```java
 WebAuthProvider.init(account)
@@ -74,9 +73,13 @@ WebAuthProvider.init(account)
                 .start(this, authCallback);
 ```
 
-**Scheme must be lowercase**
+::: note
+Scheme must be lowercase!
+:::
 
-### Specify Audience
+## withAudience
+
+To provide an audience, use `withAudience`.
 
 ```java
 WebAuthProvider.init(account)
@@ -85,9 +88,9 @@ WebAuthProvider.init(account)
                 .start(this, authCallback);
 ```
 
-### Specify state
+## withState
 
-By default a random state is always sent. If you need to use a custom one, use `withState`:
+By default a random [state](/protocols/oauth2/oauth-state) is always generated and sent. If you need to use a custom value instead, use `withState`:
 
 ```java
 WebAuthProvider.init(account)
@@ -95,9 +98,9 @@ WebAuthProvider.init(account)
                 .start(this, authCallback);
 ```
 
-### Specify nonce
+## withNonce
 
-By default a random nonce is sent when the response type includes `id_token`. If you need to use a custom one, use `withNonce`:
+By default a random [nonce](/api-auth/tutorials/nonce) is generated and sent when the response type includes `id_token`. If you need to use a custom value instead, use `withNonce`:
 
 ```java
 WebAuthProvider.init(account)

--- a/articles/libraries/auth0-android/configuration.md
+++ b/articles/libraries/auth0-android/configuration.md
@@ -1,0 +1,106 @@
+```java
+WebAuthProvider.init(account)
+                .withAudience("https://${account.namespace}/userinfo")
+                .start(this, authCallback);
+```
+
+The authentication result will be delivered to the callback.
+
+### Authenticate with a specific Auth0 connection
+
+The `withConnection` option allows you to specify a connection that you wish to authenticate with.
+
+```java
+WebAuthProvider.init(account)
+                .withConnection("twitter")
+                .start(this, authCallback);
+```
+
+### Authenticate using a code grant with PKCE
+
+Code grant is the default mode, and will always be used unless calling `useCodeGrant` with `false`, or unless the device doesn't support the signing/hashing algorithms.
+
+Before you can use `Code Grant` in Android, make sure to go to your [client's section](${manage_url}/#/applications) in dashboard and check in the Settings that `Client Type` is `Native`.
+
+```java
+WebAuthProvider.init(account)
+                .useCodeGrant(true)
+                .start(this, authCallback);
+```
+
+### Authenticate using a specific scope
+
+Using scopes can allow you to return specific claims for specific fields in your request. Adding parameters to `withScope` will allow you to add more scopes. You should read our [documentation on scopes](/scopes) for further details about them.
+
+```java
+WebAuthProvider.init(account)
+                .withScope("openid email profile")
+                .start(this, authCallback);
+```
+
+::: panel Scope
+Note that the default scope used is `openid`
+:::
+
+### Authenticate using specific connection scopes
+
+There may be times when you need to authenticate with particular connection scopes, or permissions, from the Authentication Provider in question. Auth0 has [documentation on setting up connection scopes for external Authentication Providers](/tutorials/adding-scopes-for-an-external-idp), but if you need specific access for a particular situation in your app, you can do so by passing parameters to `withConnectionScope`. A full listing of available parameters can be found in that connection's settings in your dashboard, or from the Authentication Providers's documentation. The scope requested here is added on top of the ones specified in the Dashboard's Connection settings.
+
+```java
+WebAuthProvider.init(account)
+                .withConnectionScope("email", "profile", "calendar:read")
+                .start(this, authCallback);
+```
+
+### Authenticate using custom authentication parameters
+
+To send additional parameters on the authentication, use `withParameters`:
+
+```java
+Map<String, Object> parameters = new HashMap<>();
+//Add entries
+WebAuthProvider.init(account)
+                .withParameters(parameters)
+                .start(this, authCallback);
+```
+
+### Use a custom scheme for the Redirect URI
+
+If you're not using Android "App Links" or you just want to use a different scheme for the _redirect uri_ then use `withScheme`. Note that you'll need to update the `auth0Scheme` Manifest Placeholder in the `app/build.gradle` file and the whitelisted Callback URL in the dashboard to match the chosen scheme:
+
+```java
+WebAuthProvider.init(account)
+                .withScheme("myapp")
+                .start(this, authCallback);
+```
+
+**Scheme must be lowercase**
+
+### Specify Audience
+
+```java
+WebAuthProvider.init(account)
+                .withScope("openid")
+                .withAudience("https://${account.namespace}/userinfo")
+                .start(this, authCallback);
+```
+
+### Specify state
+
+By default a random state is always sent. If you need to use a custom one, use `withState`:
+
+```java
+WebAuthProvider.init(account)
+                .withState("my-custom-state")
+                .start(this, authCallback);
+```
+
+### Specify nonce
+
+By default a random nonce is sent when the response type includes `id_token`. If you need to use a custom one, use `withNonce`:
+
+```java
+WebAuthProvider.init(account)
+                .withNonce("my-custom-nonce")
+                .start(this, authCallback);
+```

--- a/articles/libraries/auth0-android/database-authentication.md
+++ b/articles/libraries/auth0-android/database-authentication.md
@@ -5,13 +5,15 @@ description: How to use Auth0.Android with database connections
 ---
 # Auth0.Android Database Authentication
 
-## Login with a database connection
-
 ::: panel-warning Database authentication on Native Platforms
 Username/Email & Password authentication from native clients is disabled by default for new tenants as of 8 June 2017. Users are encouraged to use the [Hosted Login Page](/hosted-pages/login) and perform Web Authentication instead. If you still want to proceed you'll need to enable the Password Grant Type on your dashboard first. See [Client Grant Types](/clients/client-grant-types) for more information.
 :::
 
-Logging in with a database connection requires calling `login` with the user's **email**, **password**, and the **connection** you wish to authenticate with. The response will be a Credentials object. Additionally, specifying the **audience** will yield an OIDC conformant response during authentication.
+## Log in with a database connection
+
+To log in with a database connection, call `login` with the user's **email**, **password**, and the **connection** you wish to authenticate with. The response will be a Credentials object. 
+
+Additionally, specifying the **audience** will yield an OIDC conformant response during authentication.
 
 ```java
 authentication
@@ -30,13 +32,13 @@ authentication
     });
 ```
 
-::: panel Scope
-Note that the default scope used is `openid`
+::: note
+The default scope used is `openid`.
 :::
 
 ## Sign up with database connection
 
-Signing up with a database connection is similarly easy. Call the `signUp` method, passing the user's email, password, and connection name, to initiate the signup process.
+To sign up with a database connection you have to call the `signUp` method, passing the user's email, password, and connection name.
 
 ```java
 authentication

--- a/articles/libraries/auth0-android/database-authentication.md
+++ b/articles/libraries/auth0-android/database-authentication.md
@@ -1,0 +1,56 @@
+---
+section: libraries
+toc: true
+description: How to use Auth0.Android with database connections
+---
+# Auth0.Android Database Authentication
+
+## Login with a database connection
+
+::: panel-warning Database authentication on Native Platforms
+Username/Email & Password authentication from native clients is disabled by default for new tenants as of 8 June 2017. Users are encouraged to use the [Hosted Login Page](/hosted-pages/login) and perform Web Authentication instead. If you still want to proceed you'll need to enable the Password Grant Type on your dashboard first. See [Client Grant Types](/clients/client-grant-types) for more information.
+:::
+
+Logging in with a database connection requires calling `login` with the user's **email**, **password**, and the **connection** you wish to authenticate with. The response will be a Credentials object. Additionally, specifying the **audience** will yield an OIDC conformant response during authentication.
+
+```java
+authentication
+    .login("info@auth0.com", "a secret password", "my-database-connection")
+    .setAudience("https://${account.namespace}/userinfo")
+    .start(new BaseCallback<Credentials, AuthenticationException>() {
+        @Override
+        public void onSuccess(Credentials payload) {
+            //Logged in!
+        }
+
+        @Override
+        public void onFailure(AuthenticationException error) {
+            //Error!
+        }
+    });
+```
+
+::: panel Scope
+Note that the default scope used is `openid`
+:::
+
+## Sign up with database connection
+
+Signing up with a database connection is similarly easy. Call the `signUp` method, passing the user's email, password, and connection name, to initiate the signup process.
+
+```java
+authentication
+    .signUp("info@auth0.com", "a secret password", "my-database-connection")
+    .setAudience("https://${account.namespace}/userinfo")
+    .start(new BaseCallback<Credentials, AuthenticationException>() {
+        @Override
+        public void onSuccess(Credentials payload) {
+            //Signed Up & Logged in!
+        }
+
+        @Override
+        public void onFailure(AuthenticationException error) {
+            //Error!
+        }
+    });
+```

--- a/articles/libraries/auth0-android/index.md
+++ b/articles/libraries/auth0-android/index.md
@@ -4,7 +4,6 @@ toc: true
 description: How to install, initialize and use Auth0.Android
 url: /libraries/auth0-android
 ---
-
 # Auth0.Android
 
 Auth0.Android is a client-side library you can use with your Android app to authenticate users and access [Auth0 APIs](/api/info).
@@ -73,7 +72,7 @@ Auth0 account = new Auth0(context);
 
 ## OIDC Conformant Mode
 
-It is strongly encouraged that this SDK be used in [OIDC Conformant mode](/api-auth/intro). When this mode is enabled, it will force the SDK to use Auth0's current authentication pipeline and will prevent it from reaching legacy endpoints. By default is `false`.
+It is strongly encouraged that this SDK be used in [OIDC Conformant mode](/api-auth/intro). When this mode is enabled, it will force the SDK to use Auth0's current authentication methods and will prevent it from reaching legacy endpoints. By default is `false`.
 
 ```java
 Auth0 account = new Auth0("${account.clientId}", "${account.namespace}");
@@ -86,7 +85,7 @@ Passwordless authentication *cannot be used* with this flag set to `true`. For m
 
 ## Authentication with Auth0 Hosted Login Page
 
-First go to [Auth0 Dashboard](${manage_url}/#/clients) and go to your client's settings. Make sure you have in *Allowed Callback URLs* a URL with the following format:
+First go to the [Dashboard](${manage_url}/#/clients) and go to your client's settings. Make sure you have in **Allowed Callback URLs** a URL with the following format:
 
 ```
 https://${account.namespace}/android/{YOUR_APP_PACKAGE_NAME}/callback
@@ -171,116 +170,10 @@ The authentication result will be delivered to the callback.
 
 ## Using the Authentication API
 
-The Authentication Client provides methods to authenticate the user against Auth0 server. Create a new instance by passing in the Auth0 object created in the previous step.
+The Authentication Client provides methods to accomplish authentication and related tasks. Create a new instance by passing in the Auth0 object created in the previous step.
 
 ```java
 AuthenticationAPIClient authentication = new AuthenticationAPIClient(account);
-```
-
-To ensure an Open ID Connect compliant response you must either request an `audience` or enable the **OIDC Conformant** switch in your Auth0 dashboard under `Client / Settings / Advanced OAuth`. You can read more about this [here](https://auth0.com/docs/api-auth/intro#how-to-use-the-new-flows).
-
-### Login with database connection
-
-::: panel-warning Database authentication on Native Platforms
-Username/Email & Password authentication from native clients is disabled by default for new tenants as of 8 June 2017. Users are encouraged to use the [Hosted Login Page](/hosted-pages/login) and perform Web Authentication instead. If you still want to proceed you'll need to enable the Password Grant Type on your dashboard first. See [Client Grant Types](/clients/client-grant-types) for more information.
-:::
-
-Logging in with a database connection requires calling `login` with the user's *email*, *password*, and the *connection* you wish to authenticate with. The response will be a Credentials object. By specifying the *audience* an Open ID Connect compliant response will be yielded during authentication.
-
-```java
-authentication
-    .login("info@auth0.com", "a secret password", "my-database-connection")
-    .setAudience("https://${account.namespace}/userinfo")
-    .start(new BaseCallback<Credentials, AuthenticationException>() {
-        @Override
-        public void onSuccess(Credentials payload) {
-            //Logged in!
-        }
-
-        @Override
-        public void onFailure(AuthenticationException error) {
-            //Error!
-        }
-    });
-```
-
-::: panel Scope
-Note that the default scope used is `openid`
-:::
-
-### Passwordless login
-
-::: panel-warning Passwordless on Native Platforms
-Passwordless on native platforms is disabled by default for new tenants as of 8 June 2017. If you would like this feature enabled, please contact support to discuss your use case. See [Client Grant Types](/clients/client-grant-types) for more information.
-
-Alternatively, you can use Lock Passwordless on Auth0's [Hosted Login Page](/hosted-pages/login).
-:::
-
-Logging in with a Passwordless is slightly different. Passwordless can be done via email or via SMS, and either by sending the user a code, or sending them a link which contains a code. All of these methods of Passwordless authentication will require two steps - requesting the code, and then inputting the code for verification. Note that Passwordless authentication *cannot be used* with the [OIDC Conformant Mode](/oidc-conformant-mode) enabled.
-
-**Step 1:** Request the code
-
-In this example, requesting the code is done by calling `passwordlessWithEmail` with the user's email, `PasswordlessType.CODE`, and the name of the connection as parameters. On success, you'll probably display a notice to the user that their code is on the way, and perhaps route them to a view to input that code.
-
-```java
-authentication
-    .passwordlessWithEmail("info@auth0.com", PasswordlessType.CODE, "my-passwordless-connection")
-    .start(new BaseCallback<Void, AuthenticationException>() {
-        @Override
-        public void onSuccess(Void payload) {
-            //Code sent!
-        }
-
-        @Override
-        public void onFailure(AuthenticationException error) {
-            //Error!
-        }
-    });
-```
-
-**Step 2:** Input the code
-
-Once the user has a code, they can input it. Call the `loginWithEmail` method, and pass in the user's email, the code they received, and the name of the connection in question. Upon success, you will receive a Credentials object in the response.
-
-```java
-authentication
-    .loginWithEmail("info@auth0.com", "123456", "my-passwordless-connection")
-    .start(new BaseCallback<Credentials, AuthenticationException>() {
-        @Override
-        public void onSuccess(Credentials payload) {
-            //Logged in!
-        }
-
-        @Override
-        public void onFailure(AuthenticationException error) {
-            //Error!
-        }
-    });
-```
-
-::: note
-Note that the default scope used is `openid`.
-:::
-
-### Sign up with database connection
-
-Signing up with a database connection is similarly easy. Call the `signUp` method passing the user's given email, chosen password, and the connection name to initiate the signup process.
-
-```java
-authentication
-    .signUp("info@auth0.com", "a secret password", "my-database-connection")
-    .setAudience("https://${account.namespace}/userinfo")
-    .start(new BaseCallback<Credentials, AuthenticationException>() {
-        @Override
-        public void onSuccess(Credentials payload) {
-            //Signed Up & Logged in!
-        }
-
-        @Override
-        public void onFailure(AuthenticationException error) {
-            //Error!
-        }
-    });
 ```
 
 ### Get user information
@@ -327,84 +220,3 @@ authentication
 ::: note
 Password reset requests will fail on network related errors, but will not fail if the designated email does not exist in the database (for security reasons).
 :::
-
-## Using the Management API
-
-The Management API provides functionality that allows you to link and unlink separate user accounts from different providers, tying them to a single profile (Read more about [Linking Accounts](/link-accounts) with Auth0). It also allows you to update user metadata.
-
-To get started, create a new `UsersAPIClient` instance by passing it the `account` and the token for the primary identity. In the case of linking users, this primary identity is the user profile that you want to "keep" the data for, and which you plan to link other identities to.
-
-```java
-Auth0 account = new Auth0("${account.clientId}", "${account.namespace}");
-UsersAPIClient users = new UsersAPIClient(account, "token");
-```
-
-### Linking users
-
-Linking user accounts will allow a user to authenticate from any of their accounts and no matter which one they use, still pull up the same profile upon login. Auth0 treats all of these accounts as separate profiles by default, so if you wish a user's accounts to be linked, this is the way to go.
-
-The `link` method accepts two parameters, the primary user id and the secondary user token (the token obtained after login with this identity). The user id in question is the unique identifier for this user account. If the id is in the format `facebook|1234567890`, the id required is the portion after the delimiting pipe.
-
-```java
-users
-    .link("primary user id", "secondary user token")
-    .start(new BaseCallback<List<UserIdentity>, ManagementException>() {
-        @Override
-        public void onSuccess(List<UserIdentity> payload) {
-            //Got the updated identities! Accounts linked.
-        }
-
-        @Override
-        public void onFailure(ManagementException error) {
-            //Error!
-        }
-    });
-```
-
-### Unlinking users
-
-Unlinking users is a similar process to the linking of users. The `unlink` method takes three parameters, though: the primary user id, the secondary user id, and the secondary provider (of the secondary user).
-
-```java
-users
-    .unlink("primary user id", "secondary user id", "secondary provider")
-    .start(new BaseCallback<List<UserIdentity>, ManagementException>() {
-        @Override
-        public void onSuccess(List<UserIdentity> payload) {
-            //Got the updated identities! Accounts linked.
-        }
-
-        @Override
-        public void onFailure(ManagementException error) {
-            //Error!
-        }
-    });
-```
-
-::: note
-When accounts are linked, the secondary account's metadata is **not** merged with the primary account's metadata. Similarly, when unlinking two accounts, the secondary account does not retain the primary account's metadata when it becomes separate again.
-:::
-
-### Updating user metadata
-
-When updating user metadata, you will create a `metadata` object, and then call the `updateMetadata` method, passing it the user id and the `metadata` object. The values in this object will overwrite existing values with the same key, or add new ones for those that don't yet exist in the user metadata.
-
-```java
-Map<String, Object> metadata = new HashMap<>();
-metadata.put("name", Arrays.asList("My", "Name", "Is"));
-metadata.put("phoneNumber", "1234567890");
-
-users
-    .updateMetadata("user id", metadata)
-    .start(new BaseCallback<UserProfile, ManagementException>() {
-        @Override
-        public void onSuccess(UserProfile payload) {
-            //Metadata updated
-        }
-
-        @Override
-        public void onFailure(ManagementException error) {
-            //Error!
-        }
-    });
-```

--- a/articles/libraries/auth0-android/index.md
+++ b/articles/libraries/auth0-android/index.md
@@ -211,7 +211,6 @@ authentication
 Password reset requests will fail on network related errors, but will not fail if the designated email does not exist in the database (for security reasons).
 :::
 
-
 ## Next Steps
 
 Take a look at the following resources to see how the Auth0.Android SDK can be customized for your needs:

--- a/articles/libraries/auth0-android/index.md
+++ b/articles/libraries/auth0-android/index.md
@@ -42,19 +42,7 @@ Open your app's `AndroidManifest.xml` file and add the following permission.
 
 ## Initialize Auth0
 
-You can set up your Auth0 credentials and initiate Auth0 in one of two ways:
-
-### 1) Client information in-line
-
-Method one is to simply create an instance of `Auth0` with your client information.
-
-```java
-Auth0 account = new Auth0("${account.clientId}", "${account.namespace}");
-```
-
-### 2) Client information read from XML
-
-Method two is to save your client information in the `strings.xml` file using the following names:
+Save your client information in the `strings.xml` file using the following names:
 
 ```xml
 <resources>
@@ -85,7 +73,7 @@ Passwordless authentication *cannot be used* with this flag set to `true`. For m
 
 ## Authentication with Auth0 Hosted Login Page
 
-First go to the [Dashboard](${manage_url}/#/clients) and go to your client's settings. Make sure you have in **Allowed Callback URLs** a URL with the following format:
+The recommended and default way to authenticate your users is via the [Hosted Login Page](/hosted-pages/login). To begin, go to the [Dashboard](${manage_url}/#/clients) and go to your client's settings. Make sure you have in **Allowed Callback URLs** a URL with the following format:
 
 ```
 https://${account.namespace}/android/{YOUR_APP_PACKAGE_NAME}/callback
@@ -116,7 +104,9 @@ android {
 }
 ```
 
-It's a good practice to define reusable resources like `@string/com_auth0_domain` but you can also hard code the value to `${account.namespace}` in the file.
+::: note
+It's a good practice to define reusable resources like `@string/com_auth0_domain` (as done in a previous step with `strings.xml`) rather than just hard-coding them.
+:::
 
 Alternatively, you can declare the `RedirectActivity` in the `AndroidManifest.xml` file with your own **intent-filter** so it overrides the library's default. If you do this then the Manifest Placeholders don't need to be set as long as the activity declaration contains the `tools:node="replace"` attribute:
 

--- a/articles/libraries/auth0-android/index.md
+++ b/articles/libraries/auth0-android/index.md
@@ -73,7 +73,7 @@ Passwordless authentication *cannot be used* with this flag set to `true`. For m
 
 ## Authentication with Auth0 Hosted Login Page
 
-The recommended and default way to authenticate your users is via the [Hosted Login Page](/hosted-pages/login). To begin, go to the [Dashboard](${manage_url}/#/clients) and go to your client's settings. Make sure you have in **Allowed Callback URLs** a URL with the following format:
+The recommended way to authenticate your users is via the [Hosted Login Page](/hosted-pages/login). To begin, go to the [Dashboard](${manage_url}/#/clients) and go to your client's settings. Make sure you have in **Allowed Callback URLs** a URL with the following format:
 
 ```
 https://${account.namespace}/android/{YOUR_APP_PACKAGE_NAME}/callback

--- a/articles/libraries/auth0-android/index.md
+++ b/articles/libraries/auth0-android/index.md
@@ -210,3 +210,16 @@ authentication
 ::: note
 Password reset requests will fail on network related errors, but will not fail if the designated email does not exist in the database (for security reasons).
 :::
+
+
+## Next Steps
+
+Take a look at the following resources to see how the Auth0.Android SDK can be customized for your needs:
+
+::: next-steps
+* [Auth0.Android Configuration Options](/libraries/auth0-android/configuration)
+* [Auth0.Android Database Authentication](/libraries/auth0-android/database-authentication)
+* [Auth0.Android Passwordless Authentication](/libraries/auth0-android/passwordless)
+* [Auth0.Android Refresh Tokens](/libraries/auth0-android/save-and-refresh-tokens)
+* [Auth0.Android User Management](/libraries/auth0-android/user-management)
+:::

--- a/articles/libraries/auth0-android/index.md
+++ b/articles/libraries/auth0-android/index.md
@@ -84,7 +84,6 @@ account.setOIDCConformant(true);
 
 Passwordless authentication *cannot be used* with this flag set to `true`. For more information, please see the [OIDC adoption guide](https://auth0.com/docs/api-auth/tutorials/adoption).
 
-
 ## Authentication with Auth0 Hosted Login Page
 
 First go to [Auth0 Dashboard](${manage_url}/#/clients) and go to your client's settings. Make sure you have in *Allowed Callback URLs* a URL with the following format:
@@ -169,106 +168,6 @@ WebAuthProvider.init(account)
 ```
 
 The authentication result will be delivered to the callback.
-
-
-### Authenticate with a specific Auth0 connection
-
-The `withConnection` option allows you to specify a connection that you wish to authenticate with.
-
-```java
-WebAuthProvider.init(account)
-                .withConnection("twitter")
-                .start(this, authCallback);
-```
-
-### Authenticate using a code grant with PKCE
-
-Code grant is the default mode, and will always be used unless calling `useCodeGrant` with `false`, or unless the device doesn't support the signing/hashing algorithms.
-
-Before you can use `Code Grant` in Android, make sure to go to your [client's section](${manage_url}/#/applications) in dashboard and check in the Settings that `Client Type` is `Native`.
-
-```java
-WebAuthProvider.init(account)
-                .useCodeGrant(true)
-                .start(this, authCallback);
-```
-
-### Authenticate using a specific scope
-
-Using scopes can allow you to return specific claims for specific fields in your request. Adding parameters to `withScope` will allow you to add more scopes. You should read our [documentation on scopes](/scopes) for further details about them.
-
-```java
-WebAuthProvider.init(account)
-                .withScope("openid email profile")
-                .start(this, authCallback);
-```
-
-::: panel Scope
-Note that the default scope used is `openid`
-:::
-
-### Authenticate using specific connection scopes
-
-There may be times when you need to authenticate with particular connection scopes, or permissions, from the Authentication Provider in question. Auth0 has [documentation on setting up connection scopes for external Authentication Providers](/tutorials/adding-scopes-for-an-external-idp), but if you need specific access for a particular situation in your app, you can do so by passing parameters to `withConnectionScope`. A full listing of available parameters can be found in that connection's settings in your dashboard, or from the Authentication Providers's documentation. The scope requested here is added on top of the ones specified in the Dashboard's Connection settings.
-
-```java
-WebAuthProvider.init(account)
-                .withConnectionScope("email", "profile", "calendar:read")
-                .start(this, authCallback);
-```
-
-### Authenticate using custom authentication parameters
-
-To send additional parameters on the authentication, use `withParameters`:
-
-```java
-Map<String, Object> parameters = new HashMap<>();
-//Add entries
-WebAuthProvider.init(account)
-                .withParameters(parameters)
-                .start(this, authCallback);
-```
-
-### Use a custom scheme for the Redirect URI
-
-If you're not using Android "App Links" or you just want to use a different scheme for the _redirect uri_ then use `withScheme`. Note that you'll need to update the `auth0Scheme` Manifest Placeholder in the `app/build.gradle` file and the whitelisted Callback URL in the dashboard to match the chosen scheme:
-
-```java
-WebAuthProvider.init(account)
-                .withScheme("myapp")
-                .start(this, authCallback);
-```
-
-**Scheme must be lowercase**
-
-### Specify Audience
-
-```java
-WebAuthProvider.init(account)
-                .withScope("openid")
-                .withAudience("https://${account.namespace}/userinfo")
-                .start(this, authCallback);
-```
-
-### Specify state
-
-By default a random state is always sent. If you need to use a custom one, use `withState`:
-
-```java
-WebAuthProvider.init(account)
-                .withState("my-custom-state")
-                .start(this, authCallback);
-```
-
-### Specify nonce
-
-By default a random nonce is sent when the response type includes `id_token`. If you need to use a custom one, use `withNonce`:
-
-```java
-WebAuthProvider.init(account)
-                .withNonce("my-custom-nonce")
-                .start(this, authCallback);
-```
 
 ## Using the Authentication API
 

--- a/articles/libraries/auth0-android/passwordless.md
+++ b/articles/libraries/auth0-android/passwordless.md
@@ -13,7 +13,7 @@ Alternatively, you can use Lock Passwordless on Auth0's [Hosted Login Page](/hos
 
 Logging in with a Passwordless is slightly different. Passwordless can be done via email or via SMS, and either by sending the user a code, or sending them a link which contains a code. All of these methods of Passwordless authentication will require two steps - requesting the code, and then inputting the code for verification. Note that Passwordless authentication **cannot be used** with the [OIDC Conformant Mode](/oidc-conformant-mode) enabled.
 
-## Step 1 - Request the code
+## 1. Request the code
 
 In this example, requesting the code is done by calling `passwordlessWithEmail` with the user's email, `PasswordlessType.CODE`, and the name of the connection as parameters. On success, you may wish to display a notice to the user that their code is on the way, and perhaps route them to the view where they will input that code.
 
@@ -33,7 +33,7 @@ authentication
     });
 ```
 
-## Step 2 - Input the code
+## 2. Input the code
 
 Once the user has a code, they can input it. Call the `loginWithEmail` method, and pass in the user's email, the code they received, and the name of the connection in question. Upon success, you will receive a Credentials object in the response.
 

--- a/articles/libraries/auth0-android/passwordless.md
+++ b/articles/libraries/auth0-android/passwordless.md
@@ -13,7 +13,7 @@ Alternatively, you can use Lock Passwordless on Auth0's [Hosted Login Page](/hos
 
 Passwordless can be done via email or via SMS, and either by sending the user a code, or sending them a link which contains a code. All of these methods of Passwordless authentication will require two steps - requesting the code, and then inputting the code for verification. 
 
-Note that Passwordless authentication **cannot be used** with the [OIDC Conformant Mode](/oidc-conformant-mode) enabled.
+Note that Passwordless authentication **cannot be used** with the [OIDC Conformant Mode](/api-auth/intro) enabled.
 
 ## 1. Request the code
 

--- a/articles/libraries/auth0-android/passwordless.md
+++ b/articles/libraries/auth0-android/passwordless.md
@@ -1,0 +1,58 @@
+---
+section: libraries
+toc: true
+description: How to use Auth0.Android with passwordless connections
+---
+# Auth0.Android Passwordless Authentication
+
+::: panel-warning Passwordless on Native Platforms
+Passwordless on native platforms is disabled by default for new tenants as of 8 June 2017. If you would like this feature enabled, please contact support to discuss your use case. See [Client Grant Types](/clients/client-grant-types) for more information.
+
+Alternatively, you can use Lock Passwordless on Auth0's [Hosted Login Page](/hosted-pages/login).
+:::
+
+Logging in with a Passwordless is slightly different. Passwordless can be done via email or via SMS, and either by sending the user a code, or sending them a link which contains a code. All of these methods of Passwordless authentication will require two steps - requesting the code, and then inputting the code for verification. Note that Passwordless authentication **cannot be used** with the [OIDC Conformant Mode](/oidc-conformant-mode) enabled.
+
+## Step 1 - Request the code
+
+In this example, requesting the code is done by calling `passwordlessWithEmail` with the user's email, `PasswordlessType.CODE`, and the name of the connection as parameters. On success, you may wish to display a notice to the user that their code is on the way, and perhaps route them to the view where they will input that code.
+
+```java
+authentication
+    .passwordlessWithEmail("info@auth0.com", PasswordlessType.CODE, "my-passwordless-connection")
+    .start(new BaseCallback<Void, AuthenticationException>() {
+        @Override
+        public void onSuccess(Void payload) {
+            //Code sent!
+        }
+
+        @Override
+        public void onFailure(AuthenticationException error) {
+            //Error!
+        }
+    });
+```
+
+## Step 2 - Input the code
+
+Once the user has a code, they can input it. Call the `loginWithEmail` method, and pass in the user's email, the code they received, and the name of the connection in question. Upon success, you will receive a Credentials object in the response.
+
+```java
+authentication
+    .loginWithEmail("info@auth0.com", "123456", "my-passwordless-connection")
+    .start(new BaseCallback<Credentials, AuthenticationException>() {
+        @Override
+        public void onSuccess(Credentials payload) {
+            //Logged in!
+        }
+
+        @Override
+        public void onFailure(AuthenticationException error) {
+            //Error!
+        }
+    });
+```
+
+::: note
+Note that the default scope used is `openid`.
+:::

--- a/articles/libraries/auth0-android/passwordless.md
+++ b/articles/libraries/auth0-android/passwordless.md
@@ -11,7 +11,9 @@ Passwordless on native platforms is disabled by default for new tenants as of 8 
 Alternatively, you can use Lock Passwordless on Auth0's [Hosted Login Page](/hosted-pages/login).
 :::
 
-Logging in with a Passwordless is slightly different. Passwordless can be done via email or via SMS, and either by sending the user a code, or sending them a link which contains a code. All of these methods of Passwordless authentication will require two steps - requesting the code, and then inputting the code for verification. Note that Passwordless authentication **cannot be used** with the [OIDC Conformant Mode](/oidc-conformant-mode) enabled.
+Passwordless can be done via email or via SMS, and either by sending the user a code, or sending them a link which contains a code. All of these methods of Passwordless authentication will require two steps - requesting the code, and then inputting the code for verification. 
+
+Note that Passwordless authentication **cannot be used** with the [OIDC Conformant Mode](/oidc-conformant-mode) enabled.
 
 ## 1. Request the code
 
@@ -54,5 +56,5 @@ authentication
 ```
 
 ::: note
-Note that the default scope used is `openid`.
+The default scope used is `openid`.
 :::

--- a/articles/libraries/auth0-android/user-management.md
+++ b/articles/libraries/auth0-android/user-management.md
@@ -1,0 +1,91 @@
+---
+section: libraries
+toc: true
+description: How to use Auth0.Android to manage users
+---
+# Use Auth0.Android to Manage Users
+
+The Management API provides functionality that you can use to manage users of your application, including tasks such as the following.
+
+* Link separate user accounts from different providers, tying them to a single profile (Read more about [Linking Accounts](/link-accounts) with Auth0)
+* Unlink user accounts, returning them to separate identities
+* Update user [metadata](/metadata)
+
+## Initializing the API Client
+
+To get started, create a new `UsersAPIClient` instance by passing it the `account` and the token for the primary identity. In the case of linking users, this primary identity is the user profile that you want to "keep" the data for, and which you plan to link other identities to.
+
+```java
+Auth0 account = new Auth0("${account.clientId}", "${account.namespace}");
+UsersAPIClient users = new UsersAPIClient(account, "token");
+```
+
+## Linking users
+
+Linking user accounts will allow a user to authenticate from any of their accounts and no matter which one they use, still pull up the same profile upon login. Auth0 treats all of these accounts as separate profiles by default, so if you wish a user's accounts to be linked, this is the way to go.
+
+The `link` method accepts two parameters, the primary user id and the secondary user token (the token obtained after login with this identity). The user id in question is the unique identifier for this user account. If the id is in the format `facebook|1234567890`, the id required is the portion after the delimiting pipe.
+
+```java
+users
+    .link("primary user id", "secondary user token")
+    .start(new BaseCallback<List<UserIdentity>, ManagementException>() {
+        @Override
+        public void onSuccess(List<UserIdentity> payload) {
+            //Got the updated identities! Accounts linked.
+        }
+
+        @Override
+        public void onFailure(ManagementException error) {
+            //Error!
+        }
+    });
+```
+
+## Unlinking users
+
+Unlinking users is a similar process to the linking of users. The `unlink` method takes three parameters, though: the primary user id, the secondary user id, and the secondary provider (of the secondary user).
+
+```java
+users
+    .unlink("primary user id", "secondary user id", "secondary provider")
+    .start(new BaseCallback<List<UserIdentity>, ManagementException>() {
+        @Override
+        public void onSuccess(List<UserIdentity> payload) {
+            //Got the updated identities! Accounts linked.
+        }
+
+        @Override
+        public void onFailure(ManagementException error) {
+            //Error!
+        }
+    });
+```
+
+::: note
+When accounts are linked, the secondary account's metadata is **not** merged with the primary account's metadata. Similarly, when unlinking two accounts, the secondary account does not retain the primary account's metadata when it becomes separate again.
+:::
+
+## Updating user metadata
+
+When updating user metadata, you will create a `metadata` object, and then call the `updateMetadata` method, passing it the user id and the `metadata` object. The values in this object will overwrite existing values with the same key, or add new ones for those that don't yet exist in the user metadata.
+
+```java
+Map<String, Object> metadata = new HashMap<>();
+metadata.put("name", Arrays.asList("My", "Name", "Is"));
+metadata.put("phoneNumber", "1234567890");
+
+users
+    .updateMetadata("user id", metadata)
+    .start(new BaseCallback<UserProfile, ManagementException>() {
+        @Override
+        public void onSuccess(UserProfile payload) {
+            //Metadata updated
+        }
+
+        @Override
+        public void onFailure(ManagementException error) {
+            //Error!
+        }
+    });
+```

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -670,6 +670,18 @@ libraries:
       - title: "Overview"
         url: "/libraries/auth0-android"
 
+      - title: "Configuration"
+        url: "/libraries/auth0-android/configuration"
+
+      - title: "Database Authentication"
+        url: "/libraries/auth0-android/database-authentication"
+
+      - title: "User Management"
+        url: "/libraries/auth0-android/user-management"
+
+      - title: "Passwordless"
+        url: "/libraries/auth0-android/passwordless"
+
       - title: "Refresh Tokens"
         url: "/libraries/auth0-android/save-and-refresh-tokens"
 


### PR DESCRIPTION
Separating the singular auth0-android doc into separate sub-pages, to better organize the content and allow the user to follow what they're doing, rather than sifting through all of the possible methods and ideas.

Will be followed by similar work done to the Swift reference docs.

https://trello.com/c/2yloCrvn

https://auth0-docs-content-pr-5455.herokuapp.com/docs/libraries/auth0-android