### PR TITLE
Update load testing policy

### DIFF
--- a/articles/policies/load-testing.md
+++ b/articles/policies/load-testing.md
@@ -14,8 +14,9 @@ useCase:
 
 Load testing against the Auth0 production cloud service is not permitted at any time, as stated in our [Terms of Service](https://auth0.com/terms).
 
-Customers who have purchased an enterprise support plan that includes load testing may request one load test (with up to 2 repeats) to conduct load testing against an Auth0 test instance. For load tests that require more than 100 RPS a separate environment will have to be created and it will have a different time schedule than normal load tests.
+However, customers who have purchased an Enterprise subscription may request one load test (with up to 2 repeats) to conduct load testing against an Auth0 test instance. For load tests that require more than 100 RPS a separate environment will have to be created and it will have a different time schedule than normal load tests.
 
+Note that Auth0 reserves the right to reject the load test request, or ask for modifications to the load test plans.
 ## How to request
 
 * Customers must file a load testing request in writing, via the [Auth0 support center](${env.DOMAIN_URL_SUPPORT}).
@@ -58,9 +59,9 @@ Note that load testing will require customer to:
 * Establish a mechanism for testing that emails arrived
 
 ## Limitations
-Auth0 reserves the right to reject or request modifications to load test plans.
+Auth0 reserves the right to reject the load testing request, or ask for modifications to load test plans.
 
 A load testing approval will specify pre-arranged dates/times in which load testing can be performed.  All load testing must be limited to those pre-arranged dates/times. Load testing windows will be a maximum of 2 hours in duration. Failure to abide by this policy may result in temporary blocking of access to an tenant until the issue is remediated.
 
 ## Effectivity
-This policy is effective April 4, 2016
+This policy is effective April 4, 2016. It has been updated on July 27th, 2018.


### PR DESCRIPTION
- Change wording on who can request the policy. Enterprise subs come with Enterprise support by default. There's no terms in the contracts that specify if the subscription is subject to request load testing or not
- Add minor improvement to disclaimer that states we reserve the right to reject the request.
- Add update date