### PR TITLE
Remove Mgmt APIv2 effective dates from Rate Limits article

### DIFF
--- a/articles/policies/rate-limits.md
+++ b/articles/policies/rate-limits.md
@@ -65,8 +65,8 @@ The rate limits for this API defer depending on whether your tenant is free or p
 
 The following rate limits apply:
 
-- For all __free tenants__, usage of the Management API is restricted to 2 requests per second (and bursts up to 10 requests). This policy goes into effect on __Tuesday, September 12 at 1PM PT__.
-- For __non-production tenants__ of enterprise customers, usage of the Management API is restricted to 2 requests per second (and bursts up to 10 requests). This policy goes into effect on __Tuesday, September 19 at 1PM PT__.
+- For all __free tenants__, usage of the Management API is restricted to 2 requests per second (and bursts up to 10 requests).
+- For __non-production tenants__ of enterprise customers, usage of the Management API is restricted to 2 requests per second (and bursts up to 10 requests).
 - For __paid__ tenants, usage of the Management API is restricted to 50 requests per second.
 
 The aforementioned rate limits include calls made via [Rules](/rules).


### PR DESCRIPTION
A customer pointed out (via negative customer feedback on this doc) that we don't mention the year so it's unclear whether it is past or future. The year was 2017 and those rate limits are effective for almost a year so I'm removing them altogether.