### PR TITLE
Align content reuse styles

### DIFF
--- a/articles/protocols/saml/saml-apps/cisco-webex.md
+++ b/articles/protocols/saml/saml-apps/cisco-webex.md
@@ -8,7 +8,7 @@ topics:
     - cisco-webex
 ---
 
-${include('./_header')}
+<%= include('./_header') %>
 
 ```json
 {

--- a/articles/protocols/saml/saml-apps/datadog.md
+++ b/articles/protocols/saml/saml-apps/datadog.md
@@ -7,7 +7,7 @@ topics:
     - datadog
 ---
 
-${include('./_header')}
+<%= include('./_header') %>
 
 ```json
 {
@@ -25,6 +25,6 @@ ${include('./_header')}
 }
 ```
 
-**Callback URL**: `https://app.datadoghq.com/account/saml/assertion`
+The **Callback URL** is `https://app.datadoghq.com/account/saml/assertion`.
 
-Notice that Datadog has an option to automatically provision new users. Check [here](http://docs.datadoghq.com/guides/saml/) for more details.
+Notice that Datadog has an option to automatically provision new users. Check [Datadog docs](http://docs.datadoghq.com/guides/saml/) for more details.

--- a/articles/protocols/saml/saml-apps/egencia.md
+++ b/articles/protocols/saml/saml-apps/egencia.md
@@ -7,7 +7,7 @@ topics:
     - egencia
 ---
 
-${include('./_header')}
+<%= include('./_header') %>
 
 
 ```json

--- a/articles/protocols/saml/saml-apps/eloqua.md
+++ b/articles/protocols/saml/saml-apps/eloqua.md
@@ -7,7 +7,7 @@ topics:
     - eloqua
 ---
 
-${include('./_header')}
+<%= include('./_header') %>
 
 
 ```json

--- a/articles/protocols/saml/saml-apps/freshdesk.md
+++ b/articles/protocols/saml/saml-apps/freshdesk.md
@@ -7,7 +7,7 @@ topics:
     - freshdesk
 ---
 
-${include('./_header')}
+<%= include('./_header') %>
 
 ```json
 {
@@ -28,6 +28,4 @@ ${include('./_header')}
 }
 ```
 
-With the following callback:
-
-`https://{FD Domain}.freshdesk.com/login/saml`
+The **Callback URL** is `https://{FD Domain}.freshdesk.com/login/saml`.

--- a/articles/protocols/saml/saml-apps/google-apps.md
+++ b/articles/protocols/saml/saml-apps/google-apps.md
@@ -7,7 +7,7 @@ topics:
     - google-apps
 ---
 
-${include('./_header')}
+<%= include('./_header') %>
 
 ```json
 {

--- a/articles/protocols/saml/saml-apps/hosted-graphite.md
+++ b/articles/protocols/saml/saml-apps/hosted-graphite.md
@@ -7,7 +7,7 @@ topics:
     - hosted-graphite
 ---
 
-${include('./_header')}
+<%= include('./_header') %>
 
 ```json
 {

--- a/articles/protocols/saml/saml-apps/litmos.md
+++ b/articles/protocols/saml/saml-apps/litmos.md
@@ -7,7 +7,7 @@ topics:
     - litmos
 ---
 <!-- markdownlint-disable MD002 MD041 -->
-${include('./_header')}
+<%= include('./_header') %>
 
 ```json
 {
@@ -33,9 +33,7 @@ ${include('./_header')}
 }
 ```
 
-## Application Callback URL
-
-`https://{YOUR DOMAIN}.litmos.com/integration/samllogin`
+The **Callback URL** is `https://{YOUR DOMAIN}.litmos.com/integration/samllogin`.
 
 ## Sample SAML
 

--- a/articles/protocols/saml/saml-apps/pluralsight.md
+++ b/articles/protocols/saml/saml-apps/pluralsight.md
@@ -7,7 +7,7 @@ topics:
     - pluralsight
 ---
 
-${include('./_header')}
+<%= include('./_header') %>
 
 
 ```json

--- a/articles/protocols/saml/saml-apps/sprout-video.md
+++ b/articles/protocols/saml/saml-apps/sprout-video.md
@@ -7,7 +7,7 @@ topics:
     - sprout-video
 ---
 
-${include('./_header')}
+<%= include('./_header') %>
 
 ```json
 {

--- a/articles/protocols/saml/saml-apps/tableau-online.md
+++ b/articles/protocols/saml/saml-apps/tableau-online.md
@@ -3,7 +3,7 @@ title: Tableau Online SAML Configuration
 description: Tableau Online SAML Configuration
 ---
 
-${include('./_header')}
+<%= include('./_header') %>
 
 ```json
 {

--- a/articles/protocols/saml/saml-apps/tableau-server.md
+++ b/articles/protocols/saml/saml-apps/tableau-server.md
@@ -7,7 +7,7 @@ topics:
     - tableau
 ---
 
-${include('./_header')}
+<%= include('./_header') %>
 
 ```json
 {

--- a/articles/protocols/saml/saml-apps/workday.md
+++ b/articles/protocols/saml/saml-apps/workday.md
@@ -7,7 +7,7 @@ topics:
     - workday
 ---
 
-${include('./_header')}
+<%= include('./_header') %>
 
 ```json
 {

--- a/articles/protocols/saml/saml-apps/workpath.md
+++ b/articles/protocols/saml/saml-apps/workpath.md
@@ -3,7 +3,7 @@ title: Workpath SAML Configuration
 description: Workpath SAML Configuration
 ---
 
-${include('./_header')}
+<%= include('./_header') %>
 
 ```json
 {


### PR DESCRIPTION
In the docs repo we use includes in 2 different styles, sometimes both in the same doc: 
`<%= include('../../../_includes/_callback_url') %>`
and
`${include('../_callbackRegularWebApp')}`

I updated all docs that were using the latter (only 14, compared to the vast number of docs that were using the former). The contributing guidelines also point to the former format.