### PR TITLE
Replacing the term 'centralized login' with 'universal login'

### DIFF
--- a/articles/_includes/_login_auth0_hosted_login_page.md
+++ b/articles/_includes/_login_auth0_hosted_login_page.md
@@ -1,1 +1,1 @@
-The [Auth0 hosted login page](/hosted-pages/login) is the easiest way to set up authentication in your application. 
+Auth0's [universal login](/hosted-pages/login) is the easiest way to set up authentication in your application. 

--- a/articles/api-auth/dynamic-client-registration.md
+++ b/articles/api-auth/dynamic-client-registration.md
@@ -100,7 +100,7 @@ Where:
 
 ### Update the login page
 
-If you use or would like to use an Auth0 [Hosted Login Page](/hosted-pages/login) with the Dynamic Client feature, you need to use at least version `10.7.x` of Lock, and set `__useTenantInfo: config.isThirdPartyClient` when instantiating Lock.
+If you use or would like to use an Auth0's [universal login](/hosted-pages/login) with the Dynamic Client feature, you need to use at least version `10.7.x` of Lock, and set `__useTenantInfo: config.isThirdPartyClient` when instantiating Lock.
 
 Sample script:
 

--- a/articles/api-auth/intro.md
+++ b/articles/api-auth/intro.md
@@ -82,7 +82,7 @@ To customize the tokens, use Hooks for Client Credentials, and Rules for the res
 
 ### Single Sign On (SSO)
 
-Initiating an SSO session must now happen __only__ from an Auth0-hosted page and not from client applications. This means that for SSO to work, you must be using [universal login](/hosted-pages/login). Users must be redirected to an Auth0-hosted login page and redirected to your application once authentication is complete.
+Initiating an SSO session must now happen __only__ from an Auth0-hosted page and not from client applications. This means that for SSO to work, you must be using [universal login](/hosted-pages/login). Users must be redirected to the login page and then redirected to your application once authentication is complete.
 
 ::: note
   Support for SSO from client applications is planned for a future release.
@@ -246,7 +246,7 @@ To use the `audience` param instead, configure your app to send it when initiati
     <tr>
       <th><strong>SSO</strong></th>
       <td>Supported</td>
-      <td>Not supported for Resource Owner grant. For the rest, the users must be redirected to an Auth0-hosted login page.</td>
+      <td>Not supported for Resource Owner grant. For the rest, universal login must be employed and users redirected to the login page.
     </tr>
     <tr>
       <th><strong>Access Token format</strong></th>

--- a/articles/api-auth/intro.md
+++ b/articles/api-auth/intro.md
@@ -82,7 +82,7 @@ To customize the tokens, use Hooks for Client Credentials, and Rules for the res
 
 ### Single Sign On (SSO)
 
-Initiating an SSO session must now happen __only__ from an Auth0-hosted page and not from client applications. This means that for SSO to work, users must be redirected to an Auth0-hosted login page and redirected to your application once authentication is complete.
+Initiating an SSO session must now happen __only__ from an Auth0-hosted page and not from client applications. This means that for SSO to work, you must be using [universal login](/hosted-pages/login). Users must be redirected to an Auth0-hosted login page and redirected to your application once authentication is complete.
 
 ::: note
   Support for SSO from client applications is planned for a future release.

--- a/articles/api-auth/passwordless.md
+++ b/articles/api-auth/passwordless.md
@@ -18,4 +18,4 @@ Without passwords, your application will not need to implement a password-reset 
 
 Auth0 currently only supports an [OIDC-conformant](/api-auth/tutorials/adoption) passwordless authentication mechanism when using web clients (with Lock.js or auth0.js).
 
-Native applications need to use centralized login (with Auth0-hosted login page). Customers can use the Lock (Passwordless) template in the [Dashboard](${manage_url}) under **Hosted Pages > Default Templates**, or customize it to fit specific requirements.
+Native applications need to use universal login (with Auth0-hosted login page). Customers can use the Lock (Passwordless) template in the [Dashboard](${manage_url}) under **Hosted Pages > Default Templates**, or customize it to fit specific requirements.

--- a/articles/api-auth/passwordless.md
+++ b/articles/api-auth/passwordless.md
@@ -16,6 +16,10 @@ Without passwords, your application will not need to implement a password-reset 
 
 ## OIDC Conformant Passwordless
 
+<<<<<<< HEAD
 Auth0 currently only supports an [OIDC-conformant](/api-auth/tutorials/adoption) passwordless authentication mechanism when using web clients (with Lock.js or auth0.js).
+=======
+Auth0 currently supports [OIDC-conformant](/api-auth/tutorials/adoption) passwordless authentication using [universal login](/hosted-pages/login)).
+>>>>>>> Beginning updates involving the term 'hosted login page'
 
 Native applications need to use universal login (with Auth0-hosted login page). Customers can use the Lock (Passwordless) template in the [Dashboard](${manage_url}) under **Hosted Pages > Default Templates**, or customize it to fit specific requirements.

--- a/articles/api-auth/passwordless.md
+++ b/articles/api-auth/passwordless.md
@@ -16,6 +16,6 @@ Without passwords, your application will not need to implement a password-reset 
 
 ## OIDC Conformant Passwordless
 
-Auth0 currently only supports an [OIDC-conformant](/api-auth/tutorials/adoption) passwordless authentication mechanism when using web clients (with Lock.js or auth0.js).
+Auth0 currently supports [OIDC-conformant](/api-auth/tutorials/adoption) passwordless authentication using [universal login](/hosted-pages/login) as well as in embedded web authentication scenarios using the newest [Lock](/libraries/lock) or [Auth0.js](/libraries/auth0js) libraries.
 
 Native applications need to use universal login (with Auth0-hosted login page). Customers can use the Lock (Passwordless) template in the [Dashboard](${manage_url}) under **Hosted Pages > Default Templates**, or customize it to fit specific requirements.

--- a/articles/api-auth/passwordless.md
+++ b/articles/api-auth/passwordless.md
@@ -16,10 +16,6 @@ Without passwords, your application will not need to implement a password-reset 
 
 ## OIDC Conformant Passwordless
 
-<<<<<<< HEAD
 Auth0 currently only supports an [OIDC-conformant](/api-auth/tutorials/adoption) passwordless authentication mechanism when using web clients (with Lock.js or auth0.js).
-=======
-Auth0 currently supports [OIDC-conformant](/api-auth/tutorials/adoption) passwordless authentication using [universal login](/hosted-pages/login)).
->>>>>>> Beginning updates involving the term 'hosted login page'
 
 Native applications need to use universal login (with Auth0-hosted login page). Customers can use the Lock (Passwordless) template in the [Dashboard](${manage_url}) under **Hosted Pages > Default Templates**, or customize it to fit specific requirements.

--- a/articles/api-auth/tutorials/adoption/oidc-conformant.md
+++ b/articles/api-auth/tutorials/adoption/oidc-conformant.md
@@ -17,7 +17,7 @@ Enabling this flag on a client will have the following effects:
 * The following features are deprecated in favor of [silent authentication](/api-auth/tutorials/adoption/implicit):
     - Refresh Tokens on authentication with the [implicit grant](/api-auth/tutorials/adoption/implicit)
     - /ssodata endpoint and `getSSOData()` method from Lock/auth0.js
-* [Single sign-on (SSO)](/api-auth/tutorials/adoption/single-sign-on) can only be performed from Auth0-hosted login pages.
+* [Single sign-on (SSO)](/api-auth/tutorials/adoption/single-sign-on) can only be performed from Auth0 login pages.
 * Using `response_type=token` will only return an Access Token, not an ID Token. Use `response_type=id_token` or `response_type=token id_token` instead.
 * ID Tokens obtained with the implicit grant will be signed asymmetrically using RS256.
 * The /tokeninfo endpoint is disabled.

--- a/articles/api-auth/tutorials/adoption/single-sign-on.md
+++ b/articles/api-auth/tutorials/adoption/single-sign-on.md
@@ -7,8 +7,9 @@ title: OIDC Single sign-on
 <%= include('./_about.md') %>
 
 Single sign-on (SSO) occurs when a user logs in to one client and is then signed in to other clients automatically.
-In the context of the OIDC-conformant authentication pipeline, SSO must happen at the authorization server (that is, Auth0) and not client applications.
-This means that for SSO to happen, users must be redirected to an Auth0-hosted login page.
+
+In the context of the OIDC-conformant authentication pipeline, SSO must happen at the authorization server (i.e. Auth0) and not client applications.
+This means that for SSO to happen, you must employ [universal login](/hosted-pages/login) and redirect users to an Auth0-hosted login page.
 
 We are planning on providing support for SSO from client applications in future releases.
 
@@ -44,7 +45,8 @@ The following flows are request-based and are currently not capable of SSO:
 
 ## Custom domains
 
-The Auth0-hosted login page is currently hosted at an Auth0 domain, so any SSO will be performed at an Auth0 domain instead of your organization's domain.
+The Auth0-hosted login page is by default hosted at an Auth0 domain, so any SSO will be performed at an Auth0 domain instead of your organization's domain.
+
 This is only an aesthetic limitation and does not impact the security or functionality of SSO logins in any way.
 
-We plan on adding support for custom domains on login pages in future releases via CNAMEs.
+You can read further about [customizing your domain](/custom-domains) if you require it, to help maintain a uniform experience for your users.

--- a/articles/api-auth/tutorials/adoption/single-sign-on.md
+++ b/articles/api-auth/tutorials/adoption/single-sign-on.md
@@ -9,7 +9,7 @@ title: OIDC Single sign-on
 Single sign-on (SSO) occurs when a user logs in to one client and is then signed in to other clients automatically.
 
 In the context of the OIDC-conformant authentication pipeline, SSO must happen at the authorization server (i.e. Auth0) and not client applications.
-This means that for SSO to happen, you must employ [universal login](/hosted-pages/login) and redirect users to an Auth0-hosted login page.
+This means that for SSO to happen, you must employ [universal login](/hosted-pages/login) and redirect users to the login page.
 
 We are planning on providing support for SSO from client applications in future releases.
 
@@ -20,7 +20,7 @@ At a general level, this is what happens when performing SSO:
 1. If the user is not logged in locally, redirect them to Auth0 for authentication. This is done using the [authorization code](/api-auth/grant/authorization-code) or [implicit](/api-auth/grant/implicit) grants, depending on the type of application.
 2. If the user was logged in through SSO, Auth0 will immediately authenticate them without needing to re-enter credentials.
 
-An application that does not use SSO might decide to show a self-hosted login page to unauthenticated users instead of redirecting to Auth0 for authentication.
+An application that does not use SSO might decide to use embedded login to authenticate users instead of redirecting to Auth0 for authentication.
 
 ## Determining if users are logged in via SSO
 
@@ -45,7 +45,7 @@ The following flows are request-based and are currently not capable of SSO:
 
 ## Custom domains
 
-The Auth0-hosted login page is by default hosted at an Auth0 domain, so any SSO will be performed at an Auth0 domain instead of your organization's domain.
+When using universal login, the login page is by default hosted at an Auth0 domain, so any SSO will be performed at an Auth0 domain instead of your organization's domain.
 
 This is only an aesthetic limitation and does not impact the security or functionality of SSO logins in any way.
 

