### PR TITLE
Specify Node.js 8.10 as Lambda Runtime

### DIFF
--- a/articles/integrations/aws-api-gateway/custom-authorizers/part-3.md
+++ b/articles/integrations/aws-api-gateway/custom-authorizers/part-3.md
@@ -159,7 +159,7 @@ Now that you've configured your custom authorizer for your environment and teste
 | - | - |
 | **Name** | A name for your Lambda function, such as `jwtRsaCustomAuthorizer` |
 | **Description** | A description for your Lambda function (optional) |
-| **Runtime** | Select `Node.js 4.3` |
+| **Runtime** | Select `Node.js 8.10` |
 
 ![](/media/articles/integrations/aws-api-gateway-2/part-2/pt2-14.png)
 


### PR DESCRIPTION
`Node.js 4.3` is being deprecated by AWS.

[Code sample](https://github.com/auth0-samples/jwt-rsa-aws-custom-authorizer/pull/5) already updated for `8.10`.

[Zendesk Ticket #41576](https://auth0.zendesk.com/agent/tickets/41576)
