### PR TITLE
Adding note about checkSession triggering rules

### DIFF
--- a/articles/libraries/_includes/_review_get_ssodata.md
+++ b/articles/libraries/_includes/_review_get_ssodata.md
@@ -6,7 +6,11 @@ The function will not work as expected when you use it in Web Applications that 
 
 If you want to avoid showing the Lock dialog when there is an existing session in the server, you can use the [checkSession()](/libraries/auth0js#using-checksession-to-acquire-new-tokens) function in Auth0.js.
 
-We recommend that you do not use `getSSOData()` and use [checkSession()](/libraries/auth0js#using-checksession-to-acquire-new-tokens) instead. Note that in order for `checkSession()` to work properly, it  requires that you set the **Allowed Web Origins** field in the dashboard.
+We recommend that you do not use `getSSOData()` and use [checkSession()](/libraries/auth0js#using-checksession-to-acquire-new-tokens) instead. Note that in order for `checkSession()` to work properly, it requires that you set the **Allowed Web Origins** field in the dashboard.
+
+::: note
+Note that `checkSession()` triggers any [rules](/rules) you may have set up, whereas `getSSOData()` does not. It is possible that this could cause unintended behavior depending on what rules you have set up (if any) so you should check on your rules in the [Dashboard](${manage_url}/#/rules) prior to switching methods.
+:::
 
 If you are going to keep using `getSSOData()`, take into account the changes in the return values described in the table below. In most applications, the only value that was actually used was the `sso` property, which still has the same semantics. 
 

--- a/articles/libraries/auth0js/v9/index.md
+++ b/articles/libraries/auth0js/v9/index.md
@@ -428,7 +428,7 @@ Signups should be for database connections. Here is an example of the `signup` m
 
 ## Using checkSession to acquire new tokens
 
-The `checkSession` method allows you to acquire a new token from Auth0 for a user who is already authenticated against Auth0 for your domain. The method accepts any valid OAuth2 parameters that would normally be sent to `authorize`. If you omit them, it will use the ones provided when initializing Auth0.
+The `checkSession` method allows you to acquire a new token from Auth0 for a user who is already authenticated against Auth0 for your domain. The method accepts any valid OAuth2 parameters that would normally be sent to `authorize`. If you omit them, it will use the ones provided when initializing Auth0. 
 
 ```js
 webAuth.checkSession({}, function (err, authResult) {
@@ -436,6 +436,10 @@ webAuth.checkSession({}, function (err, authResult) {
   ...
 });
 ```
+
+::: note
+Note that `checkSession()` triggers any [rules](/rules) you may have set up, so you should check on your rules in the [Dashboard](${manage_url}/#/rules) prior to using it.
+:::
 
 The actual redirect to `/authorize` happens inside an iframe, so it will not reload your application or redirect away from it.
 


### PR DESCRIPTION
https://trello.com/c/S6myRmFJ

The method `checkSession()` triggers rules, where `getSSOData()` did not, so users should be cognizant of that fact.

https://auth0-docs-content-pr-5789.herokuapp.com/docs/libraries/auth0js/v9/migration-v8-v9

https://auth0-docs-content-pr-5789.herokuapp.com/docs/libraries/auth0js/v9#using-checksession-to-acquire-new-tokens