### PR TITLE
Remove account.clientSecret variable

### DIFF
--- a/articles/api-auth/tutorials/authorization-code-grant.md
+++ b/articles/api-auth/tutorials/authorization-code-grant.md
@@ -70,7 +70,7 @@ Now that you have an Authorization Code, you must exchange it for an Access Toke
   ],
   "postData": {
     "mimeType": "application/json",
-    "text": "{\"grant_type\":\"authorization_code\",\"client_id\": \"${account.clientId}\",\"client_secret\": \"${account.clientSecret}\",\"code\": \"YOUR_AUTHORIZATION_CODE\",\"redirect_uri\": \"${account.callback}\"}"
+    "text": "{\"grant_type\":\"authorization_code\",\"client_id\": \"${account.clientId}\",\"client_secret\": \"YOUR_CLIENT_SECRET\",\"code\": \"YOUR_AUTHORIZATION_CODE\",\"redirect_uri\": \"${account.callback}\"}"
   }
 }
 ```

--- a/articles/api-auth/tutorials/client-credentials.md
+++ b/articles/api-auth/tutorials/client-credentials.md
@@ -23,7 +23,7 @@ To ask Auth0 for tokens for any of your authorized client applications, perform 
   ],
   "postData": {
     "mimeType": "application/json",
-    "text": "{\"grant_type\":\"client_credentials\",\"client_id\": \"${account.clientId}\",\"client_secret\": \"${account.clientSecret}\",\"audience\": \"YOUR_API_IDENTIFIER\"}"
+    "text": "{\"grant_type\":\"client_credentials\",\"client_id\": \"${account.clientId}\",\"client_secret\": \"YOUR_CLIENT_SECRET\",\"audience\": \"YOUR_API_IDENTIFIER\"}"
   }
 }
 ```

--- a/articles/api-auth/tutorials/client-credentials/customize-with-hooks.md
+++ b/articles/api-auth/tutorials/client-credentials/customize-with-hooks.md
@@ -134,7 +134,7 @@ To get a token, make a `POST` request at the `https://${account.namespace}/oauth
   ],
   "postData": {
     "mimeType": "application/json",
-    "text": "{\"grant_type\":\"client_credentials\",\"client_id\": \"${account.clientId}\",\"client_secret\": \"${account.clientSecret}\",\"audience\": \"YOUR_API_IDENTIFIER\"}"
+    "text": "{\"grant_type\":\"client_credentials\",\"client_id\": \"${account.clientId}\",\"client_secret\": \"YOUR_CLIENT_SECRET\",\"audience\": \"YOUR_API_IDENTIFIER\"}"
   }
 }
 ```

