### PR TITLE
Added content-type

### DIFF
--- a/articles/api/authentication/_introduction.md
+++ b/articles/api/authentication/_introduction.md
@@ -54,7 +54,7 @@ For each endpoint you will find sample snippets you can use, in three available 
 - Curl command
 - JavaScript: depending on the endpoint each snippet may use the [Auth0.js library](/libraries/auth0js), Node.js code or simple JavaScript
 
-Each request should be sent with `Content-type: application/json`.
+Each request should be sent with a Content-Type of `application/json`.
 
 ## Testing
 

--- a/articles/api/authentication/_introduction.md
+++ b/articles/api/authentication/_introduction.md
@@ -54,6 +54,8 @@ For each endpoint you will find sample snippets you can use, in three available 
 - Curl command
 - JavaScript: depending on the endpoint each snippet may use the [Auth0.js library](/libraries/auth0js), Node.js code or simple JavaScript
 
+Each request should be sent with `Content-type: application/json`.
+
 ## Testing
 
 You can test the endpoints using either the [Authentication API Debugger](/extensions/authentication-api-debugger) or our preconfigured [Postman collection](https://app.getpostman.com/run-collection/2a9bc47495ab00cda178). For some endpoints both options are available.

--- a/articles/api/authorization-extension/_introduction.md
+++ b/articles/api/authorization-extension/_introduction.md
@@ -15,7 +15,7 @@ For each endpoint in this explorer, you will find sample snippets you can use, i
 - Curl command
 - JavaScript: depending on the endpoint each snippet may use Node.js or simple JavaScript
 
-Each request should be sent with `Content-type: application/json`.
+Each request should be sent with a Content-Type of `application/json`.
 
 ## Find your extension URL
 

--- a/articles/api/authorization-extension/_introduction.md
+++ b/articles/api/authorization-extension/_introduction.md
@@ -5,7 +5,7 @@ The Authorization Extension API enables you to:
 - automate provisioning for your users, roles, groups, and permissions
 - query the authorization context of your users in real time
 
-In order to use it you first have to [enable API access](/extensions/authorization-extension/v2#enable-api-access) from your Authorization Dashboard.
+In order to use it, you first have to [enable API access](/extensions/authorization-extension/v2#enable-api-access) from your Authorization Dashboard.
 
 For more information on the Authorization Extension and how to configure it refer to [Auth0 Authorization Extension](/extensions/authorization-extension).
 
@@ -14,6 +14,8 @@ For each endpoint in this explorer, you will find sample snippets you can use, i
 - HTTP request
 - Curl command
 - JavaScript: depending on the endpoint each snippet may use Node.js or simple JavaScript
+
+Each request should be sent with `Content-type: application/json`.
 
 ## Find your extension URL
 


### PR DESCRIPTION
Mostek requested a change a customer recommended in community--that we state explicitly in the doc for our API explorers that when using code samples, requests should be sent with content-type of application/json. Added this text.