### PR TITLE
remove unsupported feature

### DIFF
--- a/articles/multifactor-authentication/google-auth/admin-guide.md
+++ b/articles/multifactor-authentication/google-auth/admin-guide.md
@@ -55,7 +55,6 @@ function (user, context, callback) {
       context.multifactor = {
         provider: 'google-authenticator',
         // issuer: 'Label on Google Authenticator App', // optional
-        // key: 'YOUR_KEY_HERE', //  optional, the key to use for TOTP. by default one is generated for you
 
         // optional, defaults to true. Set to false to force Google Authenticator every time.
         // See https://auth0.com/docs/multifactor-authentication/custom#change-the-frequency-of-authentication-requests for details


### PR DESCRIPTION
We do not support setting a custom secret for Google Authenticator TOTP anymore.
