### PR TITLE
Removed mentions of COA setting and normalized spelling

### DIFF
--- a/articles/libraries/_includes/_configure_embedded_login.md
+++ b/articles/libraries/_includes/_configure_embedded_login.md
@@ -6,4 +6,4 @@ Add the domain to the **Allowed Web Origins** field. You can find this field in 
 
 ![Allowed Web Origins](/media/articles/libraries/lock/allowed-origins.png)
 
-If you enable [Custom Domain Names](/custom-domains) and the top level domain for your website is the same as the custom domain for the Auth0 tenant, Lock will work without any further configuration. Otherwise, you will need to configure your Auth0 client to use [Cross Origin Authentication](/cross-origin-authentication). 
+If you enable [Custom Domain Names](/custom-domains) and the top level domain for your website is the same as the custom domain for the Auth0 tenant, Lock will work without any further configuration. Otherwise, you will need to configure your Auth0 client to use [Cross-Origin Authentication](/cross-origin-authentication). 

--- a/articles/libraries/auth0js/v8/index.md
+++ b/articles/libraries/auth0js/v8/index.md
@@ -471,12 +471,7 @@ The user will then receive an email which will contain a link that they can foll
 
 ## Cross-Origin Authentication
 
-Using auth0.js within your application, rather than using the [Hosted Login Page](/hosted-pages/login), requires [cross-origin authentication](/cross-origin-authentication). In order to use embedded auth0.js via cross-origin authentication, you must do the following:
-
-* Set the [audience](/libraries/lock/v10/configuration#audience-string-) option
-* In the client settings area of the [Dashboard]($manage_url}), in the **Advanced Settings** menu, under the **OAuth** tab, turn on the **OIDC Conformant** and **Cross Origin Authentication** settings.
-
-    ![Cross-Origin Authentication switch](/media/articles/cross-origin-authentication/cross-origin-switch.png)
+Using auth0.js within your application, rather than using the [Hosted Login Page](/hosted-pages/login), requires [cross-origin authentication](/cross-origin-authentication). In order to use embedded auth0.js via cross-origin authentication you must go to the client settings area of the [Dashboard]($manage_url}). Under the **Advanced Settings** menu and the **OAuth** tab, turn on the **OIDC Conformant** setting if it is not already.
 
 ## User management
 

--- a/articles/libraries/auth0js/v8/index.md
+++ b/articles/libraries/auth0js/v8/index.md
@@ -471,7 +471,7 @@ The user will then receive an email which will contain a link that they can foll
 
 ## Cross-Origin Authentication
 
-Using auth0.js within your application, rather than using the [Hosted Login Page](/hosted-pages/login), requires [cross-origin authentication](/cross-origin-authentication). In order to use embedded auth0.js via cross-origin authentication you must go to the client settings area of the [Dashboard]($manage_url}). Under the **Advanced Settings** menu and the **OAuth** tab, turn on the **OIDC Conformant** setting if it is not already.
+Using auth0.js within your application (rather than using the [Hosted Login Page](/hosted-pages/login)) requires cross-origin authentication. Make sure you read the [cross-origin authentication documentation](/cross-origin-authentication) to understand how to properly configure your client to make it work.
 
 ## User management
 

