### PR TITLE
Adding section on error responses

### DIFF
--- a/articles/libraries/_includes/_error_responses.md
+++ b/articles/libraries/_includes/_error_responses.md
@@ -1,0 +1,35 @@
+### Error Responses
+
+The error response returned for the `/usernamepassword/login` endpoint is different from that retured from the `/co/authenticate` endpoint.
+
+The legacy error response is not OIDC Conformant. A standard DB connection had a JSON response payload similar to the following:
+
+```
+{
+  "name": "ValidationError",
+  "code": "invalid_user_password",
+  "description": "Wrong email or password.",
+  "statusCode": 400
+}
+```
+
+A custom DB connection had a JSON response payload similar to the following:
+
+```
+{
+  "name": "ValidationError",
+  "message": "Something went wrong...",
+  "code": "403",
+  "description": "Something went wrong...",
+  "fromSandbox": true
+}
+```
+
+The new error response is OIDC Conformant and has a JSON response payload similiar to the following:
+
+```
+{
+  "error": "access_denied",
+  "error_description": "Wrong email or password."
+}
+```

--- a/articles/libraries/auth0js/v9/migration-v8-v9.md
+++ b/articles/libraries/auth0js/v9/migration-v8-v9.md
@@ -27,3 +27,6 @@ This guide includes all the information you need to update [Auth0.js](/libraries
 ## Behavioral Changes
 
 <%= include('../../_includes/_default_values') %>
+
+<%= include('../../_includes/_error_responses') %>
+

--- a/articles/libraries/lock/v11/migration-v10-v11.md
+++ b/articles/libraries/lock/v11/migration-v10-v11.md
@@ -26,3 +26,4 @@ This guide includes all the information you need to update your Lock v10 applica
 <%= include('../../_includes/_ip_ranges') %>
 <%= include('../../_includes/_default_values_lock') %>
 <%= include('../../_includes/_embedded_sso') %>
+<%= include('../../_includes/_error_responses') %>


### PR DESCRIPTION
https://trello.com/c/iDHjFcDx

Noting the differences between the old and new error responses in Lock/Auth0.js

https://auth0-docs-content-pr-5809.herokuapp.com/docs/libraries/lock/v11/migration-v10-v11#error-responses

https://auth0-docs-content-pr-5809.herokuapp.com/docs/libraries/auth0js/v9/migration-v8-v9#error-responses

@arcseldon I used the exact examples you gave me, hope those are all right?