### PR TITLE
Change an username to a username

### DIFF
--- a/articles/libraries/lock/v10/configuration.md
+++ b/articles/libraries/lock/v10/configuration.md
@@ -824,7 +824,7 @@ var options = {
 
 ### defaultEnterpriseConnection {String}
 
-Specifies the enterprise connection which allows to login using an username and a password that will be used when there is more than one available or there is a database connection. If a `defaultDatabaseConnection` is provided the database connection will be used and this option will be ignored.
+Specifies the enterprise connection which allows to login using a username and a password that will be used when there is more than one available or there is a database connection. If a `defaultDatabaseConnection` is provided the database connection will be used and this option will be ignored.
 
 ```js
 var options = {

--- a/articles/libraries/lock/v11/configuration.md
+++ b/articles/libraries/lock/v11/configuration.md
@@ -825,7 +825,7 @@ var options = {
 
 ### defaultEnterpriseConnection {String}
 
-Specifies the enterprise connection which allows to login using an username and a password that will be used when there is more than one available or there is a database connection. If a `defaultDatabaseConnection` is provided the database connection will be used and this option will be ignored.
+Specifies the enterprise connection which allows to login using a username and a password that will be used when there is more than one available or there is a database connection. If a `defaultDatabaseConnection` is provided the database connection will be used and this option will be ignored.
 
 ```js
 var options = {


### PR DESCRIPTION
Where the 'u' sounds like 'you' we use 'a' (for example, a university vs an umbrella)