### PR TITLE
Add author metadata

### DIFF
--- a/articles/quickstart/backend/falcor/index.yml
+++ b/articles/quickstart/backend/falcor/index.yml
@@ -1,6 +1,8 @@
 title: Falcor API
 community: true
 thirdParty: false
+author:
+  community: true
 alias:
   - falcor
 languages:

--- a/articles/quickstart/backend/hapi/index.yml
+++ b/articles/quickstart/backend/hapi/index.yml
@@ -1,6 +1,7 @@
 title: Hapi API
-community: true
 thirdParty: false
+author:
+  community: true
 alias:
   - hapi
   - hapijs

--- a/articles/quickstart/backend/java-spring-security/index.yml
+++ b/articles/quickstart/backend/java-spring-security/index.yml
@@ -3,6 +3,10 @@ thirdParty: false
 alias:
   - spring security
   - spring
+author:
+  name: Luciano Balmaceda
+  email: luciano.balmaceda@auth0.com
+  community: false
 languages:
   - Java
 framework:

--- a/articles/quickstart/backend/laravel/index.yml
+++ b/articles/quickstart/backend/laravel/index.yml
@@ -6,6 +6,10 @@ languages:
   - PHP
 framework:
   - Laravel
+author:
+  name: Josh Cunningham
+  email: josh.cunningham@auth0.com
+  community: false
 image: /media/platforms/php.png
 tags:
   - quickstart

--- a/articles/quickstart/backend/php/index.yml
+++ b/articles/quickstart/backend/php/index.yml
@@ -3,6 +3,10 @@ alias:
   - php
 languages:
   - PHP
+author:
+  name: Josh Cunningham
+  email: josh.cunningham@auth0.com
+  community: false
 thirdParty: false
 image: /media/platforms/php.png
 tags:

--- a/articles/quickstart/backend/relay/index.yml
+++ b/articles/quickstart/backend/relay/index.yml
@@ -1,6 +1,7 @@
 title: Relay API
 thirdParty: false
-community: true
+author:
+  community: true
 alias:
   - relay
 languages:

--- a/articles/quickstart/backend/ruby/index.yml
+++ b/articles/quickstart/backend/ruby/index.yml
@@ -1,5 +1,6 @@
 title: Ruby API
-community: true
+author:
+  community: true
 alias:
   - ruby
 languages:

--- a/articles/quickstart/backend/symfony/index.yml
+++ b/articles/quickstart/backend/symfony/index.yml
@@ -1,5 +1,6 @@
 title: Symfony API
-community: true
+author:
+  community: true
 thirdParty: false
 alias:
   - symfony

--- a/articles/quickstart/config.yml
+++ b/articles/quickstart/config.yml
@@ -1,0 +1,4 @@
+author:
+  name: Andres Aguiar
+  email: andres.aguiar@auth0.com
+  community: false

--- a/articles/quickstart/native/android/index.yml
+++ b/articles/quickstart/native/android/index.yml
@@ -5,6 +5,9 @@ language:
   - Java
   - C
 hybrid: false
+author:
+  name: Luciano Balmaceda
+  email: luciano.balmaceda@auth0.com
 image: /media/platforms/android.png
 tags:
   - quickstart

--- a/articles/quickstart/native/android/index.yml
+++ b/articles/quickstart/native/android/index.yml
@@ -8,6 +8,7 @@ hybrid: false
 author:
   name: Luciano Balmaceda
   email: luciano.balmaceda@auth0.com
+  community: false
 image: /media/platforms/android.png
 tags:
   - quickstart

--- a/articles/quickstart/native/chrome/index.yml
+++ b/articles/quickstart/native/chrome/index.yml
@@ -1,5 +1,6 @@
 title: Chrome Extension
-community: true
+author:
+  community: true
 language:
   - JavaScript
 framework:

--- a/articles/quickstart/native/cordova/index.yml
+++ b/articles/quickstart/native/cordova/index.yml
@@ -1,5 +1,6 @@
 title: Cordova
-community: true
+author:
+  community: true
 language:
   - Javascript
 framework:

--- a/articles/quickstart/native/ios-objc/index.yml
+++ b/articles/quickstart/native/ios-objc/index.yml
@@ -2,6 +2,9 @@ title: iOS Objective-C
 language:
   - Objective-C
 image: /media/platforms/ios.png
+author:
+  name: Martin Walsh
+  email: martin.walsh@auth0.com
 tags:
   - quickstart
 alias:

--- a/articles/quickstart/native/ios-objc/index.yml
+++ b/articles/quickstart/native/ios-objc/index.yml
@@ -5,6 +5,7 @@ image: /media/platforms/ios.png
 author:
   name: Martin Walsh
   email: martin.walsh@auth0.com
+  community: false
 tags:
   - quickstart
 alias:

--- a/articles/quickstart/native/ios-swift/index.yml
+++ b/articles/quickstart/native/ios-swift/index.yml
@@ -6,6 +6,9 @@ language:
   - Swift
 framework:
   - Swift
+author:
+  name: Martin Walsh
+  email: martin.walsh@auth0.com
 image: /media/platforms/ios.png
 tags:
   - quickstart

--- a/articles/quickstart/native/ios-swift/index.yml
+++ b/articles/quickstart/native/ios-swift/index.yml
@@ -9,6 +9,7 @@ framework:
 author:
   name: Martin Walsh
   email: martin.walsh@auth0.com
+  community: false
 image: /media/platforms/ios.png
 tags:
   - quickstart

