### PR TITLE
Add missing quotes to literal parameters on snippet

### DIFF
--- a/articles/tokens/id-token.md
+++ b/articles/tokens/id-token.md
@@ -83,8 +83,8 @@ var options = {
 };
 
 var lock = new Auth0Lock(
-  ${account.clientId},
-  ${account.namespace},
+  '${account.clientId}',
+  '${account.namespace}',
   options
 );
 


### PR DESCRIPTION
I don't know if I need to escape the `${}` later, as that's a placeholder later replaced in docs with the logged in account data.
<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->

This is how it looks today:
![image](https://user-images.githubusercontent.com/3900123/36690643-b6b152e8-1b11-11e8-90c4-1153aa1b96d3.png)
