### PR TITLE
Added link to default page name per user feedback.

### DIFF
--- a/articles/custom-domains/index.md
+++ b/articles/custom-domains/index.md
@@ -9,6 +9,8 @@ Auth0 allows you to map the domain for your tenant to a custom domain of your ch
 
 For example, if your Auth0 domain is **northwind.auth0.com**, you can have your users to see, use, and remain on **login.northwind.com**.
 
+Currently, each tenant on the Auth0 public cloud supports **one** custom domain.
+
 Using custom domains with universal login is the most seamless and secure experience for developers and end users. For more information, please see our docs on [universal login](/hosted-pages/login).
 
 ## Prerequisites

--- a/articles/hosted-pages/custom-error-pages.md
+++ b/articles/hosted-pages/custom-error-pages.md
@@ -29,7 +29,7 @@ If you choose to display a custom error page, you have two options:
 -  Redirect the user to a custom error page.
 -  Configure Auth0 to render a custom error page on your behalf (please note that this feature is only available via the Management API).
 
-#### Redirecting Users to a Custom Error Page
+#### Redirect Users to a Custom Error Page
 
 To redirect users to a custom error page:
 
@@ -39,11 +39,11 @@ To redirect users to a custom error page:
 
 ![Error Page Redirect Option](/media/articles/error-pages/redirect-error-page.png)
 
-## Customizing Error Pages via the Management API
+## Customize Error Pages via the Management API
 
 Instead of using the Management Portal, you may configure your error pages by making the appropriate `PATCH /api/v2/tenants/settings` call to the Management API.
 
-### Redirecting Users to a Custom Error Page
+### Redirect Users to a Custom Error Page
 
 To redirect users to a custom error page, update the `url` field of your JSON body to point to the location of the error page.
 