--- a/articles/api-auth/tutorials/multifactor-resource-owner-password.md
+++ b/articles/api-auth/tutorials/multifactor-resource-owner-password.md
@@ -162,7 +162,7 @@ var options = { method: 'POST',
      audience: 'API_IDENTIFIER',
      scope: 'SCOPE',
      client_id: '${account.clientId}',
-     client_secret: '${account.clientSecret}' },
+     client_secret: 'YOUR_CLIENT_SECRET' },
   json: true };
 
 request(options, function (error, response, body) {
@@ -192,7 +192,7 @@ function mfaChallenge(mfa_token) {
     { mfa_token: mfa_token,
       challenge_type: 'oob otp', // Supported challenge types, space separated
       client_id: '${account.clientId}',
-      client_secret: '${account.clientSecret}' },
+      client_secret: 'YOUR_CLIENT_SECRET' },
     json: true };
 
   request(options, function (error, response, body) {
@@ -230,7 +230,7 @@ function mfaOTP(mfa_token, otp) {
       otp: otp,
       grant_type: 'http://auth0.com/oauth/grant-type/mfa-otp',
       client_id: '${account.clientId}',
-      client_secret: '${account.clientSecret}' },
+      client_secret: 'YOUR_CLIENT_SECRET' },
     json: true };
 
   request(options, function (error, response, body) {
@@ -277,7 +277,7 @@ function makeOOBGrantRequest(mfa_token, oob_code, /* optional  */ binding_code, 
       binding_code: binding_code, // Only when binding_method = prompt
       grant_type: 'http://auth0.com/oauth/grant-type/mfa-oob',
       client_id: '${account.clientId}',
-      client_secret: '${account.clientSecret}' },
+      client_secret: 'YOUR_CLIENT_SECRET' },
     json: true };
 
   request(options, function (error, response, body) {
@@ -315,7 +315,7 @@ function mfaRecovery(mfa_token, recovery_code) {
       otp: otp,
       grant_type: 'http://auth0.com/oauth/grant-type/mfa-recovery-code',
       client_id: '${account.clientId}',
-      client_secret: '${account.clientSecret}' },
+      client_secret: 'YOUR_CLIENT_SECRET' },
     json: true };
 
   request(options, function (error, response, body) {

--- a/articles/api-auth/tutorials/password-grant.md
+++ b/articles/api-auth/tutorials/password-grant.md
@@ -42,7 +42,7 @@ In order to execute the flow the client needs to acquire the Resource Owner's cr
   ],
   "postData": {
     "mimeType": "application/json",
-    "text": "{\"grant_type\":\"password\",\"username\": \"user@example.com\",\"password\": \"pwd\",\"audience\": \"https://someapi.com/api\", \"scope\": \"read:sample\", \"client_id\": \"${account.clientId}\", \"client_secret\": \"${account.clientSecret}\"}"
+    "text": "{\"grant_type\":\"password\",\"username\": \"user@example.com\",\"password\": \"pwd\",\"audience\": \"https://someapi.com/api\", \"scope\": \"read:sample\", \"client_id\": \"${account.clientId}\", \"client_secret\": \"YOUR_CLIENT_SECRET\"}"
   }
 }
 ```
@@ -98,7 +98,7 @@ To use this variation you will have to change the following request parameters:
   ],
   "postData": {
     "mimeType": "application/json",
-    "text": "{\"grant_type\":\"http://auth0.com/oauth/grant-type/password-realm\",\"username\": \"user@example.com\",\"password\": \"pwd\",\"audience\": \"https://someapi.com/api\", \"scope\": \"read:sample\", \"client_id\": \"${account.clientId}\", \"client_secret\": \"${account.clientSecret}\", \"realm\": \"employees\"}"
+    "text": "{\"grant_type\":\"http://auth0.com/oauth/grant-type/password-realm\",\"username\": \"user@example.com\",\"password\": \"pwd\",\"audience\": \"https://someapi.com/api\", \"scope\": \"read:sample\", \"client_id\": \"${account.clientId}\", \"client_secret\": \"YOUR_CLIENT_SECRET\", \"realm\": \"employees\"}"
   }
 }
 ```

--- a/articles/api-auth/tutorials/using-resource-owner-password-from-server-side.md
+++ b/articles/api-auth/tutorials/using-resource-owner-password-from-server-side.md
@@ -82,7 +82,7 @@ app.post('/api/auth', function(req, res, next) {
       audience: 'API_IDENTIFIER',
       scope: 'SCOPE',
       client_id: '${account.clientId}',
-      client_secret: '${account.clientSecret}' // Client is authenticated
+      client_secret: 'YOUR_CLIENT_SECRET' // Client is authenticated
     },
     json: true
   };

--- a/articles/api/authentication/api-authz/_get-token.md
+++ b/articles/api/authentication/api-authz/_get-token.md
@@ -19,7 +19,7 @@ Content-Type: application/json
 {
   "grant_type": "authorization_code",
   "client_id": "${account.clientId}",
-  "client_secret": "${account.clientSecret}",
+  "client_secret": "YOUR_CLIENT_SECRET",
   "code": "AUTHORIZATION_CODE",
   "redirect_uri": "${account.callback}"
 }
@@ -29,7 +29,7 @@ Content-Type: application/json
 curl --request POST \
   --url 'https://${account.namespace}/oauth/token' \
   --header 'content-type: application/json' \
-  --data '{"grant_type":"authorization_code","client_id": "${account.clientId}","client_secret": "${account.clientSecret}","code": "AUTHORIZATION_CODE","redirect_uri": "${account.callback}"}'
+  --data '{"grant_type":"authorization_code","client_id": "${account.clientId}","client_secret": "YOUR_CLIENT_SECRET","code": "AUTHORIZATION_CODE","redirect_uri": "${account.callback}"}'
 ```
 
 ```javascript
@@ -41,7 +41,7 @@ var options = { method: 'POST',
   body:
    { grant_type: 'authorization_code',
      client_id: '${account.clientId}',
-     client_secret: '${account.clientSecret}',
+     client_secret: 'YOUR_CLIENT_SECRET',
      code: 'AUTHORIZATION_CODE',
      redirect_uri: '${account.callback}' },
   json: true };
@@ -216,7 +216,7 @@ Content-Type: application/json
   "audience": "API_IDENTIFIER",
   "grant_type": "client_credentials",
   "client_id": "${account.clientId}",
-  "client_secret": "${account.clientSecret}"
+  "client_secret": "YOUR_CLIENT_SECRET"
 }
 ```
 
@@ -224,7 +224,7 @@ Content-Type: application/json
 curl --request POST \
   --url 'https://${account.namespace}/oauth/token' \
   --header 'content-type: application/json' \
-  --data '{"audience":"API_IDENTIFIER", "grant_type":"client_credentials", "client_id":"${account.clientId}", "client_secret":"${account.clientSecret}"}'
+  --data '{"audience":"API_IDENTIFIER", "grant_type":"client_credentials", "client_id":"${account.clientId}", "client_secret":"YOUR_CLIENT_SECRET"}'
 ```
 
 ```javascript
@@ -235,7 +235,7 @@ var options = { method: 'POST',
   headers: { 'content-type': 'application/json' },
   body:
    { client_id: '${account.clientId}',
-     client_secret: '${account.clientSecret}',
+     client_secret: 'YOUR_CLIENT_SECRET',
      audience: 'API_IDENTIFIER',
      grant_type: 'client_credentials' },
   json: true };
@@ -310,7 +310,7 @@ Content-Type: application/json
   "audience": "API_IDENTIFIER",
   "scope": "SCOPE",
   "client_id": "${account.clientId}",
-  "client_secret": "${account.clientSecret}"
+  "client_secret": "YOUR_CLIENT_SECRET"
 }
 ```
 
