### PR TITLE
Add acs migration

### DIFF
--- a/articles/users/migrations/azure-access-control.md
+++ b/articles/users/migrations/azure-access-control.md
@@ -24,7 +24,7 @@ Start by [signing up for Auth0](https://auth0.com/signup). After creating your a
 
 ## Create a client
 
-In order for an application to use Auth0 it must be registered as a [client](https://auth0.com/docs/clients). Create a new client for your application on the [Dashboard](https://manage.auth0.com/#/clients).
+In order for an application to use Auth0 it must be registered as a [client](/docs/clients). Create a new client for your application on the [Dashboard](https://manage.auth0.com/#/clients).
 
 ![Create Client window](/media/articles/applications/create-client-popup.png)
 

--- a/articles/users/migrations/azure-access-control.md
+++ b/articles/users/migrations/azure-access-control.md
@@ -15,7 +15,7 @@ In this article, you'll learn how to migrate from Azure Access Control (ACS) to 
 ## Before you start
 
 * WS-Federation identity provider connections in Auth0 return tokens in SAML2 format. If your ACS configuration uses WS-Federation protocol with JWT tokens, you'll need to update your applications when migrating to Auth0.
-* Auth0 offers both [cloud and on-premises deployments](https://auth0.com/docs/getting-started/deployment-models).
+* Auth0 offers both [cloud and on-premises deployments](/getting-started/deployment-models).
 * Review the [Getting Started](/getting-started) documentation for an overview of Auth0.
 
 ## Set up your account
@@ -24,7 +24,7 @@ Start by [signing up for Auth0](https://auth0.com/signup). After creating your a
 
 ## Create a client
 
-In order for an application to use Auth0 it must be registered as a [client](https://auth0.com/docs/clients). Create new client for your application on the [Dashboard](https://manage.auth0.com/#/clients).
+In order for an application to use Auth0 it must be registered as a [client](https://auth0.com/docs/clients). Create a new client for your application on the [Dashboard](https://manage.auth0.com/#/clients).
 
 ![Create Client window](/media/articles/applications/create-client-popup.png)
 

--- a/articles/users/migrations/azure-access-control.md
+++ b/articles/users/migrations/azure-access-control.md
@@ -1,0 +1,65 @@
+---
+title: Migrate from Azure Access Control Service to Auth0
+description: How to migrate from Azure Access Control Service to Auth0.
+toc: true
+---
+
+# Migrate from Azure Access Control Service to Auth0
+
+::: note
+Azure Access Control Service will be [retired in November 2018](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-acs-migration).
+:::
+
+In this article, you'll learn how to migrate from Azure Access Control (ACS) to Auth0, and connect to a [WS-Federation](/protocols/ws-fed) identity provider such as Azure Active Directory, Active Directory Federation Services, or IdentityServer.
+
+## Before you start
+
+* WS-Federation identity provider connections in Auth0 return tokens in SAML2 format. If your ACS configuration uses WS-Federation protocol with JWT tokens, you'll need to update your applications when migrating to Auth0.
+* Auth0 offers both [cloud and on-premises deployments](https://auth0.com/docs/getting-started/deployment-models).
+* Review the [Getting Started](/getting-started) documentation for an overview of Auth0.
+
+## Set up your account
+
+Start by [signing up for Auth0](https://auth0.com/signup). After creating your account, you'll be prompted to create a new [tenant](/getting-started/the-basics#account-and-tenants). Tenants in Auth0 are like namespaces in ACS: `${account.namespace}`.
+
+## Create a client
+
+In order for an application to use Auth0 it must be registered as a [client](https://auth0.com/docs/clients). Create new client for your application on the [Dashboard](https://manage.auth0.com/#/clients).
+
+![Create Client window](/media/articles/applications/create-client-popup.png)
+
+## Add Auth0 to your identity provider
+
+Next add Auth0 as a relying party to your identity provider using the following information:
+
+* Realm Identifier: `urn:auth0:${account.tenant}`
+* Return URL: `https://${account.namespace}/login/callback`
+
+## Create a WS-Federation connection
+
+To create a connection between Auth0 and your identity provider, navigate to [Dashboard > Connections > Enterprise](${manage_url}/#/connections/enterprise). For WS-Federation identity providers, create a new **ADFS** connection and provide the following information:
+
+* __Connection Name__: A descriptive name for the connection.
+* __Email Domains__: (Optional) A comma-separated list of valid domains. Only needed if you want to use the [Lock login widget](/libraries/lock).
+
+Next, either enter your WS-Federation server URL in the __ADFS URL__ field or upload a Federation Metadata file. If you set a WS-Federation server URL, Auth0 will retrieve the Federation Metadata endpoint and import the required parameters, certificates, and URLs.
+
+![New Connection](/media/articles/connections/enterprise/ws-fed/new.png)
+
+After saving the new connection you'll see a list of your registered [clients](${manage_url}/#/clients). Enable the connection for your client.
+
+## Update your application
+
+Depending on your application and use case, you'll have to update your application to use Auth0 for authentication instead of ACS. There are several ways to integrate Auth0 with your application:
+
+- Configure the [Lock](/libraries#lock) authentication widget.
+- Use [Auth0 SDKs](/libraries#auth0-sdks) such as [Auth0.NET](https://github.com/auth0/Auth0.net).
+- Connect to the [Authentication API](/api/authentication).
+
+## Next Steps
+
+::: next-steps
+* [Add Rules to customize user authentication](/rules/current)
+* [Set up the Hosted Login Page](/hosted-pages/login)
+* [Manage user access with groups, roles, and permissions](/extensions/authorization-extension)
+:::

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -366,6 +366,10 @@ articles:
           - title: "Stormpath"
             url: "/users/migrations/stormpath"
 
+          - title: "Azure Access Control"
+            url: "/users/migrations/azure-access-control"
+            hidden: true
+
   - title: "Multifactor Authentication"
     url: "/multifactor-authentication"
     children:

--- a/updates/2018-02-22.yml
+++ b/updates/2018-02-22.yml
@@ -1,0 +1,9 @@
+added:
+  -
+    title: "Migrate from Azure Access Control Service to Auth0"
+    tags:
+      - azure
+      - access control
+      - migration
+    description: |
+      A new tutorial, [Migrate from Azure Access Control Service to Auth0](https://auth0.com/docs/users/migrations/azure-access-control), was added with instructions on migrating from Azure Access Control to Auth0 and connecting to a WS-Federation identity provider.


### PR DESCRIPTION
Tutorial on moving from Azure Access Control to Auth0. Should this live under `/migrations` or stay where it is?

https://auth0-docs-content-pr-5743.herokuapp.com/docs/users/migrations/azure-access-control