### PR TITLE
BITBUCKET_PASSWORD description is not correct

### DIFF
--- a/articles/extensions/bitbucket-deploy.md
+++ b/articles/extensions/bitbucket-deploy.md
@@ -21,11 +21,11 @@ To install and configure this extension, click on the **Bitbucket Deployments** 
 
 Set the following configuration variables:
 
-* **BITBUCKET_REPOSITORY**: the repository from which you want to deploy your Rules and Database Connection scripts (this can be either a public or private repository);
-* **BITBUCKET_BRANCH**: the branch the extension will monitor for changes;
-* **BITBUCKET_USER**: the username used to access the Bitbucket account; (this is not an email, it's just the username)
-* **BITBUCKET_PASSWORD**: an app password you create through the bitbucket settings to grant permissions to certain apps (https://bitbucket.org/account/user/Yourusername/app-passwords);
-* **SLACK_INCOMING_WEBHOOK**: the Webhook URL for Slack used to notify you of successful and failed deployments.
+* **BITBUCKET_REPOSITORY**: The repository from which you want to deploy your Rules and Database Connection scripts. This can be either a public or private repository.
+* **BITBUCKET_BRANCH**: The branch the extension will monitor for changes.
+* **BITBUCKET_USER**: The username used to access the Bitbucket account. Make sure you use the username, and not the email.
+* **BITBUCKET_PASSWORD**: An app password you create through the bitbucket settings to grant permissions to certain apps (https://bitbucket.org/account/user/Yourusername/app-passwords)
+* **SLACK_INCOMING_WEBHOOK**: The Webhook URL for Slack used to notify you of successful and failed deployments
 
 Once you have provided this information, click **Install**.
 

--- a/articles/extensions/bitbucket-deploy.md
+++ b/articles/extensions/bitbucket-deploy.md
@@ -21,10 +21,10 @@ To install and configure this extension, click on the **Bitbucket Deployments** 
 
 Set the following configuration variables:
 
-* **BITBUCKET_REPOSITORY**: The repository from which you want to deploy your Rules and Database Connection scripts. This can be either a public or private repository.
-* **BITBUCKET_BRANCH**: The branch the extension will monitor for changes.
-* **BITBUCKET_USER**: The username used to access the Bitbucket account. Make sure you use the username, and not the email.
-* **BITBUCKET_PASSWORD**: An app password you create through the bitbucket settings to grant permissions to certain apps (https://bitbucket.org/account/user/Yourusername/app-passwords)
+* **BITBUCKET_REPOSITORY**: The repository from which you want to deploy your Rules and Database Connection scripts. This can be either a public or private repository
+* **BITBUCKET_BRANCH**: The branch the extension will monitor for changes
+* **BITBUCKET_USER**: The username used to access the Bitbucket account. Make sure you use the username, and not the email
+* **BITBUCKET_PASSWORD**: An app password you create through the Bitbucket settings to grant permissions to certain apps
 * **SLACK_INCOMING_WEBHOOK**: The Webhook URL for Slack used to notify you of successful and failed deployments
 
 Once you have provided this information, click **Install**.

--- a/articles/extensions/bitbucket-deploy.md
+++ b/articles/extensions/bitbucket-deploy.md
@@ -23,8 +23,8 @@ Set the following configuration variables:
 
 * **BITBUCKET_REPOSITORY**: the repository from which you want to deploy your Rules and Database Connection scripts (this can be either a public or private repository);
 * **BITBUCKET_BRANCH**: the branch the extension will monitor for changes;
-* **BITBUCKET_USER**: the username used to access the Bitbucket account;
-* **BITBUCKET_PASSWORD**: the password associated with the username used to access the Bitbucket account;
+* **BITBUCKET_USER**: the username used to access the Bitbucket account; (this is not an email, it's just the username)
+* **BITBUCKET_PASSWORD**: an app password you create through the bitbucket settings to grant permissions to certain apps (https://bitbucket.org/account/user/Yourusername/app-passwords);
 * **SLACK_INCOMING_WEBHOOK**: the Webhook URL for Slack used to notify you of successful and failed deployments.
 
 Once you have provided this information, click **Install**.


### PR DESCRIPTION
This isn't the password of the user's bitbucket account, it's an app password you create through the bitbucket settings to grant permissions to certain apps (https://bitbucket.org/account/user/Yourusername/app-passwords)

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
