### PR TITLE
Fixing highlighting + line length by removing code block

### DIFF
--- a/articles/migrations/guides/legacy-lock-api-deprecation.md
+++ b/articles/migrations/guides/legacy-lock-api-deprecation.md
@@ -178,11 +178,7 @@ Tenants created after Dec 27, 2017 were not allowed to begin usage of these depr
 
 ### Bookmarking the login page
 
-Bookmarking the Universal Login page is not supported. If a user bookmarks the login page and attempts to initiate authentication by going directly to the bookmarked URL instead of starting from the application, the following error message will be shown:
-
-```
-Password login is disabled for clients using externally hosted login pages with oidc_conformant flag set
-```
+Bookmarking the Universal Login page is not supported. If a user bookmarks the login page and attempts to initiate authentication by going directly to the bookmarked URL instead of starting from the application, the following error message will be shown: `Password login is disabled for clients using externally hosted login pages with oidc_conformant flag set`.
 
 ### Fingerprinting error
 


### PR DESCRIPTION
Line of text was getting highlighting, can fix by declaring it text, but you have to scroll sideways to see the whole message in the code block, so just ditched the code block altogether.

https://auth0-docs-content-pr-6155.herokuapp.com/docs/migrations/guides/legacy-lock-api-deprecation#bookmarking-the-login-page