@@ -318,7 +318,7 @@ Content-Type: application/json
 curl --request POST \
   --url 'https://${account.namespace}/oauth/token' \
   --header 'content-type: application/json' \
-  --data '{"grant_type":"password", "username":"USERNAME", "password":"PASSWORD", "audience":"API_IDENTIFIER", "scope":"SCOPE", "client_id": "${account.clientId}", "client_secret": "${account.clientSecret}"
+  --data '{"grant_type":"password", "username":"USERNAME", "password":"PASSWORD", "audience":"API_IDENTIFIER", "scope":"SCOPE", "client_id": "${account.clientId}", "client_secret": "YOUR_CLIENT_SECRET"
  }'
 ```
 
@@ -335,7 +335,7 @@ var options = { method: 'POST',
      audience: 'API_IDENTIFIER',
      scope: 'SCOPE',
      client_id: '${account.clientId}',
-     client_secret: '${account.clientSecret}' },
+     client_secret: 'YOUR_CLIENT_SECRET' },
   json: true };
 
 request(options, function (error, response, body) {
@@ -429,7 +429,7 @@ POST https://${account.namespace}/mfa/challenge
 Content-Type: application/json
 {
   "client_id": "${account.clientId}",
-  "client_secret": "${account.clientSecret}",
+  "client_secret": "YOUR_CLIENT_SECRET",
   "mfa_token": "MFA_TOKEN",
   "challenge_type": "oob|otp"
 }
@@ -439,7 +439,7 @@ Content-Type: application/json
 curl --request POST \
   --url 'https://${account.namespace}/mfa/challenge' \
   --header 'content-type: application/json' \
-  --data '{"mfa_token":"MFA_TOKEN", "challenge_type":"oob otp", "client_id": "${account.clientId}", "client_secret": "${account.clientSecret}"}'
+  --data '{"mfa_token":"MFA_TOKEN", "challenge_type":"oob otp", "client_id": "${account.clientId}", "client_secret": "YOUR_CLIENT_SECRET"}'
 ```
 
 ```javascript
@@ -452,7 +452,7 @@ var options = { method: 'POST',
    { mfa_token: 'MFA_TOKEN',
      challenge_type: 'oob otp',
      client_id: '${account.clientId}',
-     client_secret: '${account.clientSecret}' },
+     client_secret: 'YOUR_CLIENT_SECRET' },
   json: true };
 
 request(options, function (error, response, body) {
@@ -535,7 +535,7 @@ POST https://${account.namespace}/oauth/token
 Content-Type: application/json
 {
   "client_id": "${account.clientId}",
-  "client_secret": "${account.clientSecret}",
+  "client_secret": "YOUR_CLIENT_SECRET",
   "mfa_token": "MFA_TOKEN",
   "grant_type": "http://auth0.com/oauth/grant-type/mfa-otp",
   "otp": "OTP_CODE"
@@ -546,7 +546,7 @@ Content-Type: application/json
 curl --request POST \
   --url 'https://${account.namespace}/oauth/token' \
   --header 'content-type: application/json' \
-  --data '{"mfa_token":"MFA_TOKEN", "otp":"OTP_CODE", "grant_type": "http://auth0.com/oauth/grant-type/mfa-otp", "client_id": "${account.clientId}", "client_secret": "${account.clientSecret}"}'
+  --data '{"mfa_token":"MFA_TOKEN", "otp":"OTP_CODE", "grant_type": "http://auth0.com/oauth/grant-type/mfa-otp", "client_id": "${account.clientId}", "client_secret": "YOUR_CLIENT_SECRET"}'
 ```
 
 ```javascript
@@ -560,7 +560,7 @@ var options = { method: 'POST',
      otp: 'OTP_CODE',
      grant_type: 'http://auth0.com/oauth/grant-type/mfa-otp',
      client_id: '${account.clientId}',
-     client_secret: '${account.clientSecret}' },
+     client_secret: 'YOUR_CLIENT_SECRET' },
   json: true };
 
 request(options, function (error, response, body) {
@@ -610,7 +610,7 @@ POST https://${account.namespace}/oauth/token
 Content-Type: application/json
 {
   "client_id": "${account.clientId}",
-  "client_secret": "${account.clientSecret}",
+  "client_secret": "YOUR_CLIENT_SECRET",
   "mfa_token": "MFA_TOKEN",
   "grant_type": "http://auth0.com/oauth/grant-type/mfa-oob",
   "oob_code": "OOB_CODE",
@@ -622,7 +622,7 @@ Content-Type: application/json
 curl --request POST \
   --url 'https://${account.namespace}/oauth/token' \
   --header 'content-type: application/json' \
-  --data '{"mfa_token":"MFA_TOKEN", "oob_code": "OOB_CODE", "binding_code": "BINDING_CODE", "grant_type": "http://auth0.com/oauth/grant-type/mfa-oob", "client_id": "${account.clientId}", "client_secret": "${account.clientSecret}"}'
+  --data '{"mfa_token":"MFA_TOKEN", "oob_code": "OOB_CODE", "binding_code": "BINDING_CODE", "grant_type": "http://auth0.com/oauth/grant-type/mfa-oob", "client_id": "${account.clientId}", "client_secret": "YOUR_CLIENT_SECRET"}'
 ```
 
 ```javascript
@@ -637,7 +637,7 @@ var options = { method: 'POST',
      binding_code: "BINDING_CODE"
      grant_type: 'http://auth0.com/oauth/grant-type/mfa-oob',
      client_id: '${account.clientId}',
-     client_secret: '${account.clientSecret}' },
+     client_secret: 'YOUR_CLIENT_SECRET' },
   json: true };
 
 request(options, function (error, response, body) {
@@ -715,7 +715,7 @@ POST https://${account.namespace}/oauth/token
 Content-Type: application/json
 {
   "client_id": "${account.clientId}",
-  "client_secret": "${account.clientSecret}",
+  "client_secret": "YOUR_CLIENT_SECRET",
   "mfa_token": "MFA_TOKEN",
   "grant_type": "http://auth0.com/oauth/grant-type/mfa-recovery-code",
   "recovery_code": "RECOVERY_CODE"
@@ -726,7 +726,7 @@ Content-Type: application/json
 curl --request POST \
   --url 'https://${account.namespace}/oauth/token' \
   --header 'content-type: application/json' \
-  --data '{"mfa_token":"MFA_TOKEN", "recovery_code":"RECOVERY_CODE", "grant_type": "http://auth0.com/oauth/grant-type/mfa-recovery-code", "client_id": "${account.clientId}", "client_secret": "${account.clientSecret}"}'
+  --data '{"mfa_token":"MFA_TOKEN", "recovery_code":"RECOVERY_CODE", "grant_type": "http://auth0.com/oauth/grant-type/mfa-recovery-code", "client_id": "${account.clientId}", "client_secret": "YOUR_CLIENT_SECRET"}'
 ```
 
 ```javascript
@@ -740,7 +740,7 @@ var options = { method: 'POST',
      recovery_code: 'RECOVERY_CODE',
      grant_type: 'http://auth0.com/oauth/grant-type/mfa-recover-code',
      client_id: '${account.clientId}',
-     client_secret: '${account.clientSecret}' },
+     client_secret: 'YOUR_CLIENT_SECRET' },
   json: true };
 
 request(options, function (error, response, body) {
@@ -797,7 +797,7 @@ Content-Type: application/json
 Authorization: Bearer ACCESS_TOKEN or MFA_TOKEN
 {
   "client_id": "${account.clientId}",
-  "client_secret": "${account.clientSecret}",
+  "client_secret": "YOUR_CLIENT_SECRET",
   "authenticator_types": ["oob"],
   "oob_channels": "sms",
   "phone_number": "+1 555 123456"
@@ -810,7 +810,7 @@ curl --request POST \
   --url 'https://${account.namespace}/mfa/associate' \
   --header 'authorization: Bearer ACCESS_TOKEN or MFA_TOKEN' \
   --header 'content-type: application/json' \
-  --data '{"client_id": "${account.clientId}", "client_secret": "${account.clientSecret}", "authenticator_types":["oob"], "oob_channels":"sms", "phone_number": "+1 555 123456"}'
+  --data '{"client_id": "${account.clientId}", "client_secret": "YOUR_CLIENT_SECRET", "authenticator_types":["oob"], "oob_channels":"sms", "phone_number": "+1 555 123456"}'
 ```
 
 ```javascript
@@ -824,7 +824,7 @@ var options = { method: 'POST',
   },
   body:
    { client_id: '${account.clientId}',
-     client_secret: '${account.clientSecret}',
+     client_secret: 'YOUR_CLIENT_SECRET',
      authenticator_types: ["oob"],
      oob_channels: "sms",
      phone_number: "+1 555 123456" },
@@ -1042,7 +1042,7 @@ Content-Type: application/json
 {
   "grant_type": "refresh_token",
   "client_id": "${account.clientId}",
-  "client_secret": "${account.clientSecret}",
+  "client_secret": "YOUR_CLIENT_SECRET",
   "refresh_token": "YOUR_REFRESH_TOKEN"
 }
 ```
