### PR TITLE
search user v3: include a new breaking change

### DIFF
--- a/articles/users/search/v3/index.md
+++ b/articles/users/search/v3/index.md
@@ -164,6 +164,7 @@ The user search engine v2 will be deprecated soon, so we recommend migrating use
 * v3 limits the number of users you can retrieve to 1000. See [page results](#page-results).
 * You can search for strings in `app_metadata`/`user_metadata` arrays, but not in nested `app_metadata`/`user_metadata` fields. See [searchable fields](/users/search/v3/query-syntax#searchable-fields).
 * User fields are not tokenized like in v2, so `user_id:auth0` will not match a `user_id` with value `auth0|12345`, instead, use `user_id:auth0*`. See [wildcards](/users/search/v3/query-syntax#wildcards) and [exact matching](/users/search/v3/query-syntax#exact-match).
+* The `_missing_` filter is not supported, consider using `NOT _exists_:...` instead.
 
 ### Queries to migrate
 


### PR DESCRIPTION
I updated the migration guide saying that the `_missing_` filter is not supported in v3.

![image](https://user-images.githubusercontent.com/178506/40386517-509a8c6a-5de0-11e8-973d-041ae129de70.png)

https://auth0-docs-content-pr-6190.herokuapp.com/docs/users/search/v3#migrate-from-search-engine-v2-to-v3