### PR TITLE
Add note about OWIN 4 incompatibility

### DIFF
--- a/articles/quickstart/backend/webapi-owin/01-authorization.md
+++ b/articles/quickstart/backend/webapi-owin/01-authorization.md
@@ -17,6 +17,10 @@ budicon: 500
   ]
 }) %>
 
+::: panel-warning OWIN 4 Incompatibility
+Please note that the **Auth0.OpenIdConnectSigningKeyResolver** NuGet package is only compatible with **System.IdentityModel.Tokens.Jwt 4.x** and the **OWIN 3.x** packages. Attempting to use **Auth0.OpenIdConnectSigningKeyResolver** with newer versions of those packages will result in compiler errors.
+:::
+
 <%= include('../../../_includes/_api_auth_intro') %>
 
 This Quickstart will guide you through the various tasks related to using Auth0-issued Access Tokens to secure your ASP.NET (OWIN) Web API.


### PR DESCRIPTION
Added a note to inform users about incompatibility with OWIN 4. This relates to https://community.auth0.com/t/webapi-owin-example-is-not-working/9704 and https://community.auth0.com/t/owin-web-auth-identifier-bug/10037