### PR TITLE
add warning for ADFS URL

### DIFF
--- a/articles/connections/enterprise/ws-fed.md
+++ b/articles/connections/enterprise/ws-fed.md
@@ -25,13 +25,11 @@ Click __Create New Connection__ and enter the following information:
 * __Connection Name__ - A descriptive name for the connection
 * __Email Domains__ - (Optional) A comma-separated list of valid domains. Only needed if you want to use the [Lock login widget](/libraries/lock).
 
-Next, you must either provide the URL for your WS-Federation server in the __ADFS URL__ field or upload a Federation Metadata file. If you set a URL make sure it's publicly accessible and the metadata file is valid.
+Next, you must either provide the URL for your WS-Federation server in the __ADFS URL__ field or upload a Federation Metadata file.
+
+If you configure the connection with a WS-Federation server URL, Auth0 will retrieve the Federation Metadata endpoint and import the required parameters, certificates, and URLs. You must make sure that the URL is publicly accessible and the SSL certificate on your ADFS installation is valid.
 
 ![New Connection](/media/articles/connections/enterprise/ws-fed/new.png)
-
-::: note
-If you configure the connection with a WS-Federation server URL, Auth0 will retrieve the Federation Metadata endpoint and import the required parameters, certificates, and URLs.
-:::
 
 Click __Save__.
 

--- a/articles/connections/enterprise/ws-fed.md
+++ b/articles/connections/enterprise/ws-fed.md
@@ -25,7 +25,7 @@ Click __Create New Connection__ and enter the following information:
 * __Connection Name__ - A descriptive name for the connection
 * __Email Domains__ - (Optional) A comma-separated list of valid domains. Only needed if you want to use the [Lock login widget](/libraries/lock).
 
-Next, you must either provide the URL for your WS-Federation server in the __ADFS URL__ field or upload a Federation Metadata file.
+Next, you must either provide the URL for your WS-Federation server in the __ADFS URL__ field or upload a Federation Metadata file. If you set a URL make sure it's publicly accessible and the metadata file is valid.
 
 ![New Connection](/media/articles/connections/enterprise/ws-fed/new.png)
 

--- a/articles/users/migrations/azure-access-control.md
+++ b/articles/users/migrations/azure-access-control.md
@@ -47,7 +47,9 @@ To create a connection between Auth0 and your identity provider, navigate to [Da
 * __Connection Name__: A descriptive name for the connection.
 * __Email Domains__: (Optional) A comma-separated list of valid domains. Only needed if you want to use the [Lock login widget](/libraries/lock).
 
-Next, either enter your WS-Federation server URL in the __ADFS URL__ field or upload a Federation Metadata file. If you set a WS-Federation server URL, Auth0 will retrieve the Federation Metadata endpoint and import the required parameters, certificates, and URLs.
+Next, either enter your WS-Federation server URL in the __ADFS URL__ field or upload a Federation Metadata file. 
+
+If you set a WS-Federation server URL, Auth0 will retrieve the Federation Metadata endpoint and import the required parameters, certificates, and URLs. You must make sure that the URL is publicly accessible and the SSL certificate on your ADFS installation is valid.
 
 ![New Connection](/media/articles/connections/enterprise/ws-fed/new.png)
 


### PR DESCRIPTION
Based on support ticket `42575 | ADFS Connection URL option is not configurable`.

The customer was trying to use the `ADFS URL` link instead of uploading a metadata file. That is perfectly fine. However, the link they had set in the connection setting had an invalid SSL certificate which caused the connection setup to fail with an error.