@@ -1051,7 +1051,7 @@ Content-Type: application/json
 curl --request POST \
   --url 'https://${account.namespace}/oauth/token' \
   --header 'content-type: application/json' \
-  --data '{"grant_type":"refresh_token","client_id": "${account.clientId}","client_secret": "${account.clientSecret}","refresh_token": "YOUR_REFRESH_TOKEN"}'
+  --data '{"grant_type":"refresh_token","client_id": "${account.clientId}","client_secret": "YOUR_CLIENT_SECRET","refresh_token": "YOUR_REFRESH_TOKEN"}'
 ```
 
 ```javascript
@@ -1063,7 +1063,7 @@ var options = { method: 'POST',
   body:
    { grant_type: 'refresh_token',
      client_id: '${account.clientId}',
-     client_secret: '${account.clientSecret}',
+     client_secret: 'YOUR_CLIENT_SECRET',
      refresh_token: 'YOUR_REFRESH_TOKEN'},
   json: true };
 

--- a/articles/api/authentication/api-authz/_revoke-refersh-token.md
+++ b/articles/api/authentication/api-authz/_revoke-refersh-token.md
@@ -7,7 +7,7 @@ POST https://${account.namespace}/oauth/revoke
 Content-Type: application/json
 {
   "client_id": "${account.clientId}",
-  "client_secret": "${account.clientSecret}",
+  "client_secret": "YOUR_CLIENT_SECRET",
   "token": "YOUR_REFRESH_TOKEN",
 }
 ```
@@ -16,7 +16,7 @@ Content-Type: application/json
 curl --request POST \
   --url 'https://${account.namespace}/oauth/revoke' \
   --header 'content-type: application/json' \
-  --data '{ "client_id": "${account.clientId}", "client_secret": "${account.clientSecret}", "token": "YOUR_REFRESH_TOKEN" }'
+  --data '{ "client_id": "${account.clientId}", "client_secret": "YOUR_CLIENT_SECRET", "token": "YOUR_REFRESH_TOKEN" }'
 ```
 
 ```javascript
@@ -27,7 +27,7 @@ var options = { method: 'POST',
   headers: { 'content-type': 'application/json' },
   body: 
    { client_id: '${account.clientId}',
-     client_secret: '${account.clientSecret}',
+     client_secret: 'YOUR_CLIENT_SECRET',
      token: 'YOUR_REFRESH_TOKEN' },
   json: true };
 

--- a/articles/api/management/v1/reference.md
+++ b/articles/api/management/v1/reference.md
@@ -31,7 +31,7 @@ A token is obtained using the POST method:
 ```text
 POST https://${account.namespace}/oauth/token
 Content-type: application/x-www-form-urlencoded
