### PR TITLE
Fix custom error_page PATCH examples

### DIFF
--- a/articles/hosted-pages/custom-error-pages.md
+++ b/articles/hosted-pages/custom-error-pages.md
@@ -1,5 +1,7 @@
 ---
+title: Custom Error Pages
 description: How to setup a custom error page for authorization error events.
+toc: true
 crews: crew-2
 ---
 # Custom Error Pages
@@ -12,8 +14,8 @@ This article will show you how to use a customized error page. For details on th
 
 If you choose to display a custom error page, you have two options:
 
--  Redirect the user to a custom error page.
--  Configure Auth0 to render a custom error page on your behalf. This feature is only available via the Management API.
+-  [Redirect the user to a custom error page](#redirect-users-to-a-custom-error-page)
+-  [Configure Auth0 to render a custom error page on your behalf](#render-a-custom-error-page). This feature is only available via the Management API.
 
 ### Redirect users to a custom error page
 

--- a/articles/hosted-pages/custom-error-pages.md
+++ b/articles/hosted-pages/custom-error-pages.md
@@ -56,7 +56,7 @@ HTTP Request:
     "httpVersion": "HTTP/1.1",
     "cookies": [],
     "headers": [
-      { "name": "Authorization", "value": "Bearer YOUR_TOKEN" }
+      { "name": "Authorization", "value": "Bearer YOUR_TOKEN", "name": "Content-Type", "value": "application/json" }
     ],
     "queryString" : [],
     "postData": {
@@ -82,12 +82,12 @@ HTTP Request:
     "httpVersion": "HTTP/1.1",
     "cookies": [],
     "headers": [
-      { "name": "Authorization", "value": "Bearer YOUR_TOKEN" }
+      { "name": "Authorization", "value": "Bearer YOUR_TOKEN", "name": "Content-Type", "value": "application/json" }
     ],
     "queryString" : [],
     "postData": {
         "mimeType": "application/json",
-    "text": "{\"error page\": {\"html\": \"<h1>Hello {{name}}. This error was generated {{'now' | date: '%Y %h'}}.<\\h1>\"}, \"show_log_link\": false, \"url\": \"\"}"
+    "text": "{\"error_page\": {\"html\": \"<h1>Hello {{name}}. This error was generated {{'now' | date: '%Y %h'}}.<\\h1>\", \"show_log_link\": false, \"url\": \"\"}}"
     },
     "headersSize" : -1,
     "bodySize" : -1,

--- a/articles/hosted-pages/custom-error-pages.md
+++ b/articles/hosted-pages/custom-error-pages.md
@@ -56,7 +56,8 @@ HTTP Request:
     "httpVersion": "HTTP/1.1",
     "cookies": [],
     "headers": [
-      { "name": "Authorization", "value": "Bearer YOUR_TOKEN", "name": "Content-Type", "value": "application/json" }
+      { "name": "Authorization", "value": "Bearer YOUR_TOKEN"}, 
+      { "name": "Content-Type", "value": "application/json" }
     ],
     "queryString" : [],
     "postData": {
@@ -82,7 +83,8 @@ HTTP Request:
     "httpVersion": "HTTP/1.1",
     "cookies": [],
     "headers": [
-      { "name": "Authorization", "value": "Bearer YOUR_TOKEN", "name": "Content-Type", "value": "application/json" }
+      { "name": "Authorization", "value": "Bearer YOUR_TOKEN"}, 
+      { "name": "Content-Type", "value": "application/json" }
     ],
     "queryString" : [],
     "postData": {

--- a/articles/hosted-pages/custom-error-pages.md
+++ b/articles/hosted-pages/custom-error-pages.md
@@ -4,50 +4,33 @@ crews: crew-2
 ---
 # Custom Error Pages
 
-In the event of an authorization error, you may choose to display either the default Auth0 error page or a customized error page to your users. This doc will show you how to enable the use of a customized error page.
+In the event of an authorization error, you may choose to display to your users either [the default Auth0 error page](/hosted-pages/error-pages) or a customized error page. 
 
-::: note
-You can choose to display the default Auth0 Error page to your users. For additional information, see [Error Pages](/hosted-pages/error-pages)
-:::
+This article will show you how to use a customized error page. For details on the default Auth0 error page see [Error Pages](/hosted-pages/error-pages).
 
-## Customize Error Pages via the Management Dashboard
-
-You can select the type of error page Auth0 displays to your users in the event of an authorization error using the Management Dashboard.
-
-To get to the error page settings:
-
-1. Log in to the Auth0 [Management Dashboard](${manage_url}).
-2. Click on your tenant name in the top right corner to bring up the associated dropdown box.
-3.  Select **Settings** to open the [Tenant Settings](${manage_url}/#/tenant/) page.
-
-![Tenant Settings](/media/articles/error-pages/account-settings.png)
-
-### Customized Error Pages
+## How to customize the error page
 
 If you choose to display a custom error page, you have two options:
 
 -  Redirect the user to a custom error page.
--  Configure Auth0 to render a custom error page on your behalf (please note that this feature is only available via the Management API).
+-  Configure Auth0 to render a custom error page on your behalf. This feature is only available via the Management API.
 
-#### Redirecting Users to a Custom Error Page
+### Redirect users to a custom error page
 
-To redirect users to a custom error page:
+You can configure Auth0 to redirect users to a custom error page, using the Dashboard or the Management API.
 
-1.  On the [Tenant Settings](${manage_url}/#/tenant/) page, scroll down to the Error Pages section.
-2.  Select the option "redirect users to your own error page."
-3.  Provide the URL of the error page you would like your users to see.
+If you use the Dashboard, follow these steps:
+
+1. Log in to the [Dashboard](${manage_url}).
+1. Click on your tenant name in the top right corner to bring up the associated dropdown box.
+1. Select **Settings** to open the [Tenant Settings](${manage_url}/#/tenant/) page.
+1. Scroll down to the Error Pages section.
+1. Select the option **Redirect users to your own error page**.
+1. Provide the URL of the error page you would like your users to see.
 
 ![Error Page Redirect Option](/media/articles/error-pages/redirect-error-page.png)
 
-## Customizing Error Pages via the Management API
-
-Instead of using the Management Portal, you may configure your error pages by making the appropriate `PATCH /api/v2/tenants/settings` call to the Management API.
-
-### Redirecting Users to a Custom Error Page
-
-To redirect users to a custom error page, update the `url` field of your JSON body to point to the location of the error page.
-
-HTTP Request:
+If you use the API instead, use the `PATCH /api/v2/tenants/settings` endpoint. Update the `url` field of your JSON body to point to the location of the error page.
 
 ```har
 {
@@ -70,11 +53,9 @@ HTTP Request:
 }
 ```
 
-### Rendering a Custom Error Page
+### Render a custom error page
 
 To provide the appropriate HTML, pass in a string containing the appropriate Liquid syntax to the `html` element:
-
-HTTP Request:
 
 ```har
 {


### PR DESCRIPTION
Missing "application/json" content-type header and example curl requests fail with `{"statusCode":400,"error":"Bad Request" ... Payload validation error: 'Additional properties not allowed: error_page`.

Also fixed body according to management api docs: https://auth0.com/docs/api/management/v2.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
