### PR TITLE
Remove H5 from Authentication API

### DIFF
--- a/articles/api/authentication/_change-password.md
+++ b/articles/api/authentication/_change-password.md
@@ -1,7 +1,5 @@
 # Change Password
 
-<h5 class="code-snippet-title">Examples</h5>
-
 ```http
 POST https://${account.namespace}/dbconnections/change_password
 Content-Type: application/json

--- a/articles/api/authentication/_client-reg.md
+++ b/articles/api/authentication/_client-reg.md
@@ -1,7 +1,5 @@
 # Dynamic Client Registration
 
-<h5 class="code-snippet-title">Examples</h5>
-
 ```http
 POST https://${account.namespace}/oidc/register
 Content-Type: application/json

--- a/articles/api/authentication/_impersonation.md
+++ b/articles/api/authentication/_impersonation.md
@@ -1,7 +1,5 @@
 # Impersonation
 
-<h5 class="code-snippet-title">Examples</h5>
-
 ```http
 POST https://${account.namespace}/users/{user_id}/impersonate
 Content-Type:   application/json

--- a/articles/api/authentication/_login.md
+++ b/articles/api/authentication/_login.md
@@ -209,10 +209,6 @@ GET https://${account.namespace}/authorize?
 </script>
 ```
 
-::: note
-Note that in order to use `loginWithCredentials`, auth0.js needs to make cross-origin calls. Check the  [Cross-Origin Authentication](/cross-origin-authentication) to understand the limitations of this approach.
-:::
-
 <%= include('../../_includes/_http-method', {
   "http_badge": "badge-primary",
   "http_method": "GET",
@@ -252,6 +248,7 @@ Use this endpoint for passive authentication. It returns a `302` redirect to the
 - If `response_type=token`, after the user authenticates, it will redirect to your application `callback URL` passing the `access_token` and `id_token` in the address `location.hash`. This is used for Single Page Apps and also on Native Mobile SDKs.
 - Additional parameters can be sent that will be passed to the provider.
 - The sample auth0.js script uses the library version 8. If you are using auth0.js version 7, please see this [reference guide](/libraries/auth0js/v7).
+- In order to use `loginWithCredentials`, auth0.js needs to make cross-origin calls. Check the [Cross-Origin Authentication](/cross-origin-authentication) article to understand the limitations of this approach.
 
 ### More Information
 

--- a/articles/api/authentication/_login.md
+++ b/articles/api/authentication/_login.md
@@ -2,8 +2,6 @@
 
 ## Social
 
-<h5 class="code-snippet-title">Examples</h5>
-
 ```http
 GET https://${account.namespace}/authorize?
   response_type=code|token&
@@ -94,8 +92,6 @@ Social connections only support browser-based (passive) authentication because m
 
 ## Database/AD/LDAP (Passive)
 
-<h5 class="code-snippet-title">Examples</h5>
-
 ```http
 GET https://${account.namespace}/authorize?
   response_type=code|token&
@@ -175,8 +171,6 @@ Use this endpoint for browser based (passive) authentication. It returns a `302`
 - [Auth0.js /authorize Method Reference](/libraries/auth0js#webauth-authorize-)
 
 ## Enterprise (SAML and Others)
-
-<h5 class="code-snippet-title">Examples</h5>
 
 ```http
 GET https://${account.namespace}/authorize?

--- a/articles/api/authentication/_logout.md
+++ b/articles/api/authentication/_logout.md
@@ -1,7 +1,5 @@
 # Logout
 
-<h5 class="code-snippet-title">Examples</h5>
-
 ```http
 GET https://${account.namespace}/v2/logout?
   client_id=${account.clientId}&

--- a/articles/api/authentication/_passwordless.md
+++ b/articles/api/authentication/_passwordless.md
@@ -6,8 +6,6 @@ Passwordless connections do not require the user to remember a password. Instead
 
 ## Get Code or Link
 
-<h5 class="code-snippet-title">Examples</h5>
-
 ```http
 POST https://${account.namespace}/passwordless/start
 Content-Type: application/json
@@ -119,8 +117,6 @@ For the complete error code reference for this endpoint refer to [Errors > POST 
 - [Passwordless FAQ](/connections/passwordless/faq)
 
 ## Authenticate User
-
-<h5 class="code-snippet-title">Examples</h5>
 
 ```http
 POST https://${account.namespace}/oauth/ro

--- a/articles/api/authentication/_saml-sso.md
+++ b/articles/api/authentication/_saml-sso.md
@@ -4,8 +4,6 @@ The SAML protocol is used for 3rd party SaaS applications mostly, like Salesforc
 
 ## Accept Request
 
-<h5 class="code-snippet-title">Examples</h5>
-
 ```http
 GET https://${account.namespace}/samlp/${account.clientId}?
   connection=CONNECTION
@@ -55,8 +53,6 @@ Optionally, it accepts a connection parameter to login with a specific provider.
 
 ## Get Metadata
 
-<h5 class="code-snippet-title">Examples</h5>
-
 ```http
 GET https://${account.namespace}/samlp/metadata/${account.clientId}
 ```
@@ -94,8 +90,6 @@ This endpoint returns the SAML 2.0 metadata.
 
 
 ## IdP-Initiated SSO Flow
-
-<h5 class="code-snippet-title">Examples</h5>
 
 ```http
 POST https://${account.namespace}/login/callback?connection=CONNECTION

--- a/articles/api/authentication/_sign-up.md
+++ b/articles/api/authentication/_sign-up.md
@@ -1,7 +1,5 @@
 # Signup
 
-<h5 class="code-snippet-title">Examples</h5>
-
 ```http
 POST https://${account.namespace}/dbconnections/signup
 Content-Type: application/json

--- a/articles/api/authentication/_userinfo.md
+++ b/articles/api/authentication/_userinfo.md
@@ -2,8 +2,6 @@
 
 ## Get User Info
 
-<h5 class="code-snippet-title">Examples</h5>
-
 ```http
 GET https://${account.namespace}/userinfo
 Authorization: 'Bearer {ACCESS_TOKEN}'

--- a/articles/api/authentication/_wsfed-req.md
+++ b/articles/api/authentication/_wsfed-req.md
@@ -2,8 +2,6 @@
 
 ## Accept Request
 
-<h5 class="code-snippet-title">Examples</h5>
-
 ```http
 GET https://${account.namespace}/wsfed/${account.clientId}
 ```
@@ -64,8 +62,6 @@ This endpoint accepts a WS-Federation request to initiate a login.
 
 
 ## Get Metadata
-
-<h5 class="code-snippet-title">Examples</h5>
 
 ```http
 GET https://${account.namespace}/wsfed/${account.clientId}/FederationMetadata/2007-06/FederationMetadata.xml

--- a/articles/api/authentication/api-authz/_authz-client.md
+++ b/articles/api/authentication/api-authz/_authz-client.md
@@ -15,8 +15,6 @@ Based on the OAuth 2.0 flow you are implementing, the parameters slightly change
 
 ## Authorization Code Grant
 
-<h5 class="code-snippet-title">Examples</h5>
-
 ```http
 GET https://${account.namespace}/authorize?
   audience=API_IDENTIFIER&
@@ -83,8 +81,6 @@ This is the OAuth 2.0 grant that regular web apps utilize in order to access an 
 
 
 ## Authorization Code Grant (PKCE)
-
-<h5 class="code-snippet-title">Examples</h5>
 
 ```http
 GET https://${account.namespace}/authorize?
@@ -158,8 +154,6 @@ This is the OAuth 2.0 grant that mobile apps utilize in order to access an API. 
 
 
 ## Implicit Grant
-
-<h5 class="code-snippet-title">Examples</h5>
 
 ```http
 GET https://${account.namespace}/authorize?

--- a/articles/api/authentication/api-authz/_get-token.md
+++ b/articles/api/authentication/api-authz/_get-token.md
@@ -11,8 +11,6 @@ Note that the only OAuth 2.0 flows that can retrieve a Refresh Token are:
 
 ## Authorization Code
 
-<h5 class="code-snippet-title">Examples</h5>
-
 ```http
 POST https://${account.namespace}/oauth/token
 Content-Type: application/json
@@ -114,8 +112,6 @@ If you have just executed the [Authorization Code Grant](#authorization-code-gra
 
 ## Authorization Code (PKCE)
 
-<h5 class="code-snippet-title">Examples</h5>
-
 ```http
 POST https://${account.namespace}/oauth/token
 Content-Type: application/json
@@ -207,8 +203,6 @@ If you have just executed the [Authorization Code Grant (PKCE)](#authorization-c
 
 ## Client Credentials
 
-<h5 class="code-snippet-title">Examples</h5>
-
 ```http
 POST https://${account.namespace}/oauth/token
 Content-Type: application/json
@@ -297,8 +291,6 @@ This is the OAuth 2.0 grant that server processes utilize in order to access an 
 
 
 ## Resource Owner Password
-
-<h5 class="code-snippet-title">Examples</h5>
 
 ```http
 POST https://${account.namespace}/oauth/token
@@ -422,8 +414,6 @@ Next, you have to verify the MFA, using the `/oauth/token` endpoint and the chal
 
 ### MFA Challenge Request
 
-<h5 class="code-snippet-title">Examples</h5>
-
 ```http
 POST https://${account.namespace}/mfa/challenge
 Content-Type: application/json
@@ -528,8 +518,6 @@ For details on the supported challenge types refer to [Multifactor Authenticatio
 
 ### Verify MFA using OTP
 
-<h5 class="code-snippet-title">Examples</h5>
-
 ```http
 POST https://${account.namespace}/oauth/token
 Content-Type: application/json
@@ -602,8 +590,6 @@ To verify MFA using an OTP code your app must prompt the user to get the OTP cod
 
 
 ### Verify MFA using an OOB challenge
-
-<h5 class="code-snippet-title">Examples</h5>
 
 ```http
 POST https://${account.namespace}/oauth/token
@@ -708,8 +694,6 @@ When the challenge response includes a `binding_method: prompt` your app needs t
 
 ### Verify MFA using a recovery code
 
-<h5 class="code-snippet-title">Examples</h5>
-
 ```http
 POST https://${account.namespace}/oauth/token
 Content-Type: application/json
@@ -788,8 +772,6 @@ To verify MFA using a recovery code your app must prompt the user for the recove
 ::: warning
 This endpoint is still under development. It is available to customers with early access.
 :::
-
-<h5 class="code-snippet-title">Examples</h5>
 
 ```http
 POST https://${account.namespace}/mfa/associate
@@ -901,8 +883,6 @@ Content-Type: application/json
 This endpoint is still under development. It is available to customers with early access.
 :::
 
-<h5 class="code-snippet-title">Examples</h5>
-
 ```http
 GET https://${account.namespace}/mfa/authenticators
 Content-Type: application/json
@@ -987,8 +967,6 @@ Content-Type: application/json
 This endpoint is still under development. It is available to customers with early access.
 :::
 
-<h5 class="code-snippet-title">Examples</h5>
-
 ```http
 DELETE https://${account.namespace}/mfa/authenticators/AUTHENTICATOR_ID
 Authorization: Bearer ACCESS_TOKEN or MFA_TOKEN
@@ -1033,8 +1011,6 @@ HTTP/1.1 204 OK
 - [Manage the Authenticators](/multifactor-authentication/api/manage)
 
 ## Refresh Token
-
-<h5 class="code-snippet-title">Examples</h5>
 
 ```http
 POST https://${account.namespace}/oauth/token

--- a/articles/api/authentication/api-authz/_revoke-refersh-token.md
+++ b/articles/api/authentication/api-authz/_revoke-refersh-token.md
@@ -1,7 +1,5 @@
 # Revoke Refresh Token
 
-<h5 class="code-snippet-title">Examples</h5>
-
 ```http
 POST https://${account.namespace}/oauth/revoke
 Content-Type: application/json

--- a/articles/api/authentication/legacy/_delegation.md
+++ b/articles/api/authentication/legacy/_delegation.md
@@ -2,8 +2,6 @@
 
 # Delegation
 
-<h5 class="code-snippet-title">Examples</h5>
-
 ```http
 POST https://${account.namespace}/delegation
 Content-Type: application/json

--- a/articles/api/authentication/legacy/_linking.md
+++ b/articles/api/authentication/legacy/_linking.md
@@ -2,8 +2,6 @@
 
 ## Link
 
-<h5 class="code-snippet-title">Examples</h5>
-
 ```http
 GET https://${account.namespace}/authorize?
   response_type=code|token&
@@ -53,8 +51,6 @@ This endpoint will trigger the login flow to link an existing account with a new
 
 
 ## Unlink
-
-<h5 class="code-snippet-title">Examples</h5>
 
 ```http
 POST https://${account.namespace}/login/unlink

--- a/articles/api/authentication/legacy/_login.md
+++ b/articles/api/authentication/legacy/_login.md
@@ -4,8 +4,6 @@
 
 ## Social with Provider's Access Token
 
-<h5 class="code-snippet-title">Examples</h5>
-
 ```http
 POST https://${account.namespace}/oauth/access_token
 Content-Type: application/json
@@ -102,8 +100,6 @@ For the complete error code reference for this endpoint refer to [Errors > POST 
 - [Add scopes/permissions to call Identity Provider's APIs](/tutorials/adding-scopes-for-an-external-idp)
 
 ## Database/AD/LDAP (Active)
-
-<h5 class="code-snippet-title">Examples</h5>
 
 ```http
 POST https://${account.namespace}/oauth/ro

--- a/articles/api/authentication/legacy/_resource-owner.md
+++ b/articles/api/authentication/legacy/_resource-owner.md
@@ -1,7 +1,5 @@
 # Resource Owner
 
-<h5 class="code-snippet-title">Examples</h5>
-
 ```http
 POST https://${account.namespace}/oauth/ro
 Content-Type: application/json

--- a/articles/api/authentication/legacy/_userinfo.md
+++ b/articles/api/authentication/legacy/_userinfo.md
@@ -2,8 +2,6 @@
 
 ## Get Token Info
 
-<h5 class="code-snippet-title">Examples</h5>
-
 ```http
 POST https://${account.namespace}/tokeninfo
 Content-Type: application/json


### PR DESCRIPTION
The headers are hidden later on by CSS so they are not needed. 