### PR TITLE
Fix flashMessage example for authorization errors

### DIFF
--- a/articles/libraries/lock/v11/api.md
+++ b/articles/libraries/lock/v11/api.md
@@ -143,7 +143,7 @@ lock.on('authorization_error', function(error) {
   lock.show({
     flashMessage: {
       type: 'error',
-      text: error.error_description
+      text: error.errorDescription
     }
   });
 });


### PR DESCRIPTION
Fix `flashMessage` example when handling authorization errors, after `error_description` was changed to `errorDescription` in [auth0.js 8.0.0](https://github.com/auth0/auth0.js/commit/8eaf976dc937ad36ca193297c30b117bec318f22).