### PR TITLE
Fix file name for non-interactive clients

### DIFF
--- a/articles/applications/application-settings/index.yml
+++ b/articles/applications/application-settings/index.yml
@@ -5,9 +5,9 @@ versioning:
     - native
     - single-page-app
     - regular-web-app
-    - non-interactive
+    - machine-to-machine
   defaultArticles:
     native: index
     single-page-app: index
     regular-web-app: index
-    non-interactive: index
+    machine-to-machine: index

--- a/articles/applications/application-settings/machine-to-machine/index.md
+++ b/articles/applications/application-settings/machine-to-machine/index.md
@@ -1,6 +1,5 @@
 ---
 description: Application settings for Machine to Machine Applications
-url: /applications/application-settings/non-interactive
 toc: true
 ---
 

--- a/config/redirects.js
+++ b/config/redirects.js
@@ -1756,5 +1756,9 @@ module.exports = [
   {
     from: '/videos/session-and-cookies',
     to: '/security/store-tokens#understanding-sessions-and-cookies'
+  },
+  {
+    from: '/applications/application-settings/non-interactive',
+    to: '/applications/application-settings/machine-to-machine'
   }
 ];


### PR DESCRIPTION
Non-interactive clients are now machine-to-machine applications

https://auth0-docs-content-pr-6182.herokuapp.com/docs/applications/application-settings/machine-to-machine