### PR TITLE
Fix Golang jwks multi-key logic error

### DIFF
--- a/articles/quickstart/backend/golang/01-authorization.md
+++ b/articles/quickstart/backend/golang/01-authorization.md
@@ -124,10 +124,9 @@ func getPemCert(token *jwt.Token) (string, error) {
 		return cert, err
 	}
 
-	x5c := jwks.Keys[0].X5c
-	for k, v := range x5c {
+	for k, _ := range jwks.Keys {
 		if token.Header["kid"] == jwks.Keys[k].Kid {
-			cert = "-----BEGIN CERTIFICATE-----\n" + v + "\n-----END CERTIFICATE-----"
+			cert = "-----BEGIN CERTIFICATE-----\n" + jwks.Keys[k].X5c[0] + "\n-----END CERTIFICATE-----"
 		}
 	}
 


### PR DESCRIPTION
The present logic is very broken.  It steps through indexes (just "0") of the *certificate chain* of the first key (Keys[0].X5c) in the response.  It then uses those indexes to look at *each key in the response* (red flag!) and compare the kid attribute of that key, and on a match, it uses the *value offset* of the *certificate chain* to populate the match.

Using the range of one slice to walk through an entirely different slice can, of course, cause out-of-bounds crashes (if there was 1 key with 2 certificates in the chain, not that that is likely). 

The other big issues is that this doesn't actually handle multiple keys, e.g.
```{"keys":[{"kid":"mykey1", "x5c":["cert1"]},{"kid":"mykey2", "x5c":["cert2"]}]}```
e.g. during key rotations if two keys are present.  My proposed code now steps through the *keys*, and uses the first cert in the chain for the PEM (if there ever was a second certificate in the chain, it would be ignored, which I believe should be fine.)

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
