### PR TITLE
Mismatch between code sample and github repo

### DIFF
--- a/articles/quickstart/webapp/python/01-login.md
+++ b/articles/quickstart/webapp/python/01-login.md
@@ -189,7 +189,7 @@ def logout():
     session.clear()
     # Redirect user to logout endpoint
     params = {'returnTo': url_for('home', _external=True), 'client_id': '${account.clientId}'}
-    return redirect(auth0.base_url + '/v2/logout?' + urlencode(params))
+    return redirect(auth0.api_base_url + '/v2/logout?' + urlencode(params))
 ```
 
 ::: note


### PR DESCRIPTION
I found a small mismatch in the /logout sample code and the associated function in the github repo: https://github.com/auth0-samples/auth0-python-web-app

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
