### PR TITLE
API AuthZ landing page: add clarification on this article's purpose

### DIFF
--- a/articles/api-auth/index.md
+++ b/articles/api-auth/index.md
@@ -25,18 +25,6 @@ In this page you can find a list of resources that can help you secure your APIs
 
 <ul class="topic-links">
   <li>
-    <i class="icon icon-budicon-715"></i><a href="/api-auth/intro">Introducing OIDC Conformant Authentication</a>
-    <p>
-      This document presents an overview of the latest new features and changes in our authentication flows, explain why they were made and points to other detailed tutorials to help you adopt these changes.
-    </p>
-  </li>
-  <li>
-    <i class="icon icon-budicon-715"></i><a href="/api-auth/tutorials/adoption">OIDC Conformant Authentication Adoption Guide</a>
-    <p>
-      This guide details all the latest new features and changes and provides suggestions on how to adapt your existing applications.
-    </p>
-  </li>
-  <li>
     <i class="icon icon-budicon-715"></i><a href="/api-auth/which-oauth-flow-to-use">Which OAuth 2.0 flow should I use?</a>
     <p>
       OAuth 2.0 supports several different grants. Deciding which one is suited for your case depends mostly on your Application's type, but other parameters weight in as well, like the level of trust for the Application, or the experience you want your users to have. Start here if you are not familiar with all that and you need directions in order to decide the proper flow for your case.

--- a/articles/api-auth/index.md
+++ b/articles/api-auth/index.md
@@ -14,16 +14,14 @@ title: API Authorization
 </div>
 
 ::: note
-<strong>Heads up!</strong> As part of our efforts to improve security and standards-based interoperability, we have implemented several new features in our authentication flows and made changes to existing ones. For an overview of these changes, and details on how you adopt them, refer to <a href="/api-auth/intro">Introducing OIDC Conformant Authentication</a>.
+**Heads up!** As part of our efforts to improve security and standards-based interoperability, we have implemented several new features in our authentication flows and made changes to existing ones. For an overview of these changes, and details on how you adopt them, refer to [Introducing OIDC Conformant Authentication](/api-auth/intro).
 :::
 
-At some point, your APIs will need to allow limited access to users, servers, or servers on behalf of users.
+At some point, your custom APIs will need to allow limited access to users, servers, or servers on behalf of users. With Auth0 you can manage the authorization requirements for server-to-server and application-to-server applications.
 
-Auth0's API authorization features allow you to manage the authorization requirements for server-to-server and application-to-server applications.
+By using the OAuth 2.0 authorization framework, you can give your own applications or third-party applications limited access to your APIs on behalf of the application itself. With Auth0, you can easily support different flows in your own APIs without worrying about the OAuth 2.0/OpenID Connect specification, or the many other technical aspects of API authorization.
 
-By using the OAuth 2.0 authorization framework, you can give your own applications or third-party applications limited access to your APIs on behalf of the application itself.
-
-Using Auth0, you can easily support different flows in your own APIs without worrying about the OAuth 2.0/OpenID Connect specification, or the many other technical aspects of API authorization.
+In this page you can find a list of resources that can help you secure your APIs and access them in a secure manner.
 
 <ul class="topic-links">
   <li>


### PR DESCRIPTION
We received the following negative feedback on this page: `not an article but a collection of links`

This is what this is meant to be, a landing page for API Authorization listing our relevant content. I added one sentence that clarifies that (and did some copyediting along the way).