@@ -69,7 +69,7 @@ HTTP Request:
 }
 ```
 
-### Rendering a Custom Error Page
+### Render a Custom Error Page
 
 To provide the appropriate HTML, pass in a string containing the appropriate Liquid syntax to the `html` element:
 

--- a/articles/hosted-pages/error-pages.md
+++ b/articles/hosted-pages/error-pages.md
@@ -11,7 +11,7 @@ Throughout the authentication process, your users may encounter errors. Auth0 pr
 
 ![Hosted Error Page](/media/articles/hosted-pages/error-pages.png)
 
-To see the default page name for the generic error page, see [How to Use Version Control to Manage Your Hosted Pages](/hosted-pages/version-control).
+To find the default page name for the Generic Error Page, see [How to Use Version Control to Manage Your Hosted Pages](/hosted-pages/version-control).
 
 By going into the [Tenant Settings](${manage_url}/#/tenant/) page of the Management Dashboard, you may customize your Auth0 error page with the following fields:
 

--- a/articles/hosted-pages/error-pages.md
+++ b/articles/hosted-pages/error-pages.md
@@ -11,6 +11,8 @@ Throughout the authentication process, your users may encounter errors. Auth0 pr
 
 ![Hosted Error Page](/media/articles/hosted-pages/error-pages.png)
 
+To see the default page name for the generic error page, see [How to Use Version Control to Manage Your Hosted Pages](/hosted-pages/version-control).
+
 By going into the [Tenant Settings](${manage_url}/#/tenant/) page of the Management Dashboard, you may customize your Auth0 error page with the following fields:
 
 * **Friendly Name**: the name of your company;

--- a/articles/hosted-pages/guardian.md
+++ b/articles/hosted-pages/guardian.md
@@ -7,6 +7,8 @@ In the [Auth0 Dashboard](${manage_url}/#/guardian_mfa_page), you can enable 2nd 
 
 ![Hosted Guardian MFA Page](/media/articles/hosted-pages/guardian.png)
 
+To see the default page name for the Guardian Login page, see [How to Use Version Control to Manage Your Hosted Pages](/hosted-pages/version-control).
+
 ## Guardian Login Page HTML Editor
 
 To enable the Guardian Login page, go to [Dashboard > Hosted Pages > Guardian Multifactor](${manage_url}/#/guardian_mfa_page) and enable the __Customize Guardian Page__ switch.

--- a/articles/hosted-pages/guardian.md
+++ b/articles/hosted-pages/guardian.md
@@ -7,7 +7,7 @@ In the [Auth0 Dashboard](${manage_url}/#/guardian_mfa_page), you can enable 2nd 
 
 ![Hosted Guardian MFA Page](/media/articles/hosted-pages/guardian.png)
 
-To see the default page name for the Guardian Login page, see [How to Use Version Control to Manage Your Hosted Pages](/hosted-pages/version-control).
+To find the default page name for the Guardian Login Page, see [How to Use Version Control to Manage Your Hosted Pages](/hosted-pages/version-control).
 
 ## Guardian Login Page HTML Editor
 

--- a/articles/hosted-pages/login/index.md
+++ b/articles/hosted-pages/login/index.md
@@ -14,6 +14,8 @@ If you cannot use universal login, you can embed the Lock widget or a custom log
 
 ![Login Page](/media/articles/hosted-pages/hlp-lock.png)
 
+To see the default page name for the login page, see [How to Use Version Control to Manage Your Hosted Pages](/hosted-pages/version-control).
+
 ### How Does Universal Login Work
 
 Auth0 shows the login page whenever something (or someone) triggers an authentication request, such as calling the `/authorize` endpoint (OIDC/OAuth) or sending a SAML login request.
@@ -26,14 +28,14 @@ If the incoming authentication request includes a `connection` parameter that us
 
 #### Single Sign-On (SSO)
 
-If you want to use single sign on, you should use universal login rather than an embedded login solution. When a user logs in via the login page, a cookie will be created and stored. On future calls to the `authorize` endpoint, the cookie will be checked, and if SSO is achieved, the user will not ever be redirected to the login page. They will see the page only when they need to actually login. 
+If you want to use single sign on, you should use universal login rather than an embedded login solution. When a user logs in via the login page, a cookie will be created and stored. On future calls to the `authorize` endpoint, the cookie will be checked, and if SSO is achieved, the user will not ever be redirected to the login page. They will see the page only when they need to actually login.
 
 This behavior occurs without the need for any modification to the login page itself. This is a simple two step process:
 
 1. Enable SSO for the application in the [Dashboard](${manage_url}) (Go to the Application's Settings, then scroll down to the **Use Auth0 instead of the IdP to do Single Sign On** setting and toggle it on.
 1. Use the [authorize endpoint](/api/authentication#authorization-code-grant) with `?prompt=none` for [silent SSO](/api-auth/tutorials/silent-authentication).
 
-::: note 
+::: note
 For more details about how SSO works, see the [SSO documentation](/sso).
 :::
 
@@ -67,7 +69,7 @@ In order to get started customizing the login page, you'll first want to choose 
 
 - [Lock](/hosted-pages/login/lock) - Lock is a pre-built, customizable login widget that will allow your users to quickly and easily login to your application.
 - [Lock (Passwordless Mode)](/hosted-pages/login/lock-passwordless) - Lock in Passwordless Mode uses the same Lock interface, but rather than offering identity providers as login options, will simply ask the user to enter an email or SMS number to begin a passwordless authentication transaction.
-- [Auth0.js](/hosted-pages/login/auth0js) - Auth0.js is the SDK used for interacting with the Auth0 [authentication API](/api/authentication). Primarily, you would use the SDK if you need to build your own custom login UI, or implement more complex functionality than simply allowing your users to login. 
+- [Auth0.js](/hosted-pages/login/auth0js) - Auth0.js is the SDK used for interacting with the Auth0 [authentication API](/api/authentication). Primarily, you would use the SDK if you need to build your own custom login UI, or implement more complex functionality than simply allowing your users to login.
 
 ### 3. Customization
 
@@ -85,7 +87,7 @@ The `config` object contains the set of configuration values that adjusts the be
 var config = JSON.parse(decodeURIComponent(escape(window.atob('@@config@@'))));
 ```
 
-The below examples assume that you are using [Auth0.js](/libraries/auth0js) within your application to call the `authorize` endpoint and show the login page. 
+The below examples assume that you are using [Auth0.js](/libraries/auth0js) within your application to call the `authorize` endpoint and show the login page.
 
 ##### Callback URL
 
