### PR TITLE
Fix for sign up slack message rule

### DIFF
--- a/articles/rules/current/index.md
+++ b/articles/rules/current/index.md
@@ -221,8 +221,11 @@ The following example is a Rule template for sending a Slack message when a new 
 
 ```js
 function(user, context, callback) {
-  // short-circuit if the user signed up already
-  if (context.stats.loginsCount > 1) return callback(null, user, context);
+  // short-circuit if the user signed up already, i.e. the user has logged in more
+  // than once or is using a refresh token
+  if (context.stats.loginsCount > 1 || context.protocol === 'oauth2-refresh-token') {
+    return callback(null, user, context);
+  }
 
   // get your slack's hook url from: https://slack.com/services/10525858050
   var SLACK_HOOK = configuration.SLACK_HOOK;


### PR DESCRIPTION
Also considering the following case:
User requests refresh token during sign up, hence user has registered and authenticated (context.stats.loginsCount is 1), message sent --> OK!
User uses refresh token to authenticate (context.stats.loginsCount still is 1 since refresh token usage does not count as login), message sent --> WRONG!

Checking for context.protocol === 'oauth2-refresh-token' fixes this issue.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
