### PR TITLE
Adding note about universal login migration; also date fix

### DIFF
--- a/articles/libraries/_includes/_migrate_universal.md
+++ b/articles/libraries/_includes/_migrate_universal.md
@@ -1,0 +1,3 @@
+::: note
+If you do not have the ability to use [custom domains](/custom-domains) or prefer not to use them, and your application currently uses embedded login, the best migration path is to [migrate to Universal Login](/guides/login/migration-embedded-universal).
+:::

--- a/articles/libraries/auth0js/v9/migration-v8-v9.md
+++ b/articles/libraries/auth0js/v9/migration-v8-v9.md
@@ -14,6 +14,7 @@ This guide includes all the information you need to update [Auth0.js](/libraries
 
 ## Migration steps
 
+<%= include('../../_includes/_migrate_universal') %>
 <%= include('../../_includes/_get_auth0_js_latest_version') %>
 <%= include('../../_includes/_configure_embedded_login', { library : 'Auth0.js v9'}) %>
 <%= include('../../_includes/_review_get_ssodata') %>

--- a/articles/libraries/lock/v11/migration-guide.md
+++ b/articles/libraries/lock/v11/migration-guide.md
@@ -43,7 +43,7 @@ If you have any questions or concerns, you can discuss them in the [Auth0 Commun
 
 ## Disabling legacy Lock API
 
-After you update to Lock v11 and/or Auth0.js v9, it is advised that you turn off the **Legacy Lock API** toggle in the Dashboard. This will make your Auth0 tenant behave as if the legacy API is no longer available. Starting on April 1, 2018, this option will be forcibly disabled, so it is recommended you opt-in before that time to verify that your configuration will work correctly. 
+After you update to Lock v11 and/or Auth0.js v9, it is advised that you turn off the **Legacy Lock API** toggle in the Dashboard. This will make your Auth0 tenant behave as if the legacy API is no longer available. Starting on July 16, 2018, this option will be forcibly disabled, so it is recommended you opt-in before that time to verify that your configuration will work correctly. 
 
 You can find the setting in the [Advanced section](${manage_url}/#/tenant/advanced) of Tenant Settings.
 

--- a/articles/libraries/lock/v11/migration-v10-v11.md
+++ b/articles/libraries/lock/v11/migration-v10-v11.md
@@ -14,6 +14,7 @@ This guide includes all the information you need to update your Lock v10 applica
 
 ## Migration steps
 
+<%= include('../../_includes/_migrate_universal') %>
 <%= include('../../_includes/_get_lock_latest_version') %>
 <%= include('../../_includes/_configure_embedded_login', { library : 'Lock v11'}) %>
 <%= include('../../_includes/_change_get_profile') %>


### PR DESCRIPTION
Removing a leftover April date:
* https://auth0-docs-content-pr-5958.herokuapp.com/docs/libraries/lock/v11/migration-guide#disabling-legacy-lock-api

And adding a note about UL for those that don't have custom domains:
* https://auth0-docs-content-pr-5958.herokuapp.com/docs/libraries/lock/v11/migration-v10-v11#migration-steps
* https://auth0-docs-content-pr-5958.herokuapp.com/docs/libraries/auth0js/v9/migration-v8-v9#migration-steps