### PR TITLE
Remove account.clientSecret variable (quickstarts)

### DIFF
--- a/articles/quickstart/backend/nginx/01-authorization.md
+++ b/articles/quickstart/backend/nginx/01-authorization.md
@@ -29,7 +29,7 @@ http {
 
 ## Configure `nginx-jwt` with your Auth0 account
 
-1. Export the `JWT_SECRET` environment variable on the Nginx host, setting it equal to your Auth0 Client Secret (`${account.clientSecret}`).
+1. Export the `JWT_SECRET` environment variable on the Nginx host, setting it equal to your Client Secret.
 1. Expose this environment variable to the Nginx server:
 
 ```lua

--- a/articles/quickstart/webapp/java-spring-mvc/_includes/_setup.md
+++ b/articles/quickstart/webapp/java-spring-mvc/_includes/_setup.md
@@ -36,7 +36,7 @@ Your Java Spring App needs some information in order to authenticate against you
 ```xml
 com.auth0.domain: ${account.namespace}
 com.auth0.clientId: ${account.clientId}
-com.auth0.clientSecret: ${account.clientSecret}
+com.auth0.clientSecret: YOUR_CLIENT_SECRET
 ```
 
 The library we're using has this default behavior:

--- a/articles/quickstart/webapp/java/_includes/_setup.md
+++ b/articles/quickstart/webapp/java/_includes/_setup.md
@@ -55,7 +55,7 @@ Your Java App needs some information in order to authenticate against your Auth0
 
 <context-param>
     <param-name>com.auth0.clientSecret</param-name>
-    <param-value>${account.clientSecret}</param-value>
+    <param-value>YOUR_CLIENT_SECRET</param-value>
 </context-param>
 ```
 

--- a/articles/quickstart/webapp/nancyfx/01-login.md
+++ b/articles/quickstart/webapp/nancyfx/01-login.md
@@ -50,7 +50,7 @@ You need to configure your Auth0 keys in the `app.config`
 <appSettings>
     <!-- Auth0 configuration -->
     <add key="auth0:ClientId" value="${account.clientId}" />
-    <add key="auth0:ClientSecret" value="${account.clientSecret}" />
+    <add key="auth0:ClientSecret" value="YOUR_CLIENT_SECRET" />
     <add key="auth0:Domain" value="${account.namespace}" />
     <add key="auth0:CallbackUrl" value="${account.callback}" />
 </appSettings>

--- a/articles/quickstart/webapp/servicestack/01-login.md
+++ b/articles/quickstart/webapp/servicestack/01-login.md
@@ -87,7 +87,7 @@ Open your `web.config` file and change the three Auth0's parameters under `<appS
 
 ```text
 <add key="oauth.auth0.AppId" value="${account.clientId}" />
-<add key="oauth.auth0.AppSecret" value="${account.clientSecret}" />
+<add key="oauth.auth0.AppSecret" value="YOUR_CLIENT_SECRET" />
 <add key="oauth.auth0.OAuthServerUrl" value="https://${account.namespace}" />
 ```
 

--- a/snippets/server-apis/php/setup.md
+++ b/snippets/server-apis/php/setup.md
@@ -21,7 +21,7 @@
 
     // validate the token
     $token = str_replace('Bearer ', '', $authorizationHeader);
-    $secret = '${account.clientSecret}';
+    $secret = 'YOUR_CLIENT_SECRET';
     $client_id = '${account.clientId}';
     $decoded_token = null;
     try {

--- a/snippets/server-apis/ruby/use.md
+++ b/snippets/server-apis/ruby/use.md
@@ -4,7 +4,7 @@ def authenticate!
   # Extract <token> from the 'Bearer <token>' value of the Authorization header
   supplied_token = String(request.env['HTTP_AUTHORIZATION']).slice(7..-1)
 
-  JWT.decode supplied_token, '${account.clientSecret}',
+  JWT.decode supplied_token, 'YOUR_CLIENT_SECRET',
     true, # Verify the signature of this token
     algorithm: 'HS256',
     iss: 'https://${account.namespace}',

--- a/snippets/server-apis/wcf-service/setup.md
+++ b/snippets/server-apis/wcf-service/setup.md
@@ -2,7 +2,7 @@ The NuGet package will create three empty settings under the `<appSettings>` sec
 
 ```xml
 <appSettings>
-  <add key="jwt:SymmetricKey" value="${account.clientSecret}" />
+  <add key="jwt:SymmetricKey" value="YOUR_CLIENT_SECRET" />
   <add key="jwt:AllowedAudience" value="${account.clientId}" />
   <add key="jwt:AllowedIssuer" value="https://${account.namespace}/" />
 </appSettings>

--- a/snippets/server-platforms/asp-classic/use.md
+++ b/snippets/server-platforms/asp-classic/use.md
@@ -5,7 +5,7 @@
 
 <%= '\<%' %>
 CLIENT_ID = "${account.clientId}"
-CLIENT_SECRET = "${account.clientSecret}"
+CLIENT_SECRET = "YOUR_CLIENT_SECRET"
 REDIRECT_URI = "${account.callback}"
 
 AUTHORIZATION_CODE = Request.querystring( "code" )

--- a/snippets/server-platforms/aspnet/setup.md
+++ b/snippets/server-platforms/aspnet/setup.md
@@ -1,5 +1,5 @@
 ```xml
 <add key="auth0:ClientId" value="${account.clientId}" />
-<add key="auth0:ClientSecret" value="${account.clientSecret}" />
+<add key="auth0:ClientSecret" value="YOUR_CLIENT_SECRET" />
 <add key="auth0:Domain" value="${account.namespace}" />
 ```

--- a/snippets/server-platforms/java-spring-security/setup.md
+++ b/snippets/server-platforms/java-spring-security/setup.md
@@ -2,7 +2,7 @@
 auth0.domain: ${account.namespace}
 auth0.issuer: https://${account.namespace}/
 auth0.clientId: ${account.clientId}
-auth0.clientSecret: ${account.clientSecret}
+auth0.clientSecret: YOUR_CLIENT_SECRET
 auth0.onLogoutRedirectTo: /login
 auth0.securedRoute: /portal/*
 auth0.loginCallback: /callback

--- a/snippets/server-platforms/java-spring/setup.md
+++ b/snippets/server-platforms/java-spring/setup.md
@@ -2,7 +2,7 @@
 auth0.domain: ${account.namespace}
 auth0.issuer: https://${account.namespace}/
 auth0.clientId: ${account.clientId}
-auth0.clientSecret: ${account.clientSecret}
+auth0.clientSecret: YOUR_CLIENT_SECRET
 auth0.onLogoutRedirectTo: /login
 auth0.securedRoute: /portal/*
 auth0.loginCallback: /callback

--- a/snippets/server-platforms/java/setup.md
+++ b/snippets/server-platforms/java/setup.md
@@ -22,6 +22,6 @@
 
 <context-param>
     <param-name>auth0.client_secret</param-name>
-    <param-value>${account.clientSecret}</param-value>
+    <param-value>YOUR_CLIENT_SECRET</param-value>
 </context-param>
 ```

--- a/snippets/server-platforms/nodejs/setup.md
+++ b/snippets/server-platforms/nodejs/setup.md
@@ -5,7 +5,7 @@ var Auth0Strategy = require('passport-auth0');
 var strategy = new Auth0Strategy({
     domain:       '${account.namespace}',
     clientID:     '${account.clientId}',
-    clientSecret: '${account.clientSecret}',
+    clientSecret: 'YOUR_CLIENT_SECRET',
     callbackURL:  '/callback'
   }, function(accessToken, refreshToken, extraParams, profile, done) {
     // accessToken is the token to call Auth0 API (not needed in the most cases)

--- a/snippets/server-platforms/php/setup.md
+++ b/snippets/server-platforms/php/setup.md
@@ -4,7 +4,7 @@ use Auth0\SDK\Auth0;
 $auth0 = new Auth0(array(
     'domain'        => '${account.namespace}',
     'client_id'     => '${account.clientId}',
-    'client_secret' => '${account.clientSecret}',
+    'client_secret' => 'YOUR_CLIENT_SECRET',
     'redirect_uri'  => '${account.callback}'
 ));
 ```

--- a/snippets/server-platforms/python/setup.md
+++ b/snippets/server-platforms/python/setup.md
@@ -21,7 +21,7 @@ def callback_handling():
     get_token = GetToken('${account.namespace}')
     auth0_users = Users('${account.namespace}')
     token = get_token.authorization_code('${account.clientId}',
-                                         '${account.clientSecret}', code, '${account.callback}')
+                                         'YOUR_CLIENT_SECRET', code, '${account.callback}')
     user_info = auth0_users.userinfo(token['access_token'])
     session['profile'] = json.loads(user_info)
     return redirect('/dashboard')

--- a/snippets/server-platforms/rails/setup.md
+++ b/snippets/server-platforms/rails/setup.md
@@ -3,7 +3,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
   provider(
     :auth0,
     '${account.clientId}',
-    '${account.clientSecret}',
+    'YOUR_CLIENT_SECRET',
     '${account.namespace}',
     callback_path: "/auth/oauth2/callback",
     authorize_params: {


### PR DESCRIPTION
Client Secret is sensitive information, like a password. We shouldn't send it to the browser. 

Replacing the variable with the hardcoded value `YOUR_CLIENT_SECRET`