--- a/articles/architecture-scenarios/implementations/spa-api/spa-implementation-angular2.md
+++ b/articles/architecture-scenarios/implementations/spa-api/spa-implementation-angular2.md
@@ -121,7 +121,7 @@ export class AuthService {
 
 The service includes several methods for handling authentication.
 
-- __login__: calls `authorize` from auth0.js which redirects users to the hosted login page
+- __login__: calls `authorize` from auth0.js which initiates [universal login](/hosted-pages/login)
 - __handleAuthentication__: looks for an authentication result in the URL hash and processes it with the `parseHash` method from auth0.js
 - __setSession__: sets the user's `access_token`, `id_token`, and a time at which the `access_token` will expire
 - __logout__: removes the user's tokens from browser storage
@@ -129,7 +129,7 @@ The service includes several methods for handling authentication.
 
 ### Process the Authentication Result
 
-When a user authenticates at Auth0's hosted login page and is then redirected back to your application, their authentication information will be contained in a URL hash fragment. The `handleAuthentication` method in the `AuthService` is responsibile for processing the hash.
+When a user authenticates via universal login and is then redirected back to your application, their authentication information will be contained in a URL hash fragment. The `handleAuthentication` method in the `AuthService` is responsibile for processing the hash.
 
 Call `handleAuthentication` in your app's root component so that the authentication hash fragment can be processed when the app first loads after the user is redirected back to it.
 
@@ -155,7 +155,7 @@ export class AppComponent {
 
 ### Add the Callback Component
 
-Using Auth0's hosted login page means that users are taken away from your application to a page hosted by Auth0. After they successfully authenticate, they are returned to your application where a client-side session is set for them.
+Using universal login means that users are taken away from your application to a page hosted by Auth0. After they successfully authenticate, they are returned to your application where a client-side session is set for them.
  
 You can choose to have users return to any URL in your application that you like; however, it is recommended that you create a dedicated callback route to serve as a central location that the user will be returned to upon successful authentication. Having a single callback route is beneficial for two main reasons:
 

--- a/articles/clients/client-grant-types.md
+++ b/articles/clients/client-grant-types.md
@@ -166,7 +166,7 @@ If you're currently using a legacy grant type, refer to the chart below to see w
 | `http://auth0.com/oauth/legacy/grant-type/access_token` | Use browser-based social authentication. |
 
 ::: note
-Those implementing Passwordless Authentication should use hosted login pages instead of the `oauth/ro` endpoint.
+Those implementing Passwordless Authentication should use [universal login](/hosted-pages/login) instead of the `oauth/ro` endpoint.
 :::
 
 ## Enable a Legacy Grant Type

--- a/articles/cross-origin-authentication/index.md
+++ b/articles/cross-origin-authentication/index.md
@@ -5,7 +5,7 @@ description: An explanation of cross-origin authentication in Auth0 and its comp
 ---
 # Cross-Origin Authentication
 
-For most situations, Auth0 recommends that authentication transactions be handled at the [Hosted Login Page](/hosted-pages/login). Doing so offers [the easiest and most secure way to authenticate users](guides/login/centralized-vs-embedded). However, it is understood that some situations may require that authentication forms be directly embedded in an application. Cross-origin authentication provides a way to do this securely.
+For most situations, Auth0 recommends that authentication transactions be handled via [universal login](/hosted-pages/login). Doing so offers [the easiest and most secure way to authenticate users](guides/login/centralized-vs-embedded). However, it is understood that some situations may require that authentication forms be directly embedded in an application. Cross-origin authentication provides a way to do this securely.
 
 ## What is Cross-Origin Authentication? 
 
@@ -22,12 +22,11 @@ Cross-origin authentication is only necessary when authenticating against a dire
 Because cross-origin authentication is achieved using third-party cookies, disabling third-party cookies will make cross-origin authentication fail. 
 
 There are two approaches you can follow to remediate the issue:
+
 - Enable [Custom Domains](/custom-domains) and host your web application in a domain that has the same top level domain as the Auth0 custom domain. This way the cookies are no longer third-party and are not blocked by browsers.
 - Provide a [Cross-Origin fallback page](#create-a-cross-origin-fallback-page) that will make cross-origin authentication work **in some browsers** even with third-party cookies disabled (see the [browser testing matrix](#browser-testing-matrix) below).
 
-Additionally, cross-origin authentication is only enabled for [first-party clients](/clients/client-types#first-party-client).
-
-These issues are another reason why the more practical solution is to use the [Hosted Login Page](/hosted-pages/login).
+These issues are another reason why the more practical solution is to use [universal login](/hosted-pages/login).
 
 ## Configure Your Client for Cross-Origin Authentication
 

--- a/articles/custom-domains/index.md
+++ b/articles/custom-domains/index.md
@@ -8,7 +8,7 @@ toc: true
 
 Auth0 allows you to map the domain for your tenant to a custom domain of your choosing. This allows you to maintain a consistent experience for your users by keeping them on your domain instead of redirecting or using Auth0's domain. For example, if your Auth0 domain is **northwind.auth0.com**, you can have your users to see, use, and remain on **login.northwind.com**.
 
-Using custom domains with universal login is the most seamless and secure experience for developers and end users. For more information, please see our docs on [universal login and customizing the hosted login pages](/hosted-pages/login).
+Using custom domains with universal login is the most seamless and secure experience for developers and end users. For more information, please see our docs on [universal login](/hosted-pages/login).
 
 ::: warning
 Custom Domains is a beta feature available only for paying public-cloud tenants [with their environment tag set as **Development**](/dev-lifecycle/setting-up-env).
@@ -33,7 +33,9 @@ Features not in the list are **not supported** by Auth0 with custom domains.
 :::
 
 ::: panel Token issuance
-Auth0 issues tokens with the **iss** claim of whichever domain you used with the request. For example, if you used **https://northwind.auth0.com/authorize...** to obtain an Access Token, the **iss** claim of the token you receive will be **https://northwind.auth0.com/**. If you used your custom domain **https://login.northwind.com/authorize...**, the **iss** claim value will be **https://login.northwind.com/**. If you get an Access Token for the [Management API](/api/management/v2) using an authorization flow with your custom domain, you **must** call the Management API using the custom domain (your token will be considered invalid otherwise).
+Auth0 issues tokens with the **iss** claim of whichever domain you used with the request. For example, if you used **https://northwind.auth0.com/authorize...** to obtain an Access Token, the **iss** claim of the token you receive will be **https://northwind.auth0.com/**. If you used your custom domain **https://login.northwind.com/authorize...**, the **iss** claim value will be **https://login.northwind.com/**. 
+
+If you get an Access Token for the [Management API](/api/management/v2) using an authorization flow with your custom domain, you **must** call the Management API using the custom domain (your token will be considered invalid otherwise).
 :::
 
 ## Certificate management
@@ -80,7 +82,7 @@ Here's how to add the CNAME verification record to your domain's DNS record. The
 1. Create a new record:
 
 	* For the record type, indicate **CNAME**
-	* For the **Name** field, enter your custom domain name (such as **login.northwind.com**)
+	* For the **Name** field, enter your custom domain name (such as `login.northwind.com`)
 	* Leave the **Time to Live (TTL)** field set to the default value
 	* In the **Value** field, paste in the CNAME value provided by the Auth0 Dashboard
 
@@ -102,14 +104,15 @@ If you are unable to complete the verification process within three days, you'll
 There are additional steps you must complete depending on which Auth0 features you are using.
 
 :::warning
-If you have been using Auth0 for some time and decide to enable a custom domain, you will have to migrate your existing apps and update the settings as described below. Note that existing sessions created at **tenant.auth0.com** will no longer be valid once you start using your custom domain, so users will have to login again.
+If you have been using Auth0 for some time and decide to enable a custom domain, you will have to migrate your existing apps and update the settings as described below. Note that existing sessions created at `tenant.auth0.com` will no longer be valid once you start using your custom domain, so users will have to login again.
 :::
 
-#### Configure the hosted login page
+#### Configure the Login Page
 
-If you're using the **default** Hosted Login Page without customization, you will not need to make any changes. Your custom domain will work right out of the box.
+When using custom domains with [universal login](/hosted-pages/login), you will need to determine which of the following apply to you:
 
-If you're using a **custom** [Hosted Login Page](/hosted-pages/login), you'll need to update it to use your custom domain. The changes that you'll need to make are regarding the initializing of Lock. The following code sample shows the lines reflecting the necessary changes.
+* If you're using the **default** login page without customization, you will not need to make any changes. Your custom domain will work right out of the box.
+* If you're using a **customized** login page, you'll need to update the code in your [Dashboard](${manage_url}) to use your custom domain. The changes that you'll need to make are regarding the initializing of Lock. The following code sample shows the lines reflecting the necessary changes.
 
 ```js
 var lock = new Auth0Lock(config.clientID, config.auth0Domain, {
@@ -136,12 +139,12 @@ var lock = new Auth0Lock('your-client-id', 'login.northwind.com', {
 ```
 
 :::note
-The CDN URL varies by region. For regions outside of the US, use **https://cdn.{region}.auth0.com**.
+The CDN URL varies by region. For regions outside of the US, use `https://cdn.{region}.auth0.com`.
 :::
 
 #### SDKs
 
-If you are using [Auth0.js](https://github.com/auth0/auth0.js) or other SDKs, you will have to initialize the SDK using your custom domain. For example, if you are using the auth0.js SDK, you'll need to set the following:
+If you are using [Auth0.js](/libraries/auth0js) or other SDKs, you will have to initialize the SDK using your custom domain. For example, if you are using the auth0.js SDK, you'll need to set the following:
 
 ```js
 webAuth = new auth0.WebAuth({
@@ -158,10 +161,10 @@ If you would like your custom domain used with your Auth0 emails, you'll need to
 
 #### Social identity provider configuration
 
-If you want to use social identity providers with your custom domain, you must update the allowed callback URLs to include your custom domain (such as **https://login.northwind.com/login/callback**).
+If you want to use social identity providers with your custom domain, you must update the allowed callback URLs to include your custom domain (such as `https://login.northwind.com/login/callback`).
 
 :::warning
-You cannot use [Auth0 developer keys](https://auth0.com/docs/connections/social/devkeys) with custom domains.
+You cannot use [Auth0 developer keys](/connections/social/devkeys) with custom domains.
 :::
 
 #### APIs
@@ -176,17 +179,17 @@ app.use(jwt({
 ```
 
 :::note
-If you are using built-in Auth0 APIs, such as the Management API, the API identifier will use your default tenant domain name (such as **https://northwind.auth0.com/userinfo** and **https://northwind.auth0.com/api/v2/**)
+If you are using built-in Auth0 APIs, such as the Management API, the API identifier will use your default tenant domain name (such as `https://northwind.auth0.com/userinfo** and **https://northwind.auth0.com/api/v2/`)
 :::
 
 ## FAQ
 
 1. **If I use a custom domain, will I still be able to use my **tenant.auth0.com** domain to access Auth0?**
   
-  Once you enable your custom domain in Auth0, you should be able to use either the default **tenant.auth0.com** or your custom domain. There are a few exceptions:
+  Once you enable your custom domain in Auth0, you should be able to use either the default `tenant.auth0.com` or your custom domain. There are a few exceptions:
 
-  - If you are using embedded lock or an SDK, the configuration is pre-defined as using either your custom domain or the **tenant.auth0.com domain**, so you have to use one or the other.
-  - If you start a session in **tenant.auth0.com**, and go to **custom-domain.com**, the user will have to login again.
+  - If you are using embedded lock or an SDK, the configuration is pre-defined as using either your custom domain or the `tenant.auth0.com domain`, so you have to use one or the other.
+  - If you start a session in `tenant.auth0.com`, and go to `custom-domain.com`, the user will have to login again.
 
 2. **What about support for other features?**
   

--- a/articles/custom-domains/index.md
+++ b/articles/custom-domains/index.md
@@ -8,7 +8,7 @@ toc: true
 
 Auth0 allows you to map the domain for your tenant to a custom domain of your choosing. This allows you to maintain a consistent experience for your users by keeping them on your domain instead of redirecting or using Auth0's domain. For example, if your Auth0 domain is **northwind.auth0.com**, you can have your users to see, use, and remain on **login.northwind.com**.
 
-Using custom domains with centralized login is the most seamless and secure experience for developers and end users. For more information, please see our docs on [centralized login and customizing the hosted login pages](/hosted-pages/login).
+Using custom domains with universal login is the most seamless and secure experience for developers and end users. For more information, please see our docs on [universal login and customizing the hosted login pages](/hosted-pages/login).
 
 ::: warning
 Custom Domains is a beta feature available only for paying public-cloud tenants [with their environment tag set as **Development**](/dev-lifecycle/setting-up-env).

--- a/articles/design/browser-based-vs-native-experience-on-mobile.md
+++ b/articles/design/browser-based-vs-native-experience-on-mobile.md
@@ -45,7 +45,7 @@ By default, [Lock](/libraries/lock) provides the UX, but you can customize it co
 
 ## Automatic improvements
 
-By relying on a centralized login experience, you will automatically receive new features without requiring you to make any changes to your native application. For example, if Auth0 adds support for FIDO/U2F, you would not need to make any code changes to your app before you can use this functionality.
+By relying on a universal login experience, you will automatically receive new features without requiring you to make any changes to your native application. For example, if Auth0 adds support for FIDO/U2F, you would not need to make any code changes to your app before you can use this functionality.
 
 ## Load time and user experience
 

--- a/articles/extensions/account-link.md
+++ b/articles/extensions/account-link.md
@@ -18,15 +18,15 @@ The extension will create a new **Client** named `auth0-account-link` to use int
 
 ### Changing the Client Name
 
-We recommend changing the default client used for the extension to something descriptive and easy to read for your customers, like `Account Linking`, since it will appear on the **Hosted Login Page** when they authenticate their primary account.
+We recommend changing the name of the default client used for the extension to something descriptive and easy to read for your customers, like `Account Linking`, since it will appear on the **Login Page** when they authenticate their primary account.
 
-### Updating the Hosted Login Page
+### Updating the Login Page
 
-By default, Auth0's **Hosted Login Page** allows a user to sign up as one may expect. However, when the account linking asks you to authenticate your primary account in order to link it with the new account, providing a sign up option is confusing for users and could leave them in an unexpected state. 
+By default, Auth0's [universal login](/hosted-pages/login) allows a user to both login and sign up as one may expect. However, when the account linking asks you to authenticate your primary account in order to link it with the new account, providing a sign up option can be confusing for users.
 
-To prevent this, we send over a query parameter to let the **Hosted Login Page** know that it should hide the **Sign Up** option. In order for this query parameter to take effect, however, we must first customize the **Hosted Login Page**.
+To prevent this, we send over a query parameter to let the **Hosted Login Page** know that it should hide the **Sign Up** option. In order for this query parameter to take effect, however, we must first customize the **Login Page**.
 
-First go to your dashboard and click on **Hosted Pages**. It should open to the **Login Page** by default. 
+First go to your [Dashboard](${manage_url}) and click on **Hosted Pages**. It should open to the **Login Page** by default. 
 
 If it is not already enabled, toggle the **Customize Login Page** to enable the custom editor below. In the editor we're going to add a new line to the Lock config.
 
@@ -36,7 +36,7 @@ Toward the bottom of the object configuring the Lock widget, add the following l
 allowSignUp: !config.extraParams.prevent_sign_up,
 ```
 
-![Updating the Hosted Page](/media/articles/extensions/account-link/hosted-page-code.png)
+![Updating the Login Page](/media/articles/extensions/account-link/hosted-page-code.png)
 
 Then save your changes and attempt to link an account. You'll notice that the **Sign Up** option is no longer present and your users are safe from an extra level of confusion.
 
@@ -54,7 +54,7 @@ At installation, or any time after by clicking the **Settings** icon for the Acc
 This feature is available in version 2.0 and up.
 :::
 
-You can customize your account linking hosted page and widget using the extension administration panel. 
+You can customize your account linking login page and widget using the extension administration panel. 
 
 Go to **Dashboard > Extensions > Installed Extensions > Auth0 Account Link**.
 

--- a/articles/extensions/account-link.md
+++ b/articles/extensions/account-link.md
@@ -24,9 +24,9 @@ We recommend changing the name of the default client used for the extension to s
 
 By default, Auth0's [universal login](/hosted-pages/login) allows a user to both login and sign up as one may expect. However, when the account linking asks you to authenticate your primary account in order to link it with the new account, providing a sign up option can be confusing for users.
 
-To prevent this, we send over a query parameter to let the **Hosted Login Page** know that it should hide the **Sign Up** option. In order for this query parameter to take effect, however, we must first customize the **Login Page**.
+To prevent this, we send over a query parameter to let the login page know that it should hide the **Sign Up** option. In order for this query parameter to take effect, however, we must first customize the login page.
 
-First go to your [Dashboard](${manage_url}) and click on **Hosted Pages**. It should open to the **Login Page** by default. 
+First go to your [Dashboard](${manage_url}) and click on **Hosted Pages**. It should open to the login page by default. 
 
 If it is not already enabled, toggle the **Customize Login Page** to enable the custom editor below. In the editor we're going to add a new line to the Lock config.
 

--- a/articles/getting-started/the-implementation-process.md
+++ b/articles/getting-started/the-implementation-process.md
@@ -15,7 +15,7 @@ Auth0 ships [SDKs for all major platforms](/support/matrix#sdks) (.NET, Java, PH
 
 Auth0 also supports other common identity protocols, such as [WS-Federation](/protocols/ws-fed) and [SAML](/protocols/saml). Applications that are already "claims enabled" can easily connect to Auth0.
 
-The **best** solution for integrating Auth0 with your application is to use Auth0's [Hosted Login Page](/hosted-pages/login). Using the Hosted Login Page is an incredibly simple process, and circumvents the dangers of cross-origin authentication. The Hosted Login Page uses the [Lock](/libraries/lock) widget to allow your users to authenticate by default, but has other starting templates as well. You can customize the login page in the [Hosted Pages Editor](${manage_url}/#/login_page) in your dashboard.
+The **best** solution for integrating Auth0 with your application is to use Auth0's [universal login](/hosted-pages/login). Using universal login is a much less complicated process, and circumvents the dangers of cross-origin authentication. Universal login uses the [Lock](/libraries/lock) widget to allow your users to authenticate by default, but has other starting templates as well. You can customize the login page in the [Dashboard](${manage_url}/#/login_page).
 
 ## Access your APIs
 

--- a/articles/guides/login/_includes/_centralized_webapp.md
+++ b/articles/guides/login/_includes/_centralized_webapp.md
@@ -7,9 +7,9 @@ router.get('/callback',
     res.redirect(req.session.returnTo || '/user');
   });
 ```
-## Convert your Code to use Centralized Login
+## Convert your Code to use Universal Login
 
-In web applications, you don't need any client-side code to integrate centralized login. Your application should perform these steps:
+In web applications, you don't need any client-side code to integrate universal login. Your application should perform these steps:
 
 1. When the application needs to authenticate, navigate to a `/login` route in your website. If you were using plain HTML to code the web views, it would be:
 
@@ -35,6 +35,6 @@ After authentication is done, it will redirect to the `/callback` url as in the 
 
 3. Review if you are using any [legacy authentication flow in your application](guides/migration-legacy-flows), and adjust your code accordingly.
 
-You can find complete examples of implementing centralized login in web applications for different technologies in our [Quickstarts](/quickstart/webapps).
+You can find complete examples of implementing universal login in web applications for different technologies in our [Quickstarts](/quickstart/webapps).
 
 <%= include('_customizing-login-page') %>

--- a/articles/guides/login/_includes/_customizing-login-page.md
+++ b/articles/guides/login/_includes/_customizing-login-page.md
@@ -1,4 +1,4 @@
-## Customizing the Universal Login Page
+## Customizing the Login Page
 
 When you integrate universal login in your application, you redirect the user to the `/authorize` endpoint of your Auth0 tenant. If Auth0 needs to authenticate the user, it will show the default login page.
 

--- a/articles/guides/login/_includes/_customizing-login-page.md
+++ b/articles/guides/login/_includes/_customizing-login-page.md
@@ -2,18 +2,16 @@
 
 When you integrate universal login in your application, you redirect the user to the `/authorize` endpoint of your Auth0 tenant. If Auth0 needs to authenticate the user, it will show the default login page.
 
-You can enable a custom Hosted Login Page by navigating to [Hosted Pages](${manage_url}/#/login_page) and enabling the **Customize Login Page** toggle.
+You can customize the login page in your [Dashboard](${manage_url}/#/login_page) under Hosted Pages, by enabling the **Customize Login Page** toggle.
 
 ![Hosted Login Page](/media/articles/hosted-pages/login.png)
 
-## Customize Lock in the Hosted Login Page
+## Customize Lock in the Login Page
 
-The default login page for your tenant is a template that will use Lock to provide your users with an attractive interface and smooth authentication process. You can look over that template and use it as a starting point if you choose to customize it in any way. The default template uses Lock v11.
+The default login page for universal login with your tenant is a template that will use [Lock](/libraries/lock) to provide your users with an attractive interface and smooth authentication process. You can look over that template and use it as a starting point if you choose to customize it in any way.
 
-If you want to change any of Lock's [configurable options](/libraries/lock/customization), you can do so using the [Hosted Pages](${manage_url}/#/login_page) editor interface. These options can alter the behavior of Lock itself, or the look and feel of the widget using the theming options. See the [configuration documentation](/libraries/lock/customization) for details on how to customize Lock.
+If you want to change any of Lock's [configurable options](/libraries/lock/configuration), you can do so using the editor [Dashboard](${manage_url}/#/login_page) under Hosted Pages. These options can alter the behavior of Lock itself, or the look and feel of the widget using the theming options. See the [configuration documentation](/libraries/lock/configuration) for details on how to customize Lock.
 
 When you're done making changes to the code, click **Save** to persist the changes.
 
 ![Hosted Login Page](/media/articles/hosted-pages/hlp-lock.png)
-
-

--- a/articles/guides/login/_includes/_customizing-login-page.md
+++ b/articles/guides/login/_includes/_customizing-login-page.md
@@ -4,7 +4,7 @@ When you integrate universal login in your application, you redirect the user to
 
 You can customize the login page in your [Dashboard](${manage_url}/#/login_page) under Hosted Pages, by enabling the **Customize Login Page** toggle.
 
-![Hosted Login Page](/media/articles/hosted-pages/login.png)
+![Login Page](/media/articles/hosted-pages/login.png)
 
 ## Customize Lock in the Login Page
 
@@ -14,4 +14,4 @@ If you want to change any of Lock's [configurable options](/libraries/lock/confi
 
 When you're done making changes to the code, click **Save** to persist the changes.
 
-![Hosted Login Page](/media/articles/hosted-pages/hlp-lock.png)
+![Login Page](/media/articles/hosted-pages/hlp-lock.png)

--- a/articles/guides/login/_includes/_customizing-login-page.md
+++ b/articles/guides/login/_includes/_customizing-login-page.md
@@ -1,6 +1,6 @@
-## Customizing the Centralized Login Page
+## Customizing the Universal Login Page
 
-When you integrate centralized login in your application, you redirect the user to the `/authorize` endpoint of your Auth0 tenant. If Auth0 needs to authenticate the user, it will show the default login page.
+When you integrate universal login in your application, you redirect the user to the `/authorize` endpoint of your Auth0 tenant. If Auth0 needs to authenticate the user, it will show the default login page.
 
 You can enable a custom Hosted Login Page by navigating to [Hosted Pages](${manage_url}/#/login_page) and enabling the **Customize Login Page** toggle.
 

--- a/articles/guides/login/centralized-vs-embedded.md
+++ b/articles/guides/login/centralized-vs-embedded.md
@@ -39,13 +39,13 @@ In this article, we will evaluate the pros and cons of these two options and see
 
 ## Universal login with Auth0
 
-For most situations, we recommend using a a universal login strategy, where Auth0 will show the [Hosted Login Page (HLP)](/hosted-pages/login) if an authentication is required. You can enable and customize your login page using the [Dashboard](${manage_url}/#/login_page).
+For most situations, we recommend using a a universal login strategy, where Auth0 will show a [login page](/hosted-pages/login) if authentication is required. You can customize your login page using the [Dashboard](${manage_url}/#/login_page).
 
-You can use **Auth0's Custom Domains** in order to persist the same domain across the centralized login page and the app. This way the redirect to the HLP will be transparent to your users since the domain will not change. For more details refer to [Custom Domains Overview](/custom-domains).
+You can use **Auth0's Custom Domains** in order to persist the same domain across the universal login page and the app. This way the redirect to the HLP will be transparent to your users since the domain will not change. For more details refer to [Custom Domains Overview](/custom-domains).
 
-Whenever your app triggers an authentication request, the user will be redirected to the HLP in order to authenticate. This will create a cookie so in future authentication requests, Auth0 will check for this cookie and if present the user will not be redirected to the HLP. They will see the page only when they need to actually log in. That's the easiest way to implement SSO.
+Whenever your app triggers an authentication request, the user will be redirected to the login page in order to authenticate. This will create a cookie. In future authentication requests, Auth0 will check for this cookie, and if it is present the user will not be redirected to the login page. They will see the page only when they need to actually log in. This is the easiest way to implement SSO.
 
-Note that if the incoming authentication request uses an external identity provider (for example, Facebook), the HLP will not be displayed. Instead, Auth0 will direct the user to the identity provider's login page.
+Note that if the incoming authentication request uses an external identity provider (for example, Facebook), the login page will not be displayed. Instead, Auth0 will direct the user to the identity provider's login page.
 
 ::: note
 You can deploy your custom login page from an external repository, like [GitHub](/extensions/github-deploy#deploy-hosted-pages), [Bitbucket](/extensions/bitbucket-deploy#deploy-hosted-pages), [GitLab](/extensions/gitlab-deploy#deploy-hosted-pages), or [Visual Studio Team Services](/extensions/visual-studio-team-services-deploy#deployment).

--- a/articles/guides/login/centralized-vs-embedded.md
+++ b/articles/guides/login/centralized-vs-embedded.md
@@ -7,9 +7,13 @@ toc: true
 
 When you design the authentication experience for your application, you have to choose whether the login flow will use **centralized** or **embedded** login.
 
+<<<<<<< HEAD
 With centralized login, when the users try to log in they are redirected to a central domain, through which authentication is performed, and then they are redirected back to the app. An example is Google Apps. No matter which service you are trying to access (gmail, google calendar, google docs, and so on) if you are not logged in you are redirected to `https://accounts.google.com` and once you successfully log in you are redirected back to the calling app.
+=======
+With universal login, when the users try to log in they are redirected to a central domain, through which authentication is performed, and then they are redirected back to the app. An example is Google Apps. No matter which service you are trying to access (gmail, google calendar, google docs, etc) if you are not logged in you are redirected to `https://accounts.google.com` and once you successfully log in you are redirected back to the calling app.
+>>>>>>> Replacing the term 'centralized login' with 'universal login'
 
-![Google Centralized Login](/media/articles/guides/login/google-login.jpg)
+![Google Universal Login](/media/articles/guides/login/google-login.jpg)
 
 On the other hand, an embedded login flow does not redirect the user somewhere central. The login widget is served from the same page without redirecting the user to another domain. The credentials are then sent to the authentication provider for authentication. In a web app this is a **cross-origin** request.
 
@@ -21,21 +25,21 @@ In this article, we will evaluate the pros and cons of these two options and see
 
 ## Pros and cons
 
-- **Single Sign-On (SSO)**: If you are working with mobile apps you cannot have SSO unless you use centralized login. With web apps you can, although the most secure way is to use a central service so the cookies are from the same origin. With embedded login, you'd have to collect the user credentials in an application served from one origin and then send them to another origin, which can present certain security vulnerabilities, including the possibility of a phishing attack (see [Embedded Login with Auth0 > Security risks](#security-risks) for more info). There are workarounds you could use, like third-party cookies, but the most secure option for SSO, and logins in general, is using a central service.
+- **Single Sign-On (SSO)**: If you are working with mobile apps you cannot have SSO unless you use universal login. With web apps you can, although the most secure way is to use a central service so the cookies are from the same origin. With embedded login, you'd have to collect the user credentials in an application served from one origin and then send them to another origin, which can present certain security vulnerabilities, including the possibility of a phishing attack (see [Embedded Login with Auth0 > Security risks](#security-risks) for more info). There are workarounds you could use, like third-party cookies, but the most secure option for SSO, and logins in general, is using a central service.
 
-- **Consistency and Maintenance**: With embedded login, if you have more than one app, you will have to implement more than one login page. You will also have to maintain and manage these pages. Besides the extra effort it can also introduce inconsistencies which results in bad UX. Furthermore, with embedded login you would have to manage the dangers of cross-origin attack vectors. On the other hand, if you are using centralized login, then your Authorization Server (the domain that logs the users in) owns all the login pages which makes the management easier and the pages more consistent and secure. You could also use a single login page among your apps, a process that creates an impression that users are logging into a centralized system, rather than an individual app. In the following diagram you can see an example of how the centralized and embedded logins look like. The reason why the centralized login offers a more consistent and thus superior use experience is evident.
+- **Consistency and Maintenance**: With embedded login, if you have more than one app, you will have to implement more than one login page. You will also have to maintain and manage these pages. Besides the extra effort it can also introduce inconsistencies which results in bad UX. Furthermore, with embedded login you would have to manage the dangers of cross-origin attack vectors. On the other hand, if you are using universal login, then your Authorization Server (the domain that logs the users in) owns all the login pages which makes the management easier and the pages more consistent and secure. You could also use a single login page among your apps, a process that creates an impression that users are logging into a centralized system, rather than an individual app. In the following diagram you can see an example of how the centralized and embedded logins look like. The reason why the universal login offers a more consistent and thus superior use experience is evident.
 
 ![Centralized vs Embedded login UX](/media/articles/guides/login/centralized-embedded-ux.jpg)
 
-- **Central Features Management**: When you use centralized login with Auth0, you can turn on and off features across all your apps, using the Dashboard. An example is [Multifactor Authentication](/multifactor-authentication) which you can enable using the toggles located at the [Dashboard > Multifactor Auth](${manage_url}/#/guardian) page. These changes will be automatically available to all your registered apps.
+- **Central Features Management**: When you use universal login with Auth0, you can turn on and off features across all your apps, using the Dashboard. An example is [Multifactor Authentication](/multifactor-authentication) which you can enable using the toggles located at the [Dashboard > Multifactor Auth](${manage_url}/#/guardian) page. These changes will be automatically available to all your registered apps.
 
 - **User Experience**: In the past, an argument could be made that the user experience with embedded login was better because it did not require redirecting users to another subdomain. However, users are getting increasingly familiar with the process of being redirected to another subdomain to log in. As a result, they don't find the process disruptive to their experience. Think about this, when you try to access your Gmail, if you are not logged in, you get redirected to the Google Accounts subdomain in order to log in. Do you get frustrated with that? You probably don't even notice it.
 
 - **Mobile Apps & Security**: According to the [Best Current Practice for OAuth 2.0 for Native Apps Request For Comments](https://www.rfc-editor.org/rfc/rfc8252.txt), only external user agents (such as the browser) should be used by native applications for authentication flows. Using the browser to make native app authorization requests results in better security and it gives users the confidence that they are entering credentials in the right domain. It also enables use of the user's current authentication state, making single sign-on possible. Embedded user agents are deemed unsafe for third parties and should not be implemented (see [Embedded Login with Auth0 > Security risks](#security-risks) for more info). With native login a malicious app could try and phish users for username/password or tokens. Also, if your mobile apps use native login, then your users have to enter their credentials for each of your apps, hence SSO is not possible.
 
-## Centralized login with Auth0
+## Universal login with Auth0
 
-For most situations, we recommend using a a centralized login strategy, where Auth0 will show the [Hosted Login Page (HLP)](/hosted-pages/login) if an authentication is required. You can enable and customize your login page using the [Dashboard](${manage_url}/#/login_page).
+For most situations, we recommend using a a universal login strategy, where Auth0 will show the [Hosted Login Page (HLP)](/hosted-pages/login) if an authentication is required. You can enable and customize your login page using the [Dashboard](${manage_url}/#/login_page).
 
 You can use **Auth0's Custom Domains** in order to persist the same domain across the centralized login page and the app. This way the redirect to the HLP will be transparent to your users since the domain will not change. For more details refer to [Custom Domains Overview](/custom-domains).
 
@@ -47,7 +51,7 @@ Note that if the incoming authentication request uses an external identity provi
 You can deploy your custom login page from an external repository, like [GitHub](/extensions/github-deploy#deploy-hosted-pages), [Bitbucket](/extensions/bitbucket-deploy#deploy-hosted-pages), [GitLab](/extensions/gitlab-deploy#deploy-hosted-pages), or [Visual Studio Team Services](/extensions/visual-studio-team-services-deploy#deployment).
 :::
 
-Our recommendation is to use centralized logins, and Hosted Login Pages in particular when you use Auth0. The first and foremost reason is security. Using Auth0 hosted pages instead of hosting them externally provides seamless CSRF protection. This helps prevent third-party impersonation or the hijacking of sessions.
+Our recommendation is to use universal login when you use Auth0. The first and foremost reason is security. Using Auth0 hosted pages instead of hosting them externally provides seamless CSRF protection. This helps prevent third-party impersonation or the hijacking of sessions.
 
 ## Embedded login with Auth0
 
@@ -61,7 +65,7 @@ In addition, if you have not enabled [Custom Domain Names](/custom-domains) the 
 
 ### Security risks
 
-Centralized login is more secure than embedded login. Authentication takes place over the same domain, eliminating cross-origin requests. Cross-origin authentication is inherently more dangerous. Collecting user credentials in an application served from one origin and then sending them to another origin can present certain security vulnerabilities. [Phishing attacks](https://auth0.com/blog/all-you-need-to-know-about-the-google-docs-phishing-attack/) are more likely, as are [man-in-the-middle attacks](/security/common-threats#man-in-the-middle-mitm-attacks). Centralized login does not send information between origins, thereby negating cross-origin concerns.
+Universal login is more secure than embedded login. Authentication takes place over the same domain, eliminating cross-origin requests. Cross-origin authentication is inherently more dangerous. Collecting user credentials in an application served from one origin and then sending them to another origin can present certain security vulnerabilities. [Phishing attacks](https://auth0.com/blog/all-you-need-to-know-about-the-google-docs-phishing-attack/) are more likely, as are [man-in-the-middle attacks](/security/common-threats#man-in-the-middle-mitm-attacks). Universal login does not send information between origins, thereby negating cross-origin concerns.
 
 Embedded user agents are unsafe for third parties, including the authorization server itself. If an embedded login is used, the app has access to both the authorization grant and the user's authentication credentials. As a consequence, this data is left vulnerable to recording or malicious use. Even if the app is trusted, allowing it to access the authorization grant as well as the user's **full credentials** is unnecessary. This violates the [principle of least privilege](https://en.wikipedia.org/wiki/Principle_of_least_privilege) and increases the potential for attack.
 
@@ -74,9 +78,9 @@ Furthermore, according to the [Internet Engineering Task Force (IETF)](https://w
 ## Keep reading
 
 :::next-steps
-- [Migrating from Embedded to Centralized Login](/guides/login/migration-embedded-centralized)
+- [Migrating from Embedded to Universal Login](/guides/login/migration-embedded-centralized)
 - [Browser-Based vs. Native Login Flows on Mobile Devices](/design/browser-based-vs-native-experience-on-mobile)
-- [Authentication Provider Best Practices: Centralized Login](https://auth0.com/blog/authentication-provider-best-practices-centralized-login/)
+- [Authentication Provider Best Practices: Universal Login](https://auth0.com/blog/authentication-provider-best-practices-centralized-login/)
 - [OAuth 2.0 Best Practices for Native Apps](https://auth0.com/blog/oauth-2-best-practices-for-native-apps/)
 - [Modernizing OAuth interactions in Native Apps for Better Usability and Security](https://developers.googleblog.com/2016/08/modernizing-oauth-interactions-in-native-apps.html)
 :::

--- a/articles/guides/login/centralized-vs-embedded.md
+++ b/articles/guides/login/centralized-vs-embedded.md
@@ -1,11 +1,11 @@
 ---
-title: Centralized vs Embedded Login
-description: Read about the differences between Centralized and Embedded login
+title: Universal vs Embedded Login
+description: Read about the differences between Universal and Embedded login
 toc: true
 ---
-# Centralized vs Embedded Login
+# Universal vs Embedded Login
 
-When you design the authentication experience for your application, you have to choose whether the login flow will use **centralized** or **embedded** login.
+When you design the authentication experience for your application, you have to choose whether the login flow will use **universal** or **embedded** login.
 
 With universal login, when the users try to log in they are redirected to a central domain, through which authentication is performed, and then they are redirected back to the app. An example is Google Apps. No matter which service you are trying to access (gmail, google calendar, google docs, etc) if you are not logged in you are redirected to `https://accounts.google.com` and once you successfully log in you are redirected back to the calling app.
 
@@ -14,7 +14,7 @@ With universal login, when the users try to log in they are redirected to a cent
 On the other hand, an embedded login flow does not redirect the user somewhere central. The login widget is served from the same page without redirecting the user to another domain. The credentials are then sent to the authentication provider for authentication. In a web app this is a **cross-origin** request.
 
 ::: zoomable
-![Centralized vs Embedded login flow](/media/articles/guides/login/centralized-embedded-flow.svg)
+![Universal vs Embedded login flow](/media/articles/guides/login/centralized-embedded-flow.svg)
 :::
 
 In this article, we will evaluate the pros and cons of these two options and see how you can use Auth0 to implement them.
@@ -23,9 +23,9 @@ In this article, we will evaluate the pros and cons of these two options and see
 
 - **Single Sign-On (SSO)**: If you are working with mobile apps you cannot have SSO unless you use universal login. With web apps you can, although the most secure way is to use a central service so the cookies are from the same origin. With embedded login, you'd have to collect the user credentials in an application served from one origin and then send them to another origin, which can present certain security vulnerabilities, including the possibility of a phishing attack (see [Embedded Login with Auth0 > Security risks](#security-risks) for more info). There are workarounds you could use, like third-party cookies, but the most secure option for SSO, and logins in general, is using a central service.
 
-- **Consistency and Maintenance**: With embedded login, if you have more than one app, you will have to implement more than one login page. You will also have to maintain and manage these pages. Besides the extra effort it can also introduce inconsistencies which results in bad UX. Furthermore, with embedded login you would have to manage the dangers of cross-origin attack vectors. On the other hand, if you are using universal login, then your Authorization Server (the domain that logs the users in) owns all the login pages which makes the management easier and the pages more consistent and secure. You could also use a single login page among your apps, a process that creates an impression that users are logging into a centralized system, rather than an individual app. In the following diagram you can see an example of how the centralized and embedded logins look like. The reason why the universal login offers a more consistent and thus superior use experience is evident.
+- **Consistency and Maintenance**: With embedded login, if you have more than one app, you will have to implement more than one login page. You will also have to maintain and manage these pages. Besides the extra effort it can also introduce inconsistencies which results in bad UX. Furthermore, with embedded login you would have to manage the dangers of cross-origin attack vectors. On the other hand, if you are using universal login, then your Authorization Server (the domain that logs the users in) owns all the login pages which makes the management easier and the pages more consistent and secure. You could also use a single login page among your apps, a process that creates an impression that users are logging into a centralized system, rather than an individual app. In the following diagram you can see an example of how the universal and embedded logins look. The reason why the universal login offers a more consistent and thus superior use experience is evident.
 
-![Centralized vs Embedded login UX](/media/articles/guides/login/centralized-embedded-ux.jpg)
+![Universal vs Embedded login UX](/media/articles/guides/login/centralized-embedded-ux.jpg)
 
 - **Central Features Management**: When you use universal login with Auth0, you can turn on and off features across all your apps, using the Dashboard. An example is [Multifactor Authentication](/multifactor-authentication) which you can enable using the toggles located at the [Dashboard > Multifactor Auth](${manage_url}/#/guardian) page. These changes will be automatically available to all your registered apps.
 
@@ -37,7 +37,7 @@ In this article, we will evaluate the pros and cons of these two options and see
 
 For most situations, we recommend using a a universal login strategy, where Auth0 will show a [login page](/hosted-pages/login) if authentication is required. You can customize your login page using the [Dashboard](${manage_url}/#/login_page).
 
-You can use **Auth0's Custom Domains** in order to persist the same domain across the universal login page and the app. This way the redirect to the HLP will be transparent to your users since the domain will not change. For more details refer to [Custom Domains Overview](/custom-domains).
+You can use **Auth0's Custom Domains** in order to persist the same domain across the login page and the app. This way the redirect to the login page will be transparent to your users since the domain will not change. For more details refer to [Custom Domains Overview](/custom-domains).
 
 Whenever your app triggers an authentication request, the user will be redirected to the login page in order to authenticate. This will create a cookie. In future authentication requests, Auth0 will check for this cookie, and if it is present the user will not be redirected to the login page. They will see the page only when they need to actually log in. This is the easiest way to implement SSO.
 

--- a/articles/guides/login/centralized-vs-embedded.md
+++ b/articles/guides/login/centralized-vs-embedded.md
@@ -7,11 +7,7 @@ toc: true
 
 When you design the authentication experience for your application, you have to choose whether the login flow will use **centralized** or **embedded** login.
 
-<<<<<<< HEAD
-With centralized login, when the users try to log in they are redirected to a central domain, through which authentication is performed, and then they are redirected back to the app. An example is Google Apps. No matter which service you are trying to access (gmail, google calendar, google docs, and so on) if you are not logged in you are redirected to `https://accounts.google.com` and once you successfully log in you are redirected back to the calling app.
-=======
 With universal login, when the users try to log in they are redirected to a central domain, through which authentication is performed, and then they are redirected back to the app. An example is Google Apps. No matter which service you are trying to access (gmail, google calendar, google docs, etc) if you are not logged in you are redirected to `https://accounts.google.com` and once you successfully log in you are redirected back to the calling app.
->>>>>>> Replacing the term 'centralized login' with 'universal login'
 
 ![Google Universal Login](/media/articles/guides/login/google-login.jpg)
 

--- a/articles/guides/login/migrating-lock-v10-spa.md
+++ b/articles/guides/login/migrating-lock-v10-spa.md
@@ -1,12 +1,12 @@
 ---
-title: Moving SPAs using Lock to Centralized Login 
-description: Learn how to migrate from Single Page Applications using Lock to Centralized Login
+title: Moving SPAs using Lock to Universal Login 
+description: Learn how to migrate from Single Page Applications using Lock to Universal Login
 toc: true
 ---
 
-# Migrate SPAs using Lock 10+ to Centralized Login
+# Migrate SPAs using Lock 10+ to Universal Login
 
-This document explains how to migrate Single Page Applications using [Lock](/libraries/lock) to centralized login. For other migration scenarios see [Migrating from Embedded to Centralized Login](/guides/login/migration-embedded-centralized).
+This document explains how to migrate Single Page Applications using [Lock](/libraries/lock) to universal login. For other migration scenarios see [Migrating from Embedded to Universal Login](/guides/login/migration-embedded-centralized).
 
 When you use Lock, your code does basically this:
 
@@ -54,7 +54,7 @@ function login() {
 }
 ```
 
-To use **centralized login**, you need to use [auth0.js](/libraries/auth0js) to perform the same tasks:
+To use **universal login**, you need to use [auth0.js](/libraries/auth0js) to perform the same tasks:
 
 1. Initialize auth0.js, using the same parameters as when initializing Lock:
 
@@ -99,6 +99,6 @@ function login() {
 
 5. Review if you are using any [legacy authentication flow in your application](guides/migration-legacy-flows), and adjust your code accordingly.
 
-You can find complete examples of implementing centralized login in Single Page Applications for different technologies in our [Quickstarts](/quickstart/spa).
+You can find complete examples of implementing universal login in Single Page Applications for different technologies in our [Quickstarts](/quickstart/spa).
 
 <%= include('_includes/_customizing-login-page') %>

--- a/articles/guides/login/migrating-lock-v10-webapp.md
+++ b/articles/guides/login/migrating-lock-v10-webapp.md
@@ -1,11 +1,11 @@
 ---
-title: Moving Web Applications using Lock to Centralized Login 
-description: Learn how to migrate from Web Applications using Lock to Centralized Login
+title: Moving Web Applications using Lock to Universal Login 
+description: Learn how to migrate from Web Applications using Lock to Universal Login
 toc: true
 ---
-# Migrate Web Applications using Lock 10+ to Centralized Login
+# Migrate Web Applications using Lock 10+ to Universal Login
 
-This document explains how to migrate Web Applications using [Lock 10+](/libraries/lock) to centralized login. For other migration scenarios see [Migrating from Embedded to Centralized Login](/guides/login/migration-embedded-centralized).
+This document explains how to migrate Web Applications using [Lock 10+](/libraries/lock) to universal login. For other migration scenarios see [Migrating from Embedded to Universal Login](/guides/login/migration-embedded-centralized).
 
 When you use Lock in a Web Application, your code does basically this:
 

--- a/articles/guides/login/migrating-lock-v8.md
+++ b/articles/guides/login/migrating-lock-v8.md
@@ -1,11 +1,11 @@
 ---
-title: Moving Applications using Lock 8 to Centralized Login 
-description: Learn how to migrate from Applications using Lock 8 to Centralized Login
+title: Moving Applications using Lock 8 to Universal Login 
+description: Learn how to migrate from Applications using Lock 8 to Universal Login
 toc: true
 ---
-# Migrating Applications using Lock 8 to Centralized Login
+# Migrating Applications using Lock 8 to Universal Login
 
-Lock v8 is very similar to Lock v9 from an API standpoints, so the guides for v9 give you all the information you need to migrate to centralized login:
+Lock v8 is very similar to Lock v9 from an API standpoints, so the guides for v9 give you all the information you need to migrate to universal login:
 
 - [Migrating Web Applications using Lock 9](/guides/login/migrating-lock-v9-webapp)
 

--- a/articles/guides/login/migrating-lock-v9-spa-popup.md
+++ b/articles/guides/login/migrating-lock-v9-spa-popup.md
@@ -1,13 +1,13 @@
 ---
-title: Migrate SPAs Using Lock 9 Popup Mode to Centralized Login
-description: Learn how to Migrate SPAs Using Lock 9 Popup Mode to Centralized Login
+title: Migrate SPAs Using Lock 9 Popup Mode to Universal Login
+description: Learn how to Migrate SPAs Using Lock 9 Popup Mode to Universal Login
 toc: true
 ---
-# Migrate SPAs Using Lock 9 Popup Mode to Centralized Login
+# Migrate SPAs Using Lock 9 Popup Mode to Universal Login
 
-This document explains how to migrate Web Applications using [Lock](/libraries/lock) to centralized login. For other migration scenarios see [Migrating from Embedded to Centralized Login](/guides/login/migration-embedded-centralized).
+This document explains how to migrate Web Applications using [Lock](/libraries/lock) to universal login. For other migration scenarios see [Migrating from Embedded to Universal Login](/guides/login/migration-embedded-centralized).
 
-When you use 'popup mode' in Lock 9 applications, the entire authentication flow happens in a web page, without any kind of redirection. That will change when you use centralized login.
+When you use 'popup mode' in Lock 9 applications, the entire authentication flow happens in a web page, without any kind of redirection. That will change when you use universal login.
 
 1. Initialize Lock:
 
@@ -40,7 +40,7 @@ function login()
 }
 ```
 
-To use **centralized login**, you need to use [auth0.js](/libraries/auth0js) to manage the authentication flow:
+To use **universal login**, you need to use [auth0.js](/libraries/auth0js) to manage the authentication flow:
 
 1. Initialize auth0.js, using the same parameters as when initializing Lock and also including the ones you use when you call lock.show(). 
 
@@ -76,6 +76,6 @@ webAuth.parseHash(function(err, authResult) {
 
 4. Review if you are using any [legacy authentication flow in your application](guides/migration-legacy-flows), and adjust your code accordingly.
 
-You can find complete examples of implementing centralized login in Single Page Applications for different technologies in our [Quickstarts](/quickstart/spa).
+You can find complete examples of implementing universal login in Single Page Applications for different technologies in our [Quickstarts](/quickstart/spa).
 
 <%= include('_includes/_customizing-login-page') %>

--- a/articles/guides/login/migrating-lock-v9-spa.md
+++ b/articles/guides/login/migrating-lock-v9-spa.md
@@ -1,11 +1,11 @@
 ---
-title: Moving Web Applications using Lock to Centralized Login 
-description: Learn how to migrate from Web Applications using Lock to Centralized Login
+title: Moving Web Applications using Lock to Universal Login 
+description: Learn how to migrate from Web Applications using Lock to Universal Login
 toc: true
 ---
-# Migrate Single Page Applications using Lock 9 to Centralized Login
+# Migrate Single Page Applications using Lock 9 to Universal Login
 
-This document explains how to migrate Web Applications using [Lock](/libraries/lock) to centralized login. For other migration scenarios see [Migrating from Embedded to Centralized Login](/guides/login/migration-embedded-centralized).
+This document explains how to migrate Web Applications using [Lock](/libraries/lock) to universal login. For other migration scenarios see [Migrating from Embedded to Universal Login](/guides/login/migration-embedded-centralized).
 
 When you use Lock v9 in a Web Application, your code does basically this:
 
@@ -47,7 +47,7 @@ function login() {
   }
 ```
 
-To use **centralized login**, you need to use [auth0.js](/libraries/auth0js) to manage the authentication flow:
+To use **universal login**, you need to use [auth0.js](/libraries/auth0js) to manage the authentication flow:
 
 1. Initialize auth0.js, using the same parameters as when initializing Lock and also including the ones you use when you call lock.show():
 
@@ -83,6 +83,6 @@ function login() {
 
 4. Review if you are using any [legacy authentication flow in your application](guides/migration-legacy-flows), and adjust your code accordingly.
 
-You can find complete examples of implementing centralized login in Single Page Applications for different technologies in our [Quickstarts](/quickstart/spa).
+You can find complete examples of implementing universal login in Single Page Applications for different technologies in our [Quickstarts](/quickstart/spa).
 
 <%= include('_includes/_customizing-login-page') %>

--- a/articles/guides/login/migrating-lock-v9-webapp.md
+++ b/articles/guides/login/migrating-lock-v9-webapp.md
@@ -1,11 +1,11 @@
 ---
-title: Moving Web Applications using Lock to Centralized Login 
-description: Learn how to migrate from Web Applications using Lock to Centralized Login
+title: Moving Web Applications using Lock to Universal Login 
+description: Learn how to migrate from Web Applications using Lock to Universal Login
 toc: true
 ---
-# Migrate Web Applications using Lock 9 to Centralized Login
+# Migrate Web Applications using Lock 9 to Universal Login
 
-This document explains how to migrate Web Applications using Lock to centralized login. For other migration scenarios see [Migrating from Embedded to Centralized Login](/guides/login/migration-embedded-centralized).
+This document explains how to migrate Web Applications using Lock to universal login. For other migration scenarios see [Migrating from Embedded to Universal Login](/guides/login/migration-embedded-centralized).
 
 When you use Lock v9 in a Web Application, your code does basically this:
 

--- a/articles/guides/login/migration-embedded-centralized.md
+++ b/articles/guides/login/migration-embedded-centralized.md
@@ -1,20 +1,20 @@
 ---
-title: Migrating from Embedded to Centralized Login
-description: Learn how to migrate from Embedded Login using Lock to Centralized Login
+title: Migrating from Embedded to Universal Login
+description: Learn how to migrate from Embedded Login using Lock to Universal Login
 ---
 
-# Migrating to Centralized Login
+# Migrating to Universal Login
 
-When you integrate Auth0 in our applications, you have to decide whether you will use embedded or centralized login.
+When you integrate Auth0 in our applications, you have to decide whether you will use embedded or universal login.
 
 - With embedded login the login dialog is hosted in your application. You can use [Lock](/libraries/lock) or create your own UI and use [auth0.js](/libraries/auth0js).
-- With centralized login, you redirect to a [Hosted Login Page](/hosted-pages/login) where the authentication flow is performed.
+- With universal login, you redirect to a [Hosted Login Page](/hosted-pages/login) where the authentication flow is performed.
 
-Centralized login has several advantages over embedded login. For a detailed analysis refer to [Centralized vs Embedded Login](/guides/login/centralized-vs-embedded).
+Universal login has several advantages over embedded login. For a detailed analysis refer to [Centralized vs Embedded Login](/guides/login/centralized-vs-embedded).
 
-We put together a set of articles to help you migrate to centralized login in different scenarios. 
+We put together a set of articles to help you migrate to universal login in different scenarios. 
 
-You can also find how to implement centralized login in multiple technology stacks using [our Quickstarts](/quickstart).
+You can also find how to implement universal login in multiple technology stacks using [our Quickstarts](/quickstart).
 
 ## Migration Guides per Application Type
 

--- a/articles/guides/login/migration-embedded-centralized.md
+++ b/articles/guides/login/migration-embedded-centralized.md
@@ -8,7 +8,7 @@ description: Learn how to migrate from Embedded Login using Lock to Universal Lo
 When you integrate Auth0 in our applications, you have to decide whether you will use embedded or universal login.
 
 - With embedded login the login dialog is hosted in your application. You can use [Lock](/libraries/lock) or create your own UI and use [auth0.js](/libraries/auth0js).
-- With universal login, you redirect to a [Hosted Login Page](/hosted-pages/login) where the authentication flow is performed.
+- With universal login, you redirect to an Auth0-hosted [login page](/hosted-pages/login) where the authentication flow is performed.
 
 Universal login has several advantages over embedded login. For a detailed analysis refer to [Centralized vs Embedded Login](/guides/login/centralized-vs-embedded).
 

--- a/articles/hosted-pages/login/auth0js.md
+++ b/articles/hosted-pages/login/auth0js.md
@@ -3,11 +3,11 @@ description: How to Use the Auth0.js with the Hosted Login Page
 ---
 # Using Auth0.js in the Hosted Login Page
 
-Within the Hosted Login page, you can use the the [Auth0.js SDK](/libraries/auth0js), instead of [Lock](/libraries/lock), to perform authentication using a custom UI (you can also use Auth0.js _in addition_ to Lock, for authentication or user management tasks).
+Within the Hosted Login page, you can use the the [Auth0.js SDK](/libraries/auth0js), instead of [Lock](/libraries/lock), to perform authentication using a custom UI (you can also use Auth0.js in addition to Lock, for authentication or user management tasks).
 
-## Auth0.js template for Hosted Login Page
+## Auth0.js Template for Hosted Login Page
 
-You can start out with a basic template that will provide you with a working, ready-to-use example of a custom UI using Auth0.js in the Hosted Login Page. 
+You can start out with a basic template that will provide you with a working, ready-to-use example of a custom UI using Auth0.js v8 in your universal login page. 
 
 In the [dashboard](${manage_url}), go to **Hosted Pages**, and then to the **Login** page section. 
 
@@ -15,7 +15,7 @@ At the top of the code editor for the page contents, you'll see a dropdown, titl
 
 Choose `Custom UI` to get started.
 
-![Hosted Login Page](/media/articles/hosted-pages/hlp-customui.png)
+![Login Page](/media/articles/hosted-pages/hlp-customui.png)
 
 The template showcases using Auth0.js to allow users to sign up, log in with a database connection, or login with a social provider (Google, in this example).
 
@@ -25,7 +25,7 @@ Additionally, you can take a look at the following example scenario using Auth0.
 
 With [passwordless authentication](/connections/passwordless), the user is prompted to enter an email or an SMS number, at which they will receive a one-time code to enter, or a "magic link" to click, which will authenticate them. In this example, the user will enter an email, and receive a one-time code.
 
-For this example, replace the code in your Hosted Login Page editor with the following template:
+For this example, replace the code in the login page editor with the following template:
 
 ```html
 <!DOCTYPE html>
@@ -173,9 +173,9 @@ This should allow you to prompt your users to enter their email address, receive
 
 ## Next Steps
 
-Are you looking for more information about the SDK used here, or about Passwordless authentication? Or are you ready to get started with your own Hosted Login Page?
+Are you looking for more information about the SDK used here, or about Passwordless authentication? Or are you ready to get started implementing universal login?
 
 ::: next-steps
 * [Read more About the Auth0.js SDK](/libraries/auth0js)
-* [Get Started on Your Own Hosted Login Page](${manage_url}/#/login_page)
+* [Get Started with Universal Login](${manage_url}/#/login_page)
 :::

--- a/articles/hosted-pages/login/auth0js.md
+++ b/articles/hosted-pages/login/auth0js.md
@@ -3,7 +3,7 @@ description: How to Use the Auth0.js with the Hosted Login Page
 ---
 # Using Auth0.js in the Hosted Login Page
 
-Within the Hosted Login page, you can use the the [Auth0.js SDK](/libraries/auth0js), instead of [Lock](/libraries/lock), to perform authentication using a custom UI (you can also use Auth0.js in addition to Lock, for authentication or user management tasks).
+Within the login page, you can use the the [Auth0.js SDK](/libraries/auth0js), instead of [Lock](/libraries/lock), to perform authentication using a custom UI.
 
 ## Auth0.js Template for the Login Page
 

--- a/articles/hosted-pages/login/auth0js.md
+++ b/articles/hosted-pages/login/auth0js.md
@@ -5,7 +5,7 @@ description: How to Use the Auth0.js with the Hosted Login Page
 
 Within the Hosted Login page, you can use the the [Auth0.js SDK](/libraries/auth0js), instead of [Lock](/libraries/lock), to perform authentication using a custom UI (you can also use Auth0.js in addition to Lock, for authentication or user management tasks).
 
-## Auth0.js Template for Hosted Login Page
+## Auth0.js Template for the Login Page
 
 You can start out with a basic template that will provide you with a working, ready-to-use example of a custom UI using Auth0.js v8 in your universal login page. 
 

--- a/articles/hosted-pages/login/index.md
+++ b/articles/hosted-pages/login/index.md
@@ -1,38 +1,38 @@
 ---
-title: Hosted Login Page
-description: How to use the Hosted Login Page
+title: Universal Login
+description: How to use Universal Login
 toc: true
 crews: crew-2
 ---
-# Hosted Login Page
+# Universal Login
 
-## About the Hosted Login Page
+## About Universal Login
 
-Auth0's Hosted Login Page is the most secure way to easily authenticate users for your applications. The Hosted Login Page is easily customizable right from the [Dashboard](${manage_url}). By default, the Hosted Login Page uses Auth0's [Lock Widget](/libraries/lock) to authenticate your users, but the code of the Hosted Login Page can be customized to replace Lock with the Lock Passwordless widget, or an entirely custom UI can be built in its place, using the [Auth0.js SDK](/libraries/auth0js) for authentication.
+Auth0's universal login is the most secure way to easily authenticate users for your applications. The login page appearance and behavior is easily customizable right from the [Dashboard](${manage_url}). By default, the universal login page uses Auth0's [Lock Widget](/libraries/lock/v10) to authenticate your users, but the code of the login page can be customized to replace Lock with the Lock Passwordless widget, or an entirely custom UI can be built in its place, using the [Auth0.js SDK](/libraries/auth0js/v8) for authentication.
 
-If you cannot use the Hosted Login Page, you can embed the Lock widget or a custom login form in your application using [cross-origin authentication](/cross-origin-authentication), but be sure to read about its limitations before choosing to do so.
+If you cannot use universal login, you can embed the Lock widget or a custom login form in your application using [cross-origin authentication](/cross-origin-authentication), but be sure to read about its limitations before choosing to do so.
 
 ![Hosted Login Page](/media/articles/hosted-pages/hlp-lock.png)
 
-### How Does the Hosted Login Page Work
+### How Does Universal Login Work
 
-Auth0 shows the Hosted Login Page whenever something (or someone) triggers an authentication request, such as calling the `/authorize` endpoint (OIDC/OAuth) or sending a SAML login request. It can also be accessed via a request, in the following format:
+Auth0 shows the login page whenever something (or someone) triggers an authentication request, such as calling the `/authorize` endpoint (OIDC/OAuth) or sending a SAML login request. It can also be accessed via a request, in the following format:
 
 ```text
 https://${account.namespace}/login?client=${account.clientId}
 ```
 
-Users will see the Hosted Login Page, typically with either the Lock widget or with your custom UI. Once they login, they will be redirected back to your application.
+Users will see the login page, typically with either the Lock widget or with your custom UI. Once they login, they will be redirected back to your application.
 
 ::: warning
-If the incoming authentication request includes a `connection` parameter that uses an external identity provider (such as a social provider), the Hosted Login Page will not display. Instead, Auth0 will direct the user to the [identity provider's](/identityproviders) login page.
+If the incoming authentication request includes a `connection` parameter that uses an external identity provider (such as a social provider), the login page will not display. Instead, Auth0 will direct the user to the [identity provider's](/identityproviders) login page.
 :::
 
 #### Single Sign-On (SSO)
 
-If you want to use single sign on, you should use the Hosted Login Page for logins rather than an embedded login solution. When a user logs in via the Hosted Login Page, a cookie will be created and stored. On future calls to the `authorize` endpoint, the cookie will be checked, and if SSO is achieved, the user will not ever be redirected to the Hosted Login Page. They will see the page only when they need to actually login. 
+If you want to use single sign on, you should use universal login rather than an embedded login solution. When a user logs in via the login page, a cookie will be created and stored. On future calls to the `authorize` endpoint, the cookie will be checked, and if SSO is achieved, the user will not ever be redirected to the login page. They will see the page only when they need to actually login. 
 
-This behavior occurs without modification to the actual Hosted Login Page. This is a simple two step process:
+This behavior occurs without the need for any modification to the login page itself. This is a simple two step process:
 
 1. Enable SSO for the client in the [Dashboard](${manage_url}) (Go to the Client's Settings, then scroll down to the **Use Auth0 instead of the IdP to do Single Sign On** setting and toggle it on.
 1. Use the [authorize endpoint](/api/authentication#authorization-code-grant) with `?prompt=none` for [silent SSO](/api-auth/tutorials/silent-authentication).
@@ -41,33 +41,33 @@ This behavior occurs without modification to the actual Hosted Login Page. This 
 For more details about how SSO works, see the [SSO documentation](/sso).
 :::
 
-### Why Use the Hosted Login Page
+### Why Use Universal Login
 
-Why use the Hosted Login Page rather than embedding your login functionality within your application?
+Why use universal login rather than embedding your login functionality within your application?
 
-Security is the primary reason, followed by ease of setup. Cross-origin authentication is inherently more dangerous, and more likely to be vulnerable to [man-in-the-middle attacks](/security/common-threats#man-in-the-middle-mitm-attacks). Using the Hosted Login Page for the authentication process with Auth0 prevents that from ever being a concern. Additionally, the Hosted Login Page is very easy to implement, especially if a custom UI is not required.
+Security is the primary reason, followed by ease of setup. Cross-origin authentication is inherently more dangerous, and more likely to be vulnerable to [man-in-the-middle attacks](/security/common-threats#man-in-the-middle-mitm-attacks). Using universal login for the authentication process with Auth0 prevents that from ever being a concern. Additionally, universal login is very easy to implement, especially if a custom UI is not required in your login page.
 
-### What the Hosted Login Page is Not Intended For
+### What Universal Login is Not Intended For
 
-An important thing to remember is that the Hosted Login Page is intended to be only for signups and authentication. Attempting to host any significant amount of application logic in the Hosted Login Page is not advised.
+An important thing to remember is that the login page is intended to be only for signups and authentication. Attempting to host any significant amount of application logic in the login page is not advised.
 
-The Hosted Login Page is truly a single page constructed within the editor, so all custom styling and includes will need to be put into the single editor window. Hosting other files or images along with the Hosted Login Page is not possible, so those will need to be hosted in the application itself, or elsewhere.
+The login page is truly a single page constructed within the editor, so all custom styling and includes will need to be put into the single editor window. Hosting other files or images along with the login page is not possible, so those will need to be hosted in the application itself, or elsewhere.
 
 ### Passwordless on Native Platforms
 
-Currently, the Hosted Login Page is the **only** way to use [Passwordless](/connections/passwordless) authentication on Native platforms. So if your use case is a native iOS or Android application, for example, and you intend to implement Passwordless, you will need to use the Hosted Login Page.
+Currently, universal login is the **only** way to use [Passwordless](/connections/passwordless) authentication on Native platforms. So if your use case is a native iOS or Android application, for example, and you intend to implement Passwordless, you will need to use the universal login.
 
-## How to Use the Hosted Login Page
+## How to Customize Your Universal Login Page
 
-### 1. Enable the Hosted Login Page
+### 1. Enable Customization on the Login Page
 
-In the [Dashboard](${manage_url}), you can enable a custom Hosted Login Page by navigating to [Hosted Pages](${manage_url}/#/login_page) and enabling the **Customize Login Page** toggle.
+In the [Dashboard](${manage_url}), you can enable a custom login page by navigating to [Hosted Pages](${manage_url}/#/login_page) and enabling the **Customize Login Page** toggle.
 
 ![Hosted Login Page](/media/articles/hosted-pages/login.png)
 
 ### 2. Choose a Technology
 
-In order to get started using the Hosted Login Page, you'll first want to choose the technology that you'd like to use to power it. Click one of the links below to get started.
+In order to get started customizing the login page, you'll first want to choose the technology that you'd like to use to power it. Click one of the links below to get started.
 
 - [Lock](/hosted-pages/login/lock) - Lock is a pre-built, customizable login widget that will allow your users to quickly and easily login to your application.
 - [Lock Passwordless](/hosted-pages/login/lock-passwordless) - Lock Passwordless uses the same style of interface as Lock, but rather than offering identity providers as login options, will simply ask the user to enter an email or SMS number to begin a Passwordless authentication transaction.
@@ -75,17 +75,17 @@ In order to get started using the Hosted Login Page, you'll first want to choose
 
 ### 3. Customization
 
-You can customize the Hosted Login Page at will right from the editor. If you use Lock, you can alter its behavior and appearance with [customization options](/libraries/lock/customization). If you are building a custom UI, you can style the Hosted Login Page to your own specifications.
+You can customize the login page at will right from the editor. If you use Lock, you can alter its behavior and appearance with [configuration options](/libraries/lock/v10/customization). If you are building a custom UI, you can style the login page to your own specifications.
 
-All changes to the page's appearance and/or behavior will apply to **all** users shown this login page, regardless of the client or connection. Remember that the Hosted Login Page customizations are per **tenant** rather than per client. When necessary, you can provide different pages to different clients via a method discussed later in this document.
+All changes to the page's appearance and/or behavior will apply to **all** users shown this login page, regardless of the client or connection. Remember that the login page customizations are per **tenant** rather than per client. When necessary, you can provide different pages to different clients via a method discussed later in this document.
 
 #### Query String Parameters
 
-You can add query string parameters to the URL you are using to call your Hosted Login Page from your application, and use those items to customize its behavior or appearance.
+You can add query string parameters to the URL you are using to initiate universal login from your application, and use those items to customize the login page's behavior or appearance.
 
-For example, you can pass the parameter `title` in your request as a query parameter, and then access it in your Hosted Login Page Code by using `config.extraParams.title`.
+For example, you can pass the parameter `title` in your request as a query parameter, and then access it in your login page's code by using `config.extraParams.title`.
 
-The `config` object contains the set of configuration values that adjusts the behavior of the Hosted Login Page at runtime. Set the `config` object up in the Hosted Login Page editor so that you can access the config parameters to use in your page:
+The `config` object contains the set of configuration values that adjusts the behavior of the login page at runtime. Set the `config` object up in the login page editor so that you can access the config parameters to use in your page:
 
 ```js
 var config = JSON.parse(decodeURIComponent(escape(window.atob('@@config@@'))));
@@ -101,15 +101,15 @@ if (config.extraParams.title) {
 
 #### Parameters for the Authorize Endpoint
 
-If you choose to initiate the Hosted Login Page via the `authorize` endpoint, whether by an SDK like auth0.js or by calling the endpoint directly, you may also pass some customization parameters to the Hosted Login Page. However, parameters passed to the `authorize` endpoint must be [OIDC specification](http://openid.net/specs/openid-connect-core-1_0.html#AuthRequest) compliant parameters.
+If you initiate universal login via the `authorize` endpoint, whether by an SDK like auth0.js or by calling the endpoint directly, you may also pass some customization parameters to the login page. However, parameters passed to the `authorize` endpoint must be [OIDC specification](http://openid.net/specs/openid-connect-core-1_0.html#AuthRequest) compliant parameters.
 
-The `config` object contains the set of configuration values that adjusts the behavior of the Hosted Login Page at runtime. Set the `config` object up in the Hosted Login Page editor so that you can access the config parameters to use in your page:
+The `config` object contains the set of configuration values that adjusts the behavior of the login page at runtime. Set the `config` object up in the login page editor so that you can access the config parameters to use in your page:
 
 ```js
 var config = JSON.parse(decodeURIComponent(escape(window.atob('@@config@@'))));
 ```
 
-The below examples assume that you are using [Auth0.js](/libraries/auth0js) within your application to call the `authorize` endpoint and show the Hosted Login Page. 
+The below examples assume that you are using [Auth0.js](/libraries/auth0js) within your application to call the `authorize` endpoint and show the login page. 
 
 ##### Login Hint
 
@@ -125,7 +125,7 @@ You will then be able to access the value of `login_hint` within the Hosted Logi
 
 ##### Callback URL
 
-Once authentication has been performed using the Hosted Login Page, your user will then be redirected to the default callback URL set in your [Client's settings page](${manage_url}/#/clients/${account.clientId}/settings). You can also pass a specific `redirect_uri` option to `authorize`, and access it within the Hosted Login Page editor by referring to `config.callbackURL`.
+Once authentication has been performed using universal login, your user will then be redirected to the default callback URL set in your [Client's settings page](${manage_url}/#/clients/${account.clientId}/settings). You can also pass a specific `redirect_uri` option to `authorize`, and access it within the login page editor by referring to `config.callbackURL`.
 
 ::: note
 Make sure that you've added any redirect URLs you're using to the **Allowed Redirect URLs** field on the [Client's settings page](${manage_url}/#/clients/${account.clientId}/settings).
@@ -153,9 +153,9 @@ If your use case requires separate sets of custom pages, let's see how you would
 
 If you have five different applications, with three of them (`app1`, `app2`, `app3`) using the same set of hosted pages and the other two (`app4`, `app5`) using different ones, you would do the following:
 
-- If you already have an account, you have a tenant configured. Configure three clients under this tenant, one to represent each app (`app1`, `app2`, `app3`), and one hosted login page  which these clients will all share.
-- Create a second tenant, configure a new client for `app4`, and configure the hosted login page for this client.
-- Create a third tenant, configure a new client for `app5`, and configure the hosted login page for this client.
+- If you already have an account, you have a tenant configured. Configure three clients under this tenant, one to represent each app (`app1`, `app2`, `app3`), and one login page  which these clients will all share.
+- Create a second tenant, configure a new client for `app4`, and configure the login page for this client.
+- Create a third tenant, configure a new client for `app5`, and configure the login page for this client.
 
 To create a new tenant go to the [Dashboard](${manage_url}), and using the top right menu, click on the __New Account__ option.
 

--- a/articles/hosted-pages/login/index.md
+++ b/articles/hosted-pages/login/index.md
@@ -12,7 +12,7 @@ Auth0's universal login is the most secure way to easily authenticate users for 
 
 If you cannot use universal login, you can embed the Lock widget or a custom login form in your application using [cross-origin authentication](/cross-origin-authentication), but be sure to read about its limitations before choosing to do so.
 
-![Hosted Login Page](/media/articles/hosted-pages/hlp-lock.png)
+![Login Page](/media/articles/hosted-pages/hlp-lock.png)
 
 ### How Does Universal Login Work
 
@@ -63,7 +63,7 @@ Currently, universal login is the **only** way to use [Passwordless](/connection
 
 In the [Dashboard](${manage_url}), you can enable a custom login page by navigating to [Hosted Pages](${manage_url}/#/login_page) and enabling the **Customize Login Page** toggle.
 
-![Hosted Login Page](/media/articles/hosted-pages/login.png)
+![Login Page](/media/articles/hosted-pages/login.png)
 
 ### 2. Choose a Technology
 
@@ -121,7 +121,7 @@ webAuth.authorize({
 });
 ```
 
-You will then be able to access the value of `login_hint` within the Hosted Login Page editor by using `config.extraParams.login_hint`.
+You will then be able to access the value of `login_hint` within the login page editor by using `config.extraParams.login_hint`.
 
 ##### Callback URL
 
@@ -139,7 +139,7 @@ webAuth.authorize({
 
 ## Configure Multiple Pages by Using Separate Tenants
 
-In some cases, you might have multiple apps and want to configure separate login pages for each. Since the hosted pages are configured in the [Dashboard](${manage_url}) at the tenant level (every client app you have set up on a single tenant would use the same Hosted Login Page), you would have to create a new tenant for each client that requires a different hosted page. 
+In some cases, you might have multiple apps and want to configure separate login pages for each. Since the hosted pages are configured in the [Dashboard](${manage_url}) at the tenant level (every client app you have set up on a single tenant would use the same login page), you would have to create a new tenant for each client that requires a different hosted page. 
 
 In most cases, it would be preferable to use a single login page, which unifies your brand and the authentication experience for your users across the various areas in which they might encounter it. Additionally, using the same pages, and the same tenant, will allow you to share the resources that would otherwise need to be separated across multiple tenants.
 

--- a/articles/hosted-pages/login/index.md
+++ b/articles/hosted-pages/login/index.md
@@ -8,7 +8,7 @@ crews: crew-2
 
 ## About Universal Login
 
-Auth0's universal login is the most secure way to easily authenticate users for your applications. The login page appearance and behavior is easily customizable right from the [Dashboard](${manage_url}). By default, the universal login page uses Auth0's [Lock Widget](/libraries/lock/v10) to authenticate your users, but the code of the login page can be customized to replace Lock with the Lock Passwordless widget, or an entirely custom UI can be built in its place, using the [Auth0.js SDK](/libraries/auth0js/v8) for authentication.
+Auth0's universal login is the most secure way to easily authenticate users for your applications. The login page appearance and behavior is easily customizable right from the [Dashboard](${manage_url}). By default, the login page uses Auth0's [Lock Widget](/libraries/lock/v10) to authenticate your users, but the code of the login page can be customized to replace Lock with the Lock Passwordless widget, or an entirely custom UI can be built in its place, using the [Auth0.js SDK](/libraries/auth0js/v8) for authentication.
 
 If you cannot use universal login, you can embed the Lock widget or a custom login form in your application using [cross-origin authentication](/cross-origin-authentication), but be sure to read about its limitations before choosing to do so.
 
@@ -57,7 +57,7 @@ The login page is truly a single page constructed within the editor, so all cust
 
 Currently, universal login is the **only** way to use [Passwordless](/connections/passwordless) authentication on Native platforms. So if your use case is a native iOS or Android application, for example, and you intend to implement Passwordless, you will need to use the universal login.
 
-## How to Customize Your Universal Login Page
+## How to Customize Your Login Page
 
 ### 1. Enable Customization on the Login Page
 

--- a/articles/hosted-pages/login/lock-passwordless.md
+++ b/articles/hosted-pages/login/lock-passwordless.md
@@ -1,13 +1,13 @@
 ---
 description: How to use Lock Passwordless with the Hosted Login Page
 ---
-# Hosted Login with Lock Passwordless
+# Universal Login with Lock Passwordless
 
-Using Lock Passwordless in the Hosted Login Page is the easiest and most secure implementation of [passwordless authentication](/connections/passwordless) that can be achieved. Additionally, the Hosted Login Page is the **only** way to perform passwordless authentication with native applications at this time.
+Using Lock Passwordless in a universal login page is the easiest and most secure implementation of [passwordless authentication](/connections/passwordless) that can be achieved. Additionally, universal login is the **only** way to perform passwordless authentication with native applications at this time.
 
 ## Lock Passwordless Template
 
-You can start out with a basic template that will provide you with a working, ready-to-use example of Lock Passwordless in the Hosted Login Page. 
+You can start out with a basic template that will provide you with a working, ready-to-use example of Lock Passwordless in the login page. 
 
 In the [dashboard](${manage_url}), go to **Hosted Pages**, and then to the **Login** page section. 
 
@@ -15,11 +15,11 @@ At the top of the code editor for the page contents, you'll see a dropdown, titl
 
 Choose `Lock Passwordless` to get started.
 
-![Hosted Login Page](/media/articles/hosted-pages/hlp-lock-passwordless.png)
+![Login Page](/media/articles/hosted-pages/hlp-lock-passwordless.png)
 
 ## Next Steps
 
-Are you looking for more information about Lock? Or are you ready to get started with your own Hosted Login Page?
+Are you looking for more information about Lock? Or are you ready to get started with your own login page?
 
 ::: next-steps
 * [Read more About Lock](/libraries/lock/v10)

--- a/articles/hosted-pages/login/lock-passwordless.md
+++ b/articles/hosted-pages/login/lock-passwordless.md
@@ -1,5 +1,5 @@
 ---
-description: How to use Lock Passwordless with the Hosted Login Page
+description: How to use Lock Passwordless with Universal Login
 ---
 # Universal Login with Lock Passwordless
 
@@ -23,5 +23,5 @@ Are you looking for more information about Lock? Or are you ready to get started
 
 ::: next-steps
 * [Read more About Lock](/libraries/lock/v10)
-* [Get Started on Your Own Hosted Login Page](${manage_url}/#/login_page)
+* [Get Started on Your Own Login Page](${manage_url}/#/login_page)
 :::

--- a/articles/hosted-pages/login/lock.md
+++ b/articles/hosted-pages/login/lock.md
@@ -1,15 +1,15 @@
 ---
-description: How to use Lock with the Hosted Login Page
+description: How to use Lock with Universal Login
 ---
-# How to Use Lock with the Hosted Login Page
+# How to Use Lock with Universal Login
 
 [Lock](/libraries/lock) is a signup and authentication widget that provides quick and easy authentication for your application's users without requiring you to design the UI or interact manually with an Auth0 API.
 
-## Customize Lock in the Hosted Login Page
+## Customize Lock in the Login Page
 
 The default login page for your tenant is a template that will use Lock to provide your users with an attractive interface and smooth authentication process, as discussed above. You can look over that template and use it as a starting point if you choose to customize it in any way.
 
-If you want to change any of Lock's [configurable options](/libraries/lock/customization), you can do so using the [Hosted Pages](${manage_url}/#/login_page) editor interface. These options can alter the behavior of Lock itself, or the look and feel of the widget using the theming options. See the [configuration documentation](/libraries/lock/customization) for details on how to customize Lock.
+If you want to change any of Lock's [configurable options](/libraries/lock/configuration), you can do so using the [Hosted Pages](${manage_url}/#/login_page) editor interface. These options can alter the behavior of Lock itself, or the look and feel of the widget using the theming options. See the [configuration documentation](/libraries/lock/v10/configuration) for details on how to customize Lock.
 
 When you're done making changes to the code, click **Save** to persist the changes.
 

--- a/articles/hosted-pages/login/lock.md
+++ b/articles/hosted-pages/login/lock.md
@@ -13,11 +13,11 @@ If you want to change any of Lock's [configurable options](/libraries/lock/confi
 
 When you're done making changes to the code, click **Save** to persist the changes.
 
-![Hosted Login Page](/media/articles/hosted-pages/hlp-lock.png)
+![Login Page](/media/articles/hosted-pages/hlp-lock.png)
 
 ## Next Steps
 
 ::: next-steps
 * [Read more About Lock](/libraries/lock)
-* [Get Started on Your Own Hosted Login Page](${manage_url}/#/login_page)
+* [Get Started on Your Own Login Page](${manage_url}/#/login_page)
 :::

--- a/articles/hosted-pages/login/lock.md
+++ b/articles/hosted-pages/login/lock.md
@@ -18,6 +18,6 @@ When you're done making changes to the code, click **Save** to persist the chang
 ## Next Steps
 
 ::: next-steps
-* [Read more About Lock](/libraries/lock)
-* [Get Started on Your Own Login Page](${manage_url}/#/login_page)
+* [Read more about Lock](/libraries/lock)
+* [Get started on your own login page](${manage_url}/#/login_page)
 :::

--- a/articles/libraries/_includes/_ip_ranges.md
+++ b/articles/libraries/_includes/_ip_ranges.md
@@ -4,4 +4,4 @@ In earlier versions of Lock, you could configure an IP range in an Active Direct
 
 ![SSO With Lock 10 and Windows IP Ranges](/media/articles/libraries/lock/lock-11-windows-authentication.png)
 
-This functionality has been removed from Lock 11. There is no IP detection and the user will get redirected to the Active Directory login page where they will have to type in their credentials. It will still be available when using centralized login.
+This functionality has been removed from Lock 11. There is no IP detection and the user will get redirected to the Active Directory login page where they will have to type in their credentials. It will still be available when using universal login.

--- a/articles/libraries/_includes/_review_get_ssodata.md
+++ b/articles/libraries/_includes/_review_get_ssodata.md
@@ -17,6 +17,6 @@ If you are going to keep using `getSSOData()`, take into account the changes in 
 | lastUsedClientId | The client id for the last active connection | The last client used when authenticating from the current browsers |
 | lastUsedUserId | The user id for the current session | The same  |
 | lastUsedUsername | User's email or name | The same (requires `scope=’openid profile email’)` |
-| lastUsedConnection | Last used connection and strategy. | Last connection used when authenticated from the current browser. It will be `null` if the user authenticated with the Hosted Login Page. It will not return `strategy`, only `name` |
+| lastUsedConnection | Last used connection and strategy. | Last connection used when authenticated from the current browser. It will be `null` if the user authenticated via [universal login](/hosted-pages/login). It will not return `strategy`, only `name` |
 
 In order for the function to work properly, you need to ask for `scope='openid profile email'` when you initialize Auth0.js.

--- a/articles/libraries/auth0-android/database-authentication.md
+++ b/articles/libraries/auth0-android/database-authentication.md
@@ -6,7 +6,7 @@ description: How to use Auth0.Android with database connections
 # Auth0.Android Database Authentication
 
 ::: panel-warning Database authentication on Native Platforms
-Username/Email & Password authentication from native clients is disabled by default for new tenants as of 8 June 2017. Users are encouraged to use the [Hosted Login Page](/hosted-pages/login) and perform Web Authentication instead. If you still want to proceed you'll need to enable the Password Grant Type on your dashboard first. See [Client Grant Types](/clients/client-grant-types) for more information.
+Username/Email & Password authentication from native clients is disabled by default for new tenants as of 8 June 2017. Users are encouraged to use the [universal login](/hosted-pages/login) and perform Web Authentication instead. If you still want to proceed you'll need to enable the Password Grant Type on your dashboard first. See [Client Grant Types](/clients/client-grant-types) for more information.
 :::
 
 ## Log in with a database connection

--- a/articles/libraries/auth0-android/index.md
+++ b/articles/libraries/auth0-android/index.md
@@ -69,11 +69,11 @@ account.setOIDCConformant(true);
 //Use the account in the API clients
 ```
 
-Passwordless authentication *cannot be used* with this flag set to `true`. For more information, please see the [OIDC adoption guide](https://auth0.com/docs/api-auth/tutorials/adoption).
+Passwordless authentication **cannot be used** with this flag set to `true`. For more information, please see the [OIDC adoption guide](/api-auth/tutorials/adoption).
 
-## Authentication with Auth0 Hosted Login Page
+## Authentication via Universal Login
 
-The recommended way to authenticate your users is via the [Hosted Login Page](/hosted-pages/login). To begin, go to the [Dashboard](${manage_url}/#/clients) and go to your client's settings. Make sure you have in **Allowed Callback URLs** a URL with the following format:
+First go to [Auth0 Dashboard](${manage_url}/#/clients) and go to your client's settings. Make sure you have in **Allowed Callback URLs** a URL with the following format:
 
 ```
 https://${account.namespace}/android/{YOUR_APP_PACKAGE_NAME}/callback
@@ -148,7 +148,7 @@ Finally, don't forget to add the internet permission:
 In versions 1.8.0 or lower of Auth0.Android you had to define the **intent-filter** inside your activity to capture the authentication result in the `onNewIntent` method and then call `WebAuthProvider.resume()` with the received data. The intent-filter declaration and resume call are no longer required for versions greater than 1.8.0, as it's now done internally by the library for you.
 :::
 
-Now, let's authenticate a user by presenting the Auth0 [Hosted Login Page](hosted-pages/login):
+Now, let's authenticate a user by presenting the universal [login page](hosted-pages/login):
 
 ```java
 WebAuthProvider.init(account)
@@ -157,6 +157,8 @@ WebAuthProvider.init(account)
 ```
 
 The authentication result will be delivered to the callback.
+
+To ensure an Open ID Connect compliant response you must either set an `audience` using [withAudience](/libraries/auth0-android/configuration#withAudience) or enable the **OIDC Conformant** switch in your Auth0 dashboard under `Client / Settings / Advanced OAuth`. You can read more about this [here](/api-auth/intro#how-to-use-the-new-flows).
 
 ## Using the Authentication API
 

--- a/articles/libraries/auth0-android/index.md
+++ b/articles/libraries/auth0-android/index.md
@@ -73,7 +73,7 @@ Passwordless authentication **cannot be used** with this flag set to `true`. For
 
 ## Authentication via Universal Login
 
-First go to [Auth0 Dashboard](${manage_url}/#/clients) and go to your client's settings. Make sure you have in **Allowed Callback URLs** a URL with the following format:
+First go to the [Dashboard](${manage_url}/#/clients) and go to your client's settings. Make sure you have in **Allowed Callback URLs** a URL with the following format:
 
 ```
 https://${account.namespace}/android/{YOUR_APP_PACKAGE_NAME}/callback
@@ -158,7 +158,7 @@ WebAuthProvider.init(account)
 
 The authentication result will be delivered to the callback.
 
-To ensure an Open ID Connect compliant response you must either set an `audience` using [withAudience](/libraries/auth0-android/configuration#withAudience) or enable the **OIDC Conformant** switch in your Auth0 dashboard under `Client / Settings / Advanced OAuth`. You can read more about this [here](/api-auth/intro#how-to-use-the-new-flows).
+To ensure an Open ID Connect compliant response you must either set an `audience` using [withAudience](/libraries/auth0-android/configuration#withAudience) or enable the **OIDC Conformant** switch in your Auth0 dashboard under **Dashboard > Settings > Advanced > OAuth**. You can read more about this in the documentation page on [how to use new flows](/api-auth/intro#how-to-use-the-new-flows).
 
 ## Using the Authentication API
 

--- a/articles/libraries/auth0-swift/index.md
+++ b/articles/libraries/auth0-swift/index.md
@@ -108,9 +108,9 @@ func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpe
 }
 ```
 
-#### Authenticate with Auth0 hosted login page
+#### Authenticate with universal login
 
-The first step in adding authentication to your iOS application is to provide a way for your users to log in. The fastest, most secure, and most feature-rich way to do this with Auth0 is to use the [login page](/hosted-pages/login).
+The first step in adding authentication to your iOS application is to provide a way for your users to log in. The fastest, most secure, and most feature-rich way to do this with Auth0 is to use [universal login](/hosted-pages/login).
 
 ::: note
 To ensure an [OpenID Connect compliant response](/api-auth/intro), you must either request an `audience` or enable the **OIDC Conformant** switch in your [Auth0 dashboard](${manage_url}), under **Client > Settings > Show Advanced Settings > OAuth**. For more information, refer to [How to use the new flows](/api-auth/intro#how-to-use-the-new-flows).
@@ -136,7 +136,7 @@ If you need help between the two types of login flows, refer to [Browser-Based v
 
 #### Authenticate with a specific Auth0 connection
 
-The `connection` option allows you to specify a connection that you wish to authenticate with. If no connection is specified here, the browser will show the Hosted Login page, with all of the connections which are enabled for this client.
+The `connection` option allows you to specify a connection that you wish to authenticate with. If no connection is specified here, the browser will show the login page, with all of the connections which are enabled for this client.
 
 ```swift
 Auth0

--- a/articles/libraries/auth0-swift/save-and-refresh-jwt-tokens.md
+++ b/articles/libraries/auth0-swift/save-and-refresh-jwt-tokens.md
@@ -43,7 +43,7 @@ It can be useful to perform a quick sanity check that you have valid credentials
 
 ```swift
 guard credentialsManager.hasValid() else {
-    // Present Hosted Login Page
+    // Present Login Page
 }
 ```
 
@@ -54,7 +54,7 @@ You can retrieve the user's credentials as follows:
 ```swift
 credentialsManager.credentials { error, credentials in
     guard error == nil, let credentials = credentials else {
-        // Handle Error, Present Hosted Login Page
+        // Handle Error, Present Login Page
     }
     // Valid credentials, you can access the token properties such as `idToken`, `accessToken`.
 }

--- a/articles/libraries/auth0-swift/touchid-authentication.md
+++ b/articles/libraries/auth0-swift/touchid-authentication.md
@@ -27,7 +27,7 @@ credentialsManager.enableTouchAuth(withTitle: "Touch to Authenticate")
 
 ### Login
 
-Present the HLP and pass the credentials upon successful authentication to the Credentials Manager.
+Present the login page and pass the credentials upon successful authentication to the Credentials Manager.
 
 ```swift
 Auth0

--- a/articles/libraries/auth0-swift/touchid-authentication.md
+++ b/articles/libraries/auth0-swift/touchid-authentication.md
@@ -4,7 +4,7 @@ description: How to implement Touch ID authentication with Auth0.swift.
 ---
 # Auth0.swift Touch ID Authentication
 
-Here's the scenario: After user authentication, you want to store the user's credentials and use them as long as they are valid. Once they expire, you would want to renew them using the `refreshToken` in order to avoid presenting the Hosted Login Page (HLP) again. Rather than doing this automatically you require the user to validate with their fingerprint.
+Here's the scenario: After user authentication, you want to store the user's credentials and use them as long as they are valid. Once they expire, you would want to renew them using the `refreshToken` in order to avoid presenting the login page again. Rather than doing this automatically you require the user to validate with their fingerprint.
 
 You will be using the [Credentials Manager](https://github.com/auth0/Auth0.swift/blob/master/Auth0/CredentialsManager.swift) utility in [Auth0.swift](https://github.com/auth0/Auth0.swift/) to streamline the management of user credentials and perform the Touch ID authentication.
 

--- a/articles/libraries/auth0js/v8/index.md
+++ b/articles/libraries/auth0js/v8/index.md
@@ -91,7 +91,7 @@ You can choose a method for login based on the type of auth you need in your app
 
 ### webAuth.authorize()
 
-The `authorize()` method can be used for logging in users via the [Hosted Login Page](/hosted-pages/login), or via social connections, as exhibited in the examples below. This method invokes the [/authorize endpoint](/api/authentication?javascript#social) of the Authentication API, and can take a variety of parameters via the `options` object.
+The `authorize()` method can be used for logging in users via [universal login](/hosted-pages/login), or via social connections, as exhibited in the examples below. This method invokes the [/authorize endpoint](/api/authentication?javascript#social) of the Authentication API, and can take a variety of parameters via the `options` object.
 
 | **Parameter** | **Required** | **Description** |
 | --- | --- | --- |
@@ -163,7 +163,7 @@ webAuth.redirect.loginWithCredentials({
 
 The use of `webauth.redirect.loginWithCredentials` is not recommended when using Auth0.js in your apps; it is recommended that you use `webauth.login` instead. 
 
-However, using `webauth.redirect.loginWithCredentials` **is** the correct choice for use in the Hosted Login Page, and is the only way to have SSO cookies set for your users who login using the Hosted Login Page.
+However, using `webauth.redirect.loginWithCredentials` **is** the correct choice for use in the universal login page, and is the only way to have SSO cookies set for your users who login using universal login.
 
 ### webAuth.popup.loginWithCredentials()
 
@@ -473,7 +473,7 @@ The user will then receive an email which will contain a link that they can foll
 
 ## Cross-Origin Authentication
 
-Using auth0.js within your application (rather than using the [Hosted Login Page](/hosted-pages/login)) requires cross-origin authentication. Make sure you read the [cross-origin authentication documentation](/cross-origin-authentication) to understand how to properly configure your client to make it work.
+Using auth0.js within your application (rather than using [universal login](/hosted-pages/login)) requires cross-origin authentication. Make sure you read the [cross-origin authentication documentation](/cross-origin-authentication) to understand how to properly configure your client to make it work.
 
 ## User management
 

--- a/articles/libraries/auth0js/v8/migration-guide.md
+++ b/articles/libraries/auth0js/v8/migration-guide.md
@@ -57,7 +57,7 @@ The `login` method of version 7 was divided into several different methods in ve
 
 ### webAuth.authorize()
 
-The `authorize` method can be used for logging in users via the [Hosted Login Page](/hosted-pages/login), or via social connections, as exhibited below.
+The `authorize` method can be used for logging in users via [universal login](/hosted-pages/login), or via social connections, as exhibited below.
 
 For hosted login, one must call the authorize endpoint
 

--- a/articles/libraries/auth0js/v9/index.md
+++ b/articles/libraries/auth0js/v9/index.md
@@ -90,7 +90,7 @@ You can choose a method for login based on the type of auth you need in your app
 
 ### webAuth.authorize()
 
-The `authorize()` method can be used for logging in users via the [Hosted Login Page](/hosted-pages/login), or via social connections, as exhibited in the examples below. This method invokes the [/authorize endpoint](/api/authentication?javascript#social) of the Authentication API, and can take a variety of parameters via the `options` object.
+The `authorize()` method can be used for logging in users via [universal login](/hosted-pages/login), or via social connections, as exhibited in the examples below. This method invokes the [/authorize endpoint](/api/authentication?javascript#social) of the Authentication API, and can take a variety of parameters via the `options` object.
 
 | **Parameter** | **Required** | **Description** |
 | --- | --- | --- |
@@ -160,7 +160,7 @@ webAuth.redirect.loginWithCredentials({
 
 The use of `webauth.redirect.loginWithCredentials` is not recommended when using Auth0.js in your apps; it is recommended that you use `webauth.login` instead. 
 
-However, using `webauth.redirect.loginWithCredentials` **is** the correct choice for use in the Hosted Login Page, and is the only way to have SSO cookies set for your users who login using the Hosted Login Page.
+However, using `webauth.redirect.loginWithCredentials` **is** the correct choice for use in the universal login page, and is the only way to have SSO cookies set for your users who login using universal login.
 
 ### webAuth.popup.loginWithCredentials()
 

--- a/articles/libraries/auth0js/v9/migration-guide.md
+++ b/articles/libraries/auth0js/v9/migration-guide.md
@@ -6,10 +6,38 @@ toc: true
 ---
 # Migrating to Auth0.js v9
 
+<<<<<<< HEAD
 [Auth0.js v9](/libraries/auth0js) has been improved to operate with enhanced security and removes dependencies that have been deprecated as per Auth0's roadmap. In some cases, these security enhancements may impact application behavior when upgrading from an earlier versions of auth0.js. 
 ## Should I migrate to v9?
 
 Everyone should migrate to v9. All previous versions are deprecated as of April 1, 2018, and will at some point cease to work after this date. For clients who use Auth0.js within an Auth0 login page, this migration is recommended; for client applications with Auth0.js embedded within them, this migration is mandatory.
+=======
+[Auth0.js v9](/libraries/auth0js) has been improved to work better in embedded login scenarios. It operates with enhanced security and removes dependencies that have been deprecated as per Auth0's roadmap. In some cases, these security enhancements may impact application behavior when upgrading from an earlier versions of auth0.js. 
+
+::: warning
+If you are using auth0.js to implement login embedded in your applications, we recommend moving to a universal login approach, as it is the [most secure, powerful and flexible approach for authentication](/guides/login/centralized-vs-embedded). You can find examples on how to implement universal login in our [Quickstarts](/quickstarts).
+:::
+
+## Should I migrate to v9?
+
+Auth0.js can be used to implement authentication in different ways:
+
+- In your application, to trigger universal login, using the `.authorize()` method, where the user is redirected from your website to an Auth0's Hosted Login Page.
+
+- In your application, to implement embedded login, using the `.login()`, `popup.loginWithCredentials()`, `client.loginWithCredentials()` methods, where the login dialog is displayed in the application's website.
+
+- In the [Hosted Login Page](/hosted-pages/login), where you can use the same methods as in embedded login but from inside a customized Auth0's Hosted Login Page. Most customers don't customize Auth0 Hosted Login Page with auth0.js, so you probably don't need to worry about this scenario.
+
+Migration to v9 will depend on how you are using auth0.js:
+
+| **Scenario** | **Migration to v9** | 
+| --- | --- | 
+| In your application, to trigger universal login | Required (*) | 
+| In your application, to implement embedded login | Required |
+| In a customized hosted page | Not Supported |
+
+(*) There a certain usage patterns with universal login and auth0.js v8 that don't require migration. However, given that for those scenarios just updating the library version will work, we recommend that you always migrate to v9.
+>>>>>>> Replacing the term 'centralized login' with 'universal login'
 
 ## Migration Instructions
 

--- a/articles/libraries/auth0js/v9/migration-guide.md
+++ b/articles/libraries/auth0js/v9/migration-guide.md
@@ -6,58 +6,24 @@ toc: true
 ---
 # Migrating to Auth0.js v9
 
-<<<<<<< HEAD
 [Auth0.js v9](/libraries/auth0js) has been improved to operate with enhanced security and removes dependencies that have been deprecated as per Auth0's roadmap. In some cases, these security enhancements may impact application behavior when upgrading from an earlier versions of auth0.js. 
+
 ## Should I migrate to v9?
 
 Everyone should migrate to v9. All previous versions are deprecated as of April 1, 2018, and will at some point cease to work after this date. For clients who use Auth0.js within an Auth0 login page, this migration is recommended; for client applications with Auth0.js embedded within them, this migration is mandatory.
-=======
-[Auth0.js v9](/libraries/auth0js) has been improved to work better in embedded login scenarios. It operates with enhanced security and removes dependencies that have been deprecated as per Auth0's roadmap. In some cases, these security enhancements may impact application behavior when upgrading from an earlier versions of auth0.js. 
-
-::: warning
-If you are using auth0.js to implement login embedded in your applications, we recommend moving to a universal login approach, as it is the [most secure, powerful and flexible approach for authentication](/guides/login/centralized-vs-embedded). You can find examples on how to implement universal login in our [Quickstarts](/quickstarts).
-:::
-
-## Should I migrate to v9?
-
-Auth0.js can be used to implement authentication in different ways:
-
-- In your application, to trigger universal login, using the `.authorize()` method, where the user is redirected from your website to an Auth0's Hosted Login Page.
-
-- In your application, to implement embedded login, using the `.login()`, `popup.loginWithCredentials()`, `client.loginWithCredentials()` methods, where the login dialog is displayed in the application's website.
-
-- In the [Hosted Login Page](/hosted-pages/login), where you can use the same methods as in embedded login but from inside a customized Auth0's Hosted Login Page. Most customers don't customize Auth0 Hosted Login Page with auth0.js, so you probably don't need to worry about this scenario.
-
-Migration to v9 will depend on how you are using auth0.js:
-
-| **Scenario** | **Migration to v9** | 
-| --- | --- | 
-| In your application, to trigger universal login | Required (*) | 
-| In your application, to implement embedded login | Required |
-| In a customized hosted page | Not Supported |
-
-(*) There a certain usage patterns with universal login and auth0.js v8 that don't require migration. However, given that for those scenarios just updating the library version will work, we recommend that you always migrate to v9.
->>>>>>> Replacing the term 'centralized login' with 'universal login'
 
 ## Migration Instructions
 
 The documents below describe all the changes that you should be aware of when migrating from different versions of auth0.js to v9. Make sure you go through the relevant guide(s) before upgrading.
 
-[Migrating from Auth0.js v8](/libraries/auth0js/v9/migration-v8-v9)
-
-[Migrating from Auth0.js v7](/libraries/auth0js/v9/migration-v7-v9)
-
-[Migrating from Auth0.js v6](/libraries/auth0js/v9/migration-v6-v9)
-
-[Migrating from Auth0.js v8 in Angular 1.x Applications](/libraries/auth0js/v9/migration-angularjs-v8)
-
-[Migrating from Auth0.js v7 in Angular 1.x Applications](/libraries/auth0js/v9/migration-angularjs-v7)
-
-[Migrating from Auth0.js v6 in Angular 1.x Applications](/libraries/auth0js/v9/migration-angularjs-v6)
-
-[Migrating from Auth0.js v8 in Angular 2.x Applications](/libraries/auth0js/v9/migration-angular)
-
-[Migrating from Auth0.js v8 in React.js Applications](/libraries/auth0js/v9/migration-react)
+* [Migrating from Auth0.js v8](/libraries/auth0js/v9/migration-v8-v9)
+* [Migrating from Auth0.js v7](/libraries/auth0js/v9/migration-v7-v9)
+* [Migrating from Auth0.js v6](/libraries/auth0js/v9/migration-v6-v9)
+* [Migrating from Auth0.js v8 in Angular 1.x Applications](/libraries/auth0js/v9/migration-angularjs-v8)
+* [Migrating from Auth0.js v7 in Angular 1.x Applications](/libraries/auth0js/v9/migration-angularjs-v7)
+* [Migrating from Auth0.js v6 in Angular 1.x Applications](/libraries/auth0js/v9/migration-angularjs-v6)
+* [Migrating from Auth0.js v8 in Angular 2.x Applications](/libraries/auth0js/v9/migration-angular)
+* [Migrating from Auth0.js v8 in React.js Applications](/libraries/auth0js/v9/migration-react)
 
 :::note
 If you have any questions or concerns, you can discuss them in the [Auth0 Community](https://community.auth0.com/), submit them using the [Support Center](${env.DOMAIN_URL_SUPPORT}), or directly through your account representative, if applicable. 

--- a/articles/libraries/auth0js/v9/migration-v7-v9.md
+++ b/articles/libraries/auth0js/v9/migration-v7-v9.md
@@ -25,7 +25,7 @@ var auth0 = new Auth0({
   responseType: 'token'
 });
 
-// With the hosted login page
+// With universal login
 auth0.login({});
 
 // With a social connection
@@ -50,7 +50,7 @@ var webAuth = new auth0.WebAuth({
   responseType: 'token id_token'
 });
 
-// with the hosted login page
+// with universal login
 webAuth.authorize({});
 
 // with a social connection
@@ -77,7 +77,7 @@ var auth0 = new Auth0({
   responseType: 'token'
 });
 
-// With the hosted login page
+// With universal login
 auth0.login({
   popup: true
 });
@@ -106,7 +106,7 @@ var webAuth = new auth0.WebAuth({
   responseType: 'token'
 });
 
-// with the hosted login page
+// with universal login
 webAuth.popup.authorize({});
 
 // with a social connection

--- a/articles/libraries/custom-signup.md
+++ b/articles/libraries/custom-signup.md
@@ -8,7 +8,7 @@ toc: true
 In some cases, you may want to customize the user sign up form with more fields other than email and password.
 
 :::panel Universal Login
-Auth0 offers a [universal login](/hosted-pages/login) option that you can use instead of designing your own custom sign up page. If you want to offer sign up and log in options, and you only need to customize the client name, logo and background color, then using an Auth0-hosted login page and implementing universal login might be an easier option to implement.
+Auth0 offers a [universal login](/hosted-pages/login) option that you can use instead of designing your own custom sign up page. If you want to offer sign up and log in options, and you only need to customize the client name, logo and background color, then universal login via an Auth0 login page might be an easier option to implement.
 :::
 
 ## Using Lock

--- a/articles/libraries/custom-signup.md
+++ b/articles/libraries/custom-signup.md
@@ -7,8 +7,8 @@ toc: true
 
 In some cases, you may want to customize the user sign up form with more fields other than email and password.
 
-:::panel Hosted Login Pages
-Auth0 offers a [hosted login page](/hosted-pages/login) option that you can use instead of designing your own custom sign up page. If you want to offer sign up and log in options, and you only need to customize the client name, logo and background color, then the Hosted Login Page might be an easier option to implement.
+:::panel Universal Login
+Auth0 offers a [universal login](/hosted-pages/login) option that you can use instead of designing your own custom sign up page. If you want to offer sign up and log in options, and you only need to customize the client name, logo and background color, then using an Auth0-hosted login page and implementing universal login might be an easier option to implement.
 :::
 
 ## Using Lock

--- a/articles/libraries/index.md
+++ b/articles/libraries/index.md
@@ -21,7 +21,7 @@ When adding Auth0 to your web apps, the best solution is to use Auth0's [univers
 
 You can customize the page in the [Hosted Pages Editor](${manage_url}/#/login_page).
 
-If the Auth0-hosted login page does not meet your requirements, however, Auth0 has a variety of options which can be embedded in your applications to assist with authentication.
+If universal login does not meet your requirements, however, Auth0 has a variety of options which can be embedded in your applications to assist with authentication.
 
 * [Lock](#lock) is a drop-in authentication widget that provides a standard set of behaviors and a customizable user interface.
 * [Auth0 SDKs](#auth0-sdks) are client-side libraries that do not come with a user interface. These allow for expanded customization of the behavior and appearance of the login process.

--- a/articles/libraries/index.md
+++ b/articles/libraries/index.md
@@ -17,11 +17,11 @@ description: Overview of the Auth0 Libraries and SDKs
 
 ## How Should You Implement Auth0?
 
-When adding Auth0 to your web apps, the best solution is to use Auth0's [Hosted Login Page](/hosted-pages/login). Using the Hosted Login Page is a simple process, and prevents the pitfalls of [cross-origin authentication](/cross-origin-authentication). The Hosted Login Page uses by default the Lock Widget to authenticate users, but there is also a template for Lock Passwordless and a template for a custom UI built with the Auth0.js SDK available. 
+When adding Auth0 to your web apps, the best solution is to use Auth0's [universal login](/hosted-pages/login). Using universal login is a simple process, and prevents the pitfalls of [cross-origin authentication](/cross-origin-authentication). The login page uses by default the Lock Widget to authenticate users, but there is also a template for Lock Passwordless and a template for a custom UI built with the Auth0.js SDK available. 
 
 You can customize the page in the [Hosted Pages Editor](${manage_url}/#/login_page).
 
-If the Hosted Login Page does not meet your requirements, however, Auth0 has a variety of options which can be embedded in your applications to assist with authentication.
+If the Auth0-hosted login page does not meet your requirements, however, Auth0 has a variety of options which can be embedded in your applications to assist with authentication.
 
 * [Lock](#lock) is a drop-in authentication widget that provides a standard set of behaviors and a customizable user interface.
 * [Auth0 SDKs](#auth0-sdks) are client-side libraries that do not come with a user interface. These allow for expanded customization of the behavior and appearance of the login process.

--- a/articles/libraries/lock-android/v1/native-social-authentication.md
+++ b/articles/libraries/lock-android/v1/native-social-authentication.md
@@ -8,7 +8,7 @@ description: How to implement native social authentication with Lock Android
 
 ::: warning
 This feature relies on a deprecated grant type. Clients created after June 8th 2017 won't be able to use this feature.
-We recommend using browser-based flows, as explained in [Authentication with Auth0 Hosted Login Page](/libraries/auth0-android#authentication-with-auth0-hosted-login-page).
+We recommend using browser-based flows, as explained in [Authentication via Universal Login](/libraries/auth0-android#authentication-via-universal-login).
 :::
 
 **Lock** by default handles all social authentication with a Browser installed in your Android device, but for some social connections you can take advantage of our native integration.

--- a/articles/libraries/lock-android/v1/passwordless-magic-link.md
+++ b/articles/libraries/lock-android/v1/passwordless-magic-link.md
@@ -7,7 +7,7 @@ description: Passwordless with Magic Link with Lock Android
 <%= include('../_includes/_lock-version') %>
 
 ::: warning
-Passwordless on native platforms is disabled by default for new tenants as of 8 June 2017. If you would like this feature enabled, please contact support to discuss your use case. See [Client Grant Types](/clients/client-grant-types) for more information. Alternatively, you can use Lock Passwordless on Auth0's [Hosted Login Page](/hosted-pages/login).
+Passwordless on native platforms is disabled by default for new tenants as of 8 June 2017. If you would like this feature enabled, please contact support to discuss your use case. See [Client Grant Types](/clients/client-grant-types) for more information. Alternatively, you can use Lock Passwordless with Auth0's [universal login](/hosted-pages/login).
 :::
 
 ## Passwordless Authentication with Magic Link

--- a/articles/libraries/lock-android/v1/passwordless.md
+++ b/articles/libraries/lock-android/v1/passwordless.md
@@ -7,8 +7,6 @@ description: Guide on implementing Passwordless authentication with Lock for And
 
 <%= include('../_includes/_lock-version') %>
 
-<%= include('../../../_includes/_native_passwordless_warning') %>
-
 Lock Passwordless authenticates users by sending them an Email or SMS with a one-time password that the user must enter and confirm to be able to log in, similar to how WhatsApp authenticates you. This article will explain how to send a **CODE** using the `Lock.Android` library.
 
 ::: note

--- a/articles/libraries/lock-android/v1/use-your-own-ui.md
+++ b/articles/libraries/lock-android/v1/use-your-own-ui.md
@@ -135,7 +135,7 @@ public void onEvent(AuthenticationEvent event) {
 
 ::: warning
 This feature relies on a deprecated grant type. Clients created after June 8th 2017 won't be able to use this feature.
-We recommend using browser-based flows, as explained in [Authentication with Auth0 Hosted Login Page](/libraries/auth0-android/v2#authentication-with-auth0-hosted-login-page).
+We recommend using browser-based flows, as explained in [Authentication via Universal Login](/libraries/auth0-android#authentication-via-universal-login).
 :::
 
 Include the following libraries in your `build.gradle`:

--- a/articles/libraries/lock-android/v2/custom-authentication-providers.md
+++ b/articles/libraries/lock-android/v2/custom-authentication-providers.md
@@ -14,7 +14,7 @@ Create a class that implements the `AuthProvider` interface and override its met
 You can also use any **Native** implementation already provided by Auth0. The [native social authentication](/libraries/lock-android/v2/native-social-authentication) providers currently available are Google and Facebook.
 
 ::: warning
-The native social providers rely on a deprecated grant type. Clients created after June 8th 2017 won't be able to use this feature. We recommend using browser-based flows, as explained in [Authentication with Auth0 Hosted Login Page](/libraries/auth0-android#authentication-with-auth0-hosted-login-page).
+The native social providers rely on a deprecated grant type. Clients created after June 8th 2017 won't be able to use this feature. We recommend using browser-based flows, as explained in [Authentication via Universal Login](/libraries/auth0-android#authentication-via-universal-login).
 :::
 
 ## The AuthHandler class

--- a/articles/libraries/lock-android/v2/index.md
+++ b/articles/libraries/lock-android/v2/index.md
@@ -8,7 +8,7 @@ mobileimg: media/articles/libraries/lock-android.png
 # Lock Android: Getting Started
 
 ::: warning
-Username/Email & Password authentication from native clients is disabled by default for new tenants as of 8 June 2017. Users are encouraged to use the [Hosted Login Page](/hosted-pages/login) and perform Web Authentication instead. If you still want to proceed you'll need to enable the Password Grant Type on your dashboard first. See [Client Grant Types](/clients/client-grant-types) for more information.
+Username/Email & Password authentication from native clients is disabled by default for new tenants as of 8 June 2017. Users are encouraged to use [universal login](/hosted-pages/login) and perform Web Authentication instead. If you still want to proceed you'll need to enable the Password Grant Type on your dashboard first. See [Client Grant Types](/clients/client-grant-types) for more information.
 :::
 
 Lock for Android can integrate into your native Android apps to provide a beautiful way to log your users in and to sign them up in your app. It provides support for social identity providers such as Facebook, Google, or Twitter, as well as enterprise providers such as Active Directory.

--- a/articles/libraries/lock-android/v2/native-social-authentication.md
+++ b/articles/libraries/lock-android/v2/native-social-authentication.md
@@ -7,7 +7,7 @@ description: Lock for Android - Native Social Authentication
 
 ::: warning
 This feature relies on a deprecated grant type. Clients created after June 8th 2017 won't be able to use this feature. 
-We recommend using browser-based flows, as explained in [Authentication with Auth0 Hosted Login Page](/libraries/auth0-android#authentication-with-auth0-hosted-login-page).
+We recommend using browser-based flows, as explained in [Authentication via Auth0 Universal Login](/libraries/auth0-android#authentication-via-universal-login).
 :::
 
 ## Native Provider - Google

--- a/articles/libraries/lock/v10/auth0js.md
+++ b/articles/libraries/lock/v10/auth0js.md
@@ -6,7 +6,8 @@ description: How to use Lock v10 with auth0.js
 
 <%= include('../../../_includes/_version_warning_lock') %>
 
-By nature, Lock and the Auth0.js SDK are different things. Lock provides a UI that is customizable (to an extent) with behavior that is customizable (to an extent). It is an easily deployed, easily used interface for Auth0 authentication in custom applications. It is also easily used within the Auth0 [Hosted Login Page](/hosted-pages/login).
+
+By nature, Lock and the Auth0.js SDK are different things. Lock provides a UI that is customizable (to an extent) with behavior that is customizable (to an extent). It is an easily deployed, easily used interface for Auth0 authentication in custom applications.
 
 For simple uses, Lock is all that is necessary. However, while using Lock, if more customization is required in an application than Lock allows, functionality from the Auth0.js SDK can be used alongside Lock to meet those needs. An example might be using Lock to handle signups and logins, while using auth0.js to [manage users](/libraries/auth0js#user-management) (read and update user metadata, link user accounts together, and similar tasks).
 

--- a/articles/libraries/lock/v10/configuration.md
+++ b/articles/libraries/lock/v10/configuration.md
@@ -846,7 +846,7 @@ var options = {
 
 ### oidcConformant {Boolean}
 
-Lock should be used in OIDC Conformant mode when embedding it directly in your application. When this mode is enabled, it will force Lock to use Auth0's current authentication pipeline and will prevent it from reaching legacy endpoints. This mode is **not** required when using Lock on an [Auth0-hosted login page](/hosted-pages/login).
+Lock should be used in OIDC Conformant mode when embedding it directly in your application. When this mode is enabled, it will force Lock to use Auth0's current authentication pipeline and will prevent it from reaching legacy endpoints. This mode is **not** required when implementing universal login with a [login page](/hosted-pages/login).
 
 To enable OIDC conformant mode, pass a flag in the options object.
 

--- a/articles/libraries/lock/v10/configuration.md
+++ b/articles/libraries/lock/v10/configuration.md
@@ -846,7 +846,7 @@ var options = {
 
 ### oidcConformant {Boolean}
 
-Lock should be used in OIDC Conformant mode when embedding it directly in your application. When this mode is enabled, it will force Lock to use Auth0's current authentication pipeline and will prevent it from reaching legacy endpoints. This mode is **not** required when implementing universal login with a [login page](/hosted-pages/login).
+Lock should be used in OIDC Conformant mode when embedding it directly in your application. When this mode is enabled, it will force Lock to use Auth0's current authentication pipeline and will prevent it from reaching legacy endpoints. This mode is **not** required when implementing [universal login](/hosted-pages/login).
 
 To enable OIDC conformant mode, pass a flag in the options object.
 

--- a/articles/libraries/lock/v10/configuration.md
+++ b/articles/libraries/lock/v10/configuration.md
@@ -846,7 +846,7 @@ var options = {
 
 ### oidcConformant {Boolean}
 
-Lock should be used in OIDC Conformant mode when embedding it directly in your application. When this mode is enabled, it will force Lock to use Auth0's current authentication pipeline and will prevent it from reaching legacy endpoints. This mode is **not** required when using Lock at Auth0's [hosted login page](/hosted-pages/login).
+Lock should be used in OIDC Conformant mode when embedding it directly in your application. When this mode is enabled, it will force Lock to use Auth0's current authentication pipeline and will prevent it from reaching legacy endpoints. This mode is **not** required when using Lock on an [Auth0-hosted login page](/hosted-pages/login).
 
 To enable OIDC conformant mode, pass a flag in the options object.
 

--- a/articles/libraries/lock/v10/index.md
+++ b/articles/libraries/lock/v10/index.md
@@ -15,10 +15,6 @@ Lock is an embeddable login form, [configurable to your needs][lock-configuratio
 Check out the [Lock repository](https://github.com/auth0/lock) on GitHub.
 :::
 
-::: note
-Lock is also available for use within Auth0's [Hosted Login Page](/hosted-pages/login), which is the simplest and most secure method to authenticate users for your applications.
-:::
-
 ## Lock 10 Installation
 
 You can install Lock 10 via several methods. Select any of the following installation sources that best suit your environment and application.
@@ -119,7 +115,7 @@ document.getElementById('btn-login').addEventListener('click', function() {
 
 ## Cross-Origin Authentication
 
-Embedding Lock within your application, rather than using the [Hosted Login Page](/hosted-pages/login), requires [cross-origin authentication](/cross-origin-authentication). In order to use embedded Lock v10 via cross-origin authentication, you must set the [oidcconformant](/libraries/lock/v10/configuration#oidcconformant-boolean-) option to `true`.
+Embedding Lock within your application, rather than using [universal login](/hosted-pages/login), requires [cross-origin authentication](/cross-origin-authentication). In order to use embedded Lock v10 via cross-origin authentication, you must set the [oidcconformant](/libraries/lock/v10/configuration#oidcconformant-boolean-) option to `true`.
 
 ## Browser Compatibility
 

--- a/articles/libraries/lock/v11/auth0js.md
+++ b/articles/libraries/lock/v11/auth0js.md
@@ -4,7 +4,7 @@ description: How to use Lock v11 with auth0.js v9
 ---
 # Using Lock With auth0.js
 
-By nature, Lock and the Auth0.js SDK are different things. Lock provides a UI that is customizable (to an extent) with behavior that is customizable (to an extent). It is an easily deployed, easily used interface for Auth0 authentication in custom applications. It is also easily used within the Auth0 [Hosted Login Page](/hosted-pages/login).
+By nature, Lock and the Auth0.js SDK are different things. Lock provides a UI that is customizable (to an extent) with behavior that is customizable (to an extent). It is an easily deployed, easily used interface for Auth0 authentication in custom applications.
 
 For simple uses, Lock is all that is necessary. However, while using Lock, if more customization is required in an application than Lock allows, functionality from the Auth0.js SDK can be used alongside Lock to meet those needs. An example might be using Lock to handle signups and logins, while using auth0.js to [manage users](/libraries/auth0js#user-management) (read and update user metadata, link user accounts together, and similar tasks).
 

--- a/articles/libraries/lock/v11/migration-guide.md
+++ b/articles/libraries/lock/v11/migration-guide.md
@@ -5,15 +5,7 @@ description: How to migrate to Lock v11
 ---
 # Migrating to Lock v11
 
-<<<<<<< HEAD
 [Lock v11](/libraries/lock) operates with enhanced security and removes dependencies that have been deprecated as per Auth0's roadmap. In some cases, these security enhancements may impact application behavior when upgrading from an earlier version of Lock. 
-=======
-[Lock v11](/libraries/lock) is designed for [embedded login scenarios](/guides/login/centralized-vs-embedded). It operates with enhanced security and removes dependencies that have been deprecated as per Auth0's roadmap. In some cases, these security enhancements may impact application behavior when upgrading from an earlier version of Lock. 
-
-::: warning
-If you are using Lock to implement login embedded in your applications, we recommend [moving to a universal login approach](/guides/login/migration-embedded-centralized), as it is the [most secure, powerful and flexible approach for authentication](/guides/login/centralized-vs-embedded).
-:::
->>>>>>> Replacing the term 'centralized login' with 'universal login'
 
 ## Should I migrate to v11?
 

--- a/articles/libraries/lock/v11/migration-guide.md
+++ b/articles/libraries/lock/v11/migration-guide.md
@@ -5,7 +5,15 @@ description: How to migrate to Lock v11
 ---
 # Migrating to Lock v11
 
+<<<<<<< HEAD
 [Lock v11](/libraries/lock) operates with enhanced security and removes dependencies that have been deprecated as per Auth0's roadmap. In some cases, these security enhancements may impact application behavior when upgrading from an earlier version of Lock. 
+=======
+[Lock v11](/libraries/lock) is designed for [embedded login scenarios](/guides/login/centralized-vs-embedded). It operates with enhanced security and removes dependencies that have been deprecated as per Auth0's roadmap. In some cases, these security enhancements may impact application behavior when upgrading from an earlier version of Lock. 
+
+::: warning
+If you are using Lock to implement login embedded in your applications, we recommend [moving to a universal login approach](/guides/login/migration-embedded-centralized), as it is the [most secure, powerful and flexible approach for authentication](/guides/login/centralized-vs-embedded).
+:::
+>>>>>>> Replacing the term 'centralized login' with 'universal login'
 
 ## Should I migrate to v11?
 

--- a/articles/libraries/when-to-use-lock.md
+++ b/articles/libraries/when-to-use-lock.md
@@ -21,7 +21,7 @@ When adding Auth0 to your web apps, the best solution is to use Auth0's [univers
 If universal login doesn't work for you, all of the above can be embedded in your own application and used in that way, as well.  
  
 ::: note 
-Passwordless authentication from native mobile apps currently must use univeral login - there is no native passwordless option at this time. 
+Passwordless authentication from native mobile apps currently must use universal login - there is no native passwordless option at this time. 
 ::: 
 
 ## When to Implement Lock vs. a Custom UI 

--- a/articles/libraries/when-to-use-lock.md
+++ b/articles/libraries/when-to-use-lock.md
@@ -6,7 +6,7 @@ description: When should you use Lock, Auth0's drop-in authentication widget, an
 
 <%= include('../_includes/_lock_auth0js_deprecations_notice') %>
 
-When adding Auth0 to your web apps, the best solution is to use Auth0's [Hosted Login Page](/hosted-pages/login). Using the Hosted Login Page is an incredibly simple process, and prevents the dangers of cross-origin authentication. The Hosted Login Page uses the Lock Widget to allow your users to authenticate by default, but also has templates for Lock Passwordless and for a custom UI built with Auth0.js SDK. You can customize the page in the [Hosted Pages Editor](${manage_url}/#/login_page), and use any of the following to implement your authentication needs. 
+When adding Auth0 to your web apps, the best solution is to use Auth0's [universal login](/hosted-pages/login). Using universal login is an incredibly simple process, and prevents the dangers of cross-origin authentication. The login page uses the Lock Widget to allow your users to authenticate by default, but also has templates for Lock Passwordless and for a custom UI built with Auth0.js SDK. You can customize the page in the [Hosted Pages Editor](${manage_url}/#/login_page), and use any of the following to implement your authentication needs. 
 
 * Lock, Auth0's drop-in login and signup widget
   * [Lock for Web](/libraries/lock)
@@ -18,10 +18,10 @@ When adding Auth0 to your web apps, the best solution is to use Auth0's [Hosted 
   * [Auth0 SDK for Android](/libraries/auth0-android)
 * Or, a custom user interface that you have created directly tying into the [Authentication API](/auth-api).
 
-If the Hosted Login Page doesn't work for you, all of the above can be embedded in your own application and used in that way, as well.  
+If universal login doesn't work for you, all of the above can be embedded in your own application and used in that way, as well.  
  
 ::: note 
-Passwordless authentication from native mobile apps currently must go through the Hosted Login Page - there is no native passwordless option at this time. 
+Passwordless authentication from native mobile apps currently must use univeral login - there is no native passwordless option at this time. 
 ::: 
 
 ## When to Implement Lock vs. a Custom UI 

--- a/articles/pre-deployment/prelaunch-tips.md
+++ b/articles/pre-deployment/prelaunch-tips.md
@@ -45,7 +45,7 @@ Here is a list of tips our customers have found most useful when first getting s
 
 * Review your [list of rules](${manage_url}/#/rules) and make sure only the appropriate rules are turned on. 
 
-* Review your rule code, any custom DB scripts and any custom code in the hosted login page to ensure that every call has adequate error trapping and handling.  Also review to make sure that return/callback statements are called correctly.
+* Review your rule code, any custom DB scripts and any custom code in the login page to ensure that every call has adequate error trapping and handling.  Also review to make sure that return/callback statements are called correctly.
 
 * Configure your application name, support URL and support email in the [Tenant Settings General](${manage_url}/#/tenant) section so when an error occurs your end users will be directed to an appropriate page.
 

--- a/articles/pre-deployment/tests/recommended.md
+++ b/articles/pre-deployment/tests/recommended.md
@@ -14,7 +14,7 @@ See [How to Read Your Results Set](/pre-deployment/how-to-run-test#how-to-read-y
 | ---- | ----------- |
 | [Customer Error Page](/hosted-pages/custom-error-pages) Configured | [Configure a Custom Error Page](${manage_url}/#/account) with your application-specific details and corporate branding |
 | Customize [Guardian Multifactor Page](/hosted-pages/guardian) | If you're using Guardian Multifactor Authentication, [configure a Custom Hosted Page for Guardian Multifactor](${manage_url}/#/guardian_mfa_page) with your application details and corporate branding |
-| Customize [Hosted Login Page](/hosted-pages/login) | [Configure a Custom Hosted Page for Login](${manage_url}/#/login_page) with your application details and corporate branding |
+| Customize [Login Page](/hosted-pages/login) | [Configure a Custom Hosted Page for Universal Login](${manage_url}/#/login_page) with your application details and corporate branding |
 | Customize [Password Reset Page](/hosted-pages/password-reset) | [Configure a Custom Hosted Page for Password Reset](${manage_url}/#/password_reset) with your application details and corporate branding |
 | [Email Templates](/email/custom) Configured | [Configure custom email templates](${manage_url}/#/emails) with your application specific details and corporate branding |
 | Enable [MFA for Tenant Administrators](/tutorials/manage-dashboard-admins) | [Enable multifactor authentication](${manage_url}/#/account/admins) for tenant administrators |

--- a/articles/quickstart/native/_includes/_ionic_setup.md
+++ b/articles/quickstart/native/_includes/_ionic_setup.md
@@ -39,7 +39,7 @@ yarn add auth0-js @auth0/cordova
 
 ## Add Cordova Plugins
 
-You must install the `SafariViewController` plugin from Cordova to be able to show Auth0's hosted login page. The downloadable sample project already has this plugin added, but if you are adding Auth0 to your own application, install the plugin via the command line.
+You must install the `SafariViewController` plugin from Cordova to be able to use universal login. The downloadable sample project already has this plugin added, but if you are embedding Auth0 in your own application, install the plugin via the command line.
 
 ```bash
 ionic cordova plugin add cordova-plugin-safariviewcontroller

--- a/articles/quickstart/native/android/00-login.md
+++ b/articles/quickstart/native/android/00-login.md
@@ -1,6 +1,6 @@
 ---
 title: Login
-description: This tutorial will show you how to integrate the Auth0 Centralized Login in your Android project in order to present the login box.
+description: This tutorial will show you how to integrate the Auth0 Universal Login in your Android project in order to present the login box.
 seo_alias: android
 budicon: 448
 ---

--- a/articles/quickstart/native/android/01-embedded-login.md
+++ b/articles/quickstart/native/android/01-embedded-login.md
@@ -20,7 +20,7 @@ This tutorial will show you how to integrate Lock v2 in your Android project in 
 }) %>
 
 ::: warning
-Username/Email & Password authentication from native clients is disabled by default for new tenants as of 8 June 2017. Users are encouraged to use the [Hosted Login Page](/hosted-pages/login) and perform Web Authentication instead. If you still want to proceed you'll need to enable the Password Grant Type on your dashboard first. See [Client Grant Types](/clients/client-grant-types) for more information.
+Username/Email & Password authentication from native clients is disabled by default for new tenants as of 8 June 2017. Users are encouraged to use [universal login](/hosted-pages/login) and perform Web Authentication instead. If you still want to proceed you'll need to enable the Password Grant Type on your dashboard first. See [Client Grant Types](/clients/client-grant-types) for more information.
 :::
 
 <%= include('_includes/_lock') %>

--- a/articles/quickstart/native/android/02-custom-login-form.md
+++ b/articles/quickstart/native/android/02-custom-login-form.md
@@ -82,7 +82,7 @@ There are multiple ways of designing a customized login screen which are not cov
 
 ### Using a Social connection
 
-You'll use the `WebAuthProvider#init` method. If no connection name is given, the Hosted Login Page will be shown and the user may choose any of the connections enabled for your client. By calling `withConnection` you can force the user to use a specific connection. Let's do that for `Twitter`. Make sure to use a connection that is enabled in your client!
+You'll use the `WebAuthProvider#init` method. If no connection name is given, the login page will be shown and the user may choose any of the connections enabled for your client. By calling `withConnection` you can force the user to use a specific connection. Let's do that for `Twitter`. Make sure to use a connection that is enabled in your client!
 
 ```java
 private void login() {

--- a/articles/quickstart/native/android/_includes/_login.md
+++ b/articles/quickstart/native/android/_includes/_login.md
@@ -1,6 +1,6 @@
 ## Start the Authentication
 
-The [Auth0 hosted login page](/hosted-pages/login) is the easiest way to set up authentication in your application. We recommend using the Auth0 hosted login page for the best experience, best security and the fullest array of features.
+[Universal login](/hosted-pages/login) is the easiest way to set up authentication in your application. We recommend using it for the best experience, best security and the fullest array of features.
 
 ::: note
 You can also embed the Lock widget directly in your application. If you use this method, some features, such as single sign-on, will not be accessible. 

--- a/articles/quickstart/native/ios-objc/_includes/_login_centralized.md
+++ b/articles/quickstart/native/ios-objc/_includes/_login_centralized.md
@@ -1,11 +1,11 @@
-The [Auth0 hosted login page](/hosted-pages/login) is the easiest way to set up authentication in your application. We recommend using the Auth0 hosted login page for the best experience, best security and the fullest array of features.
+[Universal login]](/hosted-pages/login) is the easiest way to set up authentication in your application. We recommend using it for the best experience, best security and the fullest array of features.
 
 ::: note
 You can also embed the Lock widget directly in your application. If you use this method, some features, such as single sign-on, will not be accessible. 
 To learn how to embed the Lock widget in your application, follow the [Embedded Login sample](https://github.com/auth0-samples/auth0-ios-objc-sample/tree/embedded-login/01-Embedded-Login).
 :::
 
-<div class="phone-mockup"><img src="/media/articles/native-platforms/ios-swift/lock_centralized_login.png" alt="Hosted Login Page"></div>
+<div class="phone-mockup"><img src="/media/articles/native-platforms/ios-swift/lock_centralized_login.png" alt="universal login"></div>
 
 ::: note
 Read the [Browser-Based vs. Native Login Flows on Mobile Devices](/tutorials/browser-based-vs-native-experience-on-mobile) article to learn how to choose between the two types of login flows.

--- a/articles/quickstart/native/ios-swift/03-user-sessions.md
+++ b/articles/quickstart/native/ios-swift/03-user-sessions.md
@@ -35,11 +35,11 @@ When your users log in successfully, save their credentials. You can then log th
 
 To get a [Refresh Token](/refresh-token) during authentication, use the `offline_access` scope. You can use the Refresh Token to request a new Access Token when the previous one expires. 
 
-First, import the `Auth0` module to the file where you want to present the hosted login page (HLP):
+First, import the `Auth0` module to the file from which you wish to present the login page:
 
 ${snippet(meta.snippets.setup)}
 
-Next, present the hosted login page:
+Next, present the login page:
 
 ```swift
 // HomeViewController.swift
@@ -57,7 +57,7 @@ Auth0
             // Handle the error
             print("Error: \(error)")
         case .success(let credentials):
-            // Auth0 will automatically dismiss the hosted login page
+            // Auth0 will automatically dismiss the login page
             // Store the credentials
             credentialsManager.store(credentials: credentials)
         }
@@ -78,7 +78,7 @@ First, you check if the credentials manager has valid credentials:
 // SessionManager.swift
 
 guard credentialsManager.hasValid() else {
-    // No valid credentials exist, present the hosted login page
+    // No valid credentials exist, present the login page
 }
 ```
 

--- a/articles/quickstart/native/ios-swift/03-user-sessions.md
+++ b/articles/quickstart/native/ios-swift/03-user-sessions.md
@@ -35,7 +35,7 @@ When your users log in successfully, save their credentials. You can then log th
 
 To get a [Refresh Token](/refresh-token) during authentication, use the `offline_access` scope. You can use the Refresh Token to request a new Access Token when the previous one expires. 
 
-First, import the `Auth0` module to the file from which you wish to present the login page:
+First, import the `Auth0` module to the file that will present the login page:
 
 ${snippet(meta.snippets.setup)}
 

--- a/articles/quickstart/native/ios-swift/08-touch-id-authentication.md
+++ b/articles/quickstart/native/ios-swift/08-touch-id-authentication.md
@@ -25,7 +25,7 @@ Before you continue with this tutorial, make sure that you have completed the pr
 
 ## Apply Touch ID Authentication
 
-This tutorial shows you how to renew the user's credentials without presenting the user the hosted login page. Additionally, the guide shows you how to use Touch ID to validate the renewal. 
+This tutorial shows you how to renew the user's credentials without presenting the user with the login page. Additionally, the guide shows you how to use Touch ID to validate the renewal. 
 
 This tutorial covers how to use the [credentials manager](https://github.com/auth0/Auth0.swift/blob/master/Auth0/CredentialsManager.swift) utility in [Auth0.swift](https://github.com/auth0/Auth0.swift/) to streamline the management of user credentials and Touch ID.
 
@@ -49,10 +49,10 @@ self.credentialsManager = CredentialsManager(authentication: Auth0.authenticatio
 
 ## Add Login
 
-Present the hosted login page. Add the `offline_access` scope to receive a `refreshToken`.
+Present the login page. Add the `offline_access` scope to receive a `refreshToken`.
 
 ::: note
-Read more about presenting the hosted login page in the [User Sessions](/quickstart/native/ios-swift/03-user-sessions) tutorial.
+Read more about presenting the login page in the [User Sessions](/quickstart/native/ios-swift/03-user-sessions) tutorial.
 :::
 
 ```swift

--- a/articles/quickstart/native/ios-swift/_includes/_login_centralized.md
+++ b/articles/quickstart/native/ios-swift/_includes/_login_centralized.md
@@ -1,11 +1,11 @@
-The [Auth0 hosted login page](/hosted-pages/login) is the easiest way to set up authentication in your application. We recommend using the Auth0 hosted login page for the best experience, best security and the fullest array of features.
+[Universal login](/hosted-pages/login) is the easiest way to set up authentication in your application. We recommend using it for the best experience, best security and the fullest array of features.
 
 ::: note
 You can also embed the Lock widget directly in your application. If you use this method, some features, such as single sign-on, will not be accessible. 
 To learn how to embed the Lock widget in your application, follow the [Embedded Login sample](https://github.com/auth0-samples/auth0-ios-swift-sample/tree/embedded-login/01-Embedded-Login).
 :::
 
-<div class="phone-mockup"><img src="/media/articles/native-platforms/ios-swift/lock_centralized_login.png" alt="Hosted Login Page"></div>
+<div class="phone-mockup"><img src="/media/articles/native-platforms/ios-swift/lock_centralized_login.png" alt="login page"></div>
 
 ::: note
 Read the [Browser-Based vs. Native Login Flows on Mobile Devices](/tutorials/browser-based-vs-native-experience-on-mobile) article to learn how to choose between the two types of login flows.
@@ -37,11 +37,11 @@ To configure callback, you must configure your callback URL first. Read about th
 
 ## Implement Login
 
-First, import the `Auth0` module in the file where you want to present the hosted login page:
+First, import the `Auth0` module in the file where you want to present the login page:
 
 ${snippet(meta.snippets.setup)}
 
-Then, present the hosted login screen:
+Then, present the login screen:
 
 ${snippet(meta.snippets.use)}
 

--- a/articles/quickstart/native/react-native/_includes/_login.md
+++ b/articles/quickstart/native/react-native/_includes/_login.md
@@ -1,6 +1,6 @@
 The first step in adding authentication to your application is to provide a way for your users to log in. The fastest, most secure, and most feature-rich way to do this with Auth0 is to use the hosted [login page](/hosted-pages/login).
 
-<div class="phone-mockup"><img src="/media/articles/native-platforms/ios-swift/lock_centralized_login.png" alt="Hosted Login Page"></div>
+<div class="phone-mockup"><img src="/media/articles/native-platforms/ios-swift/lock_centralized_login.png" alt="Login Page"></div>
 
 ## Configuration
 
@@ -93,7 +93,7 @@ The value org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier) is the de
 
 ## Add Authentication with Auth0
 
-We recommend using the Auth0 hosted login page for the best experience, best security and the fullest array of features. This guide will use it to provide a way for your users to log in to your application.
+We recommend using universal login for the best experience, best security and the fullest array of features. This guide will use it to provide a way for your users to log in to your application.
 
 ::: note
 You can also embed login functionality directly in your application. If you use this method, some features, such as single sign-on, will not be accessible. 

--- a/articles/quickstart/spa/_includes/_auth_service_hash_fragment_information.md
+++ b/articles/quickstart/spa/_includes/_auth_service_hash_fragment_information.md
@@ -1,4 +1,4 @@
-Your users authenticate at the Auth0 hosted login page. They are then redirected back to your application. Their redirect URLs contain hash fragments with each user's authentication information:
+Your users authenticate via universal login, at the login page. They are then redirected back to your application. Their redirect URLs contain hash fragments with each user's authentication information:
 * `access_token`
 * `id_token`
 * `expires_in`

--- a/articles/quickstart/spa/_includes/_hosted_login_customization.md
+++ b/articles/quickstart/spa/_includes/_hosted_login_customization.md
@@ -1,3 +1,3 @@
 ::: note
-The Auth0 hosted login page uses the Lock widget. To learn more about the hosted login page, see the [hosted login page documentation](/hosted-pages/login). To customize the look and feel of the Lock widget, see the [customization options documentation](/libraries/lock/v10/customization).
+The login page uses the Lock widget. To learn more about universal login and the login page, see the [universal login documentation](/hosted-pages/login). To customize the look and feel of the Lock widget, see the [Lock customization options documentation](/libraries/lock/v10/customization).
 :::

--- a/articles/quickstart/spa/_includes/_login_preamble.md
+++ b/articles/quickstart/spa/_includes/_login_preamble.md
@@ -1,6 +1,6 @@
 ## Add Authentication with Auth0
 
-The [Auth0 hosted login page](/hosted-pages/login) is the easiest way to set up authentication in your application. We recommend using the Auth0 hosted login page for the best experience, best security and the fullest array of features. This guide will use it to provide a way for your users to log in to your ${library} application.
+[Universal login](/hosted-pages/login) is the easiest way to set up authentication in your application. We recommend using it for the best experience, best security and the fullest array of features. This guide will use it to provide a way for your users to log in to your ${library} application.
 
 ::: note
 You can also embed the Lock widget directly in your application. If you use this method, some features, such as single sign-on, will not be accessible. 

--- a/articles/quickstart/spa/angular2/_includes/_centralized_login.md
+++ b/articles/quickstart/spa/angular2/_includes/_centralized_login.md
@@ -151,13 +151,13 @@ Provide a template with controls for the user to log in and out.
 This example uses Bootstrap styles. You can use any style library, or not use one at all.
 :::
 
-Depending on whether the user is authenticated or not, they see the **Log In** or **Log Out** button. The `click` events on the buttons make calls to the `AuthService` service to let the user log in or out. When the user clicks **Log In**, they are redirected to the Auth0 hosted login page. 
+Depending on whether the user is authenticated or not, they see the **Log In** or **Log Out** button. The `click` events on the buttons make calls to the `AuthService` service to let the user log in or out. When the user clicks **Log In**, they are redirected to the login page. 
 
 <%= include('../../_includes/_hosted_login_customization' }) %>
 
 ## Add a Callback Component
 
-When you use the Auth0 hosted login page, your users are taken away from your application. After they authenticate, they are automatically returned to your application and a client-side session is set for them. 
+When you use universal login, your users are taken away from your application. After they authenticate, they are automatically returned to your application and a client-side session is set for them. 
 
 ::: note
 This example assumes you are using the default Angular path-based routing. If you are using hash-based routing with `{ useHash: true }`, you will not be able to specify a dedicated callback route. The URL hash will be used to hold the user's authentication information.
@@ -183,7 +183,7 @@ After authentication, your users are taken to the `/callback` route. They see th
 
 ## Process the Authentication Result
 
-When a user authenticates at the Auth0 hosted login page, they are redirected to your application. Their URL contains a hash fragment with their authentication information. The `handleAuthentication` method in the `AuthService` service processes the hash. 
+When a user authenticates at the login page, they are redirected to your application. Their URL contains a hash fragment with their authentication information. The `handleAuthentication` method in the `AuthService` service processes the hash. 
 
 Call the `handleAuthentication` method in your app's root component. The method processess the authentication hash while your app loads. 
 

--- a/articles/quickstart/spa/angular2/embedded-login.md
+++ b/articles/quickstart/spa/angular2/embedded-login.md
@@ -14,7 +14,7 @@ budicon: 448
   ]
 }) %>
 
-As an alternative to Auth0's centralized login page, the Lock widget can be embedded directly in your application.
+As an alternative to Auth0's universal login page, the Lock widget can be embedded directly in your application.
 
 <%= include('../_includes/_install_lock') %>
 

--- a/articles/quickstart/spa/angularjs/_includes/_centralized_login.md
+++ b/articles/quickstart/spa/angularjs/_includes/_centralized_login.md
@@ -199,13 +199,13 @@ ${snippet(meta.snippets.use)}
 This example uses Bootstrap styles. You can use any style library, or not use one at all.
 :::
 
-Depending on whether the user is authenticated or not, they see the **Log Out** or **Log In** button. The `ng-click` events on the buttons make calls to the `authService` service to let the user log in or out. When the user clicks **Log In**, they are redirected to the Auth0 hosted login page. 
+Depending on whether the user is authenticated or not, they see the **Log Out** or **Log In** button. The `ng-click` events on the buttons make calls to the `authService` service to let the user log in or out. When the user clicks **Log In**, they are redirected to the login page. 
 
 <%= include('../../_includes/_hosted_login_customization' }) %>
 
 ## Add a Callback Component
 
-When you use the Auth0 hosted login page, your users are taken away from your application. After they authenticate, they are automatically returned to your application and a client-side session is set for them. 
+When you use the login page, your users are taken away from your application. After they authenticate, they are automatically returned to your application and a client-side session is set for them. 
 
 ::: note
 This example assumes you are using path-based routing by setting `$locationProvider.html5Mode(true)`. If you are using hash-based routing, you will not be able to specify a dedicated callback route. The URL hash will be used to hold the user's authentication information.
@@ -247,7 +247,7 @@ After authentication, your users are taken to the `/callback` route. They see th
 
 ## Process the Authentication Result
 
-When a user authenticates at the Auth0 hosted login page, they are redirected to your application. Their URL contains a hash fragment with their authentication information. The `handleAuthentication` method in the `authService` service processes the hash. 
+When a user authenticates at the login page, they are redirected to your application. Their URL contains a hash fragment with their authentication information. The `handleAuthentication` method in the `authService` service processes the hash. 
 
 Call the `handleAuthentication` method in your app's run block. The method processess the authentication hash while your app loads. 
 

--- a/articles/quickstart/spa/aurelia/_includes/_centralized_login.md
+++ b/articles/quickstart/spa/aurelia/_includes/_centralized_login.md
@@ -115,17 +115,17 @@ This example uses Bootstrap styles, but that's unimportant. Use whichever style 
 
 The `click.delegate` events on the **Log In** and **Log Out** buttons make the appropriate calls to the `AuthService` to allow the user to log in and log out. Notice that these buttons are conditionally hidden and shown depending on whether or not the user is currently authenticated.
 
-When the **Log In** button is clicked, the user will be redirected to Auth0's hosted login page.
+When the **Log In** button is clicked, the user will be redirected to the login page.
 
 <%= include('../../_includes/_hosted_login_customization' }) %>
 
 ## Add a Callback Component
 
-Using Auth0's hosted login page means that users are taken away from your application to a page hosted by Auth0. After they successfully authenticate, they are returned to your application where a client-side session is set for them.
+Using universal login means that users are taken away from your application to a login page hosted by Auth0. After they successfully authenticate, they are returned to your application where a client-side session is set for them.
 
 <%= include('../../_includes/_callback_component') %>
 
-When a user authenticates at Auth0's hosted login page and is then redirected back to your application, their authentication information will be contained in a URL hash fragment. The `handleAuthentication` method in the `AuthService` is responsbile for processing the hash.
+When a user authenticates at the login page and is then redirected back to your application, their authentication information will be contained in a URL hash fragment. The `handleAuthentication` method in the `AuthService` is responsbile for processing the hash.
 
 Create a component named `CallbackComponent` and populate it with a loading indicator. The component should also call `handleAuthentication` from the `AuthService`.
 
@@ -199,4 +199,4 @@ This example assumes you are using path-based routing with `config.options.pushS
 
 ## Embedded Login
 
-Auth0's hosted login page provides the fastest, most secure, and most feature-rich way to implement authentication in your app. If required, the Lock widget can also be embedded directly into your application, but certain features such as single sign-on won't be accessible. It is highly recommended that you use the hosted login page (as covered in this tutorial), but if you wish to embed the Lock widget directly in your application, follow the [Embedded Login sample](https://github.com/auth0-community/auth0-aurelia-samples/tree/embedded-login/01-Embedded-Login).
+Auth0's universal login provides the fastest, most secure, and most feature-rich way to implement authentication in your app. If required, the Lock widget can also be embedded directly into your application, but certain features such as single sign-on won't be accessible. It is highly recommended that you use the login page (as covered in this tutorial), but if you wish to embed the Lock widget directly in your application, follow the [Embedded Login sample](https://github.com/auth0-community/auth0-aurelia-samples/tree/embedded-login/01-Embedded-Login).

--- a/articles/quickstart/spa/ember/_includes/_centralized_login.md
+++ b/articles/quickstart/spa/ember/_includes/_centralized_login.md
@@ -139,13 +139,13 @@ Provide a template with controls for the user to log in and log out.
 </div>
 ```
 
-The `action` added to the **Log In** control makes the appropriate call to the `login` method in `auth.js` to allow the user to log in. When the **Log In** control is clicked, the user will be redirected to Auth0's hosted login page.
+The `action` added to the **Log In** control makes the appropriate call to the `login` method in `auth.js` to allow the user to log in. When the **Log In** control is clicked, the user will be redirected to the login page.
 
 <%= include('../../_includes/_hosted_login_customization' }) %>
 
 ## Process the Authentication Result
 
-When a user authenticates at Auth0's hosted login page and is then redirected back to your application, their authentication information will be contained in a URL hash fragment. The `handleAuthentication` function in `auth.js` is responsbile for processing the hash.
+When a user authenticates at the login page and is then redirected back to your application, their authentication information will be contained in a URL hash fragment. The `handleAuthentication` function in `auth.js` is responsbile for processing the hash.
 
 Call `handleAuthentication` in `app.js` so that the authentication hash fragment can be processed when the app first loads after the user is redirected back to it.
 
@@ -223,4 +223,4 @@ Notice that there is also a `Log Out` control in this route which has an `action
 
 ## Embedded Login
 
-Auth0's hosted login page provides the fastest, most secure, and most feature-rich way to implement authentication in your app. If required, the Lock widget can also be embedded directly into your application, but certain features such as single sign-on won't be accessible. It is highly recommended that you use the hosted login page (as covered in this tutorial), but if you wish to embed the Lock widget directly in your application, follow the [Embedded Login sample](https://github.com/auth0-community/ember-simple-auth-auth0/tree/develop/tests/dummy).
+Auth0's universal login provides the fastest, most secure, and most feature-rich way to implement authentication in your app. If required, the Lock widget can also be embedded directly into your application, but certain features such as single sign-on won't be accessible. It is highly recommended that you use the login page (as covered in this tutorial), but if you wish to embed the Lock widget directly in your application, follow the [Embedded Login sample](https://github.com/auth0-community/ember-simple-auth-auth0/tree/develop/tests/dummy).

--- a/articles/quickstart/spa/jquery/_includes/_centralized_login.md
+++ b/articles/quickstart/spa/jquery/_includes/_centralized_login.md
@@ -173,13 +173,13 @@ Provide a template with controls for the user to log in and out.
 This example uses Bootstrap styles. You can use any style library, or not use one at all.
 :::
 
-Depending on whether the user is authenticated or not, they see the **Log In** or **Log Out** button. The `click` event listeners on the buttons make calls to functions in the `app.js` file to let the user log in or out. When the user clicks **Log In**, the user is redirected to the Auth0 hosted login page.
+Depending on whether the user is authenticated or not, they see the **Log In** or **Log Out** button. The `click` event listeners on the buttons make calls to functions in the `app.js` file to let the user log in or out. When the user clicks **Log In**, the user is redirected to the login page.
 
 <%= include('../../_includes/_hosted_login_customization' }) %>
 
 ## Process the Authentication Result
 
-When a user authenticates at the Auth0 hosted login page, they are redirected to your application. Their URL contains a hash fragment with their authentication information. The `handleAuthentication` function in the `app.js` file processes the hash.
+When a user authenticates at the login page, they are redirected to your application. Their URL contains a hash fragment with their authentication information. The `handleAuthentication` function in the `app.js` file processes the hash.
 
 Call the `handleAuthentication` function in the `app.js` file. The function processes the authentication hash while your app loads. 
 

--- a/articles/quickstart/spa/react/_includes/_centralized_login.md
+++ b/articles/quickstart/spa/react/_includes/_centralized_login.md
@@ -133,13 +133,13 @@ ${snippet(meta.snippets.use)}
 This example uses Bootstrap styles. You can use any style library you want, or not use one at all.
 :::
 
-Depending on whether the user is authenticated or not, they see the **Log In** or **Log Out** button. The `click` events on the buttons make calls to the `Auth` service to let the user log out or log in. When the user clicks the **Log In** button, they are redirected to the Auth0 hosted login page. 
+Depending on whether the user is authenticated or not, they see the **Log In** or **Log Out** button. The `click` events on the buttons make calls to the `Auth` service to let the user log out or log in. When the user clicks the **Log In** button, they are redirected to the login page. 
 
 <%= include('../../_includes/_hosted_login_customization' }) %>
 
 ## Add a Callback Component
 
-When you use the Auth0 hosted login page, your users are taken away from your application. After they authenticate, the users automatically return to your application and a client-side session is set for them. 
+When you use the login page, your users are taken away from your application. After they authenticate, the users automatically return to your application and a client-side session is set for them. 
 
 ::: note
 This example assumes you are using path-based routing with `<BrowserRouter>`. If you are using hash-based routing, you will not be able to specify a dedicated callback route. The URL hash will be used to hold the user's authentication information.
@@ -178,7 +178,7 @@ After authentication, your users are taken to the `/callback` route. They see th
 
 ## Process the Authentication Result
 
-When a user authenticates at the Auth0 hosted login page, they are redirected to your application. Their URL contains a hash fragment with their authentication information. The `handleAuthentication` method in the `Auth` service processes the hash. 
+When a user authenticates at the login page, they are redirected to your application. Their URL contains a hash fragment with their authentication information. The `handleAuthentication` method in the `Auth` service processes the hash. 
 
 Call the `handleAuthentication` method after you render the `Callback` route. The method processes the authentication hash fragment when the `Callback` component initializes.
 

--- a/articles/quickstart/spa/vanillajs/_includes/_centralized_login.md
+++ b/articles/quickstart/spa/vanillajs/_includes/_centralized_login.md
@@ -176,13 +176,13 @@ Provide a template with controls for the user to log in and out.
 This example uses Bootstrap styles. You can use any style library, or not use one at all.
 :::
 
-Depending on whether the user is authenticated or not, they see the **Log In** or **Log Out** button. The `click` event listeners on the buttons make calls to functions in the `app.js` file to let the user log in or out. When the user clicks **Log In**, they are redirected to the Auth0 hosted login page. 
+Depending on whether the user is authenticated or not, they see the **Log In** or **Log Out** button. The `click` event listeners on the buttons make calls to functions in the `app.js` file to let the user log in or out. When the user clicks **Log In**, they are redirected to the login page. 
 
 <%= include('../../_includes/_hosted_login_customization' }) %>
 
 ## Process the Authentication Result
 
-When a user authenticates at the Auth0 hosted login page, they are redirected to your application. Their URL contains a hash fragment with their authentication information. The `handleAuthentication` method in the `app.js` file processes the hash. 
+When a user authenticates at the login page, they are redirected to your application. Their URL contains a hash fragment with their authentication information. The `handleAuthentication` method in the `app.js` file processes the hash. 
 
 Call the `handleAuthentication` method in the `app.js` file. The method processes the authentication hash while your app loads. 
 

--- a/articles/quickstart/spa/vuejs/_includes/_centralized_login.md
+++ b/articles/quickstart/spa/vuejs/_includes/_centralized_login.md
@@ -138,17 +138,17 @@ This example uses Bootstrap styles, but that's unimportant. Use whichever style 
 
 The `@click` events on the **Log In** and **Log Out** buttons make the appropriate calls to the `AuthService` to allow the user to log in and log out. Notice that these buttons are conditionally hidden and shown depending on whether or not the user is currently authenticated.
 
-When the **Log In** button is clicked, the user will be redirected to Auth0's hosted login page.
+When the **Log In** button is clicked, the user will be redirected to login page.
 
 <%= include('../../_includes/_hosted_login_customization' }) %>
 
 ## Add a Callback Component
 
-Using Auth0's hosted login page means that users are taken away from your application to a page hosted by Auth0. After they successfully authenticate, they are returned to your application where a client-side session is set for them.
+Using universal login means that users are taken away from your application to a login page hosted by Auth0. After they successfully authenticate, they are returned to your application where a client-side session is set for them.
 
 <%= include('../../_includes/_callback_component') %>
 
-When a user authenticates at Auth0's hosted login page and is then redirected back to your application, their authentication information will be contained in a URL hash fragment. The `handleAuthentication` method in the `AuthService` is responsbile for processing the hash.
+When a user authenticates at the login page and is then redirected back to your application, their authentication information will be contained in a URL hash fragment. The `handleAuthentication` method in the `AuthService` is responsbile for processing the hash.
 
 Create a component named `CallbackComponent` and populate it with a loading indicator. The component should also call `handleAuthentication` from the `AuthService`.
 

--- a/articles/quickstart/webapp/aspnet-core/_includes/_login.md
+++ b/articles/quickstart/webapp/aspnet-core/_includes/_login.md
@@ -1,6 +1,6 @@
 ## Add Authentication with Auth0
 
-The [Auth0 hosted login page](/hosted-pages/login) is the easiest way to set up authentication in your application. We recommend using the Auth0 hosted login page for the best experience, best security and the fullest array of features. This guide will use it to provide a way for your users to log in to your ASP.NET Core application.
+[Universal login](/hosted-pages/login) is the easiest way to set up authentication in your application. We recommend using the login page for the best experience, best security and the fullest array of features. This guide will use it to provide a way for your users to log in to your ASP.NET Core application.
 
 ::: note
 You can also create a custom login for prompting the user for their username and password. To learn how to do this in your application, follow the [Custom Login sample](https://github.com/auth0-samples/auth0-aspnetcore-mvc-samples/tree/master/Samples/custom-login).

--- a/articles/quickstart/webapp/aspnet-core/_includes/v1/_login.md
+++ b/articles/quickstart/webapp/aspnet-core/_includes/v1/_login.md
@@ -1,6 +1,6 @@
 ## Add Authentication with Auth0
 
-The [Auth0 hosted login page](/hosted-pages/login) is the easiest way to set up authentication in your application. We recommend using the Auth0 hosted login page for the best experience, best security and the fullest array of features. This guide will use it to provide a way for your users to log in to your ASP.NET Core application.
+[Universal login](/hosted-pages/login) is the easiest way to set up authentication in your application. We recommend using universal login for the best experience, best security and the fullest array of features. This guide will use it to provide a way for your users to log in to your ASP.NET Core application.
 
 ::: note
 You can also create a custom login for prompting the user for their username and password. To learn how to do this in your application, follow the [Custom Login sample](https://github.com/auth0-samples/auth0-aspnetcore-mvc-samples/tree/v1/Samples/custom-login).

--- a/articles/quickstart/webapp/aspnet-owin/_includes/_login.md
+++ b/articles/quickstart/webapp/aspnet-owin/_includes/_login.md
@@ -1,6 +1,6 @@
 ## Add Authentication with Auth0
 
-The [Auth0 hosted login page](/hosted-pages/login) is the easiest way to set up authentication in your application. We recommend using the Auth0 hosted login page for the best experience, best security and the fullest array of features. This guide will use it to provide a way for your users to log in to your ASP.NET MVC 5 application.
+[Universal login](/hosted-pages/login) is the easiest way to set up authentication in your application. We recommend using the login page for the best experience, best security and the fullest array of features. This guide will use it to provide a way for your users to log in to your ASP.NET MVC 5 application.
 
 ::: note
 You can also create a custom login for prompting the user for their username and password. To learn how to do this in your application, follow the [Custom Login sample](https://github.com/auth0-samples/auth0-aspnet-owin-mvc-samples/tree/master/Samples/custom-login).

--- a/articles/quickstart/webapp/golang/01-login.md
+++ b/articles/quickstart/webapp/golang/01-login.md
@@ -124,7 +124,7 @@ ${snippet(meta.snippets.setup)}
 
 Create a file called `login.go` in the `routes/login` folder, and add `LoginHandler` function to handle `/login` route.
 
-This function sets the configuration for [OAuth2 Go](https://godoc.org/golang.org/x/oauth2) to get the authorization url, and redirect user to Auth0's  [hosted login page](/hosted-pages/login).
+This function sets the configuration for [OAuth2 Go](https://godoc.org/golang.org/x/oauth2) to get the authorization url, and redirects the user to the [login page](/hosted-pages/login).
 
 ```go
 // routes/login/login.go

--- a/articles/quickstart/webapp/java-spring-security-mvc/_includes/_login.md
+++ b/articles/quickstart/webapp/java-spring-security-mvc/_includes/_login.md
@@ -88,7 +88,7 @@ public AuthenticationController authenticationController() throws UnsupportedEnc
 }
 ```
 
-To authenticate the users you will redirect them to the **Auth0 Hosted Login Page** which uses the best version available of [Lock](/lock). This page is accessible from what we call the "Authorize URL". By using this library you can generate it with a simple method call. It will require a `HttpServletRequest` to store the call context in the session and the URI to redirect the authentication result to. This URI is normally the address where your app is running plus the path where the result will be parsed, which happens to be also the "Callback URL" whitelisted before. Finally, request the "User Info" *audience* in order to obtain an Open ID Connect compliant response. After you create the Authorize URL, you redirect the request there so the user can enter their credentials. The following code snippet is located on the `LoginController` class of our sample.
+To authenticate the users you will redirect them to the login page which uses [Lock](/libraries/lock/v10). This page is accessible from what we call the "Authorize URL". By using this library you can generate it with a simple method call. It will require a `HttpServletRequest` to store the call context in the session and the URI to redirect the authentication result to. This URI is normally the address where your app is running plus the path where the result will be parsed, which happens to be also the "Callback URL" whitelisted before. Finally, request the "User Info" *audience* in order to obtain an Open ID Connect compliant response. After you create the Authorize URL, you redirect the request there so the user can enter their credentials. The following code snippet is located on the `LoginController` class of our sample.
 
 ```java
 @RequestMapping(value = "/login", method = RequestMethod.GET)
@@ -142,7 +142,7 @@ To run the sample from a terminal, change the directory to the root folder of th
 ./gradlew clean bootRun
 ```
 
-After a few seconds, the application will be accessible on `http://localhost:8080/`. Try to access the protected resource [http://localhost:8080/portal/home](http://localhost:8080/portal/home) and note how you're redirected by the framework to the Auth0 Hosted Login Page. The widget displays all the social and database connections that you have defined for this application in the [dashboard](${manage_url}/#/).
+After a few seconds, the application will be accessible on `http://localhost:8080/`. Try to access the protected resource [http://localhost:8080/portal/home](http://localhost:8080/portal/home) and note how you're redirected by the framework to the login page. The widget displays all the social and database connections that you have defined for this application in the [dashboard](${manage_url}/#/).
 
 ![Login using Lock](/media/articles/java/login-with-lock.png)
 

--- a/articles/quickstart/webapp/nodejs/_includes/_login.md
+++ b/articles/quickstart/webapp/nodejs/_includes/_login.md
@@ -53,7 +53,7 @@ app.use(passport.session());
 
 ## Trigger Authentication
 
-The [Auth0 hosted login page](/hosted-pages/login) is the easiest way to set up authentication in your application. We recommend using the Auth0 hosted login page for the best experience, best security and the fullest array of features.
+[Universal login](/hosted-pages/login) is the easiest way to set up authentication in your application. We recommend using the login page for the best experience, best security and the fullest array of features.
 
 ::: note
 You can also embed the Lock widget directly in your application. If you use this method, some features, such as single sign-on, will not be accessible. 
@@ -65,7 +65,7 @@ Add a route called `/login`. Use the `env` object to set the following propertie
 * Domain
 * Callback URL
 
-The route creates an instance of the `auth0.WebAuth` object. Then, the route calls the `authorize` method and redirects the user to the Auth0 hosted login page.
+The route creates an instance of the `auth0.WebAuth` object. Then, the route calls the `authorize` method and redirects the user to the login page.
 
 You need to make sure you get an OIDC-conformant response. You can achieve it two ways:
 * set the audience. 

--- a/articles/quickstart/webapp/python/01-login.md
+++ b/articles/quickstart/webapp/python/01-login.md
@@ -41,7 +41,7 @@ six
 
 ## Initialize Flask-OAuthlib
 
-With `OAuth` you call the authorize endpoint of the Authentication API and redirect your users to our [hosted login page](/hosted-pages/login). This way, you will be implementing the [authorization code grant flow](https://auth0.com/docs/api-auth/tutorials/authorization-code-grant), so you will obtain a `code`.
+With `OAuth` you call the authorize endpoint of the Authentication API and redirect your users to the [login page](/hosted-pages/login). This way, you will be implementing the [authorization code grant flow](/api-auth/tutorials/authorization-code-grant), so you will obtain a `code`.
 Create a file named `server.py`, and instantiate a client with your client keys, scopes, and OAuth endpoints.
 
 ```python
@@ -110,7 +110,7 @@ def callback_handling():
 
 ## Trigger Authentication
 
-Add a `/login` route that uses the `Flask-OAuthlib` client instance to redirect the user to Auth0's [hosted login page](/hosted-pages/login).
+Add a `/login` route that uses the `Flask-OAuthlib` client instance to redirect the user to the [login page](/hosted-pages/login).
 
 ```python
 # /server.py
@@ -133,7 +133,7 @@ Create a `home.html` file in a `/template` folder. Add a link to the `/login` ro
 
 ## Logout
 
-To log the user out, you have to clear the data from the session, and redirect the user to the Auth0 logout endpoint. You can find more information about this in [our documentation logout documentation](/logout).
+To log the user out, you have to clear the data from the session, and redirect the user to the Auth0 logout endpoint. You can find more information about this in [our logout documentation](/logout).
 
 ```python
 # /server.py

--- a/articles/quickstart/webapp/rails/01-login.md
+++ b/articles/quickstart/webapp/rails/01-login.md
@@ -14,7 +14,7 @@ budicon: 448
   ]
 }) %>
 
-The first step in adding authentication to your Ruby on Rails application is to provide a way for your users to log in. The fastest, most secure, and most feature-rich way to do this with Auth0 is to use the [hosted login page](/hosted-pages/login).
+The first step in adding authentication to your Ruby on Rails application is to provide a way for your users to log in. The fastest, most secure, and most feature-rich way to do this with Auth0 is to use [universal login](/hosted-pages/login).
 
 ## Create a Client
 

--- a/articles/sso/current/index.md
+++ b/articles/sso/current/index.md
@@ -8,7 +8,7 @@ toc: false
 Single Sign On (SSO) occurs when a user logs in to one application and is then signed in to other applications automatically, regardless of the platform, technology, or domain the user is using.
 
 ::: note
-The [Hosted Login Page](/hosted-pages/login) is the easiest and most secure way to implement SSO with Auth0. If you need to use embedded [Lock](/libraries/lock) or an embedded custom authentication UI in your application, check out the [Cross-Origin Authentication](/cross-origin-authentication) page for information on safely conducting SSO.
+[Universal login](/hosted-pages/login) is the easiest and most secure way to implement SSO with Auth0. If you need to use embedded [Lock](/libraries/lock) or an embedded custom authentication UI in your application, check out the [Cross-Origin Authentication](/cross-origin-authentication) page for information on safely conducting SSO.
 :::
 
 ## In This Section

--- a/articles/sso/current/index.md
+++ b/articles/sso/current/index.md
@@ -8,7 +8,7 @@ toc: false
 Single Sign On (SSO) occurs when a user logs in to one application and is then signed in to other applications automatically, regardless of the platform, technology, or domain the user is using.
 
 ::: note
-[Universal login](/hosted-pages/login) is the easiest and most secure way to implement SSO with Auth0. If you need to use embedded [Lock](/libraries/lock) or an embedded custom authentication UI in your application, check out the [Cross-Origin Authentication](/cross-origin-authentication) page for information on safely conducting SSO.
+[Universal login](/hosted-pages/login) is the easiest and most secure way to implement SSO with Auth0. If for some reason you cannot use universal login with your application, check out the [Lock](/libraries/lock) page or the [Auth0.js](/libraries/auth0js) page for more information on embedded authentication.
 :::
 
 ## In This Section

--- a/articles/sso/current/introduction.md
+++ b/articles/sso/current/introduction.md
@@ -37,9 +37,9 @@ In the case of SSO with Auth0, the **Central Service** is the Auth0 Authorizatio
 
 Let's look at an example of how the SSO flow looks when using Auth0 and the [Lock](/libraries/lock) widget and a user visits your application for the first time:
 
-1. Your application will redirect the user to the Auth0 Hosted Login page where they can log in.
+1. Your application will redirect the user to the login page where they can log in.
 1. Auth0 will check to see whether there is an existing SSO cookie.
-1. Because this is the first time the user visits this Hosted Login page, and no SSO cookie is present, they may be presented with username and password fields and also possibly some Social Identity Providers such as LinkedIn, GitHub, and so on. (The exact layout of the Lock screen will depend on the [Identity Providers](/identityproviders) you have configured.
+1. Because this is the first time the user visits this login page, and no SSO cookie is present, they may be presented with username and password fields and also possibly some Social Identity Providers such as LinkedIn, GitHub, etc. (The exact layout of the Lock screen will depend on the [Identity Providers](/identityproviders) you have configured.
 
     ![](/media/articles/sso/single-sign-on/lock-no-sso-cookie.png)
 
@@ -48,7 +48,7 @@ Let's look at an example of how the SSO flow looks when using Auth0 and the [Loc
 
 Now let's look at flow when the user returns to your website for a subsequent visit:
 
-1. Your application will redirect the user to the Auth0 Hosted Login page where they can sign in.
+1. Your application will redirect the user to the login page where they can sign in.
 1. Auth0 will check to see whether there is an existing SSO cookie.
 1. This time Auth0 finds an SSO cookie and instead of displaying the normal Lock screen with the username and password fields, it will display a Lock screen which indicates that we know who the user is, as they have already logged in before. They can simply confirm that they want to log in with that same account.
 
@@ -61,4 +61,4 @@ If an SSO cookie is present you can also sign the user in silently, (that is, wi
 
 ## SSO with Native Platforms
 
-Currently, SSO is only possible with native platforms (such as iOS or Android) if the application uses the Hosted Login Page for authentication. The [Swift](/quickstart/native/ios-swift/00-login) and [Android](/quickstart/native/android/00-login) quickstarts provide some examples of usage of the Hosted Login Page for authentication from their respective platforms.
+Currently, SSO is only possible with native platforms (such as iOS or Android) if the application uses the universal login for authentication. The [Swift](/quickstart/native/ios-swift/00-login) and [Android](/quickstart/native/android/00-login) quickstarts provide some examples of usage of universal login for authentication from their respective platforms.

--- a/snippets/native-platforms/cordova/setup.md
+++ b/snippets/native-platforms/cordova/setup.md
@@ -1,6 +1,6 @@
 ## Add Cordova Plugins
 
-You must install the `SafariViewController` plugin from Cordova to be able to show Auth0's hosted login page. The downloadable sample project already has this plugin added, but if you are adding Auth0 to your own application, install the plugin via the command line.
+You must install the `SafariViewController` plugin from Cordova to be able to show the login page. The downloadable sample project already has this plugin added, but if you are adding Auth0 to your own application, install the plugin via the command line.
 
 ```bash
 cordova plugin add cordova-plugin-safariviewcontroller

--- a/snippets/native-platforms/ios-swift/use.md
+++ b/snippets/native-platforms/ios-swift/use.md
@@ -12,7 +12,7 @@ Auth0
             print("Error: \(error)")
         case .success(let credentials):
             // Do something with credentials e.g.: save them.
-            // Auth0 will automatically dismiss the hosted login page
+            // Auth0 will automatically dismiss the login page
             print("Credentials: \(credentials)")
         }
 }


### PR DESCRIPTION
Goals of this PR: 

1) Replace the term 'centralized login' with 'universal login'
2) Remove the term 'hosted login page'. Replace it with something contextually appropriate, typically either 'login page' or 'universal login' depending on the usage.

https://trello.com/c/wwbsSbQT
  