### PR TITLE
Update text from "Custom" to "Other"

### DIFF
--- a/articles/email/providers.md
+++ b/articles/email/providers.md
@@ -17,7 +17,7 @@ Auth0 currently supports the following providers:
 * [Mandrill](#configure-mandrill)
 * [SendGrid](#configure-sendgrid)
 * [SparkPost](#configure-sparkpost)
-* [Custom SMTP](#configure-a-custom-smtp-server)
+* [Other SMTP](#configure-a-custom-smtp-server)
 
 You can only configure one email provider (Amazon SES, Sendgrid, and so on.) which will be used for all emails.
 


### PR DESCRIPTION
To avoid confusion as to what we mean with "custom email providers" it's suggested that we adjust the top link to be "Other SMTP" while keeping the links the same. This follows with the question on community - https://community.auth0.com/t/smtp-socket-labs-as-email-provider/13124

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
