### PR TITLE
Fix typo in Custom domain universal login Auth0.js code

### DIFF
--- a/articles/custom-domains/additional-configuration.md
+++ b/articles/custom-domains/additional-configuration.md
@@ -56,7 +56,7 @@ var lock = new Auth0Lock(config.clientID, config.auth0Domain, {
 If you use [Auth0.js](/libraries/auth0js) on the hosted login page, you need to set the `overrides` option like this:
 
 ```js
-var webAuth = new new auth0.WebAuth({
+var webAuth = new auth0.WebAuth({
   clientID: config.clientID, 
   domain: config.auth0Domain, 
   //code omitted for brevity


### PR DESCRIPTION
Found a typo in Custom domain universal login doc. For Auth0.js initialization, two new "new new" keywords is used instead of one. 
```
var webAuth = new new auth0.WebAuth({
  clientID: config.clientID, 
  domain: config.auth0Domain, 
  //code omitted for brevity
  overrides: {
  	__tenant: config.auth0Tenant,
  	__token_issuer: 'YOUR_CUSTOM_DOMAIN'
  },
  //code omitted for brevity
});
```