### PR TITLE
Update minor typo in "Using C#" docs

### DIFF
--- a/articles/rules/current/csharp.md
+++ b/articles/rules/current/csharp.md
@@ -2,7 +2,7 @@
 description: Learn how to use C# in Rules with Edge.js
 toc: true
 ---
-# Using C# in Rules
+# Using C\# in Rules
 
 Even though you typically write Rules in JavaScript, there is support for using C# by making use of [Edge.js](http://tjanczuk.github.io/edge/#/). In order to use C# in your Rule you will first need to `require` Edge:
 


### PR DESCRIPTION
The `#` in `C#` was being parsed as a comment in the header.

<img width="937" alt="screen shot 2018-04-09 at 10 48 47 am" src="https://user-images.githubusercontent.com/823316/38474568-a7c17df6-3be3-11e8-9c25-91bea21435e4.png">
