### PR TITLE
Note the signupLink -> signUpLink casing change

### DIFF
--- a/articles/libraries/lock/v10/migration-guide.md
+++ b/articles/libraries/lock/v10/migration-guide.md
@@ -92,6 +92,7 @@ Some existing options suffered changes, in addition to the beforementioned remov
 - The `disableSignUpAction` option was renamed to [allowSignUp](/libraries/lock/v10/configuration#allowsignup-boolean-).
 - The `defaultUserPasswordConnection` option has been replaced by the [defaultDatabaseConnection](/libraries/lock/v10/configuration#defaultdatabaseconnection-string-) and the [defaultEnterpriseConnection](/libraries/lock/v10/configuration#defaultenterpriseconnection-string-) options.
 - The `resetLink` option was renamed to [forgotPasswordLink](/libraries/lock/v10/configuration#forgotpasswordlink-string-).
+- The `signupLink` option was renamed to [signUpLink](/libraries/lock/v10/configuration#signuplink-string-) (change in casing).
 
 ### Other Options
 


### PR DESCRIPTION
The change in casing was significant, with the wrong casing, it didn't work.

(At least for Lock 11, didn't try with Lock 10 as I upgrade directly to 11.)

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
