### PR TITLE
Add paid plan requirement for custom domains

### DIFF
--- a/articles/custom-domains/index.md
+++ b/articles/custom-domains/index.md
@@ -13,7 +13,8 @@ Using custom domains with universal login is the most seamless and secure experi
 
 ## Prerequisites
 
-You'll need to register and own the domain name to which you're mapping your Auth0 domain.
+* You'll need a paid Auth0 plan. Custom domains are not available to free plans.
+* You'll need to register and own the domain name to which you're mapping your Auth0 domain.
 
 ## Features supporting use of custom domains
 

--- a/articles/custom-domains/index.md
+++ b/articles/custom-domains/index.md
@@ -13,8 +13,8 @@ Using custom domains with universal login is the most seamless and secure experi
 
 ## Prerequisites
 
-* You'll need a paid Auth0 plan. Custom domains are not available to free plans.
-* You'll need to register and own the domain name to which you're mapping your Auth0 domain.
+* This feature is not available for free plans. To configure a custom domain you have to [upgrade your account to any paid plan](${manage_url}/#/tenant/billing/subscription)
+* You must register and own the domain name to which you are mapping your Auth0 domain
 
 ## Features supporting use of custom domains
 


### PR DESCRIPTION
The custom domains settings UI for free accounts informs you that you need to "upgrade your account to any paid plan", but no mention is made of this in the documentation.

I do not know if this change requires an update to the version number (it doesn't look like the page is currently versioned), and I presume it does not need an entry in the update feed?

Should my change use the word "subscription" rather than "plan"? I've copied the wording from the management console, but the contributing guidelines seem to suggest the word "subscription".

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
