### PR TITLE
add partial for the context protocol property

### DIFF
--- a/articles/rules/current/_context-protocol.md
+++ b/articles/rules/current/_context-protocol.md
@@ -1,0 +1,12 @@
+The authentication protocol. Possible values:
+- `oidc-basic-profile`: most used, web based login
+- `oidc-implicit-profile`: used on mobile devices and single page apps
+- `oauth2-resource-owner`: user/password login typically used on database connections
+- `oauth2-resource-owner-jwt-bearer`: login using a bearer JWT signed with user's private key
+- `oauth2-password`: login using the password exchange
+- `oauth2-refresh-token`: refreshing a token using the Refresh Token exchange
+- `samlp`: SAML protocol used on SaaS apps
+- `wsfed`: WS-Federation used on Microsoft products like Office365
+- `wstrust-usernamemixed`: WS-trust user/password login used on CRM and Office365
+- `delegation`: when calling the [Delegation endpoint](/api/authentication#delegation)
+- `redirect-callback`: when a redirect rule is resumed

--- a/articles/rules/current/_context-request.md
+++ b/articles/rules/current/_context-request.md
@@ -1,0 +1,15 @@
+An object containing useful information of the request. It has the following properties:
+- `userAgent`: the user-agent of the application that is trying to log in.
+- `ip`: the originating IP address of the user trying to log in.
+- `hostname`: the hostname that is being used for the authentication flow.
+- `query`: an object containing the querystring properties of the login transaction sent by the application. 
+- `body`: the body of the POST request on login transactions used on `oauth2-resource-owner`, `oauth2-resource-owner-jwt-bearer` or `wstrust-usernamemixed` protocols.
+- `geoip`: an object containing geographic IP information. It has the following properties:
+  - `country_code`: a two-character code for the country associated with the IP address
+  - `country_code3`: a three-character code for the country associated with the IP address
+  - `country_name`: the country name associated with the IP address
+  - `city_name`: the city or town name associated with the IP address
+  - `latitude`: the latitude associated with the IP address.
+  - `longitude`: the longitude associated with the IP address.
+  - `time_zone`: the timezone associated with the IP address.
+  - `continent_code`: a two-character code for the continent associated with the IP address.

--- a/articles/rules/current/_context-sso.md
+++ b/articles/rules/current/_context-sso.md
@@ -1,0 +1,4 @@
+This object will contain information about the SSO transaction (if available)
+- `with_auth0`: when a user signs in with SSO to an application where the `Use Auth0 instead of the IdP to do Single Sign On` setting is enabled.
+- `with_dbconn`: an SSO login for a user that logged in through a database connection.
+- `current_clients`: client IDs using SSO.

--- a/articles/rules/current/context.md
+++ b/articles/rules/current/context.md
@@ -22,13 +22,13 @@ The following properties are available for the `context` object.
 | `connection` | The name of the connection used to authenticate the user (such as: `twitter` or `some-google-apps-domain`) |
 | `connectionStrategy` | The type of connection. For social connection `connectionStrategy` === `connection`. For enterprise connections, the strategy will be `waad` (Windows Azure AD), `ad` (Active Directory/LDAP), `auth0` (database connections), and so on.
 | `samlConfiguration` | An object that controls the behavior of the SAML and WS-Fed endpoints. Useful for advanced claims mapping and token enrichment (only available for `samlp` and `wsfed` protocol). |
-| `protocol` | <%= include('../_context-protocol.md') %> |
+| `protocol` | <%= include('./_context-protocol.md') %> |
 | `stats` | An object containing specific user stats, like `stats.loginsCount`. Note that any of the counter variables returned as part of the `stats` object does not increase during [silent authentication](/api-auth/tutorials/silent-authentication) (as when `prompt=none`). |
-| `sso` | <%= include('../_context-sso.md') %> |
+| `sso` | <%= include('./_context-sso.md') %> |
 | `accessToken` | Used to add custom namespaced claims to the [Access Token](/tokens/access-token). |
 | `idToken` | Used to add custom namespaced claims to the [ID Token](/tokens/id-token). |
 | `sessionID` | Unique id for the authentication session. Value is kept only if `prompt=none`.
-| `request` | <%= include('../_context-request.md') %> |
+| `request` | <%= include('./_context-request.md') %> |
 
 ## Sample contents
 

--- a/articles/rules/current/context.md
+++ b/articles/rules/current/context.md
@@ -1,55 +1,36 @@
 ---
+title: Context Argument Properties in Rules
 description: Lists the properties that are available for the context argument when creating rules.
 ---
 # Context Argument Properties in Rules
 
-When creating [Rules](/rules), one of the input arguments is `context`. This is an object containing contextual information of the current authentication transaction, such as user's IP address, application, location, and so forth.
+When creating [Rules](/rules), one of the input arguments is `context`. 
 
-The following properties are available for the `context` object:
+This is an object containing contextual information of the current authentication transaction, such as user's IP address, application, location, and so forth.
 
-* `clientID`: the client id of the application the user is logging in to.
-* `clientName`: the name of the application (as defined on the dashboard).
-* `clientMetadata`: is an object, whose keys and values are strings, for holding other application properties.
-* `connection`: the name of the connection used to authenticate the user (such as: `twitter` or `some-google-apps-domain`)
-* `connectionStrategy`: the type of connection. For social connection `connectionStrategy` === `connection`. For enterprise connections, the strategy will be `waad` (Windows Azure AD), `ad` (Active Directory/LDAP), `auth0` (database connections), and so on.
-* `samlConfiguration`: an object that controls the behavior of the SAML and WS-Fed endpoints. Useful for advanced claims mapping and token enrichment (only available for `samlp` and `wsfed` protocol).
-* `protocol`: the authentication protocol. Possible values:
-  - `oidc-basic-profile`: most used, web based login
-  - `oidc-implicit-profile`: used on mobile devices and single page apps
-  - `oauth2-resource-owner`: user/password login typically used on database connections
-  - `oauth2-resource-owner-jwt-bearer`: login using a bearer JWT signed with user's private key
-  - `oauth2-password`: login using the password exchange
-  - `oauth2-refresh-token`: refreshing a token using the Refresh Token exchange
-  - `samlp`: SAML protocol used on SaaS apps
-  - `wsfed`: WS-Federation used on Microsoft products like Office365
-  - `wstrust-usernamemixed`: WS-trust user/password login used on CRM and Office365
-  - `delegation`: when calling the [Delegation endpoint](/api/authentication#delegation)
-  - `redirect-callback`: when a redirect rule is resumed
-* `stats`: an object containing specific user stats, like `stats.loginsCount`. Note that any of the counter variables returned as part of the `stats` object does not increase during [silent authentication](/api-auth/tutorials/silent-authentication) (as when `prompt=none`)
-* `sso`: this object will contain information about the SSO transaction (if available)
-  - `with_auth0`: when a user signs in with SSO to an application where the `Use Auth0 instead of the IdP to do Single Sign On` setting is enabled.
-  - `with_dbconn`: an SSO login for a user that logged in through a database connection.
-  - `current_clients`: client IDs using SSO.
-* `accessToken`: used to add custom namespaced claims to the `access_token`.
-* `idToken`: used to add custom namespaced claims to the `id_token`.
-* `sessionID`: unique id for the authentication session. Value is kept only if `prompt=none`
-* `request`: an object containing useful information of the request. It has the following properties:
-  - `userAgent`: the user-agent of the application that is trying to log in.
-  - `ip`: the originating IP address of the user trying to log in.
-  - `hostname`: the hostname that is being used for the authentication flow.
-  - `query`: an object containing the querystring properties of the login transaction sent by the application. 
-  - `body`: the body of the POST request on login transactions used on `oauth2-resource-owner`, `oauth2-resource-owner-jwt-bearer` or `wstrust-usernamemixed` protocols.
-  - `geoip`: an object containing geographic IP information. It has the following properties:
-    - `country_code`: a two-character code for the country associated with the IP address
-    - `country_code3`: a three-character code for the country associated with the IP address
-    - `country_name`: the country name associated with the IP address
-    - `city_name`: the city or town name associated with the IP address
-    - `latitude`: the latitude associated with the IP address.
-    - `longitude`: the longitude associated with the IP address.
-    - `time_zone`: the timezone associated with the IP address.
-    - `continent_code`: a two-character code for the continent associated with the IP address.
+This article lists all properties that the `context` object includes. For examples on how to use them see [Rules Examples](/rules#examples).
 
-## Sample Object
+## List of properties
+
+The following properties are available for the `context` object.
+
+| Name | Description |
+|-|-|
+| `clientID` | The client id of the application the user is logging in to. |
+| `clientName` | The name of the application (as defined on the dashboard). |
+| `clientMetadata` | An object for holding other application properties. Its keys and values are strings. |
+| `connection` | The name of the connection used to authenticate the user (such as: `twitter` or `some-google-apps-domain`) |
+| `connectionStrategy` | The type of connection. For social connection `connectionStrategy` === `connection`. For enterprise connections, the strategy will be `waad` (Windows Azure AD), `ad` (Active Directory/LDAP), `auth0` (database connections), and so on.
+| `samlConfiguration` | An object that controls the behavior of the SAML and WS-Fed endpoints. Useful for advanced claims mapping and token enrichment (only available for `samlp` and `wsfed` protocol). |
+| `protocol` | <%= include('../_context-protocol.md') %> |
+| `stats` | An object containing specific user stats, like `stats.loginsCount`. Note that any of the counter variables returned as part of the `stats` object does not increase during [silent authentication](/api-auth/tutorials/silent-authentication) (as when `prompt=none`). |
+| `sso` | <%= include('../_context-sso.md') %> |
+| `accessToken` | Used to add custom namespaced claims to the [Access Token](/tokens/access-token). |
+| `idToken` | Used to add custom namespaced claims to the [ID Token](/tokens/id-token). |
+| `sessionID` | Unique id for the authentication session. Value is kept only if `prompt=none`.
+| `request` | <%= include('../_context-request.md') %> |
+
+## Sample contents
 
 ```js
 {

--- a/articles/rules/current/context.md
+++ b/articles/rules/current/context.md
@@ -20,14 +20,14 @@ The following properties are available for the `context` object.
 | `clientName` | The name of the application (as defined on the dashboard). |
 | `clientMetadata` | An object for holding other application properties. Its keys and values are strings. |
 | `connection` | The name of the connection used to authenticate the user (such as: `twitter` or `some-google-apps-domain`) |
-| `connectionStrategy` | The type of connection. For social connection `connectionStrategy` === `connection`. For enterprise connections, the strategy will be `waad` (Windows Azure AD), `ad` (Active Directory/LDAP), `auth0` (database connections), and so on.
+| `connectionStrategy` | The type of connection. For social connection `connectionStrategy` === `connection`. For enterprise connections, the strategy will be `waad` (Windows Azure AD), `ad` (Active Directory/LDAP), `auth0` (database connections), and so on. |
 | `samlConfiguration` | An object that controls the behavior of the SAML and WS-Fed endpoints. Useful for advanced claims mapping and token enrichment (only available for `samlp` and `wsfed` protocol). |
 | `protocol` | <%= include('./_context-protocol.md') %> |
 | `stats` | An object containing specific user stats, like `stats.loginsCount`. Note that any of the counter variables returned as part of the `stats` object does not increase during [silent authentication](/api-auth/tutorials/silent-authentication) (as when `prompt=none`). |
 | `sso` | <%= include('./_context-sso.md') %> |
 | `accessToken` | Used to add custom namespaced claims to the [Access Token](/tokens/access-token). |
 | `idToken` | Used to add custom namespaced claims to the [ID Token](/tokens/id-token). |
-| `sessionID` | Unique id for the authentication session. Value is kept only if `prompt=none`.
+| `sessionID` | Unique id for the authentication session. Value is kept only if `prompt=none`. |
 | `request` | <%= include('./_context-request.md') %> |
 
 ## Sample contents


### PR DESCRIPTION
This huge list of bullets bugs me for some time now. Replacing with a table (and doing some other changes along the way). Using partials for the multiline descriptions so the markdown is more readable.