### PR TITLE
Fix APIv2 audience

### DIFF
--- a/articles/guides/migration-legacy-flows.md
+++ b/articles/guides/migration-legacy-flows.md
@@ -134,7 +134,7 @@ To get an Access Token, you need to ask Auth0 for one using the `https://${accou
 function getUserUsingManagementApi() {
     webAuth.checkSession(
       {
-        audience: `https://${account.namespace}/api/v2/˜`,
+        audience: `https://${account.namespace}/api/v2/`,
         scope: 'read:current_user'
       },
       function(err, result) {

--- a/articles/libraries/auth0js/v8/index.md
+++ b/articles/libraries/auth0js/v8/index.md
@@ -482,14 +482,14 @@ Using auth0.js within your application (rather than using [Universal Login](/hos
 
 The Management API provides functionality that allows you to link and unlink separate user accounts from different providers, tying them to a single profile (Read more about [Linking Accounts](/link-accounts) with Auth0). It also allows you to update user metadata.
 
-To get started, you first need to obtain a an Access Token that can be used to call the Management API. You can do it by specifying the `https://${account.namespace}/api/v2/˜` audience when initializing Auth0.js, in which case you will get the Access Token as part of the authentication flow.
+To get started, you first need to obtain a an Access Token that can be used to call the Management API. You can do it by specifying the `https://${account.namespace}/api/v2/` audience when initializing Auth0.js, in which case you will get the Access Token as part of the authentication flow.
 
 ```js
 var webAuth = new auth0.WebAuth({
   clientID: '${account.clientId}',
   domain: '${account.namespace}',
   redirectUri: 'http://example.com',
-  audience: `https://${account.namespace}/api/v2/˜`,
+  audience: `https://${account.namespace}/api/v2/`,
   scope: 'read:current_user',
   responseType: 'token id_token'
 });
@@ -500,7 +500,7 @@ You can also do so by using `checkSession()`:
 ```
 webAuth.checkSession(
   {
-    audience: `https://${account.namespace}/api/v2/˜`,
+    audience: `https://${account.namespace}/api/v2/`,
     scope: 'read:current_user'
   }, function(err, result) {
      // use result.accessToken

--- a/articles/libraries/auth0js/v9/index.md
+++ b/articles/libraries/auth0js/v9/index.md
@@ -460,7 +460,7 @@ The user will then receive an email which will contain a link that they can foll
 
 The Management API provides functionality that allows you to link and unlink separate user accounts from different providers, tying them to a single profile (Read more about [Linking Accounts](/link-accounts) with Auth0). It also allows you to update user metadata.
 
-To get started, you first need to obtain a an Access Token that can be used to call the Management API. You can do it by specifying the `https://${account.namespace}/api/v2/˜` audience when initializing Auth0.js, in which case you will get the Access Token as part of the authentication flow.
+To get started, you first need to obtain a an Access Token that can be used to call the Management API. You can do it by specifying the `https://${account.namespace}/api/v2/` audience when initializing Auth0.js, in which case you will get the Access Token as part of the authentication flow.
 
 ::: note
 If you use [custom domains](/custom-domains), you will need to instantiate a new copy of `webAuth` using your Auth0 domain rather than your custom one, for use with the Management API calls, as it only works with Auth0 domains.
@@ -471,7 +471,7 @@ var webAuth = new auth0.WebAuth({
   clientID: '${account.clientId}',
   domain: '${account.namespace}',
   redirectUri: 'http://example.com',
-  audience: `https://${account.namespace}/api/v2/˜`,
+  audience: `https://${account.namespace}/api/v2/`,
   scope: 'read:current_user',
   responseType: 'token id_token'
 });
@@ -482,7 +482,7 @@ You can also do so by using `checkSession()`:
 ```
 webAuth.checkSession(
   {
-    audience: `https://${account.namespace}/api/v2/˜`,
+    audience: `https://${account.namespace}/api/v2/`,
     scope: 'read:current_user'
   }, function(err, result) {
      // use result.accessToken

--- a/articles/link-accounts/index.md
+++ b/articles/link-accounts/index.md
@@ -256,7 +256,7 @@ The Auth0 Management API provides the [Link a user account](/api/v2#!/Users/post
 
 Instead of calling directly the API, you can use the [Auth0.js](/libraries/auth0js) library.
 
-First, you must get an Access Token that can be used to call the Management API. You can do it by specifying the `https://${account.namespace}/api/v2/˜` audience when initializing Auth0.js. You will get the Access Token as part of the authentication flow. Alternatively, you can use the `checkSession` method.
+First, you must get an Access Token that can be used to call the Management API. You can do it by specifying the `https://${account.namespace}/api/v2/` audience when initializing Auth0.js. You will get the Access Token as part of the authentication flow. Alternatively, you can use the `checkSession` method.
 
 Once you have the Access Token, you can create a new `auth0.Management` instance by passing it the account's Auth0 domain, and the Access Token.
 

--- a/articles/migrations/guides/_get-token-auth0js.md
+++ b/articles/migrations/guides/_get-token-auth0js.md
@@ -39,7 +39,7 @@ var webAuth = new auth0.WebAuth({
   clientID: '${account.clientId}',
   domain: '${account.namespace}',
   redirectUri: '${account.callback}',
-  audience: 'https://${account.namespace}/api/v2/˜',
+  audience: 'https://${account.namespace}/api/v2/',
   scope: '${scope}',
   responseType: 'token id_token'
 });
@@ -53,7 +53,7 @@ var auth0Manage = new auth0.Management({
       <div class="tab-pane-footer">
         <ul>
           <li>Asks for both an ID Token and an Access Token in the response (<code>responseType: 'token id_token'</code>)</li>
-          <li>Sets the Management API as the intended audience of the token (<code>audience: 'https://${account.namespace}/api/v2/˜'</code>)</li>
+          <li>Sets the Management API as the intended audience of the token (<code>audience: 'https://${account.namespace}/api/v2/'</code>)</li>
           <li>Asks for the required permission (<code>scope: '${scope}'</code>)</li>
           <li>Authenticates with the Management API using the Access Token</li>
         </ul>


### PR DESCRIPTION
Some pages had the wrong APIv2 audience URL in the docs (there is an extra `~` in `https://${account.namespace}/api/v2/~`) causing users who copy and paste the code to fail.

This PR fixes the audience value in all auth0.js scripts.

cc @jeffreylees 