### PR TITLE
ws-fed: remove client id from URL

### DIFF
--- a/articles/api/authentication/_wsfed-req.md
+++ b/articles/api/authentication/_wsfed-req.md
@@ -64,12 +64,12 @@ This endpoint accepts a WS-Federation request to initiate a login.
 ## Get Metadata
 
 ```http
-GET https://${account.namespace}/wsfed/${account.clientId}/FederationMetadata/2007-06/FederationMetadata.xml
+GET https://${account.namespace}/wsfed/FederationMetadata/2007-06/FederationMetadata.xml
 ```
 
 ```shell
 curl --request GET \
-  --url 'https://${account.namespace}/wsfed/${account.clientId}/FederationMetadata/2007-06/FederationMetadata.xml'
+  --url 'https://${account.namespace}/wsfed/FederationMetadata/2007-06/FederationMetadata.xml'
 ```
 
 <% var getMetadataPath = '/wsfed/YOUR_CLIENT_ID/FederationMetadata/2007-06/FederationMetadata.xml'; %>


### PR DESCRIPTION
If you don’t add the client id you’ll get the metadata from the global client (the cert and other info from the tenant). If you add it you get the ones from a particular client. We would like to have only the one from the tenant, so we are removing the guidance that says otherwise. Any requests to support the client id should be forwarded to crew-auth, alongside with info on the use case from the customer.