### PR TITLE
Step-up authentication: revamp amr-approach doc

### DIFF
--- a/articles/compliance/gdpr/features-aiding-compliance/protect-user-data.md
+++ b/articles/compliance/gdpr/features-aiding-compliance/protect-user-data.md
@@ -66,9 +66,11 @@ For information on how to use them see [Password Strength](/connections/database
 
 ## Step-up authentication
 
-With step-up authentication, applications can ask users to authenticate with a stronger authentication mechanism to access sensitive resources. For example, you may have a banking application which does not require [multifactor authentication](/multifactor-authentication) to view the accounts basic information, but when users try to transfer money between accounts then authenticating with one more factor (for example, a code sent via SMS) is required.
+With step-up authentication, applications can ask users to authenticate with a stronger authentication mechanism to access sensitive resources. For example, you may have a banking application which does not require [Multifactor Authentication (MFA)](/multifactor-authentication) to view the accounts basic information, but when users try to transfer money between accounts then they must authenticate with one more factor (for example, a code sent via SMS).
 
-For implementation details, and a sample application that shows how to implement step-up with Auth0, see [Step-up Authentication with custom Multifactor Authentications Rules](/multifactor-authentication/custom-mfa-rules).
+You can check if a user has logged in with MFA by reviewing the contents of their ID Token. You can then configure your application to deny access to sensitive resources if the ID Token indicates that the user did not log in with MFA.
+
+For details see [Step-up Authentication with ID Tokens](/multifactor-authentication/developer/mfa-from-id-token).
 
 ## Availability and resilience
 

--- a/articles/multifactor-authentication/custom-mfa-rules.md
+++ b/articles/multifactor-authentication/custom-mfa-rules.md
@@ -6,7 +6,7 @@ description: Learn how you can add step-up authentication to your app with Auth0
 # Step-Up Authentication with Custom MFA Rules
 
 ::: note
-Auth0 now supports `amr` and `acr` claims with `acr_values` for step-up authentication. This approach allows for more control with MFA. For details see [Determine if a user has performed multifactor authentication](/multifactor-authentication/developer/mfa-from-id-token).
+Auth0 now supports `amr` and `acr` claims with `acr_values` for step-up authentication. This approach allows for more control with MFA. For details see [Step-up Authentication with ID Tokens](/multifactor-authentication/developer/mfa-from-id-token).
 :::
 
 With Step-Up Authentication, applications that allow access to different types of resources can require users to authenticate with a stronger authentication mechanism to access sensitive resources.

--- a/articles/multifactor-authentication/custom-mfa-rules.md
+++ b/articles/multifactor-authentication/custom-mfa-rules.md
@@ -5,8 +5,8 @@ description: Learn how you can add step-up authentication to your app with Auth0
 
 # Step-Up Authentication with Custom MFA Rules
 
-::: note
-Auth0 now supports `amr` and `acr` claims with `acr_values` for step-up authentication. This approach allows for more control with MFA. For details see [Step-up Authentication with ID Tokens](/multifactor-authentication/developer/mfa-from-id-token).
+::: warning
+The functionality described in this article is outdated. Auth0 now supports `amr` and `acr` claims with `acr_values` for step-up authentication. For details see [Step-up Authentication with ID Tokens](/multifactor-authentication/developer/mfa-from-id-token).
 :::
 
 With Step-Up Authentication, applications that allow access to different types of resources can require users to authenticate with a stronger authentication mechanism to access sensitive resources.

--- a/articles/multifactor-authentication/developer/mfa-from-id-token.md
+++ b/articles/multifactor-authentication/developer/mfa-from-id-token.md
@@ -4,7 +4,7 @@ description: Describes how to check if a user has logged in with Multifactor Aut
 ---
 # Step-up Authentication with ID Tokens
 
-With Step-up Authentication, applications that allow access to different types of resources can require users to authenticate with a stronger authentication mechanism to access sensitive information or perform certain transactions.
+With Step-up Authentication, applications that allow access to different types of resources can require users to authenticate with a stronger mechanism to access sensitive information or perform certain transactions.
 
 For instance, a user may be allowed to access views with sensitive data or reset their password only after confirming their identity using Multifactor Authentication (MFA).
 
@@ -14,7 +14,9 @@ The claim that is relevant to this scenario is `amr`. If it contains the value `
 - `amr` **must** be present in the ID Token's payload (if you log in with username/password the claim will not be included in the payload)
 - `amr` **must** contain the value `mfa` (`amr` can contain claims other than `mfa`, so its existence is not a sufficient test, its contents must be examined for the value `mfa`)
 
-For a particular user session, developers can check the claims information available on the ID Token, a  provided by Auth0 . After [retrieving the id_token](/tokens/id_token), the value of the `amr` field can be evaluated to see if it contains `mfa` as a claim.
+## How to check the ID Token
+
+In order to check if a user logged in with MFA follow these steps:
 
 1. Retrieve the ID Token
 1. Verify the token's signature. The signature is used to verify that the sender of the token is who it says it is and to ensure that the message wasn't changed along the way.
@@ -22,6 +24,8 @@ For a particular user session, developers can check the claims information avail
 1. Verify that the token contains the `amr` claim.
   - If `amr` **is not** in the payload or it does not contain the value `mfa`, the user did not log in with MFA
   - If `amr` **is** in the payload and it contains the value `mfa`, then the user logged in with MFA
+
+For more information on the signature verification and claims validation, see [ID Token](/tokens/id-token).
 
 ## Example
 

--- a/articles/multifactor-authentication/developer/mfa-from-id-token.md
+++ b/articles/multifactor-authentication/developer/mfa-from-id-token.md
@@ -1,15 +1,33 @@
 ---
-description: Describes how to determine if a user has done multifactor authentication using their id_token and JWT
+title: Step-up Authentication with ID Tokens
+description: Describes how to check if a user has logged in with Multifactor Authentication by examining their ID Token
 ---
-# Determine if a user has performed multifactor authentication
+# Step-up Authentication with ID Tokens
 
-At times, it's necessary to determine if a particular user has had the additional security of multifactor authentication applied to their session. For instance, a user may be allowed access to sensitive data or allowed to reset their password only after further confirming their identity using MFA.
+With Step-up Authentication, applications that allow access to different types of resources can require users to authenticate with a stronger authentication mechanism to access sensitive information or perform certain transactions.
 
-For a particular user session, developers can check the claims information available on the `id_token`, a [JSON Web Token](/jwt) provided by Auth0 that contains claims information relevant to the user's session. After [retrieving the id_token](/tokens/id_token), the value of the `amr` field can be evaluated to see if it contains `mfa` as a claim.
+For instance, a user may be allowed to access views with sensitive data or reset their password only after confirming their identity using Multifactor Authentication (MFA).
 
-Note that `amr` can contain claims other than `mfa`, so its existence is not a sufficient test. Its contents must be examined for the `mfa` claim.
+When a user logs in you can get an [ID Token](/tokens/id-token) which is a [JSON Web Token](/jwt) that contains information relevant to the user's session, in the form of claims.
+
+The claim that is relevant to this scenario is `amr`. If it contains the value `mfa` then you know that the user has authenticated using MFA. Note the following:
+- `amr` **must** be present in the ID Token's payload (if you log in with username/password the claim will not be included in the payload)
+- `amr` **must** contain the value `mfa` (`amr` can contain claims other than `mfa`, so its existence is not a sufficient test, its contents must be examined for the value `mfa`)
+
+For a particular user session, developers can check the claims information available on the ID Token, a  provided by Auth0 . After [retrieving the id_token](/tokens/id_token), the value of the `amr` field can be evaluated to see if it contains `mfa` as a claim.
+
+1. Retrieve the ID Token
+1. Verify the token's signature. The signature is used to verify that the sender of the token is who it says it is and to ensure that the message wasn't changed along the way.
+1. Validate the standard claims: `exp` (when the token expires), `iss` (who issued the token), `aud` (who is the intented recipient of the token)
+1. Verify that the token contains the `amr` claim.
+  - If `amr` **is not** in the payload or it does not contain the value `mfa`, the user did not log in with MFA
+  - If `amr` **is** in the payload and it contains the value `mfa`, then the user logged in with MFA
+
+## Example
 
 This example is built on top of the [JSON Web Token Sample Code](https://github.com/auth0/node-jsonwebtoken).
+
+The code verifies the token's signature (`jwt.verify`), decodes the token, and checks whether the payload contains `amr` and if it does whether it contains the value `mfa`. The results are logged in the console.
 
 ```js
 const AUTH0_CLIENT_SECRET = '${account.clientSecret}';
@@ -33,8 +51,7 @@ jwt.verify(id_token, AUTH0_CLIENT_SECRET, { algorithms: ['HS256'] }, function(er
 ## Keep reading
 
 ::: next-steps
-* [Auth0 id_token](/tokens/id-token)
+* [Overview of ID Tokens](/tokens/id-token)
 * [Overview of JSON Web Tokens](/jwt)
-* [OpenID and amr](http://openid.net/specs/openid-connect-core-1_0.html)
-* [JSON Web Token Example](https://github.com/auth0/node-jsonwebtoken)
+* [OpenID specification](http://openid.net/specs/openid-connect-core-1_0.html)
 :::

--- a/articles/multifactor-authentication/developer/step-up-authentication.md
+++ b/articles/multifactor-authentication/developer/step-up-authentication.md
@@ -14,7 +14,7 @@ You can add step-up authentication to your app with Auth0's extensible multifact
 
 ## Step-up Authentication for APIs
 
-You can implement step-up authentication with Auth0 using [scopes](/scopes), [Access Tokens](/tokens/access-token) and [rules](/rules).
+When your audience is an API, you can implement step-up authentication with Auth0 using [scopes](/scopes), [Access Tokens](/tokens/access-token) and [rules](/rules).
 
 ::: note
 An Access Token is a credential you can use to access an API. The actions that you can perform to that API are defined by the scopes your Access Token includes. The rules are JavaScript functions you can use to run custom logic when a user authenticates.
@@ -32,7 +32,7 @@ The Access Token that the user currently has does not include this scope and the
 
 The solution is that the client performs another authentication call, but this time it requests the required scope. The browser redirects to Auth0 and a rule is used to challenge the user to authenticate with MFA since a high-value scope was requested.
 
-The result is a new Access Token which includes the high-value scope. The client will discard the token (that is, not store it in local storage like the original token) thereby treating it like a single-use token.
+Once the user successfully authenticates with MFA, a new Access Token which includes the high-value scope is generated and sent. The client will pass the Access Token to the API which will discard it after verification, thereby treating it like a single-use token.
 
 ## Step-up Authentication for Web Apps
 

--- a/articles/multifactor-authentication/developer/step-up-authentication.md
+++ b/articles/multifactor-authentication/developer/step-up-authentication.md
@@ -36,7 +36,7 @@ The result is a new Access Token which includes the high-value scope. The client
 ## Keep reading
 
 ::: next-steps
-* [Configure Custom MFA](/multifactor-authentication/custom)
-* [An implementation of JSON Web Tokens with Node.js](https://github.com/auth0/node-jsonwebtoken)
+* [Implement Step-up Authentication with ID Tokens](/multifactor-authentication/custom)
+* [Implement Step-Up Authentication with Custom MFA Rules](/multifactor-authentication/custom-mfa-rules)
 * [Authentication policy definitions](http://openid.net/specs/openid-provider-authentication-policy-extension-1_0.html#rfc.section.4)
 :::

--- a/articles/multifactor-authentication/developer/step-up-authentication.md
+++ b/articles/multifactor-authentication/developer/step-up-authentication.md
@@ -1,4 +1,5 @@
 ---
+title: Step-up Authentication
 description: Describes using acr_values and acr claims to perform step-up authentication with Auth0
 ---
 # Step-up Authentication
@@ -36,7 +37,7 @@ The result is a new Access Token which includes the high-value scope. The client
 ## Keep reading
 
 ::: next-steps
-* [Implement Step-up Authentication with ID Tokens](/multifactor-authentication/custom)
+* [Implement Step-up Authentication with ID Tokens](/multifactor-authentication/developer/mfa-from-id-token)
 * [Implement Step-Up Authentication with Custom MFA Rules](/multifactor-authentication/custom-mfa-rules)
 * [Authentication policy definitions](http://openid.net/specs/openid-provider-authentication-policy-extension-1_0.html#rfc.section.4)
 :::

--- a/articles/multifactor-authentication/developer/step-up-authentication.md
+++ b/articles/multifactor-authentication/developer/step-up-authentication.md
@@ -12,9 +12,9 @@ You can add step-up authentication to your app with Auth0's extensible multifact
 
 ![Step-up flow](/media/articles/mfa/step-up-flow.png)
 
-## Step-up Authentication with Auth0
+## Step-up Authentication for APIs
 
-The recommended way to implement step-up authentication with Auth0 is using [scopes](/scopes), [Access Tokens](/tokens/access-token) and [rules](/rules).
+You can implement step-up authentication with Auth0 using [scopes](/scopes), [Access Tokens](/tokens/access-token) and [rules](/rules).
 
 ::: note
 An Access Token is a credential you can use to access an API. The actions that you can perform to that API are defined by the scopes your Access Token includes. The rules are JavaScript functions you can use to run custom logic when a user authenticates.
@@ -34,9 +34,15 @@ The solution is that the client performs another authentication call, but this t
 
 The result is a new Access Token which includes the high-value scope. The client will discard the token (that is, not store it in local storage like the original token) thereby treating it like a single-use token.
 
+## Step-up Authentication for Web Apps
+
+If it is a web app that verifies the authentication level, and not an API, then you do not have an Access Token. In this case you can check if a user has logged in with MFA by reviewing the contents of their [ID Token](/tokens/id-token). You can then configure your application to deny access to pages with sensitive information if the ID Token indicates that the user did not log in with MFA.
+
+For details see [Step-up Authentication with ID Tokens](/multifactor-authentication/developer/mfa-from-id-token).
+
 ## Keep reading
 
 ::: next-steps
-* [Implement Step-up Authentication with ID Tokens](/multifactor-authentication/developer/mfa-from-id-token)
 * [Authentication policy definitions](http://openid.net/specs/openid-provider-authentication-policy-extension-1_0.html#rfc.section.4)
+* [Implement Step-up Authentication with ID Tokens](/multifactor-authentication/developer/mfa-from-id-token)
 :::

--- a/articles/multifactor-authentication/developer/step-up-authentication.md
+++ b/articles/multifactor-authentication/developer/step-up-authentication.md
@@ -38,6 +38,5 @@ The result is a new Access Token which includes the high-value scope. The client
 
 ::: next-steps
 * [Implement Step-up Authentication with ID Tokens](/multifactor-authentication/developer/mfa-from-id-token)
-* [Implement Step-Up Authentication with Custom MFA Rules](/multifactor-authentication/custom-mfa-rules)
 * [Authentication policy definitions](http://openid.net/specs/openid-provider-authentication-policy-extension-1_0.html#rfc.section.4)
 :::

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -493,11 +493,11 @@ articles:
       - title: "Step-up Authentication"
         url: "/multifactor-authentication/developer/step-up-authentication"
         children:
-          - title: "Step-up Authentication with ID Tokens"
+          - title: "Step-up with ID Tokens"
             url: "/multifactor-authentication/developer/mfa-from-id-token"
             hidden: true
           
-          - title: "Step-Up Authentication with Custom MFA Rules"
+          - title: "Step-Up with Custom MFA Rules"
             url: "/multifactor-authentication/custom-mfa-rules"
             hidden: true
 

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -489,6 +489,17 @@ articles:
 
       - title: "Yubikey NEO Example"
         url: "/multifactor-authentication/yubikey"
+        
+      - title: "Step-up Authentication"
+        url: "/multifactor-authentication/developer/step-up-authentication"
+        children:
+          - title: "Step-up Authentication with ID Tokens"
+            url: "/multifactor-authentication/developer/mfa-from-id-token"
+            hidden: true
+          
+          - title: "Step-Up Authentication with Custom MFA Rules"
+            url: "/multifactor-authentication/custom-mfa-rules"
+            hidden: true
 
   - title: "Security"
     url: "/security"


### PR DESCRIPTION
There are two ways to step-up a user's authentication level:
- add custom claims to access tokens
- examine the `amr` claim of ID tokens

This PR updates the article that discusses the second approach. More updates are needed, this is only the first iteration.