-client_id=${account.clientId}&client_secret=${account.clientSecret}&type=web_server&grant_type=client_credentials
+client_id=${account.clientId}&client_secret=YOUR_CLIENT_SECRET&type=web_server&grant_type=client_credentials
 ```
 
 The response body of this POST is a JSON object:
@@ -46,7 +46,7 @@ The response body of this POST is a JSON object:
 Here is a simple example using cURL:
 
 ```text
-curl https://${account.namespace}/oauth/token --data "client_id=${account.clientId}&client_secret=${account.clientSecret}&type=web_server&grant_type=client_credentials"
+curl https://${account.namespace}/oauth/token --data "client_id=${account.clientId}&client_secret=YOUR_CLIENT_SECRET&type=web_server&grant_type=client_credentials"
 ```
 
 ### Headers

--- a/articles/api/management/v2/tokens.md
+++ b/articles/api/management/v2/tokens.md
@@ -96,7 +96,7 @@ The payload should be in the following format:
   ],
   "postData": {
     "mimeType": "application/json",
-    "text": "{\"grant_type\":\"client_credentials\",\"client_id\": \"${account.clientId}\",\"client_secret\": \"${account.clientSecret}\",\"audience\": \"https://${account.namespace}/api/v2/\"}"
+    "text": "{\"grant_type\":\"client_credentials\",\"client_id\": \"${account.clientId}\",\"client_secret\": \"YOUR_CLIENT_SECRET\",\"audience\": \"https://${account.namespace}/api/v2/\"}"
   }
 }
 ```
