### PR TITLE
Remove braces from variable placeholders

### DIFF
--- a/articles/multifactor-authentication/administrator/guardian-for-select-clients.md
+++ b/articles/multifactor-authentication/administrator/guardian-for-select-clients.md
@@ -10,7 +10,7 @@ By default, Auth0 enables Guardian for all clients.
 ```js
 function (user, context, callback) {
 
-  var CLIENTS_WITH_MFA = ['{REPLACE_WITH_YOUR_CLIENT_ID}'];
+  var CLIENTS_WITH_MFA = ['REPLACE_WITH_YOUR_CLIENT_ID'];
 
   // Apply Guardian only for the specified clients
   if (CLIENTS_WITH_MFA.indexOf(context.clientID) !== -1) {

--- a/articles/multifactor-authentication/administrator/guardian-for-select-users.md
+++ b/articles/multifactor-authentication/administrator/guardian-for-select-users.md
@@ -10,7 +10,7 @@ By default, Auth0 enables Guardian for all clients.
 ```js
 function (user, context, callback) {
 
-  var USERS_WITH_MFA = ['{REPLACE_WITH_YOUR_USER_ID}'];
+  var USERS_WITH_MFA = ['REPLACE_WITH_YOUR_USER_ID'];
 
   // Apply Guardian only for the specified users
   if (USERS_WITH_MFA.indexOf(user.user_id) !== -1) {

--- a/articles/multifactor-authentication/duo/admin-guide.md
+++ b/articles/multifactor-authentication/duo/admin-guide.md
@@ -25,7 +25,7 @@ After you toggle the slider to enable using Duo, a portal displays a code editin
 ```JS
 function (user, context, callback) {
 
-  var CLIENTS_WITH_MFA = ['{REPLACE_WITH_YOUR_CLIENT_ID}'];
+  var CLIENTS_WITH_MFA = ['REPLACE_WITH_YOUR_CLIENT_ID'];
   // run only for the specified clients
   if (CLIENTS_WITH_MFA.indexOf(context.clientID) !== -1) {
     // uncomment the following if clause in case you want to request a second factor only from user's that have user_metadata.use_mfa === true

--- a/articles/multifactor-authentication/duo/dev-guide.md
+++ b/articles/multifactor-authentication/duo/dev-guide.md
@@ -21,7 +21,7 @@ After you toggle the slider to enable using Duo, a portal displays a code editin
 ```JS
 function (user, context, callback) {
 
-  var CLIENTS_WITH_MFA = ['{REPLACE_WITH_YOUR_CLIENT_ID}'];
+  var CLIENTS_WITH_MFA = ['REPLACE_WITH_YOUR_CLIENT_ID'];
   // run only for the specified clients
   if (CLIENTS_WITH_MFA.indexOf(context.clientID) !== -1) {
     // uncomment the following if clause in case you want to request a second factor only from user's that have user_metadata.use_mfa === true

--- a/articles/multifactor-authentication/google-auth/admin-guide.md
+++ b/articles/multifactor-authentication/google-auth/admin-guide.md
@@ -47,7 +47,7 @@ function (user, context, callback) {
       context.multifactor = {
         provider: 'google-authenticator',
         // issuer: 'Label on Google Authenticator App', // optional
-        // key: '{YOUR_KEY_HERE}', //  optional, the key to use for TOTP. by default one is generated for you
+        // key: 'YOUR_KEY_HERE', //  optional, the key to use for TOTP. by default one is generated for you
 
         // optional, defaults to true. Set to false to force Google Authenticator every time.
         // See https://auth0.com/docs/multifactor-authentication/custom#change-the-frequency-of-authentication-requests for details

--- a/articles/multifactor-authentication/google-auth/dev-guide.md
+++ b/articles/multifactor-authentication/google-auth/dev-guide.md
@@ -29,7 +29,7 @@ function (user, context, callback) {
       context.multifactor = {
         provider: 'google-authenticator',
         // issuer: 'Label on Google Authenticator App', // optional
-        // key: '{YOUR_KEY_HERE}', //  optional, the key to use for TOTP. by default one is generated for you
+        // key: 'YOUR_KEY_HERE', //  optional, the key to use for TOTP. by default one is generated for you
 
         // optional, defaults to true. Set to false to force Google Authenticator every time.
         // See https://auth0.com/docs/multifactor-authentication/custom#change-the-frequency-of-authentication-requests for details

--- a/articles/multifactor-authentication/guardian/admin-guide.md
+++ b/articles/multifactor-authentication/guardian/admin-guide.md
@@ -85,7 +85,7 @@ Once you have enabled either MFA option, you will be presented with the **Custom
 ```js
 function (user, context, callback) {
 
-  //var CLIENTS_WITH_MFA = ['{REPLACE_WITH_YOUR_CLIENT_ID}'];
+  //var CLIENTS_WITH_MFA = ['REPLACE_WITH_YOUR_CLIENT_ID'];
   // run only for the specified clients
   // if (CLIENTS_WITH_MFA.indexOf(context.clientID) !== -1) {
     // uncomment the following if clause in case you want to request a second factor only from user's that have user_metadata.use_mfa === true
@@ -108,7 +108,7 @@ If you choose to selectively apply MFA, you will need the appropriate `clientID`
 
 More specifically, you will uncomment and populate the following line of the **Customize MFA** snippet with the appropriate client IDs:
 
-`var CLIENTS_WITH_MFA = ['{REPLACE_WITH_CLIENT_ID}'];`
+`var CLIENTS_WITH_MFA = ['REPLACE_WITH_CLIENT_ID'];`
 
 By setting `allowRememberBrowser: false`, the user will always be prompted for MFA when they login. This prevents the browser cookie from saving the credentials and helps make logins more secure, especially from untrusted machines. See [here](/multifactor-authentication/custom#change-the-frequency-of-authentication-requests) for details
 

--- a/articles/multifactor-authentication/guardian/dev-guide.md
+++ b/articles/multifactor-authentication/guardian/dev-guide.md
@@ -35,7 +35,7 @@ Once you have enabled either option, you will be presented with the **Customize 
 ```js
 function (user, context, callback) {
 
-  //var CLIENTS_WITH_MFA = ['{REPLACE_WITH_YOUR_CLIENT_ID}'];
+  //var CLIENTS_WITH_MFA = ['REPLACE_WITH_YOUR_CLIENT_ID'];
   // run only for the specified clients
   // if (CLIENTS_WITH_MFA.indexOf(context.clientID) !== -1) {
     // uncomment the following if clause in case you want to request a second factor only from user's that have user_metadata.use_mfa === true
@@ -59,7 +59,7 @@ If you choose to selectively apply MFA, you will need the appropriate `clientID`
 More specifically, you will uncomment and populate the following line of the Customize MFA snippet with the appropriate client IDs:
 
 ```js
-var CLIENTS_WITH_MFA = ['{REPLACE_WITH_CLIENT_ID}'];
+var CLIENTS_WITH_MFA = ['REPLACE_WITH_CLIENT_ID'];
 ```
 
 Once you have finished making your desired changes, click "Save" so that they persist.

--- a/articles/multifactor-authentication/user-initiated-mfa.md
+++ b/articles/multifactor-authentication/user-initiated-mfa.md
@@ -38,7 +38,7 @@ Finally, if the two parameters above are met, MFA occurs every login.
 function (user, context, callback) {
 
     // run only for the specified clients
-    var CLIENTS_WITH_MFA = ['{REPLACE_WITH_YOUR_CLIENT_ID}'];
+    var CLIENTS_WITH_MFA = ['REPLACE_WITH_YOUR_CLIENT_ID'];
     
     if (CLIENTS_WITH_MFA.indexOf(context.clientID) !== -1) {
         if (user.app_metadata && user.app_metadata.use_mfa){


### PR DESCRIPTION
Removes `{` `}` from variable placeholders.

This follows recommendation @ShayMe21 . 

To be merged together with: https://github.com/auth0/rules/pull/141