### PR TITLE
Added audience to code snippet to generate a valid jwt instead of reference

### DIFF
--- a/articles/protocols/saml/samlsso-auth0-to-auth0.md
+++ b/articles/protocols/saml/samlsso-auth0-to-auth0.md
@@ -268,6 +268,7 @@ Create an HTML page and insert the following HTML and javascript code:
   var lock = new Auth0Lock('${account.clientId}', '${account.namespace}',{
         auth: {
           redirectUrl: 'http://jwt.io',
+          audience: 'https://${account.namespace}/api/v2/'
           responseType: 'token',
           params: {scope: 'openid'}
         }

--- a/articles/protocols/saml/samlsso-auth0-to-auth0.md
+++ b/articles/protocols/saml/samlsso-auth0-to-auth0.md
@@ -268,7 +268,7 @@ Create an HTML page and insert the following HTML and javascript code:
   var lock = new Auth0Lock('${account.clientId}', '${account.namespace}',{
         auth: {
           redirectUrl: 'http://jwt.io',
-          audience: 'https://your-audience.com'
+          audience: 'https://your-audience.com',
           responseType: 'token',
           params: {scope: 'openid'}
         }

--- a/articles/protocols/saml/samlsso-auth0-to-auth0.md
+++ b/articles/protocols/saml/samlsso-auth0-to-auth0.md
@@ -268,7 +268,7 @@ Create an HTML page and insert the following HTML and javascript code:
   var lock = new Auth0Lock('${account.clientId}', '${account.namespace}',{
         auth: {
           redirectUrl: 'http://jwt.io',
-          audience: 'https://${account.namespace}/api/v2/'
+          audience: 'https://your-audience.com'
           responseType: 'token',
           params: {scope: 'openid'}
         }

--- a/articles/protocols/saml/samlsso-auth0-to-auth0.md
+++ b/articles/protocols/saml/samlsso-auth0-to-auth0.md
@@ -284,7 +284,7 @@ Create an HTML page and insert the following HTML and javascript code:
 
 ```
 
-Make sure you replace `YOUR-APP-CLIENT-ID` with the actual value of the app you registered in step 7 above.  
+Make sure you replace **YOUR-APP-CLIENT-ID** with the actual value of the app you registered in step 7 above. You can also replace **audience** with the value appropriate for your Client -- however, for the purposes of this test, a placeholder will work.
 
 The client ID for your client can be found in the **Auth0 dashboard** for **Tenant 1** by going to "Clients" link and clicking on the "Settings" (gear) icon to the right of your client's name.
 


### PR DESCRIPTION
As title says. Without an audience, only a reference to JWT is returned which cannot be decoded by jwt.io creating the impression that the setup does not work.

Also maybe some additional wording needs to be added below this code snippet. 
<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
