### PR TITLE
Add deprecation warning on GA landing/admin/dev

### DIFF
--- a/articles/multifactor-authentication/google-auth/_deprecation-notice.md
+++ b/articles/multifactor-authentication/google-auth/_deprecation-notice.md
@@ -1,0 +1,3 @@
+::: warning
+The Google Authenticator provider is deprecated. You should use [Guardian](/multifactor-authentication/guardian) instead, which supports TOTP (*including Google Authenticator*), SMS, and push authentications using the [Guardian App](/multifactor-authentication/guardian/user-guide). We will send a deprecation notification and  an upgrade path for existing users in the future.
+:::

--- a/articles/multifactor-authentication/google-auth/_deprecation-notice.md
+++ b/articles/multifactor-authentication/google-auth/_deprecation-notice.md
@@ -1,3 +1,3 @@
 ::: warning
-The Google Authenticator provider is deprecated. You should use [Guardian](/multifactor-authentication/guardian) instead, which supports TOTP (*including Google Authenticator*), SMS, and push authentications using the [Guardian App](/multifactor-authentication/guardian/user-guide). We will send a deprecation notification and  an upgrade path for existing users in the future.
+The Google Authenticator provider is deprecated. You should use [Guardian](/multifactor-authentication/guardian) instead, which supports TOTP (**including Google Authenticator**), SMS, and Push Authentications. We will send a deprecation notification and  an upgrade path for existing users in the future.
 :::

--- a/articles/multifactor-authentication/google-auth/admin-guide.md
+++ b/articles/multifactor-authentication/google-auth/admin-guide.md
@@ -6,10 +6,6 @@ description:  Using Google Authenticator with Auth0 for administrators
 
 <%= include('./_deprecation-notice.md') %>
 
