### PR TITLE
Update rate limits for management API

### DIFF
--- a/articles/policies/rate-limits.md
+++ b/articles/policies/rate-limits.md
@@ -71,7 +71,7 @@ The following rate limits apply:
 
 - For all __free tenants__, usage of the Management API is restricted to 2 requests per second (and bursts up to 10 requests).
 - For __non-production tenants__ of enterprise customers, usage of the Management API is restricted to 2 requests per second (and bursts up to 10 requests).
-- For __paid__ tenants, usage of the Management API is restricted to 50 requests per second.
+- For __paid__ tenants, usage of the Management API is restricted to 15 requests per second (and bursts up to 50 requests).
 
 The aforementioned rate limits include calls made via [Rules](/rules).
 

--- a/articles/policies/rate-limits.md
+++ b/articles/policies/rate-limits.md
@@ -11,10 +11,6 @@ topics:
 
 To ensure the quality of Auth0's services, the Auth0 APIs are subject to rate limiting.
 
-::: note
-If you are looking for information on the rate limits on user logins, refer to [Rate Limits on User/Password Authentication](/connections/database/rate-limits).
-:::
-
 ::: warning
 Auth0 reserves the right to modify the rate limits at any time. For the up-to-date information on rate limits, please review the headers returned from rate limited endpoints.
 :::
@@ -286,3 +282,7 @@ The following Auth0 Authentication API endpoints return rate limit-related heade
 :::note
 (*) In all instances above, **Free** includes tenants on the Free plan, as well as the non-production tenants of enterprise customers.
 :::
+
+## Rate Limits on Database Logins
+
+For database connections Auth0 limits certain types of repeat login attempts depending on the user account and IP address. For more information on this, see [Rate Limits on User/Password Authentication](/connections/database/rate-limits).

--- a/articles/policies/rate-limits.md
+++ b/articles/policies/rate-limits.md
@@ -15,6 +15,10 @@ To ensure the quality of Auth0's services, the Auth0 APIs are subject to rate li
 If you are looking for information on the rate limits on user logins, refer to [Rate Limits on User/Password Authentication](/connections/database/rate-limits).
 :::
 
+::: warning
+Auth0 reserves the right to modify the rate limits at any time. For the up-to-date information on rate limits, please review the headers returned from rate limited endpoints.
+:::
+
 ## Limits
 
 Depending on the API endpoint, the request limit and the rate limit window in which the request limit resets, varies.
@@ -189,10 +193,6 @@ The following Auth0 Management API endpoints return rate limit-related headers. 
 ### Authentication API
 
 The following Auth0 Authentication API endpoints return rate limit-related headers.
-
-::: warning
-Auth0 reserves the right to modify the rate limits at any time. For the up-to-date information on rate limits, please review the headers returned from rate limited endpoints.
-:::
 
 <table class="table">
   <thead>

--- a/articles/policies/rate-limits.md
+++ b/articles/policies/rate-limits.md
@@ -283,6 +283,6 @@ The following Auth0 Authentication API endpoints return rate limit-related heade
 (*) In all instances above, **Free** includes tenants on the Free plan, as well as the non-production tenants of enterprise customers.
 :::
 
-## Rate Limits on Database Logins
+## Limits on Database Logins
 
-For database connections Auth0 limits certain types of repeat login attempts depending on the user account and IP address. For more information on this, see [Rate Limits on User/Password Authentication](/connections/database/rate-limits).
+For database connections Auth0 limits certain types of repeat login attempts depending on the user account and IP address. For more information, see [Rate Limits on User/Password Authentication](/connections/database/rate-limits).


### PR DESCRIPTION
Does the following changes:

1. Updates the rate limit for management API to reflect current limits.
1. Moves the 'reserve right to modify rate limits' warning to the start of the page. This helps indicate that that right is reserved for all endpoints, and not only authorization endpoints.