### PR TITLE
Fixing broken image URL

### DIFF
--- a/articles/design/creating-invite-only-applications.md
+++ b/articles/design/creating-invite-only-applications.md
@@ -46,7 +46,7 @@ Since this application needs to access the [Management API](/api/v2), you'll nee
 * Use the **down arrow** to open up the scopes selection area. Select the following scopes: `read:users`, `update:users`, `delete:users`, `create:users`, and `create:user_tickets`.
 * Click **Update**.
 
-![Authorize Application](/media/articles/invite-only/invite-only-authorize-application.png)
+![Authorize Application](/media/articles/invite-only/invite-only-authorize-client.png)
 
 ### Import Users
 


### PR DESCRIPTION
https://auth0-docs-content-pr-6188.herokuapp.com/docs/design/creating-invite-only-applications

Image was broken (just above the heading "Import Users") - possibly because of errant find-replace client->application? In the future we should rework the images in these pages to match current dashboard, but just fixing the broken URL for now.
