### PR TITLE
Document redirectURI for checkSession (#6432)

### DIFF
--- a/articles/libraries/auth0js/v9/index.md
+++ b/articles/libraries/auth0js/v9/index.md
@@ -431,6 +431,10 @@ webAuth.checkSession(
 Note that `checkSession()` triggers any [rules](/rules) you may have set up, so you should check on your rules in the [Dashboard](${manage_url}/#/rules) prior to using it.
 :::
 
+::: note
+Note that `checkSession()` requires a `redirectUri` that matches one of the allowed URLs in the **Allowed Callback URLs** setting for your application, but it does not load the URL you provide. You can provide `redirectUri` in either the call to `checkSession()` or the call to `new WebAuth()`.
+:::
+
 The actual redirect to `/authorize` happens inside an iframe, so it will not reload your application or redirect away from it.
 
 However, the browser **must** have third-party cookies enabled. Otherwise, **checkSession()** is unable to access the current user's session (making it impossible to obtain a new token without displaying anything to the user). The same will happen if users have [Safari's ITP enabled](/api-auth/token-renewal-in-safari).


### PR DESCRIPTION
This PR documents that checkSession requires redirectURI to be set, but does not use it, as explained in #6432.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
