### PR TITLE
Added a space in the README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is the repository for the Auth0 documentation.
 **Please review the [Contributing Guidelines](CONTRIBUTING.md) before sending a PR or opening an issue.**
 
 ## Running the Docs Site
-You can run and test the docs site locally (you will need access - only employees). For instructions on running the site and testing see the [README](https://github.com/auth0/auth0-docs/blob/master/README.md)(requires Auth0 team access).
+You can run and test the docs site locally (you will need access - only employees). For instructions on running the site and testing see the [README](https://github.com/auth0/auth0-docs/blob/master/README.md) (requires Auth0 team access).
 
 ## Issue Reporting
 


### PR DESCRIPTION
Added a space in the README.md file, after the URL for the README.md location but before the parens mentioning Auth0 team access.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
