### PR TITLE
Fixing a broken link

### DIFF
--- a/articles/migrations/guides/legacy-lock-api-deprecation.md
+++ b/articles/migrations/guides/legacy-lock-api-deprecation.md
@@ -166,7 +166,7 @@ The deprecation does not require any changes for [logout](/logout), but if a cus
 
 ### How to tell if you have deprecated usage
 
-Please take a look at the [Deprecation Error Reference](/articles/errors/deprecation-errors) to assist with verifying that your application does, or does not, use deprecated features.
+Please take a look at the [Deprecation Error Reference](/errors/deprecation-errors) to assist with verifying that your application does, or does not, use deprecated features.
 
 ### How to test whether you are ready before the removal of service date
 


### PR DESCRIPTION
https://auth0-docs-content-pr-6233.herokuapp.com/docs/migrations/guides/legacy-lock-api-deprecation#how-to-tell-if-you-have-deprecated-usage

Broken link fix (to deprecation errors doc)