### PR TITLE
Section Folders

### DIFF
--- a/config/sections.yml
+++ b/config/sections.yml
@@ -7,6 +7,8 @@
 - id: "articles"
   title: "Articles"
   url: "/getting-started"
+  folder: "articles"
+  default: true
 
 # - id: "sdks"
 #   title: "SDKs"
@@ -15,15 +17,19 @@
 - id: "apis"
   title: "Auth0 APIs"
   url: "/api/info"
+  folder: "articles/apis"
 
 - id: "quickstarts"
   title: "QuickStarts"
   url: "/quickstarts"
+  folder: "articles/quickstart"
 
 - id: "libraries"
   title: "Libraries"
   url: "/libraries"
+  folder: "articles/libraries"
 
 - id: "appliance"
   title: "PSaaS Appliance"
   url: "/appliance"
+  folder: "articles/appliance"


### PR DESCRIPTION
This adds relative folder paths to sections to help classify articles automatically based off their location.

Default set to true makes it the default section an article lives under if it doesn't match a sections path