### PR TITLE
behavior app-specific admins will see when browsing the dashboard

### DIFF
--- a/articles/dashboard/manage-dashboard-admins.md
+++ b/articles/dashboard/manage-dashboard-admins.md
@@ -21,7 +21,7 @@ Tenant Administrators can be added and removed from the dashboard, by going to *
 To add an Admin, enter the email of the account and then select the applications you would like this user to have admin access to in the **Application** box. Then click the **ADD** button. Admins can be removed by clicking the **REMOVE** button after they have been added.
 
 ::: note
-If a user is an app-specific admin, when browsing the dashboard certain pages made appear blank like APIs, Rules, Hooks, Hosted Pages, etc.
+If you're an app-specific administrator, pages to which you don't have access (such as APIs, Rules, Hooks, Hosted Pages, and so on) may appear blank.
 :::
 
 The MFA indicator will indicate whether an Admin has enabled their account for [Multifactor Authentication](/multifactor-authentication), which they can do in their Account Settings.

--- a/articles/dashboard/manage-dashboard-admins.md
+++ b/articles/dashboard/manage-dashboard-admins.md
@@ -20,6 +20,10 @@ Tenant Administrators can be added and removed from the dashboard, by going to *
 
 To add an Admin, enter the email of the account and then select the applications you would like this user to have admin access to in the **Application** box. Then click the **ADD** button. Admins can be removed by clicking the **REMOVE** button after they have been added.
 
+::: note
+If a user is an app-specific admin, when browsing the dashboard certain pages made appear blank like APIs, Rules, Hooks, Hosted Pages, etc.
+:::
+
 The MFA indicator will indicate whether an Admin has enabled their account for [Multifactor Authentication](/multifactor-authentication), which they can do in their Account Settings.
 
 ![Dashboard Admins with MFA Indicator](/media/articles/tutorials/dashboard-admins.png)


### PR DESCRIPTION
When a Dashboard Admin goes to APIs, Rules, Hooks, Hosted Pages, etc. They see a blank screen with the navigation bar visible, but nothing rendered on the page.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
