### PR TITLE
Fix typo in Access Token docs

### DIFF
--- a/articles/tokens/access-token.md
+++ b/articles/tokens/access-token.md
@@ -9,7 +9,7 @@ toc: true
 
 The access token is a credential that can be used by a client to access an API. 
 
-It can be any type of token (such as an opaque string, or a JWT) and is meant for an API. It's purpose is to inform the API that the bearer of this token has been authorized to access the API and perform specific actions (as specified by the **scope** that has been granted). 
+It can be any type of token (such as an opaque string, or a JWT) and is meant for an API. Its purpose is to inform the API that the bearer of this token has been authorized to access the API and perform specific actions (as specified by the **scope** that has been granted). 
 
 The access token should be used as a **Bearer** credential and transmitted in an HTTP **Authorization** header to the API. 
 


### PR DESCRIPTION
It's (it is) to its.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
