### PR TITLE
Replace auth0Domain with custom domain

### DIFF
--- a/articles/custom-domains/additional-configuration.md
+++ b/articles/custom-domains/additional-configuration.md
@@ -43,7 +43,7 @@ var lock = new Auth0Lock(config.clientID, config.auth0Domain, {
   configurationBaseUrl: config.clientConfigurationBaseUrl,
   overrides: {
   	__tenant: config.auth0Tenant,
-  	__token_issuer: config.auth0Domain
+  	__token_issuer: 'YOUR_CUSTOM_DOMAIN'
   },
   //code omitted for brevity
 });
@@ -58,7 +58,7 @@ var webAuth = new new auth0.WebAuth({
   //code omitted for brevity
   overrides: {
   	__tenant: config.auth0Tenant,
-  	__token_issuer: config.auth0Domain
+  	__token_issuer: 'YOUR_CUSTOM_DOMAIN'
   },
   //code omitted for brevity
 });


### PR DESCRIPTION
Auth0 Lock and WebAuth classes need to be initialized with the token issuer set to the user's custom domain, not config.auth0Domain in the Additional Configuration for Custom Domains docs.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