--- a/articles/libraries/auth0js/v9/index.md
+++ b/articles/libraries/auth0js/v9/index.md
@@ -181,7 +181,7 @@ webAuth.login({
 
 ### webAuth.crossOriginVerification()
 
-The `crossOriginVerification()` method can be used to help provide cross origin authentication to customers who have third-party cookies disabled in their browsers. Further details about its usage can be read in the [cross-origin authentication](/cross-origin-authentication#create-a-cross-origin-fallback-page) document.
+The `crossOriginVerification()` method can be used to help provide cross-origin authentication to customers who have third-party cookies disabled in their browsers. Further details about its usage can be read in the [cross-origin authentication](/cross-origin-authentication#create-a-cross-origin-fallback-page) document.
 
 ### buildAuthorizeUrl(options)
 

--- a/articles/libraries/lock/v10/configuration.md
+++ b/articles/libraries/lock/v10/configuration.md
@@ -854,7 +854,7 @@ var options = {
 }
 ```
 
-Using OIDC Conformant mode in Lock necessitates a cross-origin authentication flow which makes use of third party cookies to process the authentication transaction securely. Ensure that **Cross-Origin Authentication** is enabled by switching it on in the [settings](${manage_url}/#/applications/${account.clientId}/settings) for your client in the Auth0 dashboard.
+Using OIDC Conformant mode in Lock necessitates a cross-origin authentication flow which makes use of third party cookies to process the authentication transaction securely.
 
 For more information, please see the [OIDC adoption guide](/api-auth/tutorials/adoption) and the [cross-origin authentication documentation](/cross-origin-authentication).
 

--- a/articles/libraries/lock/v10/index.md
+++ b/articles/libraries/lock/v10/index.md
@@ -120,10 +120,7 @@ document.getElementById('btn-login').addEventListener('click', function() {
 Embedding Lock within your application, rather than using the [Hosted Login Page](/hosted-pages/login), requires [cross-origin authentication](/cross-origin-authentication). In order to use embedded Lock via cross-origin authentication, you must do the following:
 
 * Set the [oidcconformant](/libraries/lock/v10/configuration#oidcconformant-boolean-) option to true
-* Set the [audience](/libraries/lock/v10/configuration#audience-string-) option
-* In the client settings area of the [Dashboard]($manage_url}), in the **Advanced Settings** menu, under the **OAuth** tab, turn on the **OIDC Conformant** and **Cross Origin Authentication** settings.
-
-    ![Cross-Origin Authentication switch](/media/articles/cross-origin-authentication/cross-origin-switch.png)
+* In the client settings area of the [Dashboard]($manage_url}), in the **Advanced Settings** menu, under the **OAuth** tab, turn on the **OIDC Conformant** setting.
 
 ## Browser Compatibility
 

--- a/articles/libraries/lock/v10/index.md
+++ b/articles/libraries/lock/v10/index.md
@@ -117,10 +117,7 @@ document.getElementById('btn-login').addEventListener('click', function() {
 
 ## Cross-Origin Authentication
 
-Embedding Lock within your application, rather than using the [Hosted Login Page](/hosted-pages/login), requires [cross-origin authentication](/cross-origin-authentication). In order to use embedded Lock via cross-origin authentication, you must do the following:
-
-* Set the [oidcconformant](/libraries/lock/v10/configuration#oidcconformant-boolean-) option to true
-* In the client settings area of the [Dashboard]($manage_url}), in the **Advanced Settings** menu, under the **OAuth** tab, turn on the **OIDC Conformant** setting.
+Embedding Lock within your application, rather than using the [Hosted Login Page](/hosted-pages/login), requires [cross-origin authentication](/cross-origin-authentication). In order to use embedded Lock v10 via cross-origin authentication, you must set the [oidcconformant](/libraries/lock/v10/configuration#oidcconformant-boolean-) option to `true`.
 
 ## Browser Compatibility
 

--- a/articles/logs/index.md
+++ b/articles/logs/index.md
@@ -63,7 +63,7 @@ The following table lists the codes associated with the appropriate log events.
 | `fc` | Failed by Connector | | [Active Directory/LDAP Connector](/connector) |
 | `fce` | Failed Change Email | Failed to change user email | [User Profile](/user-profile) |
 | `fco` | Failed by CORS | Origin is not in the Allowed Origins list for the specified client | [Clients](/clients#client-settings) |
-| `fcoa` | Failed cross origin authentication | | |
+| `fcoa` | Failed cross-origin authentication | | |
 | `fcp` | Failed Change Password | | [Changing a User's Password](/connections/database/password-change) |
 | `fcph` | Failed Post Change Password Hook | | |
 | `fcpn` | Failed Change Phone Number | | [User Profile](/user-profile) |


### PR DESCRIPTION
Removing mentions of COA setting that no longer exists. Also fixing a few instances of `cross origin` to say `cross-origin` so that the docs are normalized on one spelling.

Andres can you review Lock v10 and Auth0.js v8 usage of COA here and ensure that the changes are valid? I was thinking that setting the audience wasn't needed, but the OIDC Conformant toggle is (And the COA toggle doesn't exist).

Relevant Card:
* https://trello.com/c/0xxpucw9

Main pages altered:
* https://auth0-docs-content-pr-5512.herokuapp.com/docs/libraries/lock/v10#cross-origin-authentication
* https://auth0-docs-content-pr-5512.herokuapp.com/docs/libraries/lock/v10/configuration#oidcconformant-boolean-
* https://auth0-docs-content-pr-5512.herokuapp.com/docs/libraries/auth0js/v8#cross-origin-authentication