### PR TITLE
ws-fed: remove client id from URL

### DIFF
--- a/articles/api/authentication/_wsfed-req.md
+++ b/articles/api/authentication/_wsfed-req.md
@@ -64,15 +64,15 @@ This endpoint accepts a WS-Federation request to initiate a login.
 ## Get Metadata
 
 ```http
-GET https://${account.namespace}/wsfed/${account.clientId}/FederationMetadata/2007-06/FederationMetadata.xml
+GET https://${account.namespace}/wsfed/FederationMetadata/2007-06/FederationMetadata.xml
 ```
 
 ```shell
 curl --request GET \
-  --url 'https://${account.namespace}/wsfed/${account.clientId}/FederationMetadata/2007-06/FederationMetadata.xml'
+  --url 'https://${account.namespace}/wsfed/FederationMetadata/2007-06/FederationMetadata.xml'
 ```
 
-<% var getMetadataPath = '/wsfed/YOUR_CLIENT_ID/FederationMetadata/2007-06/FederationMetadata.xml'; %>
+<% var getMetadataPath = '/wsfed/FederationMetadata/2007-06/FederationMetadata.xml'; %>
 <%=
 include('../../_includes/_http-method', {
   "http_badge": "badge-primary",

--- a/articles/integrations/office-365.md
+++ b/articles/integrations/office-365.md
@@ -82,7 +82,7 @@ Set-MsolDomainAuthentication
     -Authentication Federated
     -PassiveLogOnUri "https://fabrikam.auth0.com/wsfed/yNqQMENaYIONxAaQmrct341tZ9joEjTi"
     -ActiveLogonUri "https://fabrikam.auth0.com/yNqQMENaYIONxAaQmrct341tZ9joEjTi/trust/usernamemixed?connection=FabrikamAD"
-    -MetadataExchangeUri "https://fabrikam.auth0.com/wsfed/yNqQMENaYIONxAaQmrct341tZ9joEjTi/FederationMetadata/2007-06/FederationMetadata.xml?connection=FabrikamAD"
+    -MetadataExchangeUri "https://fabrikam.auth0.com/wsfed/FederationMetadata/2007-06/FederationMetadata.xml?connection=FabrikamAD"
     -SigningCertificate "MIID..."
     -IssuerUri "urn:fabrikam"
     -LogOffUri "https://fabrikam.auth0.com/logout"

--- a/articles/protocols/ws-fed/index.md
+++ b/articles/protocols/ws-fed/index.md
@@ -27,7 +27,7 @@ You can find all available options for configuring WS-Federation under the [adva
 You will need to configure the **Relying Party**, which can be done using the following metadata endpoint:
 
 ```text
-https://${account.namespace}/wsfed/${account.clientId}/FederationMetadata/2007-06/FederationMetadata.xml
+https://${account.namespace}/wsfed/FederationMetadata/2007-06/FederationMetadata.xml
 ```
 
 You can also use the **samlConfiguration** object (available in [rules](/rules)) to configure claims sent via the SAML token, as well as other lower-level WS-Fed and SAML-P settings.
@@ -52,7 +52,7 @@ If you're using using Auth0 with an identity provider that utilizes the WD-Feder
 
 Click **Save** to proceed. You will then be presented with the instructions you need to finish configuring the integration.
 
-The Federation Metadata file contains information about the the identity provider's certificates. If you provide the Federation Metadata endpoint (typically of the form ending with **/FederationMetadata/2007-06/FederationMetadata.xml**), Auth0 can check daily for changes in the configuration, such as the addition of a new signing certificate that was added in preparation for a rollover.
+The Federation Metadata file contains information about the the identity provider's certificates. If you provide the Federation Metadata endpoint (typically of the form ending with `/FederationMetadata/2007-06/FederationMetadata.xml`), Auth0 can check daily for changes in the configuration, such as the addition of a new signing certificate that was added in preparation for a rollover.
 
 Because of this, enabling the Federation Metadata endpoint is preferred to providing a standalone metadata file. If you provide a standalone metadata file, we will notify you via email when the certificates are close to their expiration date.
 


### PR DESCRIPTION
If you don’t add the client id you’ll get the metadata from the global client (the cert and other info from the tenant). If you add it you get the ones from a particular client. We would like to have only the one from the tenant, so we are removing the guidance that says otherwise. Any requests to support the client id should be forwarded to crew-auth, alongside with info on the use case from the customer.
