### PR TITLE
Adding Extending page with hook examples

### DIFF
--- a/articles/cms/wordpress/configuration.md
+++ b/articles/cms/wordpress/configuration.md
@@ -288,14 +288,14 @@ add_action( 'auth0_user_login', 'auth0UserLoginAction', 0, 5 );
 
 Click [here](https://developer.wordpress.org/reference/functions/add_action/) to learn more about the `add_action` function.
 
-## Keep reading 
+## Keep Reading
 
-For more information on the Login by Auth0 WordPress Plugin, follow these links.
+More information on the Login by Auth0 WordPress plugin:
 
 ::: next-steps
 * [How does it work?](/cms/wordpress/how-does-it-work)
-* [Installation](/cms/wordpress/installation)
-* [JWT Authentication](/cms/wordpress/jwt-authentication)
-* [Troubleshoot](/cms/wordpress/troubleshoot)
-* [Extension](/cms/wordpress/extension)
+* [Install the plugin](/cms/wordpress/installation)
+* [JWT API authentication](/cms/wordpress/jwt-authentication)
+* [Troubleshooting](/cms/wordpress/troubleshoot)
+* [Extend the plugin](/cms/wordpress/extending)
 :::

--- a/articles/cms/wordpress/configuration.md
+++ b/articles/cms/wordpress/configuration.md
@@ -297,4 +297,5 @@ For more information on the Login by Auth0 WordPress Plugin, follow these links.
 * [Installation](/cms/wordpress/installation)
 * [JWT Authentication](/cms/wordpress/jwt-authentication)
 * [Troubleshoot](/cms/wordpress/troubleshoot)
+* [Extension](/cms/wordpress/extension)
 :::

--- a/articles/cms/wordpress/extending.md
+++ b/articles/cms/wordpress/extending.md
@@ -12,7 +12,7 @@ WordPress plugins can be extended to fit your specific requirements by using act
 
 Actions in WordPress run custom code at specific points during processing. [Learn more about actions here](https://developer.wordpress.org/plugins/hooks/actions/). 
 
-`auth0_before_login`
+### auth0_before_login
 
 This action runs in `WP_Auth0_LoginManager` after a user has been authenticated successfully but before they have been logged into WordPress. It can be used to stop the login process if needed using `wp_die()` or throwing an exception.
 
@@ -28,7 +28,7 @@ function a0_docs_ex_auth0_before_login ( $user ) {
 add_action( 'auth0_before_login', 'a0_docs_ex_auth0_before_login' );
 ``` 
 
-`auth0_user_login` 
+### auth0_user_login 
 
 This action runs in `WP_Auth0_LoginManager` after a user has been authenticated successfully and logged into 
 WordPress. It can be used to set specific meta values, send notifications, or ping other services. 
@@ -49,7 +49,7 @@ function a0_docs_ex_auth0_user_login ( $user_id, $userinfo, $is_new, $id_token, 
 add_action( 'auth0_user_login', 'a0_docs_ex_auth0_user_login', 10, 5 );
 ``` 
 
-`wpa0_user_created` 
+### wpa0_user_created 
 
 This action runs in `WP_Auth0_Users` just after a WordPress user is successfully created. It can be used to change 
 user values, set additional user metas, or trigger other new user actions. 
@@ -75,7 +75,7 @@ add_action( 'wpa0_user_created', 'a0_docs_ex_wpa0_user_created', 10, 5 );
 
 Filters in WordPress also run custom code at specific points during processing but always return a modified value of the same type that was passed in. [Learn more about filters here](https://developer.wordpress.org/plugins/hooks/filters/). 
 
-`auth0_get_wp_user`
+### auth0_get_wp_user
 
 This filter is called after the plugin finds the related user to login (based on the auth0 `user_id`) and is used to override the default behaviour with custom matching rules (for example, always match by email).
 
@@ -97,7 +97,7 @@ function auth0_theme_hook_auth0_get_wp_user( $user, $userinfo ) {
 add_filter( 'auth0_get_wp_user', 'auth0_theme_hook_auth0_get_wp_user', 1, 2 );
 ```
 
-`auth0_verify_email_page`
+### auth0_verify_email_page
 
 This filter runs in `WP_Auth0_Email_Verification` to change the HTML rendered when a user who is logging in needs to verify their email before gaining access to the site. Note that this HTML is passed to `wp_die()` where it is modified before being displayed (see the `_default_wp_die_handler()` definition in core for more information). 
 
@@ -118,7 +118,7 @@ function a0_docs_ex_auth0_verify_email_page ( $html, $userinfo, $id_token ) {
 add_filter( 'auth0_verify_email_page', 'a0_docs_ex_auth0_verify_email_page', 10, 3 );
 ```
 
-`auth0_get_auto_login_connection`
+### auth0_get_auto_login_connection
 
 This filter is used in `WP_Auth0_LoginManager` to modify what connection is used for the auto-login process. The 
 setting in wp-admin is pulled and then passed through this filter. 
@@ -138,7 +138,7 @@ function a0_docs_ex_auth0_get_auto_login_connection( $connection ) {
 add_filter( 'auth0_get_auto_login_connection', 'a0_docs_ex_auth0_get_auto_login_connection');
 ```
 
-`wp_auth0_get_option`
+### wp_auth0_get_option
 
 This filter is used by option-getting functions and methods to modify the output value.  
 
@@ -158,7 +158,7 @@ function a0_docs_ex_wp_auth0_get_option( $value, $key ) {
 add_filter( 'wp_auth0_get_option', 'a0_docs_ex_wp_auth0_get_option', 10, 2 );
 ```
 
-`auth0_migration_ws_authenticated`
+### auth0_migration_ws_authenticated
 
 This filter is used in `WP_Auth0_Routes` to alter the WP_User object that is JSON-encoded and returned to Auth0 
 during a user migration. 
@@ -178,7 +178,7 @@ function a0_docs_ex_auth0_migration_ws_authenticated( $user ) {
 add_filter( 'auth0_migration_ws_authenticated', 'a0_docs_ex_auth0_migration_ws_authenticated' );
 ```
 
-`wpa0_should_create_user`
+### wpa0_should_create_user
 
 This filter is used in `WP_Auth0_Users` when deciding whether a user should be created. The initial value passed in 
 is `TRUE`. If `FALSE` is returned for any reason, registration will be rejected and the registering user will see an 
@@ -200,7 +200,7 @@ function a0_docs_ex_wpa0_should_create_user( $should_create, $userinfo ) {
 add_filter( 'wpa0_should_create_user', 'a0_docs_ex_wpa0_should_create_user' );
 ```
 
-`auth0_login_css`
+### auth0_login_css
 
 This filter is used to modify the CSS on the login page, including the login widget itself. This filter runs before 
 CSS is retrieved from the wp-admin settings page.

--- a/articles/cms/wordpress/extending.md
+++ b/articles/cms/wordpress/extending.md
@@ -1,0 +1,35 @@
+---
+description: How to extend the Login by Auth0 WordPress Plugin with hooks, filters, and functions.
+---
+
+# Extending Login by Auth0 WordPress Plugin
+
+## Actions
+
+Actions in WordPress run custom code at specific points during processing. [More about actions here](https://developer.wordpress.org/plugins/hooks/actions/). 
+
+## `auth0_before_login` 
+
+## `auth0_user_login` 
+
+## `wpa0_user_created` 
+
+`do_action( 'auth0_before_login', $user );`
+
+`do_action( 'auth0_user_login' , $user->ID, $userinfo, $is_new, $id_token, $access_token );`
+
+`do_action( 'wpa0_user_created', $user_id, $email, $password, $firstname, $lastname );`
+
+## Filters
+
+Filters in WordPress also run custom code at specific points during processing but typically return a modified value of some kind. [More about filters here](https://developer.wordpress.org/plugins/hooks/filters/). 
+
+`apply_filters( 'auth0_verify_email_page', $html, $userinfo, '' );`
+`apply_filters( 'auth0_get_auto_login_connection', $this->a0_options->get( 'auto_login_method' ) );`
+`apply_filters( 'auth0_get_wp_user', $user, $userinfo );`
+`apply_filters( 'auth0_get_wp_user' , $user, $userinfo );`
+`apply_filters( 'wp_auth0_get_option', $default, $key );`
+`apply_filters( 'auth0_migration_ws_authenticated', $user );`
+`apply_filters( 'wpa0_should_create_user', true, $userinfo );`
+`apply_filters( 'auth0_login_css', '' );`
+

--- a/articles/cms/wordpress/extending.md
+++ b/articles/cms/wordpress/extending.md
@@ -79,7 +79,8 @@ Filters in WordPress also run custom code at specific points during processing b
 #### `auth0_verify_email_page`
 
 This filter runs in `WP_Auth0_Email_Verification` to change the HTML rendered when a logging-in user needs to verify 
-their email before gaining access to the site. This HTML is 
+their email before gaining access to the site. Note that this HTML is passed to `wp_die()` where it is modified 
+before being displayed (see the `_default_wp_die_handler()` definition in core for more information). 
 
 **Example:**
 
@@ -107,9 +108,24 @@ add_filter( 'auth0_verify_email_page', 'a0_docs_ex_auth0_verify_email_page', 10,
 
 #### `auth0_get_wp_user`
 
+This filter is called after the plugin finds the related user to login (based on the auth0 `user_id`) and is used to override the default behaviour with custom matching rules (for example, always match by email).
+
+If the filter returns null, it will lookup by email as described in the [How does it work?](https://auth0.com/docs/cms/wordpress/how-does-it-work) document.
+
 **Example:**
 
 ```php
+/**
+ * @param WP_User|null $user - found WordPress user, null if no user was found
+ * @param stdClass $userinfo - user information from Auth0
+ *
+ * @return WP_User|null
+ */
+function auth0_theme_hook_auth0_get_wp_user( $user, $userinfo ) {
+	// ... try to match another way
+	return $user;
+}
+add_filter( 'auth0_get_wp_user', 'auth0_theme_hook_auth0_get_wp_user', 1, 2 );
 ```
 
 #### `wp_auth0_get_option`

--- a/articles/cms/wordpress/extending.md
+++ b/articles/cms/wordpress/extending.md
@@ -6,30 +6,136 @@ description: How to extend the Login by Auth0 WordPress Plugin with hooks, filte
 
 ## Actions
 
-Actions in WordPress run custom code at specific points during processing. [More about actions here](https://developer.wordpress.org/plugins/hooks/actions/). 
+Actions in WordPress run custom code at specific points during processing. [Learn more about actions here](https://developer.wordpress.org/plugins/hooks/actions/). 
 
-## `auth0_before_login` 
+#### `auth0_before_login`
 
-## `auth0_user_login` 
+This action runs in `WP_Auth0_LoginManager` after a user has been authenticated successfully but before they have been logged into WordPress. It can be used to stop the login process if needed using `wp_die()` or throwing an exception.
 
-## `wpa0_user_created` 
+**Example:**
 
-`do_action( 'auth0_before_login', $user );`
+```php
+/**
+ * @param WP_User $user - WordPress user ID
+ */
+function a0_docs_ex_auth0_before_login ( $user ) {
+ // ... do something before logging in
+}
+add_action( 'auth0_before_login', 'a0_docs_ex_auth0_before_login' );
+``` 
 
-`do_action( 'auth0_user_login' , $user->ID, $userinfo, $is_new, $id_token, $access_token );`
+#### `auth0_user_login` 
 
-`do_action( 'wpa0_user_created', $user_id, $email, $password, $firstname, $lastname );`
+This action runs in `WP_Auth0_LoginManager` after a user has been authenticated successfully and logged into 
+WordPress. It can be used to set specific meta values, send notifications, or ping other services. 
+
+**Example:**
+
+```php
+/**
+ * @param integer $user_id - WordPress user ID
+ * @param stdClass $userinfo - user information object from Auth0
+ * @param boolean $is_new - true if the user was created in WordPress, false if not
+ * @param string $id_token - ID token for the user from Auth0 (not used in code flow)
+ * @param string $access_token - bearer access token from Auth0 (not used in implicit flow)
+ */
+function a0_docs_ex_auth0_user_login ( $user_id, $userinfo, $is_new, $id_token, $access_token ) {
+  // ... do something after logging in
+}
+add_action( 'auth0_user_login', 'a0_docs_ex_auth0_user_login', 10, 5 );
+``` 
+
+#### `wpa0_user_created` 
+
+This action runs in `WP_Auth0_Users` just after a WordPress user is successfully created. It can be used to change 
+user values, set additional user metas, or trigger other new user actions. 
+
+**Example:**
+
+```php
+/**
+ * @param integer $user_id - WordPress user ID for created user
+ * @param string $email - email address for created user
+ * @param string $password - password used for created user
+ * @param string $f_name - first name for created user
+ * @param string $l_name - last name for created user
+ */
+function a0_docs_ex_wpa0_user_created ( $user_id, $email, $password, $f_name, $l_name ) {
+	echo '<strong>User ID</strong>:<br>' . $user_id . '<hr>';
+	echo '<strong>Email</strong>:<br>' . $email . '<hr>';
+	echo '<strong>Password</strong>:<br>' . $password . '<hr>';
+	echo '<strong>First name</strong>:<br>' . $f_name . '<hr>';
+	echo '<strong>Last name</strong>:<br>' . $l_name . '<hr>';
+	wp_die( 'User created!' );
+}
+
+add_action( 'wpa0_user_created', 'a0_docs_ex_wpa0_user_created', 10, 5 );
+```
 
 ## Filters
 
-Filters in WordPress also run custom code at specific points during processing but typically return a modified value of some kind. [More about filters here](https://developer.wordpress.org/plugins/hooks/filters/). 
+Filters in WordPress also run custom code at specific points during processing but typically return a modified value of some kind. [Learn more about filters here](https://developer.wordpress.org/plugins/hooks/filters/). 
 
-`apply_filters( 'auth0_verify_email_page', $html, $userinfo, '' );`
-`apply_filters( 'auth0_get_auto_login_connection', $this->a0_options->get( 'auto_login_method' ) );`
-`apply_filters( 'auth0_get_wp_user', $user, $userinfo );`
-`apply_filters( 'auth0_get_wp_user' , $user, $userinfo );`
-`apply_filters( 'wp_auth0_get_option', $default, $key );`
-`apply_filters( 'auth0_migration_ws_authenticated', $user );`
-`apply_filters( 'wpa0_should_create_user', true, $userinfo );`
-`apply_filters( 'auth0_login_css', '' );`
+#### `auth0_verify_email_page`
 
+This filter runs in `WP_Auth0_Email_Verification` to change the HTML rendered when a logging-in user needs to verify 
+their email before gaining access to the site. This HTML is 
+
+**Example:**
+
+```php
+/**
+ * @param string $html - HTML to modify, echoed out within wp_die()
+ * @param stdClass $userinfo - user info object from Auth0
+ * @param string $id_token - DEPRECATED, do not use
+ *
+ * @return string
+ */
+function a0_docs_ex_auth0_verify_email_page ( $html, $userinfo, $id_token ) {
+	// ... modify $html
+	return $html;
+}
+add_filter( 'auth0_verify_email_page', 'a0_docs_ex_auth0_verify_email_page', 10, 3 );
+```
+
+#### `auth0_get_auto_login_connection`
+
+**Example:**
+
+```php
+```
+
+#### `auth0_get_wp_user`
+
+**Example:**
+
+```php
+```
+
+#### `wp_auth0_get_option`
+
+**Example:**
+
+```php
+```
+
+#### `auth0_migration_ws_authenticated`
+
+**Example:**
+
+```php
+```
+
+#### `wpa0_should_create_user`
+
+**Example:**
+
+```php
+```
+
+#### `auth0_login_css`
+
+**Example:**
+
+```php
+```

--- a/articles/cms/wordpress/extending.md
+++ b/articles/cms/wordpress/extending.md
@@ -1,17 +1,18 @@
 ---
 description: How to extend the Login by Auth0 WordPress Plugin with hooks, filters, and functions.
+toc: true
 ---
 
-# Extending Login by Auth0 WordPress Plugin
+# Extending the Login by Auth0 WordPress Plugin
 
-We're happy to review and approve new filters and actions that help you integrate even further in this plugin. Please
+WordPress plugins can be extended to fit your specific requirements by using actions and filters to run custom code at specific points during runtime. This document outlines the existing hooks in the Login by Auth0 plugin. We're happy to review and approve new filters and actions that help you integrate even further in this plugin. Please
  see the Contributing section on the [GitHub repo readme for this plugin](https://github.com/auth0/wp-auth0/blob/master/README.md).
 
 ## Actions
 
 Actions in WordPress run custom code at specific points during processing. [Learn more about actions here](https://developer.wordpress.org/plugins/hooks/actions/). 
 
-### `auth0_before_login`
+`auth0_before_login`
 
 This action runs in `WP_Auth0_LoginManager` after a user has been authenticated successfully but before they have been logged into WordPress. It can be used to stop the login process if needed using `wp_die()` or throwing an exception.
 
@@ -27,7 +28,7 @@ function a0_docs_ex_auth0_before_login ( $user ) {
 add_action( 'auth0_before_login', 'a0_docs_ex_auth0_before_login' );
 ``` 
 
-### `auth0_user_login` 
+`auth0_user_login` 
 
 This action runs in `WP_Auth0_LoginManager` after a user has been authenticated successfully and logged into 
 WordPress. It can be used to set specific meta values, send notifications, or ping other services. 
@@ -48,7 +49,7 @@ function a0_docs_ex_auth0_user_login ( $user_id, $userinfo, $is_new, $id_token, 
 add_action( 'auth0_user_login', 'a0_docs_ex_auth0_user_login', 10, 5 );
 ``` 
 
-### `wpa0_user_created` 
+`wpa0_user_created` 
 
 This action runs in `WP_Auth0_Users` just after a WordPress user is successfully created. It can be used to change 
 user values, set additional user metas, or trigger other new user actions. 
@@ -74,7 +75,7 @@ add_action( 'wpa0_user_created', 'a0_docs_ex_wpa0_user_created', 10, 5 );
 
 Filters in WordPress also run custom code at specific points during processing but always return a modified value of the same type that was passed in. [Learn more about filters here](https://developer.wordpress.org/plugins/hooks/filters/). 
 
-### `auth0_get_wp_user`
+`auth0_get_wp_user`
 
 This filter is called after the plugin finds the related user to login (based on the auth0 `user_id`) and is used to override the default behaviour with custom matching rules (for example, always match by email).
 
@@ -96,7 +97,7 @@ function auth0_theme_hook_auth0_get_wp_user( $user, $userinfo ) {
 add_filter( 'auth0_get_wp_user', 'auth0_theme_hook_auth0_get_wp_user', 1, 2 );
 ```
 
-### `auth0_verify_email_page`
+`auth0_verify_email_page`
 
 This filter runs in `WP_Auth0_Email_Verification` to change the HTML rendered when a user who is logging in needs to verify their email before gaining access to the site. Note that this HTML is passed to `wp_die()` where it is modified before being displayed (see the `_default_wp_die_handler()` definition in core for more information). 
 
@@ -117,7 +118,7 @@ function a0_docs_ex_auth0_verify_email_page ( $html, $userinfo, $id_token ) {
 add_filter( 'auth0_verify_email_page', 'a0_docs_ex_auth0_verify_email_page', 10, 3 );
 ```
 
-### `auth0_get_auto_login_connection`
+`auth0_get_auto_login_connection`
 
 This filter is used in `WP_Auth0_LoginManager` to modify what connection is used for the auto-login process. The 
 setting in wp-admin is pulled and then passed through this filter. 
@@ -137,7 +138,7 @@ function a0_docs_ex_auth0_get_auto_login_connection( $connection ) {
 add_filter( 'auth0_get_auto_login_connection', 'a0_docs_ex_auth0_get_auto_login_connection');
 ```
 
-### `wp_auth0_get_option`
+`wp_auth0_get_option`
 
 This filter is used by option-getting functions and methods to modify the output value.  
 
@@ -157,7 +158,7 @@ function a0_docs_ex_wp_auth0_get_option( $value, $key ) {
 add_filter( 'wp_auth0_get_option', 'a0_docs_ex_wp_auth0_get_option', 10, 2 );
 ```
 
-### `auth0_migration_ws_authenticated`
+`auth0_migration_ws_authenticated`
 
 This filter is used in `WP_Auth0_Routes` to alter the WP_User object that is JSON-encoded and returned to Auth0 
 during a user migration. 
@@ -177,7 +178,7 @@ function a0_docs_ex_auth0_migration_ws_authenticated( $user ) {
 add_filter( 'auth0_migration_ws_authenticated', 'a0_docs_ex_auth0_migration_ws_authenticated' );
 ```
 
-### `wpa0_should_create_user`
+`wpa0_should_create_user`
 
 This filter is used in `WP_Auth0_Users` when deciding whether a user should be created. The initial value passed in 
 is `TRUE`. If `FALSE` is returned for any reason, registration will be rejected and the registering user will see an 
@@ -199,7 +200,7 @@ function a0_docs_ex_wpa0_should_create_user( $should_create, $userinfo ) {
 add_filter( 'wpa0_should_create_user', 'a0_docs_ex_wpa0_should_create_user' );
 ```
 
-### `auth0_login_css`
+`auth0_login_css`
 
 This filter is used to modify the CSS on the login page, including the login widget itself. This filter runs before 
 CSS is retrieved from the wp-admin settings page.
@@ -219,10 +220,14 @@ function a0_docs_ex_auth0_login_css( $css ) {
 add_filter( 'auth0_login_css', 'a0_docs_ex_auth0_login_css' );
 ```
 
+## Keep Reading
+
+More information on the Login by Auth0 WordPress plugin:
+
 ::: next-steps
 * [How does it work?](/cms/wordpress/how-does-it-work)
-* [Installation](/cms/wordpress/installation)
-* [Configuration](/cms/wordpress/configuration)
-* [JWT Authentication](/cms/wordpress/jwt-authentication)
-* [Troubleshoot](/cms/wordpress/troubleshoot)
+* [Install the plugin](/cms/wordpress/installation)
+* [Configure the plugin](/cms/wordpress/configuration)
+* [JWT API authentication](/cms/wordpress/jwt-authentication)
+* [Troubleshooting](/cms/wordpress/troubleshoot)
 :::

--- a/articles/cms/wordpress/extending.md
+++ b/articles/cms/wordpress/extending.md
@@ -4,11 +4,14 @@ description: How to extend the Login by Auth0 WordPress Plugin with hooks, filte
 
 # Extending Login by Auth0 WordPress Plugin
 
+We're happy to review and approve new filters and actions that help you integrate even further in this plugin. Please
+ see the Contributing section on the [GitHub repo readme for this plugin](https://github.com/auth0/wp-auth0/blob/master/README.md).
+
 ## Actions
 
 Actions in WordPress run custom code at specific points during processing. [Learn more about actions here](https://developer.wordpress.org/plugins/hooks/actions/). 
 
-#### `auth0_before_login`
+### `auth0_before_login`
 
 This action runs in `WP_Auth0_LoginManager` after a user has been authenticated successfully but before they have been logged into WordPress. It can be used to stop the login process if needed using `wp_die()` or throwing an exception.
 
@@ -24,7 +27,7 @@ function a0_docs_ex_auth0_before_login ( $user ) {
 add_action( 'auth0_before_login', 'a0_docs_ex_auth0_before_login' );
 ``` 
 
-#### `auth0_user_login` 
+### `auth0_user_login` 
 
 This action runs in `WP_Auth0_LoginManager` after a user has been authenticated successfully and logged into 
 WordPress. It can be used to set specific meta values, send notifications, or ping other services. 
@@ -45,7 +48,7 @@ function a0_docs_ex_auth0_user_login ( $user_id, $userinfo, $is_new, $id_token, 
 add_action( 'auth0_user_login', 'a0_docs_ex_auth0_user_login', 10, 5 );
 ``` 
 
-#### `wpa0_user_created` 
+### `wpa0_user_created` 
 
 This action runs in `WP_Auth0_Users` just after a WordPress user is successfully created. It can be used to change 
 user values, set additional user metas, or trigger other new user actions. 
@@ -61,12 +64,7 @@ user values, set additional user metas, or trigger other new user actions.
  * @param string $l_name - last name for created user
  */
 function a0_docs_ex_wpa0_user_created ( $user_id, $email, $password, $f_name, $l_name ) {
-	echo '<strong>User ID</strong>:<br>' . $user_id . '<hr>';
-	echo '<strong>Email</strong>:<br>' . $email . '<hr>';
-	echo '<strong>Password</strong>:<br>' . $password . '<hr>';
-	echo '<strong>First name</strong>:<br>' . $f_name . '<hr>';
-	echo '<strong>Last name</strong>:<br>' . $l_name . '<hr>';
-	wp_die( 'User created!' );
+	// ... do something once a user has been created
 }
 
 add_action( 'wpa0_user_created', 'a0_docs_ex_wpa0_user_created', 10, 5 );
@@ -74,9 +72,31 @@ add_action( 'wpa0_user_created', 'a0_docs_ex_wpa0_user_created', 10, 5 );
 
 ## Filters
 
-Filters in WordPress also run custom code at specific points during processing but typically return a modified value of some kind. [Learn more about filters here](https://developer.wordpress.org/plugins/hooks/filters/). 
+Filters in WordPress also run custom code at specific points during processing but always return a modified value of the same type that was passed in. [Learn more about filters here](https://developer.wordpress.org/plugins/hooks/filters/). 
 
-#### `auth0_verify_email_page`
+### `auth0_get_wp_user`
+
+This filter is called after the plugin finds the related user to login (based on the auth0 `user_id`) and is used to override the default behaviour with custom matching rules (for example, always match by email).
+
+If the filter returns null, it will lookup by email as described in the [How does it work?](https://auth0.com/docs/cms/wordpress/how-does-it-work) document.
+
+**Example:**
+
+```php
+/**
+ * @param WP_User|null $user - found WordPress user, null if no user was found
+ * @param stdClass $userinfo - user information from Auth0
+ *
+ * @return WP_User|null
+ */
+function auth0_theme_hook_auth0_get_wp_user( $user, $userinfo ) {
+	// ... try to match another way, decide to replace $user
+	return $user;
+}
+add_filter( 'auth0_get_wp_user', 'auth0_theme_hook_auth0_get_wp_user', 1, 2 );
+```
+
+### `auth0_verify_email_page`
 
 This filter runs in `WP_Auth0_Email_Verification` to change the HTML rendered when a logging-in user needs to verify 
 their email before gaining access to the site. Note that this HTML is passed to `wp_die()` where it is modified 
@@ -93,65 +113,118 @@ before being displayed (see the `_default_wp_die_handler()` definition in core f
  * @return string
  */
 function a0_docs_ex_auth0_verify_email_page ( $html, $userinfo, $id_token ) {
-	// ... modify $html
+	// ... modify $html by replacing or concatenating
 	return $html;
 }
 add_filter( 'auth0_verify_email_page', 'a0_docs_ex_auth0_verify_email_page', 10, 3 );
 ```
 
-#### `auth0_get_auto_login_connection`
+### `auth0_get_auto_login_connection`
 
-**Example:**
-
-```php
-```
-
-#### `auth0_get_wp_user`
-
-This filter is called after the plugin finds the related user to login (based on the auth0 `user_id`) and is used to override the default behaviour with custom matching rules (for example, always match by email).
-
-If the filter returns null, it will lookup by email as described in the [How does it work?](https://auth0.com/docs/cms/wordpress/how-does-it-work) document.
+This filter is used in `WP_Auth0_LoginManager` to modify what connection is used for the auto-login process. The 
+setting in wp-admin is pulled and then passed through this filter. 
 
 **Example:**
 
 ```php
 /**
- * @param WP_User|null $user - found WordPress user, null if no user was found
- * @param stdClass $userinfo - user information from Auth0
+ * @param string $connection - name of the connection, initially pulled from Auth0 plugin settings
  *
- * @return WP_User|null
+ * @return string mixed
  */
-function auth0_theme_hook_auth0_get_wp_user( $user, $userinfo ) {
-	// ... try to match another way
+function a0_docs_ex_auth0_get_auto_login_connection( $connection ) {
+	// ... modify $connection
+	return $connection;
+}
+add_filter( 'auth0_get_auto_login_connection', 'a0_docs_ex_auth0_get_auto_login_connection');
+```
+
+### `wp_auth0_get_option`
+
+This filter is used by option-getting functions and methods to modify the output value.  
+
+**Example:**
+
+```php
+/**
+ * @param mixed $value - value of the option, initially pulled from the database
+ * @param string $key - key of the settings array
+ *
+ * @return mixed
+ */
+function a0_docs_ex_wp_auth0_get_option( $value, $key ) {
+	// ... modify $value
+	return $value;
+}
+add_filter( 'wp_auth0_get_option', 'a0_docs_ex_wp_auth0_get_option', 10, 2 );
+```
+
+### `auth0_migration_ws_authenticated`
+
+This filter is used in `WP_Auth0_Routes` to alter the WP_User object that is JSON-encoded and returned to Auth0 
+during a user migration. 
+
+**Example:**
+
+```php
+/**
+ * @param WP_User $user - WordPress user object found during migration and authenticated
+ *
+ * @return WP_User
+ */
+function a0_docs_ex_auth0_migration_ws_authenticated( $user ) {
+	// ... modify $user
 	return $user;
 }
-add_filter( 'auth0_get_wp_user', 'auth0_theme_hook_auth0_get_wp_user', 1, 2 );
+add_filter( 'auth0_migration_ws_authenticated', 'a0_docs_ex_auth0_migration_ws_authenticated' );
 ```
 
-#### `wp_auth0_get_option`
+### `wpa0_should_create_user`
+
+This filter is used in `WP_Auth0_Users` when deciding whether a user should be created. The initial value passed in 
+is `TRUE`. If `FALSE` is returned for any reason, registration will be rejected and the registering user will see an 
+error message (see `WP_Auth0_UsersRepo::create()`).
 
 **Example:**
 
 ```php
+/**
+ * @param bool $should_create - should the user be created, initialized as TRUE
+ * @param stdClass $userinfo - Auth0 user information
+ *
+ * @return bool
+ */
+function a0_docs_ex_wpa0_should_create_user( $should_create, $userinfo ) {
+	// ... modify $should_create
+	return $should_create;
+}
+add_filter( 'wpa0_should_create_user', 'a0_docs_ex_wpa0_should_create_user' );
 ```
 
-#### `auth0_migration_ws_authenticated`
+### `auth0_login_css`
+
+This filter is used to modify the CSS on the login page, including the login widget itself. This filter runs before 
+CSS is retrieved from the wp-admin settings page.
 
 **Example:**
 
 ```php
+/**
+ * @param string $css, initialized as empty
+ *
+ * @return string
+ */
+function a0_docs_ex_auth0_login_css( $css ) {
+	// ... modify $css by replacing or concatenating
+	return $css;
+}
+add_filter( 'auth0_login_css', 'a0_docs_ex_auth0_login_css' );
 ```
 
-#### `wpa0_should_create_user`
-
-**Example:**
-
-```php
-```
-
-#### `auth0_login_css`
-
-**Example:**
-
-```php
-```
+::: next-steps
+* [How does it work?](/cms/wordpress/how-does-it-work)
+* [Installation](/cms/wordpress/installation)
+* [Configuration](/cms/wordpress/configuration)
+* [JWT Authentication](/cms/wordpress/jwt-authentication)
+* [Troubleshoot](/cms/wordpress/troubleshoot)
+:::

--- a/articles/cms/wordpress/extending.md
+++ b/articles/cms/wordpress/extending.md
@@ -78,7 +78,7 @@ Filters in WordPress also run custom code at specific points during processing b
 
 This filter is called after the plugin finds the related user to login (based on the auth0 `user_id`) and is used to override the default behaviour with custom matching rules (for example, always match by email).
 
-If the filter returns null, it will lookup by email as described in the [How does it work?](https://auth0.com/docs/cms/wordpress/how-does-it-work) document.
+If the filter returns null, it will lookup by email as described in the [How does it work?](/cms/wordpress/how-does-it-work) document.
 
 **Example:**
 
@@ -98,9 +98,7 @@ add_filter( 'auth0_get_wp_user', 'auth0_theme_hook_auth0_get_wp_user', 1, 2 );
 
 ### `auth0_verify_email_page`
 
-This filter runs in `WP_Auth0_Email_Verification` to change the HTML rendered when a logging-in user needs to verify 
-their email before gaining access to the site. Note that this HTML is passed to `wp_die()` where it is modified 
-before being displayed (see the `_default_wp_die_handler()` definition in core for more information). 
+This filter runs in `WP_Auth0_Email_Verification` to change the HTML rendered when a user who is logging in needs to verify their email before gaining access to the site. Note that this HTML is passed to `wp_die()` where it is modified before being displayed (see the `_default_wp_die_handler()` definition in core for more information). 
 
 **Example:**
 

--- a/articles/cms/wordpress/how-does-it-work.md
+++ b/articles/cms/wordpress/how-does-it-work.md
@@ -63,4 +63,5 @@ The login flow is as follows:
 - [Configuration](/cms/wordpress/configuration)
 - [JWT Authentication](/cms/wordpress/jwt-authentication)
 - [Troubleshoot](/cms/wordpress/troubleshoot)
+* [Extension](/cms/wordpress/extension)
 :::

--- a/articles/cms/wordpress/how-does-it-work.md
+++ b/articles/cms/wordpress/how-does-it-work.md
@@ -56,12 +56,14 @@ The login flow is as follows:
 3. The Auth0-WordPress plugin find a user in your WordPress database with the provided username/email, so it verifies the password.
 4. Auth0 creates the user in your Auth0 account, authenticates the user, and logs them in.
 
-## More on the Login by Auth0 WordPress Plugin
+## Keep Reading
 
-:::next-steps
-- [Installation](/cms/wordpress/installation)
-- [Configuration](/cms/wordpress/configuration)
-- [JWT Authentication](/cms/wordpress/jwt-authentication)
-- [Troubleshoot](/cms/wordpress/troubleshoot)
-* [Extension](/cms/wordpress/extension)
+More information on the Login by Auth0 WordPress plugin:
+
+::: next-steps
+* [Install the plugin](/cms/wordpress/installation)
+* [Configure the plugin](/cms/wordpress/configuration)
+* [JWT API authentication](/cms/wordpress/jwt-authentication)
+* [Troubleshooting](/cms/wordpress/troubleshoot)
+* [Extend the plugin](/cms/wordpress/extending)
 :::

--- a/articles/cms/wordpress/index.md
+++ b/articles/cms/wordpress/index.md
@@ -28,4 +28,5 @@ For more information on the Login by Auth0 WordPress Plugin, follow these links.
 * [Configuration](/cms/wordpress/configuration)
 * [JWT Authentication](/cms/wordpress/jwt-authentication)
 * [Troubleshoot](/cms/wordpress/troubleshoot)
+* [Extending](/cms/wordpress/extending)
 :::

--- a/articles/cms/wordpress/index.md
+++ b/articles/cms/wordpress/index.md
@@ -18,10 +18,14 @@ Login features are implemented through a new Login Widget (powered by Auth0) tha
 - Reporting and Analytics
 
 
-## Login by Auth0 WordPress Plugin
+## Keep Reading
 
-- [How does it work?](/cms/wordpress/how-does-it-work)
-- [Installation](/cms/wordpress/installation)
-- [Configuration](/cms/wordpress/configuration)
-- [JWT Authentication](/cms/wordpress/jwt-authentication)
-- [Troubleshoot](/cms/wordpress/troubleshoot)
+For more information on the Login by Auth0 WordPress Plugin, follow these links.
+
+::: next-steps
+* [How does it work?](/cms/wordpress/how-does-it-work)
+* [Installation](/cms/wordpress/installation)
+* [Configuration](/cms/wordpress/configuration)
+* [JWT Authentication](/cms/wordpress/jwt-authentication)
+* [Troubleshoot](/cms/wordpress/troubleshoot)
+:::

--- a/articles/cms/wordpress/index.md
+++ b/articles/cms/wordpress/index.md
@@ -20,13 +20,12 @@ Login features are implemented through a new Login Widget (powered by Auth0) tha
 
 ## Keep Reading
 
-For more information on the Login by Auth0 WordPress Plugin, follow these links.
+More information on the Login by Auth0 WordPress plugin:
 
 ::: next-steps
 * [How does it work?](/cms/wordpress/how-does-it-work)
-* [Installation](/cms/wordpress/installation)
-* [Configuration](/cms/wordpress/configuration)
-* [JWT Authentication](/cms/wordpress/jwt-authentication)
-* [Troubleshoot](/cms/wordpress/troubleshoot)
-* [Extending](/cms/wordpress/extending)
+* [Install the plugin](/cms/wordpress/installation)
+* [Configure the plugin](/cms/wordpress/configuration)
+* [Troubleshooting](/cms/wordpress/troubleshoot)
+* [Extend the plugin](/cms/wordpress/extending)
 :::

--- a/articles/cms/wordpress/installation.md
+++ b/articles/cms/wordpress/installation.md
@@ -58,12 +58,14 @@ This is a good time to confirm that the basics are working for your site before 
 
 Now you're ready to [Configure](/cms/wordpress/configuration)!
 
-## Read Next
+## Keep Reading
+
+More information on the Login by Auth0 WordPress plugin:
 
 ::: next-steps
-* [Configuration](/cms/wordpress/configuration)
 * [How does it work?](/cms/wordpress/how-does-it-work)
-* [JWT Authentication](/cms/wordpress/jwt-authentication)
-* [Troubleshoot](/cms/wordpress/troubleshoot)
-* [Extension](/cms/wordpress/extension)
+* [Configure the plugin](/cms/wordpress/configuration)
+* [JWT API authentication](/cms/wordpress/jwt-authentication)
+* [Troubleshooting](/cms/wordpress/troubleshoot)
+* [Extend the plugin](/cms/wordpress/extending)
 :::

--- a/articles/cms/wordpress/installation.md
+++ b/articles/cms/wordpress/installation.md
@@ -65,4 +65,5 @@ Now you're ready to [Configure](/cms/wordpress/configuration)!
 * [How does it work?](/cms/wordpress/how-does-it-work)
 * [JWT Authentication](/cms/wordpress/jwt-authentication)
 * [Troubleshoot](/cms/wordpress/troubleshoot)
+* [Extension](/cms/wordpress/extension)
 :::

--- a/articles/cms/wordpress/jwt-authentication.md
+++ b/articles/cms/wordpress/jwt-authentication.md
@@ -56,12 +56,12 @@ Vydcvl6gpWNeUE
 
 ## Keep Reading
 
-For more information on the Login by Auth0 WordPress Plugin, follow these links.
+More information on the Login by Auth0 WordPress plugin:
 
 ::: next-steps
 * [How does it work?](/cms/wordpress/how-does-it-work)
-* [Installation](/cms/wordpress/installation)
-* [Configuration](/cms/wordpress/configuration)
-* [Troubleshoot](/cms/wordpress/troubleshoot)
-* [Extending](/cms/wordpress/extending)
+* [Install the plugin](/cms/wordpress/installation)
+* [Configure the plugin](/cms/wordpress/configuration)
+* [Troubleshooting](/cms/wordpress/troubleshoot)
+* [Extend the plugin](/cms/wordpress/extending)
 :::

--- a/articles/cms/wordpress/jwt-authentication.md
+++ b/articles/cms/wordpress/jwt-authentication.md
@@ -53,3 +53,15 @@ Vydcvl6gpWNeUE
 
 - [Cookies vs Tokens. Getting auth right with Angular.JS](https://auth0.com/blog/2014/01/07/angularjs-authentication-with-cookies-vs-token/)
 - [10 Things You Should Know about Tokens](https://auth0.com/blog/2014/01/27/ten-things-you-should-know-about-tokens-and-cookies/)
+
+## Keep Reading
+
+For more information on the Login by Auth0 WordPress Plugin, follow these links.
+
+::: next-steps
+* [How does it work?](/cms/wordpress/how-does-it-work)
+* [Installation](/cms/wordpress/installation)
+* [Configuration](/cms/wordpress/configuration)
+* [Troubleshoot](/cms/wordpress/troubleshoot)
+* [Extending](/cms/wordpress/extending)
+:::

--- a/articles/cms/wordpress/troubleshoot.md
+++ b/articles/cms/wordpress/troubleshoot.md
@@ -81,16 +81,16 @@ The Auth0 plugin does not handle sessions, it uses the WordPress settings. By de
 
 ::: note
 This plugin leverages WordPress session handling and uses [wp_set_auth_cookie()](https://developer.wordpress.org/reference/functions/wp_set_auth_cookie/) to create the session cookie. This setting will send `true` as a second parameter to allow the session to last longer.
+:::
 
 ## Keep Reading
 
-For more information on the Login by Auth0 WordPress Plugin, follow these links.
+More information on the Login by Auth0 WordPress plugin:
 
 ::: next-steps
 * [How does it work?](/cms/wordpress/how-does-it-work)
-* [Installation](/cms/wordpress/installation)
-* [Configuration](/cms/wordpress/configuration)
-* [JWT Authentication](/cms/wordpress/jwt-authentication)
-* [Extending](/cms/wordpress/extending)
-:::
+* [Install the plugin](/cms/wordpress/installation)
+* [Configure the plugin](/cms/wordpress/configuration)
+* [JWT API authentication](/cms/wordpress/jwt-authentication)
+* [Extend the plugin](/cms/wordpress/extending)
 :::

--- a/articles/cms/wordpress/troubleshoot.md
+++ b/articles/cms/wordpress/troubleshoot.md
@@ -81,4 +81,16 @@ The Auth0 plugin does not handle sessions, it uses the WordPress settings. By de
 
 ::: note
 This plugin leverages WordPress session handling and uses [wp_set_auth_cookie()](https://developer.wordpress.org/reference/functions/wp_set_auth_cookie/) to create the session cookie. This setting will send `true` as a second parameter to allow the session to last longer.
+
+## Keep Reading
+
+For more information on the Login by Auth0 WordPress Plugin, follow these links.
+
+::: next-steps
+* [How does it work?](/cms/wordpress/how-does-it-work)
+* [Installation](/cms/wordpress/installation)
+* [Configuration](/cms/wordpress/configuration)
+* [JWT Authentication](/cms/wordpress/jwt-authentication)
+* [Extending](/cms/wordpress/extending)
+:::
 :::

--- a/updates/2018-02-26.yml
+++ b/updates/2018-02-26.yml
@@ -1,0 +1,8 @@
+added:
+  -
+    title: "Extending the Login by Auth0 WordPress Plugin"
+    tags:
+      - wordpress
+      - CMS
+    description: |
+      A new document, [Extending the plugin](https://auth0.com/docs/cms/wordpress/extending), was added with instructions on extending the Login by Auth0 WordPress plugin.


### PR DESCRIPTION
We've got documentation all over and this is a first step towards consolidating on auth0.com/docs. This new page replaces the examples that are currently on the repo README page (removed on the next release) with tested, documented examples. I also cleaned up the "read more" links at the end of each article. 
