### PR TITLE
Updating canirequire link

### DIFF
--- a/articles/appliance/webtasks/index.md
+++ b/articles/appliance/webtasks/index.md
@@ -46,11 +46,11 @@ You may use Webtasks by calling its endpoints directly. This can be done using t
 
 ### Node.js Modules
 
-Currently, not all of the [Node.js modules available for the Auth0 Cloud Environment](https://tehsis.github.io/webtaskio-canirequire/) are available for the PSaaS Appliance.
+Currently, not all of the [Node.js modules available for the Auth0 Cloud Environment](https://auth0-extensions.github.io/canirequire/) are available for the PSaaS Appliance.
 
-To see which modules are available for Webtasks running on PSaaS Appliance instances, execute the [`List Modules` Webtask](https://github.com/tehsis/webtaskio-canirequire/blob/gh-pages/tasks/list_modules.js) using the appropriate sandbox on your PSaaS Appliance instance.
+To see which modules are available for Webtasks running on PSaaS Appliance instances, execute the [`List Modules` Webtask](https://github.com/auth0-extensions/canirequire/blob/gh-pages/tasks/list_modules.js) using the appropriate sandbox on your PSaaS Appliance instance.
 
-First, copy locally the [`List Modules` Webtask](https://github.com/tehsis/webtaskio-canirequire/blob/gh-pages/tasks/list_modules.js), either by downloading the file or by copying this code:
+First, copy locally the [`List Modules` Webtask](https://github.com/auth0-extensions/canirequire/blob/gh-pages/tasks/list_modules.js), either by downloading the file or by copying this code:
 
 ```js
 'use npm';

--- a/articles/connections/database/custom-db.md
+++ b/articles/connections/database/custom-db.md
@@ -28,7 +28,7 @@ In this tutorial you'll learn how to connect your user database to Auth0 and con
 
 Here are some things to know before you start this process.
 
-* Database action scripts are written in Javascript and run in a [Webtask](https://webtask.io/) environment. In the environment you can use the full JavaScript language and [these Node.js libraries](https://tehsis.github.io/webtaskio-canirequire/).
+* Database action scripts are written in Javascript and run in a [Webtask](https://webtask.io/) environment. In the environment you can use the full JavaScript language and [these Node.js libraries](https://auth0-extensions.github.io/canirequire/).
 * Auth0 provides templates for most common databases, such as: **ASP.NET Membership Provider**, **MongoDB**, **MySQL**, **Oracle**, **PostgreSQL**, **SQLServer**, **Windows Azure SQL Database**, and for a web service accessed by **Basic Auth**. Essentially, you can connect to any kind of database or web service with a custom script.
 * You can use the [auth0-custom-db-testharness library](https://www.npmjs.com/package/auth0-custom-db-testharness) to deploy, execute, and test the output of database action scripts using a Webtask sandbox environment.
 * The [Update Users Using Your Database](/user-profile/customdb) article has information on updating user profile fields.

--- a/articles/integrations/office-365-custom-provisioning.md
+++ b/articles/integrations/office-365-custom-provisioning.md
@@ -62,7 +62,7 @@ In the code you'll also see that the rule will wait about 15 seconds after the u
 function (user, context, callback) {
   // Require the Node.js packages that we are going to use.
   // Check this website for a complete list of the packages available:
-  // https://tehsis.github.io/webtaskio-canirequire/
+  // https://auth0-extensions.github.io/canirequire/
   var rp = require('request-promise');
   var uuidv4 = require('uuid');
 

--- a/articles/rules/current/index.md
+++ b/articles/rules/current/index.md
@@ -360,7 +360,7 @@ Notice that the code sandbox in which Rules run on, can be recycled at any time.
 
 For security reasons, your Rules code executes isolated from the code of other Auth0 tenants in a sandbox based on [Extend](https://goextend.io?utm_source=docs&utm_medium=page&utm_campaign=auth0-com&utm_content=docs-rules). 
 
-Within the sandbox, you can access the full power of Node.js with a large number of Node.js modules. For a list of currently supported sandbox modules, see [Modules Supported by the Sandbox](https://tehsis.github.io/webtaskio-canirequire) and [Additional Modules Available in Rules](/appliance/modules).
+Within the sandbox, you can access the full power of Node.js with a large number of Node.js modules. For a list of currently supported sandbox modules, see [Modules Supported by the Sandbox](https://auth0-extensions.github.io/canirequire/) and [Additional Modules Available in Rules](/appliance/modules).
 
 ## Keep reading
 

--- a/articles/rules/legacy/index.md
+++ b/articles/rules/legacy/index.md
@@ -283,7 +283,7 @@ Notice that the code sandbox in which Rules run on, can be recycled at any time.
 
 For security reasons, the Rules code runs in a JavaScript sandbox based on [webtask.io](https://webtask.io) where you can use the full power of the ECMAScript 5 language.
 
-For a list of currently supported sandbox modules, see: [Modules Supported by the Sandbox](https://tehsis.github.io/webtaskio-canirequire).
+For a list of currently supported sandbox modules, see: [Modules Supported by the Sandbox](https://auth0-extensions.github.io/canirequire/).
 
 ## Read more
 


### PR DESCRIPTION
The canirequire link was posting to the old tehsis repo. This Github site was moved to our auth0-extensions repo. While the previous one redirected to it, it's always nice to have direct links!