@@ -103,11 +105,11 @@ webAuth.authorize({
 
 ## Configure Multiple Pages by Using Separate Tenants
 
-In some cases, you might have multiple apps and want to configure separate login pages for each. Since the hosted pages are configured in the [Dashboard](${manage_url}) at the tenant level (every app you have set up on a single tenant would use the same login page), you would have to create a new tenant for each application that requires a different hosted page. 
+In some cases, you might have multiple apps and want to configure separate login pages for each. Since the hosted pages are configured in the [Dashboard](${manage_url}) at the tenant level (every app you have set up on a single tenant would use the same login page), you would have to create a new tenant for each application that requires a different hosted page.
 
 In most cases, it would be preferable to use a single login page, which unifies your brand and the authentication experience for your users across the various areas in which they might encounter it. Additionally, using the same pages, and the same tenant, will allow you to share the resources that would otherwise need to be separated across multiple tenants.
 
-Creating a separate tenant is only really a viable option for an organization that needs two or more separate sets of custom pages, such as for branding reasons. If an example corporation has multiple branded subsidiaries or products, and separate APIs for all of them, it might make sense for them to create several separate Auth0 tenants, each with their own hosted pages set up for that brand or product's specific needs. 
+Creating a separate tenant is only really a viable option for an organization that needs two or more separate sets of custom pages, such as for branding reasons. If an example corporation has multiple branded subsidiaries or products, and separate APIs for all of them, it might make sense for them to create several separate Auth0 tenants, each with their own hosted pages set up for that brand or product's specific needs.
 
 Bear in mind that separating tenants with the goal of having separate hosted pages will also mean that those separate tenants will have two distinct sets of applications, users, settings, and so on as these things are not shared between tenants.
 

--- a/articles/hosted-pages/login/index.md
+++ b/articles/hosted-pages/login/index.md
@@ -14,7 +14,7 @@ If you cannot use universal login, you can embed the Lock widget or a custom log
 
 ![Login Page](/media/articles/hosted-pages/hlp-lock.png)
 
-To see the default page name for the login page, see [How to Use Version Control to Manage Your Hosted Pages](/hosted-pages/version-control).
+To find the default page name for the login page, see [How to Use Version Control to Manage Your Hosted Pages](/hosted-pages/version-control).
 
 ### How Does Universal Login Work
 

--- a/articles/hosted-pages/password-reset.md
+++ b/articles/hosted-pages/password-reset.md
@@ -7,6 +7,12 @@ crews: crew-2
 
 The Password Reset Page allows users to change their passwords in the event that they're unable to log in. Using this page, you can maintain consistency in the appearance of your pages (login, password reset, and so on), and your users can easily change their passwords as needed.
 
+To see the default page name for the password reset page, see [How to Use Version Control to Manage Your Hosted Pages](/hosted-pages/version-control).
+
+::: note
+The Password Reset Page allows users to enter and confirm a new password; the email address requiring the password reset should already have been specified.
+:::
+
 ## Enable the Custom Password Reset Page
 
 Using the [Auth0 Dashboard](${manage_url}/#/password_reset), you can enable your Hosted Password Reset Page by flipping the toggle switch.
@@ -23,16 +29,16 @@ You can use JavaScript to retrieve the following custom variables:
 
 | Variable | Description |
 | - | - |
-| `email` | The email address of the user requesting the password change | 
-| `ticket` | The ticket representing the given password reset request | 
-| `csrf_token` | Token used to prevent CSRF activity | 
-| `tenant.name` | The name associated with your Auth0 tenant | 
-| `tenant.friendly_name` | The name displayed for your Auth0 tenant | 
-| `tenant.picture_url` | The URL leading to the logo representing you in Auth0 | 
-| `tenant.support_email` | The support email address for your company displayed to your Auth0 users | 
-| `tenant.support_url` | The support URL for your company displayed to your Auth0 users | 
-| `lang` | The user's language | 
-| `password_policy` | The active connection's security policy You can see what this is using `${manage_url}/#/connections/database/con_YOUR-CONNECTION-ID/security`. Be sure to provide your connection ID in the URL.) | 
+| `email` | The email address of the user requesting the password change |
+| `ticket` | The ticket representing the given password reset request |
+| `csrf_token` | Token used to prevent CSRF activity |
+| `tenant.name` | The name associated with your Auth0 tenant |
+| `tenant.friendly_name` | The name displayed for your Auth0 tenant |
+| `tenant.picture_url` | The URL leading to the logo representing you in Auth0 |
+| `tenant.support_email` | The support email address for your company displayed to your Auth0 users |
+| `tenant.support_url` | The support URL for your company displayed to your Auth0 users |
+| `lang` | The user's language |
+| `password_policy` | The active connection's security policy You can see what this is using `${manage_url}/#/connections/database/con_YOUR-CONNECTION-ID/security`. Be sure to provide your connection ID in the URL.) |
 
 ::: note
 You can set/check the values for your `tenant` variables in the **Settings** area in [Tenant Settings](${manage_url}/#/tenant)

--- a/articles/hosted-pages/password-reset.md
+++ b/articles/hosted-pages/password-reset.md
@@ -7,7 +7,7 @@ crews: crew-2
 
 The Password Reset Page allows users to change their passwords in the event that they're unable to log in. Using this page, you can maintain consistency in the appearance of your pages (login, password reset, and so on), and your users can easily change their passwords as needed.
 
-To see the default page name for the password reset page, see [How to Use Version Control to Manage Your Hosted Pages](/hosted-pages/version-control).
+To find the default page name for the Password Reset Page, see [How to Use Version Control to Manage Your Hosted Pages](/hosted-pages/version-control).
 
 ::: note
 The Password Reset Page allows users to enter and confirm a new password; the email address requiring the password reset should already have been specified.

--- a/articles/hosted-pages/password-reset.md
+++ b/articles/hosted-pages/password-reset.md
@@ -10,7 +10,7 @@ The Password Reset Page allows users to change their passwords in the event that
 To find the default page name for the Password Reset Page, see [How to Use Version Control to Manage Your Hosted Pages](/hosted-pages/version-control).
 
 ::: note
-The Password Reset Page allows users to enter and confirm a new password; the email address requiring the password reset should already have been specified.
+The Password Reset Page allows users to enter and confirm a new password. The email address requiring the password reset should already have been specified.
 :::
 
 ## Enable the Custom Password Reset Page

--- a/articles/hosted-pages/password-reset.md
+++ b/articles/hosted-pages/password-reset.md
@@ -9,6 +9,10 @@ The Password Reset Page allows users to change their passwords in the event that
 
 To find the default page name for the Password Reset Page, see [How to Use Version Control to Manage Your Hosted Pages](/hosted-pages/version-control).
 
+::: note
+The Password Reset Page allows users to enter and confirm a new password. The email address requiring the password reset should already have been specified.
+:::
+
 ## Enable the Custom Password Reset Page
 
 Using the [Auth0 Dashboard](${manage_url}/#/password_reset), you can enable your Hosted Password Reset Page by flipping the toggle switch.

--- a/articles/hosted-pages/password-reset.md
+++ b/articles/hosted-pages/password-reset.md
@@ -9,10 +9,6 @@ The Password Reset Page allows users to change their passwords in the event that
 
 To find the default page name for the Password Reset Page, see [How to Use Version Control to Manage Your Hosted Pages](/hosted-pages/version-control).
 
-::: note
-The Password Reset Page allows users to enter and confirm a new password; the email address requiring the password reset should already have been specified.
-:::
-
 ## Enable the Custom Password Reset Page
 
 Using the [Auth0 Dashboard](${manage_url}/#/password_reset), you can enable your Hosted Password Reset Page by flipping the toggle switch.

--- a/articles/hosted-pages/password-reset.md
+++ b/articles/hosted-pages/password-reset.md
@@ -10,7 +10,7 @@ The Password Reset Page allows users to change their passwords in the event that
 To find the default page name for the Password Reset Page, see [How to Use Version Control to Manage Your Hosted Pages](/hosted-pages/version-control).
 
 ::: note
-The Password Reset Page allows users to enter and confirm a new password. The email address requiring the password reset should already have been specified.
+The Password Reset Page allows users to enter and confirm a new password; the email address requiring the password reset should already have been specified.
 :::
 
 ## Enable the Custom Password Reset Page

--- a/articles/hosted-pages/password-reset.md
+++ b/articles/hosted-pages/password-reset.md
@@ -9,10 +9,6 @@ The Password Reset Page allows users to change their passwords in the event that
 
 To find the default page name for the Password Reset Page, see [How to Use Version Control to Manage Your Hosted Pages](/hosted-pages/version-control).
 
-::: note
-The Password Reset Page allows users to enter and confirm a new password. The email address requiring the password reset should already have been specified.
-:::
-
 ## Enable the Custom Password Reset Page
 
 Using the [Auth0 Dashboard](${manage_url}/#/password_reset), you can enable your Hosted Password Reset Page by flipping the toggle switch.


### PR DESCRIPTION
Per user feedback, added links to version control page to help users find default page names. Also, updated password reset page to specify that the user email address should already have been specified. (User feedback indicated confusion about where in the password reset process this page appeared.)