### PR TITLE
revert update

### DIFF
--- a/config/sections.yml
+++ b/config/sections.yml
@@ -7,7 +7,7 @@
 - id: "articles"
   title: "Articles"
   url: "/getting-started"
-  folder: ""
+  folder: "articles"
   default: true
 
 # - id: "sdks"
@@ -17,19 +17,19 @@
 - id: "apis"
   title: "Auth0 APIs"
   url: "/api/info"
-  folder: "api"
+  folder: "articles/apis"
 
 - id: "quickstarts"
   title: "QuickStarts"
   url: "/quickstarts"
-  folder: "quickstart"
+  folder: "articles/quickstart"
 
 - id: "libraries"
   title: "Libraries"
   url: "/libraries"
-  folder: "libraries"
+  folder: "articles/libraries"
 
 - id: "appliance"
   title: "PSaaS Appliance"
   url: "/appliance"
-  folder: "appliance"
+  folder: "articles/appliance"


### PR DESCRIPTION
When you click on any sidebar entry that contains the word "API" you get redirected to the Auth0 APIs section.
Reverting the changes of PR https://github.com/auth0/docs/pull/6165 to see if this fixes it.
