### PR TITLE
Specify that policy doesn't apply to Enterprise subs

### DIFF
--- a/articles/dev-lifecycle/child-tenants.md
+++ b/articles/dev-lifecycle/child-tenants.md
@@ -13,12 +13,10 @@ useCase:
 
 This request process is for self-service customers requesting a development, test, or staging tenant that's linked to their paid production tenant. This tenant is called a **child tenant**.
 
-::: warning
-Please note that this policy doesn't apply if you have an Enterprise subscription. If you need to add Child tenants to your subscription, please contact your designated CSM, or the Auth0 Support team using the [Support Center](${env.DOMAIN_URL_SUPPORT}).
-:::
-
-::: note
 Free tenants do not include a child tenant.
+
+::: warning
+This policy does not apply if you have an Enterprise subscription. If you need to add child tenants to your subscription, contact your designated CSM or our [Support](${env.DOMAIN_URL_SUPPORT}).
 :::
 
 ## Child Tenant Policy

--- a/articles/dev-lifecycle/child-tenants.md
+++ b/articles/dev-lifecycle/child-tenants.md
@@ -13,6 +13,10 @@ useCase:
 
 This request process is for self-service customers requesting a development, test, or staging tenant that's linked to their paid production tenant. This tenant is called a **child tenant**.
 
+::: warning
+Please note that this policy doesn't apply if you have an Enterprise subscription. If you need to add Child tenants to your subscription, please contact your designated CSM, or the Auth0 Support team using the [Support Center](${env.DOMAIN_URL_SUPPORT}).
+:::
+
 ::: note
 Free tenants do not include a child tenant.
 :::


### PR DESCRIPTION
I added a disclaimer at the top, to explicitly note that the policy doesn't apply to Enterprise subscription, and that they should reach to their CSM or the Technical Support team to request for additional Child tenants.