### PR TITLE
Add legal warning at GDPR docs

### DIFF
--- a/articles/compliance/gdpr/features-aiding-compliance/_legal-warning.md
+++ b/articles/compliance/gdpr/features-aiding-compliance/_legal-warning.md
@@ -1,0 +1,3 @@
+::: warning
+The contents of this document are **not** intended to be legal advice, nor should they be considered a substitute for legal assistance. The final responsibility for understanding and complying with GDPR resides with you, though Auth0 will assist you in meeting GDPR requirements where possible.
+:::

--- a/articles/compliance/gdpr/features-aiding-compliance/data-minimization.md
+++ b/articles/compliance/gdpr/features-aiding-compliance/data-minimization.md
@@ -9,6 +9,8 @@ According to Article 5 of GDPR, the personal data you collect must be limited to
 
 There are several Auth0 features than can help you achieve these goals, like account linking, user profile encryption, and more.
 
+<%= include('./_legal-warning.md') %>
+
 ## Restrict user profile information
 
 To limit the amount of personal information in the Auth0 user profile, you can:

--- a/articles/compliance/gdpr/features-aiding-compliance/data-portability.md
+++ b/articles/compliance/gdpr/features-aiding-compliance/data-portability.md
@@ -9,6 +9,8 @@ According to Article 20 of GDPR, users have the right to receive the personal da
 
 You can export user data, stored in the Auth0 user store, either manually or programmatically. Raw data from Auth0 can be exported in JSON format (which is machine-readable).
 
+<%= include('./_legal-warning.md') %>
+
 ## Export data manually
 
 To export a user's data manually from the Dashboard:

--- a/articles/compliance/gdpr/features-aiding-compliance/index.md
+++ b/articles/compliance/gdpr/features-aiding-compliance/index.md
@@ -7,6 +7,8 @@ toc: true
 
 In this article, you will find a list of GDPR regulations and how Auth0 can help you comply with them.
 
+<%= include('./_legal-warning.md') %>
+
 ## Conditions for consent
 
 According to Article 7 of GDPR, you must:

--- a/articles/compliance/gdpr/features-aiding-compliance/protect-user-data.md
+++ b/articles/compliance/gdpr/features-aiding-compliance/protect-user-data.md
@@ -13,6 +13,8 @@ As per article 32 of GDPR, you must implement appropriate security measures in o
 
 There are several Auth0 features than can help you achieve that, like user profile encryption, brute-force protection, breached password detection, step-up authentication, and more.
 
+<%= include('./_legal-warning.md') %>
+
 ## Encrypt user profile information
 
 <%= include('./_encrypt-data.md') %>

--- a/articles/compliance/gdpr/features-aiding-compliance/right-to-access-data.md
+++ b/articles/compliance/gdpr/features-aiding-compliance/right-to-access-data.md
@@ -11,6 +11,8 @@ With Auth0, you can access, edit, and delete user information:
 - manually, using the [Dashboard](${manage_url}/#/users), or
 - programatically, using the [Management API](/api/management/v2)
 
+<%= include('./_legal-warning.md') %>
+
 ## Manual process
 
 You can view, edit, and delete user information at [Dashboard > Users](${manage_url}/#/users). Drill down to a user to view their info. The information you can change are:

--- a/articles/compliance/gdpr/features-aiding-compliance/user-consent/index.md
+++ b/articles/compliance/gdpr/features-aiding-compliance/user-consent/index.md
@@ -9,6 +9,8 @@ According to Article 7 of GDPR, you must ask users to consent on the processing 
 
 This article explains how you can use Auth0 features to implement these requirements.
 
+<%= include('../_legal-warning.md') %>
+
 ## Ask for consent
 
 Upon signup you have to ask your users for consent. With Auth0, you can save this information at the [user metadata](/metadata). There are several available options here, depending on how you use Auth0 to authenticate your users.

--- a/articles/compliance/gdpr/features-aiding-compliance/user-consent/track-consent-with-custom-ui.md
+++ b/articles/compliance/gdpr/features-aiding-compliance/user-consent/track-consent-with-custom-ui.md
@@ -7,6 +7,8 @@ toc: true
 
 In this tutorial we will see how you can use auth0.js or the Auth0 APIs to ask for consent information and save the input at the user's [metadata](/metadata).
 
+<%= include('../_legal-warning.md') %>
+
 ## Overview
 
 We will capture consent information, under various scenarios, and save this at the user's metadata, as follows:

--- a/articles/compliance/gdpr/features-aiding-compliance/user-consent/track-consent-with-lock.md
+++ b/articles/compliance/gdpr/features-aiding-compliance/user-consent/track-consent-with-lock.md
@@ -7,6 +7,8 @@ toc: true
 
 In this tutorial we will see how you can use Lock to ask for consent information, and then save this input at the user's [metadata](/metadata).
 
+<%= include('../_legal-warning.md') %>
+
 ## Overview
 
 We will configure a simple JavaScript Single Page Application and a database connection (we will use Auth0's infrastructure, instead of setting up our own database).


### PR DESCRIPTION
Add a warning panel to all of our GDPR guidance, making it clear that these docs are **not** intended to be legal advice, nor should they be considered a substitute for legal assistance. The final responsibility for understanding and complying with GDPR resides with the customer, though Auth0 will assist in meeting GDPR requirements where possible.