@@ -172,7 +172,7 @@ def main():
   AUDIENCE = "https://${account.namespace}/api/v2/"
   DOMAIN = "${account.namespace}"
   CLIENT_ID = "${account.clientId}"
-  CLIENT_SECRET = "${account.clientSecret}"
+  CLIENT_SECRET = "YOUR_CLIENT_SECRET"
   GRANT_TYPE = "client_credentials" # OAuth 2.0 flow to use
 
   # Get an Access Token from Auth0

--- a/articles/appliance/admin/creating-tenants.md
+++ b/articles/appliance/admin/creating-tenants.md
@@ -68,7 +68,7 @@ Once you have created your New Client Grant, you may use it to complete the foll
     "queryString" : [],
     "postData" : {
         "mimeType": "application/json",
-        "text": "{\"audience\": \"https://ROOT_TENANT_AUTHORITY/api/v2/\", \"grant_type\": \"client_credentials\",\"client_id\": \"${account.clientId}\", \"client_secret\": \"${account.clientSecret}\"}"
+        "text": "{\"audience\": \"https://ROOT_TENANT_AUTHORITY/api/v2/\", \"grant_type\": \"client_credentials\",\"client_id\": \"${account.clientId}\", \"client_secret\": \"YOUR_CLIENT_SECRET\"}"
     },
     "headersSize" : -1,
     "bodySize" : -1,

--- a/articles/architecture-scenarios/implementations/server-api/cron-implementation-python.md
+++ b/articles/architecture-scenarios/implementations/server-api/cron-implementation-python.md
@@ -26,7 +26,7 @@ def main():
   domain = "${account.namespace}" # Your Auth0 Domain
   api_identifier = "API_IDENTIFIER" # API Identifier of your API
   client_id = "${account.clientId}" # Client ID of your Non Interactive Client
-  client_secret = "${account.clientSecret}" # Client Secret of your Non Interactive Client
+  client_secret = "YOUR_CLIENT_SECRET" # Client Secret of your Non Interactive Client
   api_url = "http://localhost:8080/timesheets/upload"
   grant_type = "client_credentials" # OAuth 2.0 flow to use
 

--- a/articles/architecture-scenarios/implementations/web-app-sso/implementation-aspnetcore.md
+++ b/articles/architecture-scenarios/implementations/web-app-sso/implementation-aspnetcore.md
@@ -50,7 +50,7 @@ public class Startup
 
             // Configure the Auth0 Client ID and Client Secret
             ClientId = ${account.clientId},
-            ClientSecret = ${account.clientSecret},
+            ClientSecret = YOUR_CLIENT_SECRET,
 
             // Do not automatically authenticate and challenge
             AutomaticAuthenticate = false,

