### PR TITLE
add rate limit warning and other metadata

### DIFF
--- a/articles/connections/passwordless/regular-web-app-email-code.md
+++ b/articles/connections/passwordless/regular-web-app-email-code.md
@@ -1,7 +1,13 @@
 ---
 title: Using Passwordless Authentication with a one-time code via email on Regular Web Apps
+description: How to authenticate users with a one-time code via email in a traditional web app that runs on the server
+toc: true
 ---
 # Passwordless Authentication with a one-time code via e-mail on Regular Web Apps
+
+:::warning
+Passwordless is designed to be called from the client-side, and has a [rate limit](/policies/rate-limits#authentication-api) of 50 requests per hour per IP. If you call it from the server-side, your backend's IP may easily hit these rate limits.
+:::
 
 <%= include('_introduction-email', { isMobile: false }) %>
 

--- a/articles/connections/passwordless/regular-web-app-email-link.md
+++ b/articles/connections/passwordless/regular-web-app-email-link.md
@@ -1,7 +1,13 @@
 ---
 title: Using Passwordless Authentication with a magic link via email on Regular Web Apps
+description: How to authenticate users with a magic link via email in a traditional web app that runs on the server
+toc: true
 ---
 # Passwordless Authentication with a magic link via e-mail on Regular Web Apps
+
+:::warning
+Passwordless is designed to be called from the client-side, and has a [rate limit](/policies/rate-limits#authentication-api) of 50 requests per hour per IP. If you call it from the server-side, your backend's IP may easily hit these rate limits.
+:::
 
 <%= include('_introduction-email-magic-link') %>
 

--- a/articles/connections/passwordless/regular-web-app-sms.md
+++ b/articles/connections/passwordless/regular-web-app-sms.md
@@ -1,7 +1,13 @@
 ---
 title: Using Passwordless Authentication in a Regular Web App with SMS
+description: How to authenticate users with a one-time code via SMS in a traditional web app that runs on the server
+toc: true
 ---
 # Authenticate users with a one-time code via SMS in a Regular Web App
+
+:::warning
+Passwordless is designed to be called from the client-side, and has a [rate limit](/policies/rate-limits#authentication-api) of 50 requests per hour per IP. If you call it from the server-side, your backend's IP may easily hit these rate limits.
+:::
 
 <%= include('_introduction-sms', { isMobile: false }) %>
 
@@ -13,7 +19,7 @@ title: Using Passwordless Authentication in a Regular Web App with SMS
 
 ## Implementation
 
-### Use Lock (the Auth0 UI widget)
+### Use Lock
 
 <%= include('_init-passwordless-lock') %>
 


### PR DESCRIPTION
Based on ticket "37456 | Too many Requests response on passwordless/start endpoint"
