### PR TITLE
Quickstarts React-native: Improve download instructions

### DIFF
--- a/articles/quickstart/native/react-native/download.md
+++ b/articles/quickstart/native/react-native/download.md
@@ -8,14 +8,10 @@ auth0.samples.Auth0Sample://${account.namespace}/ios/auth0.samples.Auth0Sample/c
 2) Make sure [Node.JS LTS](https://nodejs.org/en/download/) is installed and execute the following commands in the sample's directory:
 
 ```bash
-# Install dependencies
-npm install
- # Link the native module
-react-native link react-native-auth0
- # Run on iOS device
-react-native run-ios
- # Run on Android device
-react-native run-android
+npm install # Install dependencies
+react-native link react-native-auth0 # Link the native module
+react-native run-ios # Run on iOS device
+react-native run-android # Run on Android device
 ```
 
 Read more about how to run react-native apps in their [official documentation](https://facebook.github.io/react-native/docs/running-on-device.html).

--- a/articles/quickstart/native/react-native/download.md
+++ b/articles/quickstart/native/react-native/download.md
@@ -5,14 +5,16 @@ To run the sample follow these steps:
 auth0.samples.Auth0Sample://${account.namespace}/ios/auth0.samples.Auth0Sample/callback,com.auth0sample://${account.namespace}/android/com.auth0sample/callback
 ```
 
-2) Execute the following commands in the sample's directory:
+2) Make sure [Node.JS LTS](https://nodejs.org/en/download/) is installed and execute the following commands in the sample's directory:
 
 ```bash
-# Link the native module
+# Install dependencies
+npm install
+ # Link the native module
 react-native link react-native-auth0
-# Run on iOS device
+ # Run on iOS device
 react-native run-ios
-# Run on Android device
+ # Run on Android device
 react-native run-android
 ```
 


### PR DESCRIPTION
This PR contains two changesets:

* [the first commit](https://github.com/auth0/docs/commit/92281676672a5e9dc33defa6e8a9f899d5ae348c) addresses #6420 and adds npm install as a step to run the sample
* [the second commit](https://github.com/auth0/docs/pull/6430/commits/2ca4af1698b9c585f34354574348903b874520f1) is an experiment to add the comments in the bash section in-line to prevent the modal window from getting to large and keep the download button visible. This can be reverted if undesired. 