### PR TITLE
Update list of reserved words

### DIFF
--- a/articles/appliance/infrastructure/dns.md
+++ b/articles/appliance/infrastructure/dns.md
@@ -137,7 +137,7 @@ The following are reserved tenant names and **may not** be used for the **app** 
         <td>help</td>
         <td>support</td>
         <td>int</td>
-        <td></td>
+        <td>auth</td>
         <td></td>
     </tr>
 </table>


### PR DESCRIPTION
`auth` is a commonly chosen tenant name, and it became a reserved word in `14591`
See https://auth0.slack.com/archives/C1RC8M1MY/p1519738583000331

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