-::: note
-This page refers to using Google Authenticator instead of Auth0 Guardian. Google Authenticator can also be used with Guardian (your users choose which to use) when **Push Notifications** is enabled. [Click here for more information on Guardian.](/multifactor-authentication/guardian)
-:::
-
 ## Enabling Google Authenticator for MFA
 
 To turn on Google Authenticator for two-step verification, first visit the [Multifactor Auth](${manage_url}/#/guardian) page from the dashboard. Then click on the link to use a different provider.

--- a/articles/multifactor-authentication/google-auth/admin-guide.md
+++ b/articles/multifactor-authentication/google-auth/admin-guide.md
@@ -4,7 +4,7 @@ description:  Using Google Authenticator with Auth0 for administrators
 
 # Google Authenticator for Administrators
 
-::: warn
+::: warning
 The Google Authenticator provider is deprecated. You should use [Guardian](/multifactor-authentication/guardian) instead, which supports TOTP (*including Google Authenticator*), SMS, and push authentication using the [Guardian App](/multifactor-authentication/guardian/user-guide). We will send a deprecation notification and  an upgrade path for existing users in the future.
 :::
 

--- a/articles/multifactor-authentication/google-auth/admin-guide.md
+++ b/articles/multifactor-authentication/google-auth/admin-guide.md
@@ -4,9 +4,7 @@ description:  Using Google Authenticator with Auth0 for administrators
 
 # Google Authenticator for Administrators
 
-::: warning
-The Google Authenticator provider is deprecated. You should use [Guardian](/multifactor-authentication/guardian) instead, which supports TOTP (*including Google Authenticator*), SMS, and push authentication using the [Guardian App](/multifactor-authentication/guardian/user-guide). We will send a deprecation notification and  an upgrade path for existing users in the future.
-:::
+<%= include('./_deprecation-notice.md') %>
 
 ::: note
 This page refers to using Google Authenticator instead of Auth0 Guardian. Google Authenticator can also be used with Guardian (your users choose which to use) when **Push Notifications** is enabled. [Click here for more information on Guardian.](/multifactor-authentication/guardian)

--- a/articles/multifactor-authentication/google-auth/admin-guide.md
+++ b/articles/multifactor-authentication/google-auth/admin-guide.md
@@ -4,6 +4,10 @@ description:  Using Google Authenticator with Auth0 for administrators
 
 # Google Authenticator for Administrators
 
+::: warn
+The Google Authenticator provider is deprecated. You should use [Guardian](/multifactor-authentication/guardian) instead, which supports TOTP (*including Google Authenticator*), SMS, and push authentication using the [Guardian App](/multifactor-authentication/guardian/user-guide). We will send a deprecation notification and  an upgrade path for existing users in the future.
+:::
+
 ::: note
 This page refers to using Google Authenticator instead of Auth0 Guardian. Google Authenticator can also be used with Guardian (your users choose which to use) when **Push Notifications** is enabled. [Click here for more information on Guardian.](/multifactor-authentication/guardian)
 :::

--- a/articles/multifactor-authentication/google-auth/dev-guide.md
+++ b/articles/multifactor-authentication/google-auth/dev-guide.md
@@ -4,9 +4,7 @@ description:  Using Google Authenticator with Auth0 for developers
 
 # Google Authenticator for Developers
 
-::: warning
-The Google Authenticator provider is deprecated. You should use [Guardian](/multifactor-authentication/guardian) instead, which supports TOTP (*including Google Authenticator*), SMS, and push authentication using the [Guardian App](/multifactor-authentication/guardian/user-guide). We will send a deprecation notification and  an upgrade path for existing users in the future.
-:::
+<%= include('./_deprecation-notice.md') %>
 
 ::: note
 This page refers to using Google Authenticator instead of Auth0 Guardian. Google Authenticator can also be used with Guardian (your users choose which to use) when **Push Notifications** is enabled. [Click here for more information on Guardian.](/multifactor-authentication/guardian)

--- a/articles/multifactor-authentication/google-auth/dev-guide.md
+++ b/articles/multifactor-authentication/google-auth/dev-guide.md
@@ -4,6 +4,10 @@ description:  Using Google Authenticator with Auth0 for developers
 
 # Google Authenticator for Developers
 
+::: warn
+The Google Authenticator provider is deprecated. You should use [Guardian](/multifactor-authentication/guardian) instead, which supports TOTP (*including Google Authenticator*), SMS, and push authentication using the [Guardian App](/multifactor-authentication/guardian/user-guide). We will send a deprecation notification and  an upgrade path for existing users in the future.
+:::
+
 ::: note
 This page refers to using Google Authenticator instead of Auth0 Guardian. Google Authenticator can also be used with Guardian (your users choose which to use) when **Push Notifications** is enabled. [Click here for more information on Guardian.](/multifactor-authentication/guardian)
 :::

--- a/articles/multifactor-authentication/google-auth/dev-guide.md
+++ b/articles/multifactor-authentication/google-auth/dev-guide.md
@@ -6,10 +6,6 @@ description:  Using Google Authenticator with Auth0 for developers
 
 <%= include('./_deprecation-notice.md') %>
 
-::: note
-This page refers to using Google Authenticator instead of Auth0 Guardian. Google Authenticator can also be used with Guardian (your users choose which to use) when **Push Notifications** is enabled. [Click here for more information on Guardian.](/multifactor-authentication/guardian)
-:::
-
 ## Enabling Google Authenticator for MFA
 
 To turn on Google Authenticator for two-step verification, first visit the [Multifactor Auth](${manage_url}/#/guardian) page from the dashboard. Then click on the link to use a different provider.

--- a/articles/multifactor-authentication/google-auth/dev-guide.md
+++ b/articles/multifactor-authentication/google-auth/dev-guide.md
@@ -4,7 +4,7 @@ description:  Using Google Authenticator with Auth0 for developers
 
 # Google Authenticator for Developers
 
-::: warn
+::: warning
 The Google Authenticator provider is deprecated. You should use [Guardian](/multifactor-authentication/guardian) instead, which supports TOTP (*including Google Authenticator*), SMS, and push authentication using the [Guardian App](/multifactor-authentication/guardian/user-guide). We will send a deprecation notification and  an upgrade path for existing users in the future.
 :::
 

--- a/articles/multifactor-authentication/google-auth/google-landing.md
+++ b/articles/multifactor-authentication/google-auth/google-landing.md
@@ -6,9 +6,7 @@ url: /multifactor-authentication/google-authenticator
 
 # Google Authenticator
 
-::: warning
-The Google Authenticator provider is deprecated. You should use [Guardian](/multifactor-authentication/guardian) instead, which supports TOTP (*including Google Authenticator*), SMS, and push authentication using the [Guardian App](/multifactor-authentication/guardian/user-guide). We will send a deprecation notification and  an upgrade path for existing users in the future.
-:::
+<%= include('./_deprecation-notice.md') %>
 
 Google Authenticator is a mobile application made by Google that implements two-step verification.  Authenticator provides a six to eight digit one-time password which users must provide in addition to their username and password to log into an application.
 

--- a/articles/multifactor-authentication/google-auth/google-landing.md
+++ b/articles/multifactor-authentication/google-auth/google-landing.md
@@ -6,6 +6,10 @@ url: /multifactor-authentication/google-authenticator
 
 # Google Authenticator
 
+::: warn
+The Google Authenticator provider is deprecated. You should use [Guardian](/multifactor-authentication/guardian) instead, which supports TOTP (*including Google Authenticator*), SMS, and push authentication using the [Guardian App](/multifactor-authentication/guardian/user-guide). We will send a deprecation notification and  an upgrade path for existing users in the future.
+:::
+
 Google Authenticator is a mobile application made by Google that implements two-step verification.  Authenticator provides a six to eight digit one-time password which users must provide in addition to their username and password to log into an application.
 
 ::: note

--- a/articles/multifactor-authentication/google-auth/google-landing.md
+++ b/articles/multifactor-authentication/google-auth/google-landing.md
@@ -10,10 +10,6 @@ url: /multifactor-authentication/google-authenticator
 
 Google Authenticator is a mobile application made by Google that implements two-step verification.  Authenticator provides a six to eight digit one-time password which users must provide in addition to their username and password to log into an application.
 
-::: note
-This page refers to using Google Authenticator instead of Auth0 Guardian. Google Authenticator can also be used with Guardian (your users choose which to use) when **Push Notifications** is enabled. [Click here for more information on Guardian.](/multifactor-authentication/guardian)
-:::
-
 **Click the link below that most fits your role to learn more:**
 
 [Google Authenticator for Administrators](/multifactor-authentication/google-auth/admin-guide) - this page explains how to enable/disable using Google Authenticator, how to reset accounts, supported devices and customization.

--- a/articles/multifactor-authentication/google-auth/google-landing.md
+++ b/articles/multifactor-authentication/google-auth/google-landing.md
@@ -6,7 +6,7 @@ url: /multifactor-authentication/google-authenticator
 
 # Google Authenticator
 
-::: warn
+::: warning
 The Google Authenticator provider is deprecated. You should use [Guardian](/multifactor-authentication/guardian) instead, which supports TOTP (*including Google Authenticator*), SMS, and push authentication using the [Guardian App](/multifactor-authentication/guardian/user-guide). We will send a deprecation notification and  an upgrade path for existing users in the future.
 :::
 


### PR DESCRIPTION
Adds a deprecation warning notice on Google Authenticator landing, admin and dev pages.

Tracked by: https://auth0team.atlassian.net/browse/GUAR-105