### PR TITLE
Removed paragraph saying that auth0.js v8 was the latest version of the SDK.

### DIFF
--- a/articles/hosted-pages/login/auth0js/v8/index.md
+++ b/articles/hosted-pages/login/auth0js/v8/index.md
@@ -3,9 +3,7 @@ description: How to Use the Auth0.js v8 with the Hosted Login Page
 ---
 # Using Auth0.js v8 in the Hosted Login Page
 
-Within the Hosted Login page, you can use the the [Auth0.js v8 SDK](/libraries/auth0js/v8), instead of [Lock](/libraries/lock), to perform authentication using a custom UI (you can also use Auth0.js _in addition_ to Lock, for authentication or user management tasks).
-
-Auth0.js v8 is the current version of the SDK, and is the recommended version for projects that are able to use it. You can read the Reasons to Migrate and the API Auth sections of the [Auth0.js Migration Guide](/libraries/auth0js/v8/migration-guide#reasons-to-migrate) to learn whether version 8 of Auth0.js is appropriate for your applications.
+Within the Hosted Login page, you can use the the [Auth0.js v8 SDK](/libraries/auth0js/v8), instead of [Lock](/libraries/lock/v10), to perform authentication using a custom UI (you can also use Auth0.js _in addition_ to Lock, for authentication or user management tasks).
 
 ## Auth0.js Template for Hosted Login Page
 


### PR DESCRIPTION
Removed paragraph saying that auth0.js v8 was the latest version of the SDK.

https://trello.com/c/CVa1gpqP addresses accurate customer feedback

https://auth0-docs-content-pr-5654.herokuapp.com/docs/hosted-pages/login/auth0js/v8