### PR TITLE
Fix broken link

### DIFF
--- a/articles/integrations/azure-api-management/configure-auth0.md
+++ b/articles/integrations/azure-api-management/configure-auth0.md
@@ -15,7 +15,7 @@ To use Auth0 as an [OAuth 2.0 authorization server](/protocols/oauth2#oauth-role
 
 An API is an entity that represents an external resource that's capable of accepting and responding to requests made by clients. You'll need to create an [Auth0 API](/apis) using the Management Dashboard to represent the API managed by Azure's API Management Service that you want secured by Auth0.
 
-You'll also need a [Non Interactive Client](/client), which represents your application and allows use of Auth0 for authentication. When you create an API, Auth0 automatically creates an associated non interactive client by default.
+You'll also need a [Non Interactive Client](/clients#client-types), which represents your application and allows use of Auth0 for authentication. When you create an API, Auth0 automatically creates an associated non interactive client by default.
 
 To begin, you'll need to log into the Auth0 Management Dashboard. Go the [APIs](${manage_url}/#/apis) and click **Create API**.
 


### PR DESCRIPTION
<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
### Briefing

Link with text "Non interactive clients" was pointing to the non-existent path `/client`, it was changed to `/clients#client-types`, client types was added to be more specific to the section where the "Non interactive clients" definition is placed 🙂 

Blame on me, I didn't read the whole contributing guide, hope it's not necessary for this minor fix, sorry 🙏 