### PR TITLE
Update dates for ID Token/Mgmt API migration

### DIFF
--- a/articles/migrations/guides/calling-api-with-idtokens.md
+++ b/articles/migrations/guides/calling-api-with-idtokens.md
@@ -6,11 +6,15 @@ toc: true
 
 # Migration Guide: Management API and ID Tokens
 
-For some use cases you could use [ID Tokens](/tokens/id-token) in order to call some of the [/users](/api/management/v2#!/Users/get_users_by_id) and [/device-credentials](/api/management/v2#!/Device_Credentials/get_device_credentials) endpoints of the Management API. This functionality is being deprecated. You will have to use proper [Access Tokens](/tokens/access-token) in order to access any of the endpoints of the [Management API](/api/management/v2).
+For some use cases you could use [ID Tokens](/tokens/id-token) in order to call some of the [Users](/api/management/v2#!/Users/get_users_by_id) and [Device Credentials](/api/management/v2#!/Device_Credentials/get_device_credentials) endpoints of the Management API. 
 
-The grace period for this migration starts on **March 31, 2018** and ends on **March 31, 2019**. That day forward you will no longer be able to use ID Tokens as credentials for the Management API.
+This functionality is being deprecated. You will have to use proper [Access Tokens](/tokens/access-token) in order to access any of the endpoints of the [Management API](/api/management/v2).
 
-This article will help you migrate your implementation. First, we will see which use cases are affected. We will continue with reviewing how you can use [scopes](/scopes) to get tokens with different access rights, and then see all the ways you can use to get an Access Token. Finally, we will review the changes introduced in the [Account Linking](/link-accounts) process.
+The grace period for this migration starts on **March 31, 2018** and at the moment is open-ended. This means that you will still be able to use ID Tokens to access these endpoints. When a mandatory opt-in date is set for this migration customers will be notified beforehand.
+
+However, customers are encouraged to migrate to Access Tokens. This article will help you with that. 
+
+First, we will see which use cases are affected. We will continue with reviewing how you can use [scopes](/scopes) to get tokens with different access rights, and then see all the ways you can use to get an Access Token. Finally, we will review the changes introduced in the [Account Linking](/link-accounts) process.
 
 ## Does this affect me?
 

--- a/articles/migrations/guides/calling-api-with-idtokens.md
+++ b/articles/migrations/guides/calling-api-with-idtokens.md
@@ -10,7 +10,7 @@ For some use cases you could use [ID Tokens](/tokens/id-token) in order to call 
 
 This functionality is being deprecated. You will have to use proper [Access Tokens](/tokens/access-token) in order to access any of the endpoints of the [Management API](/api/management/v2).
 
-The grace period for this migration starts on **March 31, 2018** and at the moment is open-ended. This means that you will still be able to use ID Tokens to access these endpoints. When a mandatory opt-in date is set for this migration customers will be notified beforehand.
+The grace period for this migration started on **March 31, 2018** and at the moment is open-ended. This means that you will still be able to use ID Tokens to access these endpoints. When a mandatory opt-in date is set for this migration customers will be notified beforehand.
 
 However, customers are encouraged to migrate to Access Tokens. This article will help you with that. 
 

--- a/articles/migrations/index.md
+++ b/articles/migrations/index.md
@@ -67,11 +67,13 @@ If you have any questions, create a ticket in our [Support Center](${env.DOMAIN_
 
 | Severity | Grace Period Start | Mandatory Opt-In|
 | --- | --- | --- |
-| Medium | 2018-03-31 |  2019-03-31 |
+| Medium | 2018-03-31 |  - |
 
-For some use cases you could use [ID Tokens](/tokens/id-token) as credentials in order to call the [Management API](/api/management/v2). This functionality is being deprecated.
+For some use cases you can use [ID Tokens](/tokens/id-token) as credentials in order to call the [Management API](/api/management/v2). This functionality is being deprecated.
 
-This was used by the [/users](/api/management/v2#!/Users/get_users_by_id) and [/device-credentials](/api/management/v2#!/Device_Credentials/get_device_credentials) endpoints. The affected endpoints are the following.
+This is used by the [Users](/api/management/v2#!/Users/get_users_by_id) and [Device Credentials](/api/management/v2#!/Device_Credentials/get_device_credentials) endpoints. 
+
+List of affected endpoints:
 
 | **Endpoint** | **Use Case** |
 |-|-|
@@ -84,11 +86,11 @@ This was used by the [/users](/api/management/v2#!/Users/get_users_by_id) and [/
 | [POST/api/v2/users/{id}/identities](/api/management/v2#!/Users/post_identities) | [Link user accounts](/link-accounts) from various identity providers |
 | [DELETE /api/v2/users/{id}/identities/{provider}/{user_id}](/api/management/v2#!/Users/delete_provider_by_user_id) | [Unlink user accounts](/link-accounts#unlinking-accounts) |
 
-These endpoints will now accept regular [Access Tokens](/access-token). The functionality is available now.
+These endpoints can now accept regular [Access Tokens](/access-token). 
 
-Applications must be updated by **March 31, 2019**, when the ability to use ID Tokens will be disabled.
+The functionality is available and affected users are encouraged to migrate. However the ability to use ID Tokens will not be disabled in the foreseeable future so the mandatory opt-in date for this migration remains open. When this changes customers will be notified beforehand.
 
-For more information on this migration and the steps you should follow to upgrade your implementation, see [Migration Guide: Management API and ID Tokens](/migrations/guides/calling-api-with-idtokens).
+For more information on this migration and the steps you should follow to upgrade your implementation, see the [Migration Guide: Management API and ID Tokens](/migrations/guides/calling-api-with-idtokens).
 
 #### Am I affected by the change?
 

--- a/articles/migrations/index.md
+++ b/articles/migrations/index.md
@@ -88,7 +88,7 @@ List of affected endpoints:
 
 These endpoints can now accept regular [Access Tokens](/access-token). 
 
-The functionality is available and affected users are encouraged to migrate. However the ability to use ID Tokens will not be disabled in the foreseeable future so the mandatory opt-in date for this migration remains open. When this changes customers will be notified beforehand.
+The functionality is available and affected users are encouraged to migrate. However the ability to use ID Tokens will not be disabled in the foreseeable future so the mandatory opt-in date for this migration remains open. When this changes, customers will be notified beforehand.
 
 For more information on this migration and the steps you should follow to upgrade your implementation, see the [Migration Guide: Management API and ID Tokens](/migrations/guides/calling-api-with-idtokens).
 


### PR DESCRIPTION
- [x] remove mandatory opt-in date from migrations index and guide
- [x] update wording so it's clear customer are encouraged, but **not** required to migrate atm