### PR TITLE
Add Tableau Online SSO Integration Configuration

### DIFF
--- a/articles/protocols/saml/saml-apps/index.md
+++ b/articles/protocols/saml/saml-apps/index.md
@@ -27,6 +27,7 @@ classes: topic-page
   'protocols/saml/saml-apps/litmos',
   'protocols/saml/saml-apps/pluralsight',
   'protocols/saml/saml-apps/sprout-video',
+  'protocols/saml/saml-apps/tableau-online',
   'protocols/saml/saml-apps/tableau-server',
   'protocols/saml/saml-apps/workday',
   'protocols/saml/saml-apps/workpath'

--- a/articles/protocols/saml/saml-apps/tableau-online.md
+++ b/articles/protocols/saml/saml-apps/tableau-online.md
@@ -1,0 +1,33 @@
+---
+title: Tableau Online SAML Configuration
+description: Tableau Online SAML Configuration
+---
+
+${include('./_header')}
+
+```json
+{
+ "audience":  "https://sso.online.tableau.com/public/sp/metadata?alias={YOUR TABLEAU ALIAS}",
+ "recipient": "https://sso.online.tableau.com/public/sp/SSO?alias={YOUR TABLEAU ALIAS}",
+ "mappings": {
+    "email": "Email"
+ },
+ "createUpnClaim":       false,
+ "passthroughClaimsWithNoMapping": false,
+ "mapUnknownClaimsAsIs": false,
+ "mapIdentities":        false,
+ "signatureAlgorithm":   "rsa-sha1",
+ "digestAlgorithm":      "sha1",
+ "destination":          "https://sso.online.tableau.com/public/sp/SSO?alias={YOUR TABLEAU ALIAS}",
+ "lifetimeInSeconds":    3600,
+ "signResponse":         false,
+ "nameIdentifierFormat": "urn:oasis:names:tc:SAML:2.0:attrname-format:basic",
+ "nameIdentifierProbes": [
+   "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"
+ ]
+}
+```
+
+The **Callback URL** is `https://sso.online.tableau.com/public/sp/SSO?alias={YOUR TABLEAU ALIAS}`.
+
+See https://onlinehelp.tableau.com/current/online/en-us/saml_config_site.htm for more information.

--- a/articles/protocols/saml/saml-apps/tableau-online.md
+++ b/articles/protocols/saml/saml-apps/tableau-online.md
@@ -30,4 +30,4 @@ ${include('./_header')}
 
 The **Callback URL** is `https://sso.online.tableau.com/public/sp/SSO?alias={YOUR TABLEAU ALIAS}`.
 
-See https://onlinehelp.tableau.com/current/online/en-us/saml_config_site.htm for more information.
+See [https://onlinehelp.tableau.com/current/online/en-us/saml_config_site.htm](https://onlinehelp.tableau.com/current/online/en-us/saml_config_site.htm) for more information.


### PR DESCRIPTION
This PR adds a `saml-apps` page for configuring Tableau Online, and adds a link to the index.