--- a/articles/client-auth/current/server-side-web.md
+++ b/articles/client-auth/current/server-side-web.md
@@ -93,7 +93,7 @@ You application will need to handle the request to this callback URL, extract th
   ],
   "postData": {
     "mimeType": "application/json",
-    "text": "{\"grant_type\":\"authorization_code\",\"client_id\": \"${account.clientId}\",\"client_secret\": \"${account.clientSecret}\",\"code\": \"YOUR_AUTHORIZATION_CODE\",\"redirect_uri\": \"${account.callback}\"}"
+    "text": "{\"grant_type\":\"authorization_code\",\"client_id\": \"${account.clientId}\",\"client_secret\": \"YOUR_CLIENT_SECRET\",\"code\": \"YOUR_AUTHORIZATION_CODE\",\"redirect_uri\": \"${account.callback}\"}"
   }
 }
 ```

--- a/articles/client-auth/legacy/server-side-web.md
+++ b/articles/client-auth/legacy/server-side-web.md
@@ -87,7 +87,7 @@ You application will need to handle the request to this callback URL, extract th
   ],
   "postData": {
     "mimeType": "application/json",
-    "text": "{\"grant_type\":\"authorization_code\",\"client_id\": \"${account.clientId}\",\"client_secret\": \"${account.clientSecret}\",\"code\": \"YOUR_AUTHORIZATION_CODE\",\"redirect_uri\": \"${account.callback}\"}"
+    "text": "{\"grant_type\":\"authorization_code\",\"client_id\": \"${account.clientId}\",\"client_secret\": \"YOUR_CLIENT_SECRET\",\"code\": \"YOUR_AUTHORIZATION_CODE\",\"redirect_uri\": \"${account.callback}\"}"
   }
 }
 ```

--- a/articles/link-accounts/auth-api.md
+++ b/articles/link-accounts/auth-api.md
@@ -71,7 +71,7 @@ The SDK for your platform should make the `access_token` available in simplest w
   var strategy = new Auth0Strategy({
      domain:       '${account.namespace}',
      clientID:     '${account.clientId}',
-     clientSecret: '${account.clientSecret}',
+     clientSecret: 'YOUR_CLIENT_SECRET',
      callbackURL:  '${account.callback}',
      passReqToCallback: true //need this to save the accessToken to session
     },

--- a/articles/multifactor-authentication/developer/mfa-from-id-token.md
+++ b/articles/multifactor-authentication/developer/mfa-from-id-token.md
@@ -126,7 +126,7 @@ Send a `POST` to the [Token URL](/api/authentication?http#authorization-code), s
   ],
   "postData": {
     "mimeType": "application/json",
-    "text": "{\"grant_type\":\"authorization_code\",\"client_id\": \"${account.clientId}\",\"client_secret\": \"${account.clientSecret}\",\"code\": \"YOUR_AUTHORIZATION_CODE\",\"redirect_uri\": \"${account.callback}\"}"
+    "text": "{\"grant_type\":\"authorization_code\",\"client_id\": \"${account.clientId}\",\"client_secret\": \"YOUR_CLIENT_SECRET\",\"code\": \"YOUR_AUTHORIZATION_CODE\",\"redirect_uri\": \"${account.callback}\"}"
   }
 }
 ```

--- a/articles/quickstart/backend/_includes/_api_using.md
+++ b/articles/quickstart/backend/_includes/_api_using.md
@@ -35,7 +35,7 @@ You can also obtain an Access Token using [cUrl](https://curl.haxx.se/) by using
   ],
   "postData": {
     "mimeType": "application/json",
-    "text": "{\"grant_type\":\"client_credentials\",\"client_id\": \"${account.clientId}\",\"client_secret\": \"${account.clientSecret}\",\"audience\": \"YOUR_API_IDENTIFIER\"}"
+    "text": "{\"grant_type\":\"client_credentials\",\"client_id\": \"${account.clientId}\",\"client_secret\": \"YOUR_CLIENT_SECRET\",\"audience\": \"YOUR_API_IDENTIFIER\"}"
   }
 }
 ```
