### PR TITLE
Database connection updates

### DIFF
--- a/articles/connections/database/custom-db.md
+++ b/articles/connections/database/custom-db.md
@@ -35,12 +35,12 @@ To create the database connection for your database, follow these steps.
 2. Click the **+ Create DB Connection** button.
 3. Provide a name for the database and configure the available options.
 
-![](/media/articles/connections/database/database-connections.png)
+![Database connections](/media/articles/connections/database/database-connections.png)
 
 3. Navigate to the **Custom Database** tab.
 4. Toggle on the **Use my own database** switch.
 
-![](/media/articles/connections/database/custom-database.png)
+![Custom database tab](/media/articles/connections/database/custom-database.png)
 
 ## Create database action scripts
 
@@ -65,13 +65,13 @@ When creating users, Auth0 calls the **Get User** script before the **Create** s
 
 ### Create the Login script
 
-Create the required Login script to authenticate users. The Login script will run each time a user attempts to log in. You can write your own Login script or select a template from the **Templates** dropdown.
+The Login script will run each time a user attempts to log in. You can write your own Login script or select a template from the **Templates** dropdown.
 
 ::: note
 If you are using [IBM's DB2](https://www.ibm.com/analytics/us/en/technology/db2/) product, [click here](/connections/database/db2-script) for a sample login script.
 :::
 
-![](/media/articles/connections/database/mysql/db-connection-login-script.png)
+![Database action script templates](/media/articles/connections/database/mysql/db-connection-login-script.png)
 
 For example, the MySQL Login template:
 
@@ -117,14 +117,11 @@ The above script connects to a MySQL database and executes a query to retrieve t
 
 ## Add configuration parameters
 
-Store the credentials required to connect to your database in the **Settings** section below the script editor. Parameters stored there are available in all of your scripts.
+You can store parameters, like the credentials required to connect to your database, in the Settings section below the script editor. These will be available to all of your scripts and you can access them using the global configuration object.
 
-You can access parameter values using the `configuration` object in your database action scripts, for example: `configuration.PARAMETER_NAME`.
+You can access parameter values using the `configuration` object in your database action scripts, for example: `configuration.MYSQL_PASSWORD`.
 
-![](/media/articles/connections/database/mysql/db-connection-configurate.png)
-
-Heads up! You can use this section to store values which are available in all scripts. 
-The values are accessible through the global configuration object.
+![Custom database settings](/media/articles/connections/database/mysql/db-connection-configurate.png)
 
 Use the added parameters in your scripts to configure the connection. For example, in the MySQL Login template:
 
@@ -141,17 +138,17 @@ function login (username, password, callback) {
 
 ## Error Handling
 
+There are three different errors you can return from a database connection:
+
+* `new WrongUsernameOrPasswordError(<email or user_id>, <message>)`: when you know who the user is and want to keep track of a wrong password.
+* `new ValidationError(<error code>, <message>)`: a generic error with an error code.
+* `new Error(<message>)`: simple errors (no error code).
+
 To return an error, call the callback with an error as the first parameter:
 
 ```js
 callback(error);
 ```
-
-There are three different errors you can return from a DB Connection:
-
-* `new WrongUsernameOrPasswordError(<email or user_id>, <message>)`: when you know who the user is and want to keep track of a wrong password.
-* `new ValidationError(<error code>, <message>)`: a generic error with an error code.
-* `new Error(<message>)`: simple errors (no error code).
 
 For example:
 
@@ -163,9 +160,9 @@ callback(new ValidationError('email-too-long', 'Email is too long.'));
 
 Test the script using the **TRY** button. If your settings are correct you should see the resulting profile:
 
-![](/media/articles/connections/database/mysql/db-connection-try-ok.png)
+![Try the login script](/media/articles/connections/database/mysql/db-connection-try-ok.png)
 
-If you add a `console.log` statement to the script you will be able to see the output here.
+If you do not get the expected result or receive an error, use `console.log`statements in your script and try the connection again. The output of `console.log` prints in the try the script window.
 
 ::: note
 The [auth0-custom-db-testharness library](https://www.npmjs.com/package/auth0-custom-db-testharness) can be used to deploy, execute, and test the output of database action scripts using a Webtask sandbox environment.
@@ -173,8 +170,8 @@ The [auth0-custom-db-testharness library](https://www.npmjs.com/package/auth0-cu
 
 ## Auth0 Login widget
 
-After you enabling the database connection, the Auth0 Login widget will automatically change its appearance to allow users to enter their `username` and `password`. Once entered, this data is passed to your scripts.
+If you use [Lock](https://auth0.com/docs/libraries#lock), enabling the database connection lets users enter their username and password on the Auth0 Login widget. Once entered, this data is passed to your scripts.
 
-![](/media/articles/connections/database/mysql/db-connection-widget.png)
+![Auth0 login widget](/media/articles/connections/database/mysql/db-connection-widget.png)
 
 <%= include('../_quickstart-links.md') %>

--- a/articles/connections/database/custom-db.md
+++ b/articles/connections/database/custom-db.md
@@ -25,7 +25,7 @@ Here are some things to know before you start this process.
 * Database action scripts are written in Javascript and run in a [Webtask](https://webtask.io/) environment. In the environment you can use the full JavaScript language and [these Node.js libraries](https://tehsis.github.io/webtaskio-canirequire/).
 * Auth0 provides templates for most common databases, such as: **ASP.NET Membership Provider**, **MongoDB**, **MySQL**, **Oracle**, **PostgreSQL**, **SQLServer**, **Windows Azure SQL Database**, and for a web service accessed by **Basic Auth**. Essentially, you can connect to any kind of database or web service with a custom script.
 * You can use the [auth0-custom-db-testharness library](https://www.npmjs.com/package/auth0-custom-db-testharness) to deploy, execute, and test the output of database action scripts using a Webtask sandbox environment.
-* The [Update Users using a Custom Database](/user-profile/customdb) article has information on updating user profile fields.
+* The [Update Users Using Your Database](/user-profile/customdb) article has information on updating user profile fields.
 
 ## Create the database connection
 

--- a/articles/connections/database/custom-db.md
+++ b/articles/connections/database/custom-db.md
@@ -170,7 +170,7 @@ The [auth0-custom-db-testharness library](https://www.npmjs.com/package/auth0-cu
 
 ## Auth0 Login widget
 
-If you use [Lock](https://auth0.com/docs/libraries#lock), enabling the database connection lets users enter their username and password on the Auth0 Login widget. Once entered, this data is passed to your scripts.
+If you use [Lock](libraries#lock), enabling the database connection lets users enter their username and password on the Auth0 Login widget. Once entered, this data is passed to your scripts.
 
 ![Auth0 login widget](/media/articles/connections/database/mysql/db-connection-widget.png)
 

--- a/articles/connections/database/custom-db.md
+++ b/articles/connections/database/custom-db.md
@@ -1,54 +1,57 @@
 ---
-title: Authenticate Users using a Custom Database
+title: Authenticate Users Using Your Database
 connection: MySQL
 image: /media/connections/mysql.svg
 seo_alias: mysql
-description: How to authenticate users with username and password using a Custom Database.
+description: Learn how to authenticate users using your database as an identity provider.
 crews: crew-2
 toc: true
 ---
 
-# Authenticate Users using a Custom Database
+# Authenticate Users Using Your Database
 
-Applications often rely on user databases for authentication. Auth0 enables you to connect to these repositories and use them as identity providers while preserving user credentials and providing additional features. You can read more about database connections and the different user store options at [Database Identity Providers](/connections/database).
-
-This tutorial will guide you through a series of steps to connect your custom user store to Auth0. If you are looking to manage authentication in your application, see [Next Steps](#next-steps) below.
+If you have your own user database, you can use that database as an identity provider in Auth0 to authenticate users by creating a [database connection](/connections/database). In this tutorial you'll learn how to connect your user database to Auth0.
 
 ::: note
-Please also read the section on [Updating Users using a Custom Database](/user-profile/customdb), as it contains important information about how to update fields of the User Profile.
+Check out [Update Users using a Custom Database](/user-profile/customdb) for information on updating user profile fields.
 :::
 
-## 1. Create a database connection
+## Before You Begin
 
-Log into Auth0, and select the [Connections > Database](${manage_url}/#/connections/database) menu option. Click the **New Database Connection** button and provide a name for the database, or select a database you have created.
+Here are some things to know before you start this process.
+
+* Your database will need fields to populate user profiles such as: `id`, `nickname`, `email`, and `password`. See [Auth0 Normalized User Profile](/user-profile/normalized) for details on Auth0's user profile schema and expected fields.
+* Configuring your database as an identity provider in Auth0 involves creating custom scripts for login and get user actions. These database actions scripts execute each time a user performs an action, such as attempting to log in.
+* Database action scripts are written in Javascript and run in a Javascript sandbox. In the sandbox you can use the full JavaScript language and [these Node.js libraries](https://tehsis.github.io/webtaskio-canirequire/).
+* Auth0 provides templates for most common databases, such as: **ASP.NET Membership Provider**, **MongoDB**, **MySQL**, **Oracle**, **PostgreSQL**, **SQLServer**, **Windows Azure SQL Database**, and for a web service accessed by **Basic Auth**. Essentially, you can connect to any kind of database or web service with a custom script.
+* You can use the [auth0-custom-db-testharness library](https://www.npmjs.com/package/auth0-custom-db-testharness) to deploy, execute, and test the output of database action scripts using a Webtask sandbox environment.
+
+## Create and configure a database connection
+
+To connect your database to Auth0 and use it to authenticate users, follow these steps.
+
+1. Navigate to [Connections > Database](${manage_url}/#/connections/database) on the Auth0 dashboard.
+2. Click the **+ Create DB Connection** button.
+3. Provide a name for the database and configure the available options.
 
 ![](/media/articles/connections/database/database-connections.png)
 
-## 2. Customize the database connection
-
-Click **Custom Database** and turn on the **Use my own database** switch.
+3. Navigate to the **Custom Database** tab.
+4. Toggle on the **Use my own database** switch.
 
 ![](/media/articles/connections/database/custom-database.png)
 
-## 3. Provide action scripts
-
-You have to provide a login script to authenticate the user that will execute each time a user attempts to log in. Optionally, you can create scripts for sign-up, email verification, password reset and delete user functionality.
+5. In the **Database Action Scripts** section, provide a Login script to authenticate users. This script is required, and will execute each time a user attempts to log in. You can write your own script or select a template from the **Templates** dropdown.
 
 ::: note
-When creating users, Auth0 calls the **Get User** script before the **Create** script. Be sure that you have implemented both. Refer to the [Dashboard](${manage_url}) for sample scripts.
+If you are using [IBM's DB2](https://www.ibm.com/analytics/us/en/technology/db2/) product, [click here](/connections/database/db2-script) for a sample login script.
 :::
-
-These custom scripts are *Node.js* code that run in the tenant's sandbox. Auth0 provides templates for most common databases, such as: **ASP.NET Membership Provider**, **MongoDB**, **MySQL**, **Oracle**, **PostgreSQL**, **SQLServer**, **Windows Azure SQL Database**, and for a web service accessed by **Basic Auth**. Essentially, you can connect to any kind of database or web service with a custom script.
-
-This article shows how to implement the login script for **MySQL**. If you want a sample script for another action (sign-up, password reset, etc) or another database, use the dropdown options at the [Dashboard](${manage_url}).
-
-In the **Templates** drop-down, select **MySQL**:
 
 ![](/media/articles/connections/database/mysql/db-connection-login-script.png)
 
-You will see the following sample code in the Connection editor:
+For example, the MySQL Login template:
 
-```js
+```
 function login(email, password, callback) {
   var connection = mysql({
     host: 'localhost',
@@ -83,39 +86,28 @@ function login(email, password, callback) {
 
   });
 }
+
 ```
 
-This script connects to a **MySQL** database and executes a query to retrieve the first user with `email == user.email`. With the `bcrypt.compareSync` method, it then validates that the passwords match, and if successful, returns an object containing the user profile information including `id`, `nickname`, and `email`. This script assumes that you have a `users` table containing these columns. You can tweak this script in the editor to adjust it to your own requirements.
+This script connects to a MySQL database and executes a query to retrieve the first user with `email == user.email`. With the `bcrypt.compareSync` method, it then validates that the passwords match, and if successful, returns an object containing the user profile information including `id`, `nickname`, and `email`. This script assumes that you have a `users` table containing these columns. You can change this script in the editor to adjust it to your own requirements.
 
-You can also [cache connections](/rules#cache-expensive-resources) such that it will survive individual execution.
-
-::: note
-If you are using [IBM's DB2](https://www.ibm.com/analytics/us/en/technology/db2/) product, [click here](/connections/database/db2-script) for a sample login script.
-:::
+6. Optionally, provide scripts for sign-up, verification, password resets, and delete user functionality.
 
 ::: note
-You can use the [auth0-custom-db-testharness library](https://www.npmjs.com/package/auth0-custom-db-testharness) to deploy, execute, and test the output of Custom DB Scripts using a Webtask sandbox environment.
+When creating users, Auth0 calls the **Get User** script before the **Create** script. Be sure that you have implemented both.
 :::
 
-### Database Field Requirements
 
-Of course, your custom database will need to have fields in it that will provide the information to populate user profiles. In the above example, the script is checking for an `id`, `nickname`, `email`, and `password`.
-
-For more information on Auth0 user profile schema and the fields that are expected, as well as additional ones that are available, take a look at the [Auth0 Normalized User Profile](/user-profile/normalized) documentation.
-
-
-## 4. Add configuration parameters
-
-You can securely store the credentials needed to connect to your database in the **Settings** section at the bottom of the page.
+7. Store the credentials required to connect to your database in the **Settings** section, below the **Datbase Action Scripts** editor.
 
 ![](/media/articles/connections/database/mysql/db-connection-configurate.png)
 
-In the connection script, refer to these parameters as: `configuration.PARAMETER_NAME`. For example, you could enter:
+8. Use the parameters you added in your scripts to configure the connection. Refer to your parameters using `configuration.PARAMETER_NAME`, for example:
 
 ```js
 function login (username, password, callback) {
   var connection = mysql({
-    host     : 'localhost',
+    host     : configuration.MYSQL_HOST,
     user     : 'me',
     password : configuration.MYSQL_PASSWORD,
     database : 'mydb'

--- a/articles/connections/database/index.md
+++ b/articles/connections/database/index.md
@@ -1,14 +1,14 @@
 ---
-description: How to create and use a database connection using either the Auth0 user store or a custom database connection.
+description: How to create and use a database connection using either the Auth0 user store or your own user store.
 crews: crew-2
 url: /connections/database
 ---
 
 # Database Identity Providers
 
-Auth0 provides database connections to authenticate users with an email or username and a password and securely store these credentials in the Auth0 user store, or in your own database.
+Auth0 provides database connections to authenticate users with an email/username and password. These credentials are securely stored in the Auth0 user store or in your own database.
 
-You can create a new database connection or manage existing ones in the [Dashboard](${manage_url}/#/connections/database):
+You can create a new database connection and manage existing ones in the [Dashboard](${manage_url}/#/connections/database):
 
 ![](/media/articles/connections/database/database-connections.png)
 
@@ -17,7 +17,7 @@ You can create a new database connection or manage existing ones in the [Dashboa
 Typical database connection scenarios include:
 
 * [Using the Auth0 user store](#using-the-auth0-user-store)
-* [Using a custom user store](#using-a-custom-user-store)
+* [Using your own user store](#using-your-own-store)
 * [Migrating to Auth0 from a custom user store](#migrating-to-auth0-from-a-custom-user-store)
 * [Requiring a username for users](/connections/database/require-username)
 
@@ -31,24 +31,24 @@ The Auth0-hosted database is highly secure. Passwords are never stored or logged
 For database connections, Auth0 limits the number of repeat login attempts per user and IP address. For more information, see: [Rate Limits on User/Password Authentication](/connections/database/rate-limits).
 :::
 
-### Using a custom user store
+### Using your own user store
 
-If you have an existing user store, or wish to store user credentials on your own server, Auth0 enables you to easily connect to a custom repository and use it as the identity provider.
+If you have an existing user store, or wish to store user credentials on your own server, Auth0 enables you to connect to a database or repository and use it as the identity provider.
 
 ![](/media/articles/connections/database/custom-database.png)
 
 In this scenario, you provide the login script to authenticate the user that will execute each time a user attempts to log in. Optionally, you can create scripts for sign-up, email verification, password reset and delete user functionality.
 
-These custom scripts are *Node.js* code that run in the tenant's sandbox. Auth0 provides templates for most common databases, such as: **ASP.NET Membership Provider**, **MongoDB**, **MySQL**, **Oracle**, **PostgreSQL**, **SQL Server**, **Windows Azure SQL Database**, and for a web service accessed by **Basic Auth**. Essentially, you can connect to any kind of database or web service with a custom script.
+These custom scripts are Node.js code that run in the tenant's [Webtask](https://webtask.io/) environment. Auth0 provides templates for most common databases, such as: **ASP.NET Membership Provider**, **MongoDB**, **MySQL**, **Oracle**, **PostgreSQL**, **SQL Server**, **Windows Azure SQL Database**, and for a web service accessed by **Basic Auth**. Essentially, you can connect to any kind of database or web service with a custom script.
 
-Some specifics to keep in mind:
+When using your own user database or user store:
 
 * Latency will be greater compared to Auth0-hosted user stores
 * The database or service must be reachable from the Auth0 servers. You will need to configure inbound connections if your store is behind a firewall.
 * Database scripts run in the same [Webtask](https://webtask.io) container, which is shared with all other extensibility points (i.e. rules, webtasks or other databases) belonging to the same Auth0 domain. Therefore, you must carefully code for error handling and throttling.
 
 ::: note
-See the custom database connection tutorial at [Authenticate Users using a Custom Database](/connections/database/mysql) for detailed steps on how to setup and configure a custom user store.
+Check out [Authenticate Users Using Your Database](/connections/database/custom-db) for instructions on how to set up your own user store as an identity provider for Auth0.
 :::
 
 ### Migrating to Auth0 from a custom user store

--- a/articles/getting-started/the-basics.md
+++ b/articles/getting-started/the-basics.md
@@ -99,7 +99,7 @@ For now we won't get into details about the next steps, but in case you want to 
 
 - **Hook it up to your app**: Assuming that your app has a login and a logout button, you have to add some code in order to invoke Auth0 APIs each time one of these buttons is clicked. For details you can refer to one of our [quickstarts](/quickstarts). Alternatively, you can call directly our API to [login](/api/authentication#login) or [logout](/api/authentication#logout) a user.
 
-- **Migrate your users to Auth0**: Assuming that you already have a user store, you have to migrate these users to Auth0 before you go live. For more information refer to [User Migration](/users/migrations). Alternatively, you can [connect your app to a custom database](/connections/database/custom-db) and access it via Auth0.
+- **Migrate your users to Auth0**: If you already have a user store, you have to migrate these users to Auth0 before you go live. For more information refer to [User Migration](/users/migrations). Alternatively, you can [connect your app to your own user database](/connections/database/custom-db) and access it via Auth0.
 
 ## Keep reading
 

--- a/articles/user-profile/customdb.md
+++ b/articles/user-profile/customdb.md
@@ -1,26 +1,41 @@
 ---
-description: Considerations regarding the User Profile when using a Custom DB.
+title: Update Users using your Database
+description: How to update user profiles when using your own database as an identity provider.
+toc: true
 ---
-# Update Users using a Custom Database
 
-Auth0 [caches the User Profile](/user-profile/user-profile-details#caching-of-the-user-profile-in-auth0) received from a Custom Database Connection prior to passing it on to the calling client application. This cache is stored in the Auth0 database, and the information in the cache that originates from the Custom Database Connection is refreshed each time the user authenticates.
+# Update Users using your Database
 
-The values of the fields for the [Normalized User Profile](/user-profile/normalized) which is cached will be populated based on the values being returned from the Login Script of your Custom Database Connection.
+You can update user profiles when using [your own database as an identity provider](/connections/database/custom-db) by:
 
-## Updating via the Management API
+* Using the [Management API](/api/management/v2#!/Users/patch_users_by_id).
+* Updating the user in your database.
+* [Enabling user migration](/users/migrations/automatic) from your database to Auth0.
 
-The only fields you are allowed to update for a user in a Custom Database Connection using the [Management API](/api/management/v2) are the `user_metadata`, `app_metadata` and `blocked` fields.
+## Update users with the Management API
 
-If you need to update any of the other user fields you will need to do it directly in the custom database.
+When using your own database for authentication, you can use the [Management API](/api/management/v2) to update the following fields:
 
-## Updating the Custom Database directly
+* `app_metadata`
+* `user_metadata`
+* `blocked`
 
-You can update the fields of your user directly in the custom database to which your Custom Database Connection is connecting to. You can do this using whatever mechanism you already have in place to update that database. It is however important to note that the cached User Profile in Auth0 will not be updated until the next time that the user logs in. At that point the cached User Profile will be updated based on the values received from your custom database via the [Login script](/connections/database/mysql#3-provide-action-scripts). 
+If you need to update other user fields you will need to do it directly in your database.
 
-It is therefore important to note that you should consider the custom database as the primariy source of truth.
+## Update users in your database
 
-### Using Database Migration
+You can update user profiles in your database as you normally do, and Auth0 will update its cached user profile the next time that user logs in.
 
-One caveat to updating a user in the custom database (and considering it as the primary source of truth) is enabling user migration. If you have [enabled user migration](/connections/database/migrating), and a user has already been migrated to the Auth0 database, then Auth0 will not query your database again for the user profile. And therefore all changes made in the custom database for that user will never reflect in Auth0.
+See the [User profile cache](#user-profile-cache) section below for a brief overview of how Auth0 caches user profiles.
+
+## Update users through migration
+
+If you have [enabled user migration](/connections/database/migrating), and a user has already been migrated to the Auth0 database, then Auth0 will not query your database again for the user profile. And therefore all changes made in the custom database for that user will never reflect in Auth0.
 
 Once a user has been migrated, you will also be able to update fields such as `email` and `email_verified` via the Management API. However, normal rules for updating other user fields will still apply as described in the [Normalized User Profile](/user-profile/normalized) (e.g. you will still not be able to update fields such as `nickname`, `picture` etc.).
+
+## User profile cache
+
+Auth0 [caches the user profile](/user-profile/user-profile-details#caching-of-the-user-profile-in-auth0) received from a [database connection](/connections/database) before sending it to the client application. This cache is stored in the Auth0 database and is refreshed each time the user authenticates.
+
+The cached values for the [Normalized User Profile](/user-profile/normalized) fields are based on the values returned from the Login Script of your custom database connection.

--- a/articles/user-profile/customdb.md
+++ b/articles/user-profile/customdb.md
@@ -1,10 +1,10 @@
 ---
-title: Update Users using your Database
+title: Update Users Using Your Database
 description: How to update user profiles when using your own database as an identity provider.
 toc: true
 ---
 
-# Update Users using your Database
+# Update Users Using Your Database
 
 You can update user profiles when using [your own database as an identity provider](/connections/database/custom-db) by:
 

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -181,7 +181,7 @@ articles:
           - title: "Custom Social Extensions"
             url: "/extensions/custom-social-extensions"
 
-      - title: "Custom Database"
+      - title: "Your Database"
         url: "/connections/database/custom-db"
 
       - title: "Passwordless Authentication"


### PR DESCRIPTION
Updated custom database tutorial & small changes to database identity providers page. Renamed custom db tutorial to "Authenticate Users Using Your Database", maybe something like "Use Your Database To Authenticate Users" would be better?

- [Authenticate Users Using Your Database](https://auth0-docs-content-pr-5571.herokuapp.com/docs/connections/database/custom-db)
- [Database Identity Providers](https://auth0-docs-content-pr-5571.herokuapp.com/docs/connections/database)
- [Update Users Using Your Database](https://auth0-docs-content-pr-5571.herokuapp.com/docs/connections/database/custom-db)