### PR TITLE
Emails: add paragraph on IP whitelisting

### DIFF
--- a/articles/email/providers.md
+++ b/articles/email/providers.md
@@ -1,27 +1,33 @@
 ---
-description: How to configure your own SMTP email provider.
+description: How to configure your own SMTP email provider
 toc: true
 topics:
   - email
   - smtp
 ---
-# Use your own SMTP Email Provider
+# Use Your Own SMTP Email Provider
 
 Auth0 allows you to configure your own SMTP email provider. Auth0's built-in email infrastructure should be used for testing level emails only. By using your own provider you can more completely manage, monitor and troubleshoot your email communications.
 
 Auth0 currently supports the following providers:
 
-* [Amazon SES](#configure-amazon-ses-for-sending-email)
-* [Mandrill](#configure-mandrill-for-sending-email)
-* [SendGrid](#configure-sendgrid-for-sending-email)
-* [SparkPost](#configure-sparkpost-for-sending-email)
-* [Custom SMTP](#configure-a-custom-smtp-server-for-sending-email)
+* [Amazon SES](#configure-amazon-ses)
+* [Mandrill](#configure-mandrill)
+* [SendGrid](#configure-sendgrid)
+* [SparkPost](#configure-sparkpost)
+* [Custom SMTP](#configure-a-custom-smtp-server)
 
-::: note
 You can only configure one email provider (Amazon SES, Sendgrid, and so on.) which will be used for all emails.
-:::
 
-## Configure Amazon SES for Sending Email
+## Whitelist IP addresses
+
+To make sure that emails can be sent from Auth0 to your SMTP, you must allow inbound connections from the following IP addresses:
+
+```text
+52.64.84.177,  52.64.111.197, 54.153.131.0, 13.210.52.131, 13.55.232.24, 13.54.254.182, 52.62.91.160, 52.63.36.78, 52.64.120.184, 54.66.205.24, 54.79.46.4
+```
+
+## Configure Amazon SES
 
 There are several steps to follow to configure Amazon SES for sending email. If you want to use the SES API, please follow this guide.
 
@@ -32,7 +38,7 @@ You can use two types of credentials
 
 For more information about SES credentials, visit [Using Credentials With Amazon SES](http://docs.aws.amazon.com/ses/latest/DeveloperGuide/using-credentials.html).
 
-### Using API Credentials
+### Use API credentials
 
 1. Sign up for an [Amazon AWS](http://aws.amazon.com/ses/) account, or login.
 2. [Verify your domain](http://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-domains.html).
@@ -61,7 +67,7 @@ Now you can send a test email using the **SEND TEST EMAIL** button on the [Custo
 
 The [Amazon SES console](https://console.aws.amazon.com/ses) will now display all emails which have been sent to your users.
 
-### Using SMTP Credentials
+### Use SMTP credentials
 
 1. Sign up for an [Amazon AWS](http://aws.amazon.com/ses/) account, or login.
 2. [Verify your domain](http://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-domains.html).
@@ -86,7 +92,7 @@ Now you can send a test email using the **SEND TEST EMAIL** button on the [Custo
 
 The [Amazon SES console](https://console.aws.amazon.com/ses) will now display all emails which have been sent to your users.
 
-## Configure Mandrill for Sending Email
+## Configure Mandrill
 
 1. Sign up for a [Mandrill](https://www.mandrill.com/signup/) account, or login. Go to the [Settings page](https://mandrillapp.com/settings) and click **Add API key**. Save this key value.
 
@@ -104,7 +110,7 @@ The [Outbound Activity](https://mandrillapp.com/activity) page in Mandrill will 
 
 ![](/media/articles/email/providers/email-mandrill-monitoring.png)
 
-## Configure SendGrid for Sending Email
+## Configure SendGrid
 
 1. Sign up for a [SendGrid](https://sendgrid.com) account, or login. (If you have a Microsoft Azure subscription you can get a free account in the Azure Marketplace).
 
@@ -136,7 +142,7 @@ The [Email Activity](https://sendgrid.com/logs/index) page in SendGrid will now 
 
 ![](/media/articles/email/providers/email-sendgrid-monitoring.png)
 
-## Configure SparkPost for Sending Email
+## Configure SparkPost
 
 1. Sign up for a [SparkPost](https://www.sparkpost.com/) account, or login. Go to the [Account API Keys page](https://app.sparkpost.com/account/credentials) and click **New API key**. Save this key value. The key must have `Transmissions: Read/Write` access.
 
@@ -156,7 +162,7 @@ The [Message Events](https://app.sparkpost.com/reports/message-events) page in S
 
 ![](/media/articles/email/providers/sparkpost-message-events.png)
 
-## Configure a Custom SMTP Server for Sending Email
+## Configure a custom SMTP server
 
 You can use your own SMTP server to send email. There are three requirements for the SMTP server:
 

--- a/articles/email/providers.md
+++ b/articles/email/providers.md
@@ -21,11 +21,9 @@ You can only configure one email provider (Amazon SES, Sendgrid, and so on.) whi
 
 ## Whitelist IP addresses
 
-To make sure that emails can be sent from Auth0 to your SMTP, you must allow inbound connections from the following IP addresses:
+To make sure that emails can be sent from Auth0 to your SMTP, you must open the right ports and allow inbound connections from specific IP addresses.
 
-```text
-52.64.84.177,  52.64.111.197, 54.153.131.0, 13.210.52.131, 13.55.232.24, 13.54.254.182, 52.62.91.160, 52.63.36.78, 52.64.120.184, 54.66.205.24, 54.79.46.4
-```
+To get the list of IPs, go to [Dashboard > Emails > Provider](${manage_url}/#/emails/provider).
 
 ## Configure Amazon SES
 


### PR DESCRIPTION
A customer opened a support ticket (43000) to ask for the Auth0 IPs they must whitelist in order to send emails from Auth0 to their SMTP. This information was missing from our docs so I added a section on the doc that talks about how to configure your own SMTP provider.