### PR TITLE
Add nonce to buildAuthorizeUrl() code example

### DIFF
--- a/articles/libraries/auth0js/v9/index.md
+++ b/articles/libraries/auth0js/v9/index.md
@@ -211,7 +211,8 @@ var url = webAuth.client.buildAuthorizeUrl({
   clientID: '${account.clientId}', // string
   responseType: 'token id_token', // code
   redirectUri: '${account.callback}',
-  state: 'YOUR_STATE'
+  state: 'YOUR_STATE',
+  nonce: 'YOUR_NONCE'
 });
 
 // Redirect to url


### PR DESCRIPTION
<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
### Description

In the `buildAuthorizeUrl(options)` documentation the code doesn't have the `nonce` option and is using `responseType: 'token id_token'`.
This option is required when [this condition](https://github.com/auth0/auth0.js/blob/master/src/authentication/index.js#L128) is satisfied.

I think a test can be added [here](https://github.com/auth0/auth0.js/blob/master/src/authentication/index.js) in auth0.js for that case and that would help document usages 🙂 