### PR TITLE
Fix broken link

### DIFF
--- a/articles/quickstart/spa/_includes/_getting_started.md
+++ b/articles/quickstart/spa/_includes/_getting_started.md
@@ -2,7 +2,7 @@
 
 This guide walks you through setting up authentication and authorization in your ${library} apps with Auth0. If you are new to Auth0, check our [Overview](/overview). For a complete picture of authentication and authorization for all Single Page Applications, check our [SPA + API documentation](/architecture-scenarios/application/spa-api).
 
-Auth0 uses OAuth. If you want to learn more about the OAuth flows used by Single Page Applications, read about [Authentication for Client-side Web Apps](/client-auth/current/client-side-web).
+Auth0 uses OAuth. If you want to learn more about the OAuth flows used by Single Page Applications, read about [Authentication for Client-side Web Apps](/application-auth/current/client-side-web).
 
 <%= include('../../../_includes/_new_app') %>
 


### PR DESCRIPTION
Fixing broken link pointing to https://auth0.com/docs/client-auth/current/client-side-web. It looks like the article moved to https://auth0.com/docs/application-auth/current/client-side-web.