@@ -57,7 +57,7 @@ Auth0 customers are billed based on the number of Client Credential Access Token
   ],
   "postData": {
     "mimeType": "application/json",
-    "text": "{\"grant_type\":\"password\",\"username\": \"user@example.com\",\"password\": \"pwd\",\"audience\": \"YOUR_API_IDENTIFIER\", \"scope\": \"read:messages\", \"client_id\": \"${account.clientId}\", \"client_secret\": \"${account.clientSecret}\"}"
+    "text": "{\"grant_type\":\"password\",\"username\": \"user@example.com\",\"password\": \"pwd\",\"audience\": \"YOUR_API_IDENTIFIER\", \"scope\": \"read:messages\", \"client_id\": \"${account.clientId}\", \"client_secret\": \"YOUR_CLIENT_SECRET\"}"
   }
 }
 ```

--- a/articles/tokens/access-token.md
+++ b/articles/tokens/access-token.md
@@ -92,7 +92,7 @@ Server-to-server Access Tokens can be obtained using the [Client Credentials flo
   ],
   "postData": {
     "mimeType": "application/json",
-    "text": "{\"grant_type\":\"client_credentials\",\"client_id\": \"${account.clientId}\",\"client_secret\": \"${account.clientSecret}\",\"audience\": \"https://api.example.com/geocoding/v1/\"}"
+    "text": "{\"grant_type\":\"client_credentials\",\"client_id\": \"${account.clientId}\",\"client_secret\": \"YOUR_CLIENT_SECRET\",\"audience\": \"https://api.example.com/geocoding/v1/\"}"
   }
 }
 ```

--- a/articles/tokens/refresh-token/current/index.md
+++ b/articles/tokens/refresh-token/current/index.md
@@ -62,7 +62,7 @@ Once the user authenticates successfully, the client will be redirected to the `
   ],
   "postData": {
     "mimeType": "application/json",
-    "text": "{\"grant_type\":\"authorization_code\",\"client_id\": \"${account.clientId}\",\"client_secret\": \"${account.clientSecret}\",\"code\": \"YOUR_AUTHORIZATION_CODE\",\"redirect_uri\": \"${account.callback}\"}"
+    "text": "{\"grant_type\":\"authorization_code\",\"client_id\": \"${account.clientId}\",\"client_secret\": \"YOUR_CLIENT_SECRET\",\"code\": \"YOUR_AUTHORIZATION_CODE\",\"redirect_uri\": \"${account.callback}\"}"
   }
 }
 ```
@@ -105,7 +105,7 @@ To refresh your token, using the `refresh_token` you already got during authoriz
     "queryString" : [],
     "postData" : {
       "mimeType": "application/json",
-      "text" : "{ \"grant_type\": \"refresh_token\", \"client_id\": \"${account.clientId}\", \"client_secret\": \"${account.clientSecret}\", \"refresh_token\": \"YOUR_REFRESH_TOKEN\" }"
+      "text" : "{ \"grant_type\": \"refresh_token\", \"client_id\": \"${account.clientId}\", \"client_secret\": \"YOUR_CLIENT_SECRET\", \"refresh_token\": \"YOUR_REFRESH_TOKEN\" }"
     },
     "headersSize" : 150,
     "bodySize" : 0,
@@ -155,7 +155,7 @@ To revoke a Refresh Token you can send a `POST` request to `https://${account.na
     "queryString" : [],
     "postData" : {
       "mimeType": "application/json",
-      "text" : "{ \"client_id\": \"${account.clientId}\", \"client_secret\": \"${account.clientSecret}\", \"token\": \"YOUR_REFRESH_TOKEN\" }"
+      "text" : "{ \"client_id\": \"${account.clientId}\", \"client_secret\": \"YOUR_CLIENT_SECRET\", \"token\": \"YOUR_REFRESH_TOKEN\" }"
     },
     "headersSize" : 150,
     "bodySize" : 0,

--- a/articles/user-profile/user-impersonation.md
+++ b/articles/user-profile/user-impersonation.md
@@ -184,7 +184,7 @@ If not you should send a `POST` request to the [Token endpoint in Auth0](/api/au
   ],
   "postData": {
     "mimeType": "application/json",
-    "text": "{\"client_id\": \"${account.clientId}\",\"client_secret\": \"${account.clientSecret}\",\"code\": \"AUTHORIZATION_CODE\",\"grant_type\": \"authorization_code\",\"redirect_uri\": \"${account.callback}\"}"
+    "text": "{\"client_id\": \"${account.clientId}\",\"client_secret\": \"YOUR_CLIENT_SECRET\",\"code\": \"AUTHORIZATION_CODE\",\"grant_type\": \"authorization_code\",\"redirect_uri\": \"${account.callback}\"}"
   }
 }
 ```


### PR DESCRIPTION
Client Secret is sensitive information, like a password. We shouldn't send it to the browser. 

Replacing the variable with the hardcoded value `YOUR_CLIENT_SECRET`