### PR TITLE
Adding deprecation notices in libraries pages

### DIFF
--- a/articles/_includes/_lock_auth0js_deprecations_notice.md
+++ b/articles/_includes/_lock_auth0js_deprecations_notice.md
@@ -1,0 +1,3 @@
+::: panel-warning Lock and Auth0.js Deprecations
+The Lock v8, v9, and v10 widgets as well as the Auth0.js v6, v7, and v8 SDKs will be deprecated and should be migrated away from on or before March 31, 2018. The [migration guide for Lock v11](/libraries/lock/v11/migration-guide) and [Auth0.js v9](/libraries/auth0js/v9/migration-guide) provide details about the steps required to update. For more information, the [migrations page](/migrations) can also be consulted. 
+:::

--- a/articles/libraries/index.md
+++ b/articles/libraries/index.md
@@ -13,6 +13,8 @@ description: Overview of the Auth0 Libraries and SDKs
 </p>
 </div>
 
+<%= include('../_includes/_lock_auth0js_deprecations_notice') %>
+
 ## How Should You Implement Auth0?
 
 When adding Auth0 to your web apps, the best solution is to use Auth0's [Hosted Login Page](/hosted-pages/login). Using the Hosted Login Page is a simple process, and prevents the pitfalls of [cross-origin authentication](/cross-origin-authentication). The Hosted Login Page uses by default the Lock Widget to authenticate users, but there is also a template for Lock Passwordless and a template for a custom UI built with the Auth0.js SDK available. 

--- a/articles/libraries/when-to-use-lock.md
+++ b/articles/libraries/when-to-use-lock.md
@@ -2,8 +2,9 @@
 section: libraries
 description: When should you use Lock, Auth0's drop-in authentication widget, and when should you use a custom UI with an Auth0 Library? This page will help you decide.
 ---
-
 # Lock vs. a Custom UI
+
+<%= include('../_includes/_lock_auth0js_deprecations_notice') %>
 
 When adding Auth0 to your web apps, the best solution is to use Auth0's [Hosted Login Page](/hosted-pages/login). Using the Hosted Login Page is an incredibly simple process, and prevents the dangers of cross-origin authentication. The Hosted Login Page uses the Lock Widget to allow your users to authenticate by default, but also has templates for Lock Passwordless and for a custom UI built with Auth0.js SDK. You can customize the page in the [Hosted Pages Editor](${manage_url}/#/login_page), and use any of the following to implement your authentication needs. 
 

--- a/articles/support/matrix.md
+++ b/articles/support/matrix.md
@@ -266,9 +266,7 @@ Auth0 support is limited to the most recent version of the OS listed (unless oth
 
 ## SDKs and Libraries
 
-::: note
-See the [Libraries](/libraries) page for more information about supported versions of Auth0's SDKs and the Lock widget.
-:::
+<%= include('../_includes/_lock_auth0js_deprecations_notice') %>
 
 ### Auth0 Lock Widgets
 


### PR DESCRIPTION
Adding deprecation notices to libraries page + sub-pages. 

Also removed the snippet in the support page about more info on libraries support, as we put the libraries support back into that page already as well, so no need to send them elsewhere anymore.

https://auth0-docs-content-pr-5764.herokuapp.com/docs/libraries
https://auth0-docs-content-pr-5764.herokuapp.com/docs/libraries/when-to-use-lock
https://auth0-docs-content-pr-5764.herokuapp.com/docs/support/matrix