### PR TITLE
Remove or deprecate Apple Touch ID references

### DIFF
--- a/articles/connections/passwordless/faq.md
+++ b/articles/connections/passwordless/faq.md
@@ -28,7 +28,7 @@ Websites and web applications are trending toward longer session expirations so 
 
 ### Q: Is it difficult for users to become accustomed to passwordless login?
 
-**A:** Passwordless login is so simple that most users will immediately get it. The user experience is nearly effortless, especially with *magic links* in emails or with Apple *Touch ID*. For most end-users, a passwordless login is easier than recalling a hard-to-remember password.
+**A:** Passwordless login is so simple that most users will immediately get it. The user experience is nearly effortless, especially with *magic links* in emails. For most end-users, a passwordless login is easier than recalling a hard-to-remember password.
 
 ### Q: How is passwordless login different from a social login?
 
@@ -88,27 +88,9 @@ Auth0 supports **Twilio SMS** for passwordless login with codes sent via SMS, an
 
 ### Q: How can I use Passwordless as another factor in multi-factor authentication?
 
-**A:** While Auth0’s passwordless connections (including SMS, email, and Apple *Touch ID*) are not built into the dashboard MFA capability at this time, Auth0’s flexible [rules execution pipeline](/rules) make it easy to use these passwordless authentication methods as part of an MFA flow. Rules are snippets of JavaScript that execute on the Auth0 server as part of the authentication pipeline and give you the flexibility to call APIs or perform arbitrary computations in order to implement customized authentication logic. Simply call the passwordless connection using a redirect rule, and treat it as a [custom MFA provider](/mfa).
+**A:** While Auth0’s passwordless connections (including SMS and email) are not built into the dashboard MFA capability at this time, Auth0’s flexible [rules execution pipeline](/rules) make it easy to use these passwordless authentication methods as part of an MFA flow. Rules are snippets of JavaScript that execute on the Auth0 server as part of the authentication pipeline and give you the flexibility to call APIs or perform arbitrary computations in order to implement customized authentication logic. Simply call the passwordless connection using a redirect rule, and treat it as a [custom MFA provider](/mfa).
 
 In future versions of passwordless connections, supported MFA providers will be built-in.
-
-### Q: What are the advantages of Apple *Touch ID* for passwordless authentication?
-
-**A:** Apple’s *Touch ID* fingerprint identity system is an easy way for users to identify themselves to their iPhone or iPad equipped with a fingerprint scanner. To the user, the application unlocks with the touch of a finger.
-
-After a one-time enrollment process, each time the user logs into your app, the *Touch ID* passwordless library uses the matched fingerprint to retrieve a private key saved in the IOS key store. *Touch ID* then generates and signs a JWT with that private key and sends it to Auth0. Auth0 validates the JWT with the user’s saved public key, and returns a token authenticating the user.
-
-The disadvantage of *Touch ID* as a means of authenticating users is that it only works on native IOS apps installed on later-model iPhones and iPads. It does not work on other devices, like Android, nor can it protect a website or web application. Also, a backup password authentication mechanism must be available to handle new or lost devices. Auth0 makes it simple to link accounts so that you can offer *Touch ID* on Apple devices, and SMS or email-based passwordless logins for other mobile platforms and the web.
-
-Auth0’s standard Lock widget for IOS fully supports *Touch ID* with a very simple UI that is easily styled to your brand identity. You can implement passwordless login for your IOS app with just a few lines of code.
-
-### Q: Does the Passwordless Lock Widget support Apple *Touch ID*?
-
-**A:** No. For *Touch ID* passwordless logins, the standard Auth0 IOS lock widget provides all the same benefits. The web-based passwordless lock widget doesn’t support *Touch ID*.
-
-### Q: Can I combine email or SMS Passwordless authentication with Apple *Touch ID*?
-
-**A:** Instead of using a backup password to handle new or lost devices, you can use the email or SMS passwordless login and link the two user identities through Auth0’s account linking feature. Your application will recognize the same authenticated user whether they log in through *Touch ID*, or through email or SMS.
 
 ### Q: What happens if a user changes email or phone number?
 

--- a/articles/connections/passwordless/index.md
+++ b/articles/connections/passwordless/index.md
@@ -36,7 +36,6 @@ See the following tutorials for a step-by-step guide on how to implement passwor
  - [Authenticate users with Universal Login](/connections/passwordless/native-passwordless-universal)
  - [Authenticate users with a one time code via SMS](/connections/passwordless/ios-sms-swift)
  - [Authenticate users with a one time code via e-mail](/connections/passwordless/ios-email-swift)
- - [Authenticate users with Touch ID](/connections/passwordless/ios-touch-id-swift)
  - [Authenticate users with Magic Link](/connections/passwordless/ios-magic-link)
 
 ### Passwordless on Android

--- a/articles/connections/passwordless/ios-touch-id-swift.md
+++ b/articles/connections/passwordless/ios-touch-id-swift.md
@@ -25,7 +25,7 @@ useCase: customize-connections
 <!-- markdownlint-disable -->
 
 ::: warning
-This feature is disabled for new tenants as of June 8th 2017. Any tenant created after that date won't have the necessary legacy [grant types](/applications/application-grant-types) to use Touch ID. This document is offered as reference for older implementations.
+Touch ID with Auth0 has been deprecated. This document is offered as reference for older implementations.
 :::
 
 ::: note

--- a/articles/libraries/lock-ios/v1/index.md
+++ b/articles/libraries/lock-ios/v1/index.md
@@ -32,7 +32,6 @@ Auth0 is an authentication broker that supports social identity providers as wel
 * Provides support for **Social Providers** (Facebook, Twitter, and so on), **Enterprise Providers** (AD, LDAP, and so on) and **Username & Password** authentication.
 * Provides the ability to do **SSO** with 2 or more mobile apps, similar to Facebook and Messenger apps.
 * [1Password](https://agilebits.com/onepassword) integration using the **iOS 8** [Extension](https://github.com/AgileBits/onepassword-app-extension).
-* Passwordless authentication using **Touch ID** and **SMS**.
 
 ::: note
 Check out the [Lock.swift repository](https://github.com/auth0/Lock.swift/tree/v1) on GitHub.

--- a/articles/multifactor-authentication/touchid.md
+++ b/articles/multifactor-authentication/touchid.md
@@ -9,6 +9,10 @@ useCase:
 ---
 # Touch ID Settings
 
+::: warning
+Touch ID with Auth0 has been deprecated, however you can still use it on a native app to protect the Refresh Token and achieve the effect you see in banking apps. You have to at least login once using credentials.
+:::
+
 Below you can find useful links in our documentation to handle Touch ID within Auth0.
 
 -  [Authenticate users with Touch ID in iOS](/connections/passwordless/ios-touch-id-swift)


### PR DESCRIPTION
Update docs to ensure any guidance on Touch ID + Passwordless is removed or labeled as deprecated.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
