### PR TITLE
Clarify use of client id and secret for client credentials

### DIFF
--- a/articles/quickstart/backend/_includes/_api_using.md
+++ b/articles/quickstart/backend/_includes/_api_using.md
@@ -29,8 +29,10 @@ You can also obtain an access token using [cUrl](https://curl.haxx.se/) by using
 curl --request POST \
   --url 'https://${account.namespace}/oauth/token' \
   --header 'content-type: application/json' \
-  --data '{ "client_id":"${account.clientId}", "client_secret": "${account.clientSecret}", "audience": "YOUR_API_AUDIENCE", "grant_type": "client_credentials" }'
+  --data '{ "client_id":"YOUR_CLIENT_ID", "client_secret": "YOUR_CLIENT_SECRET", "audience": "YOUR_API_AUDIENCE", "grant_type": "client_credentials" }'
 ```
+
+When using the Client Credentials flow, you will need to register a [Non Interactive Client](/clients). You should then subsequently use the **Client ID** and **Client Secret** of this Non Interactive Client when making the request shown above and pass those along in the `client_id` and `client_secret` parameters respectively.
 
 **2. Using Resource Owner Password**
 


### PR DESCRIPTION
Removed the variable from the client credentials code snippet and explain where they should get these values from. The reason for this is that the client picker in the docs website does not currently support non interactive clients