### PR TITLE
replace div with metadata

### DIFF
--- a/articles/support/matrix.md
+++ b/articles/support/matrix.md
@@ -2,10 +2,8 @@
 title: Auth0 Product Support Matrix
 description: This doc covers what features, platforms, and software configurations Auth0 supports.
 toc: true
+classes: support-matrix-page
 ---
-<!-- markdownlint-disable -->
-<div class="support-matrix-page">
-
 # Auth0 Product Support Matrix
 
 For customers with valid [subscriptions](${manage_url}/#/account/billing/subscription), this article covers the features, platforms, and software configurations that are eligible for Auth0 support.


### PR DESCRIPTION
The page does not work correctly atm. The _In this Article_ dropdown loads up empty and the headers do not have anchors.

That's because the page is inside a div. Replacing the HTML with metadata to fix this.