### PR TITLE
Add example for user profile data encryption

### DIFF
--- a/articles/compliance/gdpr/features-aiding-compliance/data-minimization.md
+++ b/articles/compliance/gdpr/features-aiding-compliance/data-minimization.md
@@ -20,7 +20,7 @@ To limit the amount of personal information in the Auth0 user profile, you can:
 
 ## Encrypt user profile information
 
-You can encrypt user information before you save it in the user profile. You can use any encryption mechanism you like prior to storing data in the metadata fields. When you have sensitive information to set for a user, call the [Update a user endpoint](/api/management/v2#!/Users/patch_users_by_id).
+You can encrypt user information before you save it in the user profile. You can use any encryption mechanism you like prior to storing data in the metadata fields. When a user sets sensitive information, call the [Update a user endpoint](/api/management/v2#!/Users/patch_users_by_id).
 
 For example, to save the encrypted `passportNumber` in the user's profile, send this request:
 

--- a/articles/compliance/gdpr/features-aiding-compliance/data-minimization.md
+++ b/articles/compliance/gdpr/features-aiding-compliance/data-minimization.md
@@ -20,9 +20,33 @@ To limit the amount of personal information in the Auth0 user profile, you can:
 
 ## Encrypt user profile information
 
-You can encrypt user information before you save it in the user profile. You can use any encryption mechanism you like prior to storing data in the metadata fields, or you can use the built-in [rules](/rules) template **Encrypt sensitive data in the user profile** to implement this functionality.
+You can encrypt user information before you save it in the user profile. You can use any encryption mechanism you like prior to storing data in the metadata fields. When you have sensitive information to set for a user, call the [Update a user endpoint](/api/management/v2#!/Users/patch_users_by_id).
 
-To decrypt your data, you can use the Decrypt sensitive data from the user profile built-in [rules](/rules) template.
+For example, to save the encrypted `passportNumber` in the user's profile, send this request:
+
+```har
+{
+  "method": "PATCH",
+  "url": "https://${account.namespace}/api/v2/users/user_id",
+  "httpVersion": "HTTP/1.1",
+  "cookies": [],
+  "headers": [{
+    "name": "Authorization",
+    "value": "Bearer YOUR_ACCESS_TOKEN"
+  }, {
+    "name": "Content-Type",
+    "value": "application/json"
+  }],
+  "queryString": [],
+  "postData": {
+    "mimeType": "application/json",
+    "text": "{\"user_metadata\": {\"passportNumber\": \"B9MuhaDoreVr69MDqx3p8A==\"}}"
+  },
+  "headersSize": -1,
+  "bodySize": -1,
+  "comment": ""
+}
+```
 
 ## Use account linking
 

--- a/articles/compliance/gdpr/features-aiding-compliance/data-minimization.md
+++ b/articles/compliance/gdpr/features-aiding-compliance/data-minimization.md
@@ -48,6 +48,10 @@ For example, to save the encrypted `passportNumber` in the user's profile, send 
 }
 ```
 
+:::note
+Replace the `YOUR_ACCESS_TOKEN` placeholder with a token that will allow you to access this endpoint. This should be a [Management API Token](/api/management/v2/tokens), with the scopes `update:users` and `update:users_app_metadata`.
+:::
+
 ## Use account linking
 
 Every time a user uses a connection to log in to your application, a user profile is created if it doeasn't already exist. Note that this is per connection.


### PR DESCRIPTION
[Rules are not executed when the /dbconnections/signup endpoint is called](https://auth0.slack.com/archives/C0FMEGMDY/p1518441833000178), they run as part of the login flow. Therefore those rule templates cannot be used (since the data would have to be saved in plain text upon signup, and updated during the login).

I left only the other option: encrypt the data in your app and save the encoded values at the metadata using the Management API.