### PR TITLE
maximum value of 2592000 seconds on property token_lifetime

### DIFF
--- a/articles/api-auth/apis.md
+++ b/articles/api-auth/apis.md
@@ -78,7 +78,7 @@ Click on the *Settings* tab of your [API](${manage_url}/#/apis) to review the av
 
 - **Identifier**: A unique identifier for your API. This value is set upon API creation and cannot be modified afterwards. We recommend using a URL but note that this doesn't have to be a publicly available URL, Auth0 will not call your API at all.
 
-- **Token Expiration (Seconds)**: The amount of time (in seconds) before the Auth0 Access Token expires.
+- **Token Expiration (Seconds)**: The amount of time (in seconds) before the Auth0 Access Token expires. The default value is 86400 seconds (24 hours). The maximum value you can set is 2592000 seconds (30 days).
 
 - **Allow Skipping User Consent**: When a first party application requests authorized access against an API with the *Allow Skipping User Consent* flag set, the User Consent dialog will not be shown to the final user. Note that if the hostname of your application's **callbackURL** is `localhost` or `127.0.0.1` the consent dialog will always be displayed.
 

--- a/articles/api/management/v2/tokens-flows.md
+++ b/articles/api/management/v2/tokens-flows.md
@@ -7,12 +7,8 @@ topics:
   - apis
   - management-api
   - tokens
-<<<<<<< HEAD
 contentType: concept
-=======
-contentType: discussion
 useCase: invoke-api
->>>>>>> Add useCase tags, part 1
 ---
 # Changes in Auth0 Management APIv2 Tokens
 

--- a/articles/connections/calling-an-external-idp-api.md
+++ b/articles/connections/calling-an-external-idp-api.md
@@ -80,7 +80,7 @@ The snippets make a `POST` operation to the [/oauth/token endpoint of the Auth0 
 
 #### Token expiration
 
-The token you received has, by default, an expiration time of 24 hours (86400 seconds). To change this, update the **Token Expiration (Seconds)** field, at the [Settings tab](${manage_url}/#/apis/management/settings) and save your changes. The next token you generate will use the updated expiration time.
+The token you received has, by default, an expiration time of 24 hours (86400 seconds). To change this, update the **Token Expiration (Seconds)** field, at the [Settings tab](${manage_url}/#/apis/management/settings) and save your changes. The next token you generate will use the updated expiration time. The maximum value you can set is 2592000 seconds (30 days) however our recommendation is to keep the default value.
 
 ::: panel-warning Security warning
 These tokens **cannot be revoked**. To minimize the risk, we recommend issuing short-lived tokens (and granting only the necessary scopes for each application). For a production environment you can configure a simple CLI that will fetch a new token when the old one expires. You can find a sample implementation in Python [here](/api/management/v2/tokens#sample-implementation-python).

--- a/articles/tokens/access-token.md
+++ b/articles/tokens/access-token.md
@@ -135,7 +135,7 @@ For an example of how to add a custom claim, refer to [Add Custom Claims](/scope
 
 The token lifetime can be controlled on a per-API basis. The validity period can be increased or decreased based on the security requirements of each API.
 
-To configure the amount of time a token lives, use the **Token Expiration (Seconds)** field for your API at the [Dashboard](${manage_url}/#/apis) APIs section. The default value is `24` hours (`86400` seconds).
+To configure the amount of time a token lives, use the **Token Expiration (Seconds)** field for your API at the [Dashboard](${manage_url}/#/apis) APIs section. The default value is `24` hours (`86400` seconds). The maximum amount of time (in seconds) that the token can be valid after being issued is 2592000 seconds (30 days).
 
 ![Token Expiration - API](/media/articles/tokens/tokens-expiration-api.png)
 


### PR DESCRIPTION
Making customer aware that the max value for token_lifetime is 2592000 seconds

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
