### PR TITLE
Migration custom domains

### DIFF
--- a/articles/custom-domains/index.md
+++ b/articles/custom-domains/index.md
@@ -148,6 +148,10 @@ webAuth = new auth0.WebAuth({
 });
 ```
 
+::: note
+If you use custom domains and intend to perform [management API actions with Auth0.js](/libraries/auth0js/v9#user-management), you will need to instantiate a new copy of `webAuth` using your Auth0 domain rather than your custom one, just for for use with the Management API calls, as it only works with Auth0 domains. 
+:::
+
 #### Auth0 emails
 
 If you would like your custom domain used with your Auth0 emails, you'll need to enable this feature in the [Dashboard](${manage_url}/#/tenant). You can do this by clicking the toggle associated with the **Use Custom Domain in Emails**. When the toggle is green, this feature is enabled.

--- a/articles/custom-domains/index.md
+++ b/articles/custom-domains/index.md
@@ -148,9 +148,7 @@ webAuth = new auth0.WebAuth({
 });
 ```
 
-::: note
-If you use custom domains and intend to perform [management API actions with Auth0.js](/libraries/auth0js/v9#user-management), you will need to instantiate a new copy of `webAuth` using your Auth0 domain rather than your custom one, just for for use with the Management API calls, as it only works with Auth0 domains. 
-:::
+Note that the Management API only accepts Auth0 domains. If you use a [custom domain](/custom-domains) and also intend to perform [Management API actions with Auth0.js](/libraries/auth0js/v9#user-management), you must instantiate a new copy of `webAuth` using your Auth0 domain.
 
 #### Auth0 emails
 

--- a/articles/libraries/_includes/_configure_custom_domain.md
+++ b/articles/libraries/_includes/_configure_custom_domain.md
@@ -1,22 +1,20 @@
-### Configure Your Custom Domain
+### Configure your custom domain
 
-::: note
-Make sure that your application changes are made prior to setting up Custom Domains in your application, as the older versions of ${library} will not work with a custom domain set at initialization, and will return a 404 error.
-:::
+1. Ensure that your application updates are made prior to setting up custom domains in your application, as the older versions of ${library} will not work when configured with a custom domain.
 
-Set up your [Custom Domain](/custom-domains). Once the custom domain is set up, remember to make the following changes in your Lock instantiation:
+2. Set up your [custom domain](/custom-domains) in the Auth0 [Dashboard](${manage_url}/#/tenant).
 
-1. Use the custom domain when instantiating Lock.
+3. Use the custom domain when instantiating Lock.
 
 ```
 var lock = new Auth0Lock('your-client-id', 'login.northwind.com', options);
 ```
 
-2. Set the `configurationBaseUrl` option to `https://cdn.auth0.com`.
+4. Set the `configurationBaseUrl` option to `https://cdn.auth0.com`.
 
 ```
 var options = {
-	configurationBaseUrl: 'https://cdn.auth0.com'
+  configurationBaseUrl: 'https://cdn.auth0.com'
 }
 ```
 
@@ -26,4 +24,6 @@ The CDN URL varies by region. For regions outside of the US, use `https://cdn.{r
 
 #### Management Client
 
-If you intend to use the Auth0.js `auth0.Management` to get user information or perform account linking operations (see the Auth0.js documentation on [user management](/libraries/auth0js/v9#user-management) for more information on using the Management API in Auth0.js), you will need to instantiate a new Auth0 object with the Auth0 domain rather than your custom domain. The Management API only accepts Auth0 domains.
+If you intend to use the Auth0.js `auth0.Management` to get user information or perform account linking operations, you will need to instantiate a new Auth0 object with the Auth0 domain rather than your custom domain. The Management API only accepts Auth0 domains. 
+
+See the Auth0.js documentation on [user management](/libraries/auth0js/v9#user-management) for more information on using the Management API in Auth0.js.

--- a/articles/libraries/_includes/_configure_custom_domain.md
+++ b/articles/libraries/_includes/_configure_custom_domain.md
@@ -24,6 +24,6 @@ var options = {
 The CDN URL varies by region. For regions outside of the US, use `https://cdn.{region}.auth0.com`.
 :::
 
-
 #### Management Client
 
+If you intend to use the Auth0.js `auth0.Management` to get user information or perform account linking operations (see the Auth0.js documentation on [user management](/libraries/auth0js/v9#user-management) for more information on using the Management API in Auth0.js), you will need to instantiate a new Auth0 object with the Auth0 domain rather than your custom domain. The Management API only accepts Auth0 domains.

--- a/articles/libraries/_includes/_configure_custom_domain.md
+++ b/articles/libraries/_includes/_configure_custom_domain.md
@@ -7,7 +7,7 @@
 3. Use the custom domain when instantiating Lock.
 
 ```
-var lock = new Auth0Lock('your-client-id', 'login.northwind.com', options);
+var lock = new Auth0Lock('${account.clientId}', 'login.your-domain.com', options);
 ```
 
 4. Set the `configurationBaseUrl` option to `https://cdn.auth0.com`.
@@ -15,11 +15,11 @@ var lock = new Auth0Lock('your-client-id', 'login.northwind.com', options);
 ```
 var options = {
   configurationBaseUrl: 'https://cdn.auth0.com'
-}
+};
 ```
 
 ::: note
-The CDN URL varies by region. For regions outside of the US, use `https://cdn.{region}.auth0.com`.
+The CDN URL varies by region. For regions outside of the US, use `https://cdn.{region}.auth0.com` (for example, use `eu` for Europe, `au` for Australia).
 :::
 
 #### Management Client

--- a/articles/libraries/_includes/_configure_custom_domain.md
+++ b/articles/libraries/_includes/_configure_custom_domain.md
@@ -1,0 +1,29 @@
+### Configure Your Custom Domain
+
+::: note
+Make sure that your application changes are made prior to setting up Custom Domains in your application, as the older versions of ${library} will not work with a custom domain set at initialization, and will return a 404 error.
+:::
+
+Set up your [Custom Domain](/custom-domains). Once the custom domain is set up, remember to make the following changes in your Lock instantiation:
+
+1. Use the custom domain when instantiating Lock.
+
+```
+var lock = new Auth0Lock('your-client-id', 'login.northwind.com', options);
+```
+
+2. Set the `configurationBaseUrl` option to `https://cdn.auth0.com`.
+
+```
+var options = {
+	configurationBaseUrl: 'https://cdn.auth0.com'
+}
+```
+
+::: note
+The CDN URL varies by region. For regions outside of the US, use `https://cdn.{region}.auth0.com`.
+:::
+
+
+#### Management Client
+

--- a/articles/libraries/_includes/_configure_embedded_login.md
+++ b/articles/libraries/_includes/_configure_embedded_login.md
@@ -5,7 +5,3 @@ When implementing embedded login, ${library} will use cross-origin calls inside 
 Add the domain to the **Allowed Web Origins** field. You can find this field in the [Client Settings](${manage_url}/#/clients/${account.clientId}/settings) area of your Dashboard.
 
 ![Allowed Web Origins](/media/articles/libraries/lock/allowed-origins.png)
-
-::: note
-If you enable [Custom Domain Names](/custom-domains) and the top level domain for your website is the same as the custom domain for the Auth0 tenant, ${library} will work without any further configuration. Otherwise, you will need to configure your Auth0 client to use [Cross-Origin Authentication](/cross-origin-authentication).
-:::

--- a/articles/libraries/auth0js/v9/index.md
+++ b/articles/libraries/auth0js/v9/index.md
@@ -477,6 +477,10 @@ The Management API provides functionality that allows you to link and unlink sep
 
 To get started, you first need to obtain a an Access Token that can be used to call the Management API. You can do it by specifying the `https://${account.namespace}/api/v2/˜` audience when initializing Auth0.js, in which case you will get the Access Token as part of the authentication flow.
 
+::: note
+If you use [custom domains](/custom-domains), you will need to instantiate a new copy of `webAuth` using your Auth0 domain rather than your custom one, for use with the Management API calls, as it only works with Auth0 domains.
+:::
+
 ```js
 var webAuth = new auth0.WebAuth({
   clientID: '${account.clientId}',

--- a/articles/libraries/auth0js/v9/migration-v8-v9.md
+++ b/articles/libraries/auth0js/v9/migration-v8-v9.md
@@ -6,7 +6,7 @@ toc: true
 ---
 # Migrating from Auth0.js v8 to v9
 
-This guide includes all the information you need to update [Auth0.js](/libraries/auth0js) from v8 to v9.  Find out if you should upgrade or not by reading [Migrating to Auth0.js v9](/libraries/auth0js/v9/migration-guide).
+This guide includes all the information you need to update [Auth0.js](/libraries/auth0js) from v8 to v9. Find out if you should upgrade or not by reading [Migrating to Auth0.js v9](/libraries/auth0js/v9/migration-guide).
 
 ## Migration demo
 
@@ -17,11 +17,12 @@ This guide includes all the information you need to update [Auth0.js](/libraries
 <%= include('../../_includes/_get_auth0_js_latest_version') %>
 <%= include('../../_includes/_configure_embedded_login', { library : 'Auth0.js v9'}) %>
 <%= include('../../_includes/_review_get_ssodata') %>
-<%= include('../../_includes/_configure_custom_domain', { library : 'Auth0.js v9'}) %>
 
 #### Migration with getSSOData demo
 
 <script src="https://fast.wistia.com/embed/medias/is2d4ocwwn.jsonp" async></script><script src="https://fast.wistia.com/assets/external/E-v1.js" async></script><div class="wistia_responsive_padding" style="padding:62.5% 0 0 0;position:relative;"><div class="wistia_responsive_wrapper" style="height:100%;left:0;position:absolute;top:0;width:100%;"><div class="wistia_embed wistia_async_is2d4ocwwn videoFoam=true" style="height:100%;width:100%">&nbsp;</div></div></div>
+
+<%= include('../../_includes/_configure_custom_domain', { library : 'Auth0.js v9'}) %>
 
 <%= include('../../_includes/_legacy_flows') %>
 

--- a/articles/libraries/auth0js/v9/migration-v8-v9.md
+++ b/articles/libraries/auth0js/v9/migration-v8-v9.md
@@ -17,6 +17,7 @@ This guide includes all the information you need to update [Auth0.js](/libraries
 <%= include('../../_includes/_get_auth0_js_latest_version') %>
 <%= include('../../_includes/_configure_embedded_login', { library : 'Auth0.js v9'}) %>
 <%= include('../../_includes/_review_get_ssodata') %>
+<%= include('../../_includes/_configure_custom_domain', { library : 'Auth0.js v9'}) %>
 
 #### Migration with getSSOData demo
 

--- a/articles/libraries/lock/v11/migration-v10-v11.md
+++ b/articles/libraries/lock/v11/migration-v10-v11.md
@@ -18,6 +18,7 @@ This guide includes all the information you need to update your Lock v10 applica
 <%= include('../../_includes/_configure_embedded_login', { library : 'Lock v11'}) %>
 <%= include('../../_includes/_change_get_profile') %>
 <%= include('../../_includes/_oidc_conformant') %>
+<%= include('../../_includes/_configure_custom_domain', { library : 'Lock v11'}) %>
 
 ## Behavioral changes in Lock v11
 


### PR DESCRIPTION
Adding information about the usage of custom domains to migration guides:

* https://auth0-docs-content-pr-5849.herokuapp.com/docs/libraries/auth0js/v9/migration-v8-v9#configure-your-custom-domain
* https://auth0-docs-content-pr-5849.herokuapp.com/docs/libraries/lock/v11/migration-v10-v11#configure-your-custom-domain

As well as notes about management API use when using custom domains in Auth0.js:

* https://auth0-docs-content-pr-5849.herokuapp.com/docs/custom-domains#sdks
* https://auth0-docs-content-pr-5849.herokuapp.com/docs/libraries/auth0js/v9#user-management