### PR TITLE
Fix heading typo on extension

### DIFF
--- a/articles/extensions/index.md
+++ b/articles/extensions/index.md
@@ -32,7 +32,7 @@ Auth0 provides the following pre-defined extensions, and they are available for 
 ### Monitor your AD/LDAP connectors
 - [Auth0 AD/LDAP Connector Health Monitor](/extensions/adldap-connector)
 
-### Import or Export exisiting users
+### Import or Export existing users
 - [Users Import / Export](/extensions/user-import-export)
 
 ### Export Auth0 logs to an external service


### PR DESCRIPTION
Replaces "Exisiting" with "Existing" on the heading for the export/import extension.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
