### PR TITLE
Rule example shows incorrect parameter

### DIFF
--- a/articles/rules/current/metadata-in-rules.md
+++ b/articles/rules/current/metadata-in-rules.md
@@ -57,12 +57,12 @@ function(user, context, callback){
 
 ### Reading `client_metadata`
 
-`client_metadata` is an optional, top-level property of the Client object. Existing clients will have no value for this property.
+`clientMetadata` is an optional, top-level property of the context object. Existing clients will have no value for this property.
 
 ```js
-function(client, context, callback){
-  client.client_metadata = client.client_metadata || {};
-  if (client.client_metadata.usersuppliedkey1 === 'black'){
+function(user, context, callback){
+  context.clientMetadata = context.clientMetadata || {};
+  if (context.clientMetadata.usersuppliedkey1 === 'black'){
     // this code would not be executed for the user
   }
   ...


### PR DESCRIPTION
[Customer asked about this](https://auth0.zendesk.com/agent/tickets/37299) doc that seems to imply the first parameter of a rule can arbitrarily change between `user` and `client`. This is not the case. First parameter is always `user`. Client information is found on the second (client) parameter.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
