### PR TITLE
Typo in file descriptor

### DIFF
--- a/articles/quickstart/backend/django/01-authorization.md
+++ b/articles/quickstart/backend/django/01-authorization.md
@@ -251,7 +251,7 @@ Django has a [URL dispatcher](https://docs.djangoproject.com/en/1.11/topics/http
 Create the file `urls.py` in your application folder. Add the URL patterns.
 
 ```python
-# auth0authorization/views.py
+# auth0authorization/urls.py
 
 from django.conf.urls import url
 


### PR DESCRIPTION
Example referred to 'auth0authorization/urls.py' but the file has a header which referred to 'auth0authorization/views.py'

https://auth0-docs-content-pr-5816.herokuapp.com/docs/quickstart/backend/django#add-url-mappings