### PR TITLE
Update link to to point to #authorize-application

### DIFF
--- a/articles/api-auth/intro.md
+++ b/articles/api-auth/intro.md
@@ -198,7 +198,7 @@ Native applications need to use Universal Login (with an Auth0-hosted login page
 To use the new pipeline, at least one of the following should apply:
 
 - The application is flagged as __OIDC Conformant__, or
-- The `audience` parameter is set in the [/authorize](/api/authentication#authorize-client) or [/token](/api/authentication#get-token) endpoints
+- The `audience` parameter is set in the [/authorize](/api/authentication#authorize-application) or [/token](/api/authentication#get-token) endpoints
 
 If none of these applies, then the legacy flows will be used.
 

--- a/articles/api-auth/tutorials/silent-authentication.md
+++ b/articles/api-auth/tutorials/silent-authentication.md
@@ -14,7 +14,7 @@ However, redirecting users away from your application is usually considered disr
 
 ## Initiate a Silent Authentication request
 
-To initiate a silent authentication request, add the `prompt=none` parameter when you redirect a user to the [`/authorize` endpoint of Auth0's authentication API](/api/authentication#authorize-client).
+To initiate a silent authentication request, add the `prompt=none` parameter when you redirect a user to the [`/authorize` endpoint of Auth0's authentication API](/api/authentication#authorize-application).
 
 For example:
 

--- a/articles/connections/pass-parameters-to-idps.md
+++ b/articles/connections/pass-parameters-to-idps.md
@@ -123,7 +123,7 @@ Send the update request, copying the existing `options` contents and adding also
 }
 ```
 
-Now, when you call the [Authorize endpoint](/api/authentication#authorize-client) for a specific user, you can pass their email address in the `login_hint` parameter.
+Now, when you call the [Authorize endpoint](/api/authentication#authorize-application) for a specific user, you can pass their email address in the `login_hint` parameter.
 
 ```text
 https://${account.namespace}/authorize

--- a/articles/migrations/guides/calling-api-with-idtokens.md
+++ b/articles/migrations/guides/calling-api-with-idtokens.md
@@ -62,13 +62,13 @@ The Access Tokens used to access the Management API **must hold only one value a
 In this section we will see the changes that are introduced in how you get a token for the aforementioned endpoints. We will see sample scripts side-by-side so you can identify the changes.
 
 There are several variations on how you authenticate a user and get tokens, depending on the technology and the [OAuth 2.0 flow you use to authenticate](/api-auth/which-oauth-flow-to-use):
-- Using the [Authorization endpoint](/api/authentication#authorize-client). This is where you redirect your users to login or sign up. You get your tokens from this endpoint if you authenticate users from a [single-page app](/api/authentication#implicit-grant) (running on the browser).
+- Using the [Authorization endpoint](/api/authentication#authorize-application). This is where you redirect your users to login or sign up. You get your tokens from this endpoint if you authenticate users from a [single-page app](/api/authentication#implicit-grant) (running on the browser).
 - Using the [Token endpoint](/api/authentication#get-token).You get your tokens from this endpoint if you authenticate users from a [web app](/api/authentication#authorization-code) (running on a server), a [mobile app](/api/authentication#authorization-code-pkce-), a [server process](/api/authentication#client-credentials), or a [highly trusted app](/api/authentication#resource-owner-password).
 - Using [Lock](/libraries/lock/v11#cross-origin-authentication) or [auth0.js](/libraries/auth0js/v9#configure-your-auth0-application-for-embedded-login) embedded in your application. In this case you are using [cross-origin authentication](/cross-origin-authentication) (used to authenticate users when the requests come from different domains). 
 
 ### The Authorization endpoint
 
-In this section we will use an example to showcase the differences in how you get a token with the [Authorization endpoint](/api/authentication#authorize-client). Keep in mind though that no matter which endpoint you want to migrate, the changes are the same, the only thing that differs is the [scopes](#changes-in-scopes) you will specify in the request.
+In this section we will use an example to showcase the differences in how you get a token with the [Authorization endpoint](/api/authentication#authorize-application). Keep in mind though that no matter which endpoint you want to migrate, the changes are the same, the only thing that differs is the [scopes](#changes-in-scopes) you will specify in the request.
 
 In the example below, we want to use the [GET User by ID endpoint](/api/management/v2#!/Users/get_users_by_id) to retrieve the full profile information of the logged-in user. To do so, first we will authenticate our user (using the [Implicit grant](/api/authentication?http#implicit-grant)) and retrieve the token(s).
 

--- a/articles/migrations/guides/legacy-lock-api-deprecation.md
+++ b/articles/migrations/guides/legacy-lock-api-deprecation.md
@@ -146,7 +146,7 @@ The `getSSOData()` and `checkSession()` functions should only be used from a Sin
 
 * The Auth0.js v9 `getSSOData()` function will continue to work, but it now [behaves differently than in the past](/libraries/auth0js/v9/migration-v8-v9#review-calls-to-getssodata-).
 * In Auth0.js v9, `getSSOData()` will check if a user has an existing session and perform a further check to determine if the user is the same one as in the last interactive authentication transaction. This supports Lock’s feature of showing the last logged-in user to facilitate subsequent logins.
-* Invoking the `getSSOData()` function will now trigger a call to the [/authorize](/api/authentication#authorize-client) endpoint, which will in turn result in the execution of [rules](/rules).
+* Invoking the `getSSOData()` function will now trigger a call to the [/authorize](/api/authentication#authorize-application) endpoint, which will in turn result in the execution of [rules](/rules).
 
 ##### Polling for an existing session
 
@@ -158,7 +158,7 @@ The poll interval between checks to `checkSession()` should be at least 15 minut
 
 #### Web applications
 
-In "web applications", the backend typically has a session for the user. Over time, the application session may expire, in which case the application should renew the session. The application backend should invoke a call to the [/authorize](/api/authentication#authorize-client) endpoint to get a new token. If the Authorization Server (Auth0 in this case) still has a session for the user, the user will not have to re-enter their credentials to log in again. If Auth0 no longer has a session for the user, the user has to log in again.
+In "web applications", the backend typically has a session for the user. Over time, the application session may expire, in which case the application should renew the session. The application backend should invoke a call to the [/authorize](/api/authentication#authorize-application) endpoint to get a new token. If the Authorization Server (Auth0 in this case) still has a session for the user, the user will not have to re-enter their credentials to log in again. If Auth0 no longer has a session for the user, the user has to log in again.
 
 Customers with web applications which call the API from their backend should use this approach. Specifically, they should [call /oauth/token](/tokens/refresh-token/current#use-a-refresh-token) to renew their token.
 

--- a/articles/tokens/access-token.md
+++ b/articles/tokens/access-token.md
@@ -17,10 +17,10 @@ The Access Token should be used as a **Bearer** credential and transmitted in an
 
 Auth0 currently generates Access Tokens in two formats: as opaque strings or as [JSON Web Tokens (JWTs)](/jwt).
 
-This depends on the value that the **audience** parameter has in the [authorization request](/api/authentication#authorize-client).
+This depends on the value that the **audience** parameter has in the [authorization request](/api/authentication#authorize-application).
 
 ::: panel What is the audience?
-The **audience** is a parameter set during [authorization](/api/authentication#authorize-client), and it contains the unique identifier of the target API. This is how you tell Auth0 for which API to issue an Access Token (in other words, which is the intended *audience* of this token). If you do not want to access a custom API, then by setting the audience to `${account.namespace}/userinfo`, you can use the opaque Access Token to [retrieve the user's profile](/api/authentication#get-user-info).
+The **audience** is a parameter set during [authorization](/api/authentication#authorize-application), and it contains the unique identifier of the target API. This is how you tell Auth0 for which API to issue an Access Token (in other words, which is the intended *audience* of this token). If you do not want to access a custom API, then by setting the audience to `${account.namespace}/userinfo`, you can use the opaque Access Token to [retrieve the user's profile](/api/authentication#get-user-info).
 :::
 
 * If the **audience** is set to `${account.namespace}/userinfo`, then the Access Token will be an opaque string.
@@ -38,7 +38,7 @@ Remember always that the application should not depend on the Access Token to be
 
 ## How to get an Access Token
 
-Access Tokens are issued via Auth0's OAuth 2.0 endpoints: [/authorize](/api/authentication#authorize-client) and [/oauth/token](/api/authentication#get-token). You can use any OAuth 2.0-compatible library to obtain Access Tokens. If you do not already have a preferred OAuth 2.0 library, Auth0 provides libraries for many languages and frameworks that work seamlessly with our endpoints.
+Access Tokens are issued via Auth0's OAuth 2.0 endpoints: [/authorize](/api/authentication#authorize-application) and [/oauth/token](/api/authentication#get-token). You can use any OAuth 2.0-compatible library to obtain Access Tokens. If you do not already have a preferred OAuth 2.0 library, Auth0 provides libraries for many languages and frameworks that work seamlessly with our endpoints.
 
 ### Using the Authentication API
 
@@ -56,7 +56,7 @@ Access Tokens are issued via Auth0's OAuth 2.0 endpoints: [/authorize](/api/auth
 
 Access Tokens are typically obtained in order to access user-owned resources. For example, a Calendar application needs access to a Calendar API in the cloud in order to read the user's scheduled events and create new events.
 
-Such access is requested by the application and granted by the user, using the [Authorize endpoint](/api/authentication#authorize-client).
+Such access is requested by the application and granted by the user, using the [Authorize endpoint](/api/authentication#authorize-application).
 
 ```text
 https://${account.namespace}/authorize?


### PR DESCRIPTION
Update link to point to the right section of the auth explorer that changed after rename of Clients -> Applications