--- a/articles/quickstart/native/phonegap/_index.yml
+++ b/articles/quickstart/native/phonegap/_index.yml
@@ -1,5 +1,6 @@
 title: Phonegap
-community: true
+author:
+  community: true
 alias:
   - phonegap
 language:

--- a/articles/quickstart/native/react-native/index.yml
+++ b/articles/quickstart/native/react-native/index.yml
@@ -4,6 +4,9 @@ alias:
   - react native
   - react native ios
   - react native android
+author:
+  name: Martin Walsh
+  email: martin.walsh@auth0.com
 language:
   - Javascript
 framework:

--- a/articles/quickstart/native/react-native/index.yml
+++ b/articles/quickstart/native/react-native/index.yml
@@ -7,6 +7,7 @@ alias:
 author:
   name: Martin Walsh
   email: martin.walsh@auth0.com
+  community: false
 language:
   - Javascript
 framework:

--- a/articles/quickstart/native/windows-uwp-csharp/index.yml
+++ b/articles/quickstart/native/windows-uwp-csharp/index.yml
@@ -1,5 +1,6 @@
 title: Windows Universal App C#
-community: true
+author:
+  community: true
 hybrid: false
 alias:
   - windows app

--- a/articles/quickstart/native/wpf-winforms/index.yml
+++ b/articles/quickstart/native/wpf-winforms/index.yml
@@ -1,5 +1,6 @@
 title: WPF / Winforms
-community: true
+author:
+  community: true
 hybrid: false
 language:
   - Javascript

--- a/articles/quickstart/native/xamarin/index.yml
+++ b/articles/quickstart/native/xamarin/index.yml
@@ -1,5 +1,6 @@
 title: Xamarin
-community: true
+author:
+  community: true
 language:
   - C#
 framework:

--- a/articles/quickstart/spa/aurelia/index.yml
+++ b/articles/quickstart/spa/aurelia/index.yml
@@ -1,5 +1,6 @@
 title: Aurelia
-community: true
+author:
+  community: true
 alias:
   - aurelia
   - aureliajs

--- a/articles/quickstart/spa/cyclejs/index.yml
+++ b/articles/quickstart/spa/cyclejs/index.yml
@@ -1,5 +1,6 @@
 title: Cycle
-community: true
+author:
+  community: true
 alias:
   - cyclejs
 language:

--- a/articles/quickstart/spa/ember/index.yml
+++ b/articles/quickstart/spa/ember/index.yml
@@ -1,5 +1,6 @@
 title: Ember
-community: true
+author:
+  community: true
 alias:
   - ember
   - emberjs

--- a/articles/quickstart/spa/socket-io/index.yml
+++ b/articles/quickstart/spa/socket-io/index.yml
@@ -1,5 +1,6 @@
 title: Socket.io
-community: true
+author:
+  community: true
 alias:
   - socket.io
 language:

--- a/articles/quickstart/webapp/apache/index.yml
+++ b/articles/quickstart/webapp/apache/index.yml
@@ -1,5 +1,6 @@
 title: Apache
-community: true
+author:
+  community: true
 image: /media/platforms/apache.jpg
 tags:
   - quickstart

--- a/articles/quickstart/webapp/java-spring-mvc/index.yml
+++ b/articles/quickstart/webapp/java-spring-mvc/index.yml
@@ -1,6 +1,9 @@
 title: Java Spring MVC
 image: /media/platforms/spring.png
 logo_name: java
+author:
+  name: Luciano Balmaceda
+  email: luciano.balmaceda@auth0.com
 tags:
   - quickstart
 alias:

--- a/articles/quickstart/webapp/java-spring-mvc/index.yml
+++ b/articles/quickstart/webapp/java-spring-mvc/index.yml
@@ -4,6 +4,7 @@ logo_name: java
 author:
   name: Luciano Balmaceda
   email: luciano.balmaceda@auth0.com
+  community: false
 tags:
   - quickstart
 alias:

--- a/articles/quickstart/webapp/java-spring-security-mvc/index.yml
+++ b/articles/quickstart/webapp/java-spring-security-mvc/index.yml
@@ -1,6 +1,9 @@
 title: Java Spring Security
 image: /media/platforms/spring.png
 logo_name: java
+author:
+  name: Luciano Balmaceda
+  email: luciano.balmaceda@auth0.com
 tags:
   - quickstart
 alias:

--- a/articles/quickstart/webapp/java-spring-security-mvc/index.yml
+++ b/articles/quickstart/webapp/java-spring-security-mvc/index.yml
@@ -4,6 +4,7 @@ logo_name: java
 author:
   name: Luciano Balmaceda
   email: luciano.balmaceda@auth0.com
+  community: false
 tags:
   - quickstart
 alias:

--- a/articles/quickstart/webapp/java/index.yml
+++ b/articles/quickstart/webapp/java/index.yml
@@ -2,6 +2,9 @@ title: Java
 image: /media/platforms/java.png
 tags:
   - quickstart
+author:
+  name: Luciano Balmaceda
+  email: luciano.balmaceda@auth0.com
 alias:
   - java
 seo_alias: java

--- a/articles/quickstart/webapp/java/index.yml
+++ b/articles/quickstart/webapp/java/index.yml
@@ -5,6 +5,7 @@ tags:
 author:
   name: Luciano Balmaceda
   email: luciano.balmaceda@auth0.com
+  community: false
 alias:
   - java
 seo_alias: java


### PR DESCRIPTION
- Add metadata keys for all platforms.
- Add default author metadata (`quickstart/config.yml`)

This PR should be merged before the [Author component PR in auth0-docs](https://github.com/auth0/auth0-docs/pull/1594).