### PR TITLE
Fix a typo in the `/oauth/token` example response

### DIFF
--- a/articles/tokens/refresh-token/current/index.md
+++ b/articles/tokens/refresh-token/current/index.md
@@ -75,7 +75,7 @@ The response should contain an Access Token and a Refresh Token.
 ```text
 {
   "access_token": "eyJz93a...k4laUWw",
-  "Refresh Token": "GEbRxBN...edjnXbL",
+  "refresh_token": "GEbRxBN...edjnXbL",
   "token_type": "Bearer"
 }
 ```


### PR DESCRIPTION
Just a small typo I noticed while reading through https://auth0.com/docs/tokens/refresh-token/current

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
