### PR TITLE
## 2. Secure the API endpoints - Code error

### DIFF
--- a/articles/architecture-scenarios/implementations/spa-api/api-implementation-nodejs.md
+++ b/articles/architecture-scenarios/implementations/spa-api/api-implementation-nodejs.md
@@ -146,7 +146,7 @@ app.use(jwt({
 // Enable the use of request body parsing middleware - code omitted
 
 // create timesheets API endpoint - code omitted
-app.post('/timesheets', checkJwt, function(req, res){
+app.post('/timesheets', function(req, res){
   var timesheet = req.body;
 
   // Save the timesheet to the database...


### PR DESCRIPTION
Line 149 has a call to checkJwt which doesn't exist in this example.
The middleware for checking the JWT has been added twice; in the call to 'app.use' (line 131) and in app.post to /timesheets (line 149). 
Personally I prefer the call to the middleware on each endpoint rather than the whole api. However I've just removed the call to the middleware on line 149 as I assume this example is supposed to protect the whole api regardless of the endpoint. 
Cheers, Dave

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
