### PR TITLE
Removing `loginWithCredentials` section

### DIFF
--- a/articles/_includes/_lock-sdk.html
+++ b/articles/_includes/_lock-sdk.html
@@ -146,11 +146,10 @@
   });
 
   $('.signin-db').on('click', function() {
-    webAuth.redirect.loginWithCredentials({
-      connection: 'Username-Password-Authentication',
+    webAuth.login({
+      realm: 'tests',
       username: 'testuser',
       password: 'testpass',
-      scope: 'openid'
     });
   });
   // Parse the authentication result

--- a/articles/libraries/auth0js/v8/migration-guide.md
+++ b/articles/libraries/auth0js/v8/migration-guide.md
@@ -24,13 +24,6 @@ The first question to answer before getting into the changes is why to migrate y
 
 There are often situations where your APIs will need to authorize limited access to users, servers, or servers on behalf of users. Managing these types of authorization flows and access to your APIs is much easier with Auth0. If you need to use these [API Auth](/api-auth) features, we recommend that you upgrade to [auth0.js v8](/libraries/auth0js/v8).
 
-However, if your application is currently relying on being able to request metadata via scopes (as described in the legacy [scopes documentation](/scopes/legacy)), and you do not wish to use API Auth features to handle that instead, you have two choices:
-
-* Continue to use Auth0.js v7 until it is no longer an option
-* Use Auth0.js v8 without using API Auth. 
-  * Do not mark your client as OIDC Conformant in the dashboard
-  * Do not pass the `audience` parameter when using `authorize()`, or use methods which do not support API Auth, such as `loginWithCredentials()`, `signupAndLogin()` or `loginWithResourceOwner()` (note that `loginWithResourceOwner()` requires the legacy Resource Owner grant in order to be used and is unavailable to some customers).
-
 Alternatively, you could also simply request the metadata in a different way, for example with a rule to add custom claims to either the returned `id_token` or `access_token` as described in the [custom claims](/scopes/current#custom-claims) section of the scopes documentation.
 
 ::: note

--- a/articles/libraries/auth0js/v9/index.md
+++ b/articles/libraries/auth0js/v9/index.md
@@ -144,40 +144,6 @@ webAuth.popup.authorize({
 });
 ```
 
-### webAuth.redirect.loginWithCredentials()
-
-To login using redirect with credentials to enterprise connections, the `redirect.loginWithCredentials` method is used.
-
-```js
-webAuth.redirect.loginWithCredentials({
-  connection: 'Username-Password-Authentication',
-  username: 'testuser',
-  password: 'testpass',
-  scope: 'openid'
-}, function(err, authResult) {
-  // Auth tokens in the result or an error
-});
-```
-
-The use of `webauth.redirect.loginWithCredentials` is not recommended when using Auth0.js in your apps; it is recommended that you use `webauth.login` instead. 
-
-However, using `webauth.redirect.loginWithCredentials` **is** the correct choice for use in the universal login page, and is the only way to have SSO cookies set for your users who login using universal login.
-
-### webAuth.popup.loginWithCredentials()
-
-To login using popup mode with credentials to enterprise connections, the `popup.loginWithCredentials` method is used.
-
-```js
-webAuth.popup.loginWithCredentials({
-  connection: 'Username-Password-Authentication',
-  username: 'testuser',
-  password: 'testpass',
-  scope: 'openid'
-}, function(err, authResult) {
-  // Auth tokens in the result or an error
-});
-```
-
 ### webAuth.login()
 
 The `login` method allows for [cross-origin authentication](/cross-origin-authentication) using database connections, using `/co/authenticate`.


### PR DESCRIPTION
Removing the `loginWithCredentials()` method per request. Removed a relevant section of the v7 to v8 migration guide, which only really serves to point people to v8 so that they can migrate to v9 now. Replaced this method in the includable widget with Lock examples.

https://auth0-docs-content-pr-5891.herokuapp.com/docs/libraries/auth0js