### PR TITLE
Update ASP.NET Core samples for .NET Core 2.1

### DIFF
--- a/articles/quickstart/backend/aspnet-core-webapi/01-authorization.md
+++ b/articles/quickstart/backend/aspnet-core-webapi/01-authorization.md
@@ -11,9 +11,10 @@ budicon: 500
   repo: 'auth0-aspnetcore-webapi-samples',
   path: 'Quickstart/01-Authorization',
   requirements: [
-    '.NET Core 2.0',
-    'ASP.NET Core 2.0',
-    'Visual Studio 2017 (Optional)',
+    '.NET Core SDK 2.1.300',
+    '.NET Core 2.1.0',
+    'ASP.NET Core 2.1.0',
+    'Visual Studio 2017 15.7 (Optional)',
     'Visual Studio Code (Optional)'
   ]
 }) %>

--- a/articles/quickstart/webapp/aspnet-core/00-intro.md
+++ b/articles/quickstart/webapp/aspnet-core/00-intro.md
@@ -7,9 +7,9 @@ budicon: 715
 
 ::: panel System requirements
 This tutorial and seed project have been tested with the following:
-* .NET Core SDK 2.0
-* .NET Core 2.0
-* ASP.NET Core 2.0
+* .NET Core SDK 2.1.300
+* .NET Core 2.1.0
+* ASP.NET Core 2.1.0
 
 To complete this tutorial, you can use command line tools and any code editor. Alternatively, you can use Microsoft Visual Studio 2017 Update 3. For more details on how to use .NET Core on your platform, read the [.NET Core](https://www.microsoft.com/net/core) documentation.
 :::

--- a/articles/quickstart/webapp/aspnet-core/01-login.md
+++ b/articles/quickstart/webapp/aspnet-core/01-login.md
@@ -10,9 +10,9 @@ budicon: 448
   path: 'Quickstart/01-Login',
   branch: 'master',
   requirements: [
-    '.NET Core SDK 2.0',
-    '.NET Core 2.0',
-    'ASP.NET Core 2.0'
+    '.NET Core SDK 2.1.300',
+    '.NET Core 2.1.0',
+    'ASP.NET Core 2.1.0'
   ]
 }) %>
 

--- a/articles/quickstart/webapp/aspnet-core/02-user-profile.md
+++ b/articles/quickstart/webapp/aspnet-core/02-user-profile.md
@@ -10,9 +10,9 @@ budicon: 292
   path: 'Quickstart/02-User-Profile',
   branch: 'master',
   requirements: [
-    '.NET Core SDK 2.0',
-    '.NET Core 2.0',
-    'ASP.NET Core 2.0'
+    '.NET Core SDK 2.1.300',
+    '.NET Core 2.1.0',
+    'ASP.NET Core 2.1.0'
   ]
 }) %>
 
@@ -65,6 +65,8 @@ You must update the list of scopes to request the `profile` scope. The user's pr
 ```csharp
 public void ConfigureServices(IServiceCollection services)
 {
+    // Some code omitted for brevity...
+
     // Add authentication services
     services.AddAuthentication(options => {
         options.DefaultAuthenticateScheme = CookieAuthenticationDefaults.AuthenticationScheme;

--- a/articles/quickstart/webapp/aspnet-core/03-authorization.md
+++ b/articles/quickstart/webapp/aspnet-core/03-authorization.md
@@ -10,9 +10,9 @@ budicon: 546
   path: 'Quickstart/03-Authorization',
   branch: 'master',
   requirements: [
-    '.NET Core SDK 2.0',
-    '.NET Core 2.0',
-    'ASP.NET Core 2.0'
+    '.NET Core SDK 2.1.300',
+    '.NET Core 2.1.0',
+    'ASP.NET Core 2.1.0'
   ]
 }) %>
 
@@ -72,6 +72,8 @@ Configure the OIDC authentication handler registration inside your ASP.NET appli
 ```csharp
 public void ConfigureServices(IServiceCollection services)
 {
+    // Some code omitted for brevity...
+
     // Add authentication services
     services.AddAuthentication(options => {
         options.DefaultAuthenticateScheme = CookieAuthenticationDefaults.AuthenticationScheme;

--- a/articles/quickstart/webapp/aspnet-core/_includes/_login.md
+++ b/articles/quickstart/webapp/aspnet-core/_includes/_login.md
@@ -26,6 +26,13 @@ In the code sample below, only the `openid` scope is requested.
 
 public void ConfigureServices(IServiceCollection services)
 {
+    services.Configure<CookiePolicyOptions>(options =>
+    {
+        // This lambda determines whether user consent for non-essential cookies is needed for a given request.
+        options.CheckConsentNeeded = context => true;
+        options.MinimumSameSitePolicy = SameSiteMode.None;
+    });
+
     // Add authentication services
     services.AddAuthentication(options => {
         options.DefaultAuthenticateScheme = CookieAuthenticationDefaults.AuthenticationScheme;
@@ -83,7 +90,8 @@ public void ConfigureServices(IServiceCollection services)
     });
 
     // Add framework services.
-    services.AddMvc();
+    services.AddMvc()
+        .SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
 }
 ```
 
@@ -101,9 +109,12 @@ public void Configure(IApplicationBuilder app, IHostingEnvironment env)
     else
     {
         app.UseExceptionHandler("/Home/Error");
+        app.UseHsts();
     }
 
+    app.UseHttpsRedirection();
     app.UseStaticFiles();
+    app.UseCookiePolicy();
 
     app.UseAuthentication();
 
@@ -129,6 +140,8 @@ In the configuration for the `OpenIdConnectOptions` object, handle the `OnRedire
 
 public void ConfigureServices(IServiceCollection services)
 {
+    // Some code omitted for brevity...
+
     services.AddAuthentication(options => {
         options.DefaultAuthenticateScheme = CookieAuthenticationDefaults.AuthenticationScheme;
         options.DefaultSignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;
@@ -201,10 +214,11 @@ In the `Startup.cs` file, update the call to `AddOpenIdConnect` with the followi
 
 ```csharp
 // Startup.cs
-// some code was omitted for brevity...
 
 public void ConfigureServices(IServiceCollection services)
 {
+    // Some code omitted for brevity...
+
     // Add authentication services
     services.AddAuthentication(options => {
         options.DefaultAuthenticateScheme = CookieAuthenticationDefaults.AuthenticationScheme;
@@ -310,6 +324,8 @@ You may want to Access Tokens received from Auth0. For example, you can use the 
 
 public void ConfigureServices(IServiceCollection services)
 {
+    // Some code omitted for brevity...
+
     // Add authentication services
     services.AddAuthentication(options => {
         options.DefaultAuthenticateScheme = CookieAuthenticationDefaults.AuthenticationScheme;


### PR DESCRIPTION
All the ASP.NET Core sample code has been updated to .NET Core 2.1. This PR makes the necessary updates to the Quickstart docs.

After this has been merged and the docs deployed, I will merge the following PRs:
* https://github.com/auth0-samples/auth0-aspnetcore-mvc-samples/pull/36
* https://github.com/auth0-samples/auth0-aspnetcore-webapi-samples/pull/24