### PR TITLE
fix architecture-scenarios URLs

### DIFF
--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -26,79 +26,79 @@ articles:
 
     children:
       - title: SSO for Regular Web Apps
-        url: /architecture-scenarios/application/web-app-sso
+        url: /architecture-scenarios/web-app-sso
         children:
            - title: Solution Overview
-             url: /architecture-scenarios/application/web-app-sso/part-1
+             url: /architecture-scenarios/web-app-sso/part-1
            
            - title: Configuration
-             url: /architecture-scenarios/application/web-app-sso/part-2
+             url: /architecture-scenarios/web-app-sso/part-2
            
            - title: Implementation
-             url: /architecture-scenarios/application/web-app-sso/part-3
+             url: /architecture-scenarios/web-app-sso/part-3
            
            - title: Conclusion
-             url: /architecture-scenarios/application/web-app-sso/part-4
+             url: /architecture-scenarios/web-app-sso/part-4
 
       - title: Server Application + API
-        url: /architecture-scenarios/application/server-api
+        url: /architecture-scenarios/server-api
         children:
            - title: Solution Overview
-             url: /architecture-scenarios/application/server-api/part-1
+             url: /architecture-scenarios/server-api/part-1
            
            - title: Configuration
-             url: /architecture-scenarios/application/server-api/part-2
+             url: /architecture-scenarios/server-api/part-2
            
            - title: Implementation
-             url: /architecture-scenarios/application/server-api/part-3
+             url: /architecture-scenarios/server-api/part-3
            
            - title: Conclusion
-             url: /architecture-scenarios/application/server-api/part-4
+             url: /architecture-scenarios/server-api/part-4
 
       - title: SPA + API
-        url: /architecture-scenarios/application/spa-api
+        url: /architecture-scenarios/spa-api
         children:
            - title: Solution Overview
-             url: /architecture-scenarios/application/spa-api/part-1
+             url: /architecture-scenarios/spa-api/part-1
            
            - title: Configuration
-             url: /architecture-scenarios/application/spa-api/part-2
+             url: /architecture-scenarios/spa-api/part-2
            
            - title: Implementation
-             url: /architecture-scenarios/application/spa-api/part-3
+             url: /architecture-scenarios/spa-api/part-3
            
            - title: Conclusion
-             url: /architecture-scenarios/application/spa-api/part-4
+             url: /architecture-scenarios/spa-api/part-4
 
       - title: Mobile + API
-        url: /architecture-scenarios/application/mobile-api
+        url: /architecture-scenarios/mobile-api
         children:
            - title: Solution Overview
-             url: /architecture-scenarios/application/mobile-api/part-1
+             url: /architecture-scenarios/mobile-api/part-1
            
            - title: Configuration
-             url: /architecture-scenarios/application/mobile-api/part-2
+             url: /architecture-scenarios/mobile-api/part-2
            
            - title: Implementation
-             url: /architecture-scenarios/application/mobile-api/part-3
+             url: /architecture-scenarios/mobile-api/part-3
            
            - title: Conclusion
-             url: /architecture-scenarios/application/mobile-api/part-4
+             url: /architecture-scenarios/mobile-api/part-4
 
       # - title: SAML for Regular Web Apps
-      #   url: /architecture-scenarios/application/web-saml
+      #   url: /architecture-scenarios/web-saml
 
       # - title: B2B + B2E
-      #   url: /architecture-scenarios/business/b2b-b2e
+      #   url: /architecture-scenarios/b2b-b2e
 
       # - title: B2B
-      #   url: /architecture-scenarios/business/b2b
+      #   url: /architecture-scenarios/b2b
 
       # - title: B2C
-      #   url: /architecture-scenarios/business/b2c
+      #   url: /architecture-scenarios/b2c
 
       # - title: B2E
-      #   url: /architecture-scenarios/business/b2e 
+      #   url: /architecture-scenarios/b2e 
 
   - title: "Applications"
     url: "/applications"


### PR DESCRIPTION
We re-organized the folders yesterday but forgot to update the sidebar, hence broken links. 
This fixes that.