### PR TITLE
Client Authentication docs: update overview

### DIFF
--- a/articles/application-auth/current/client-side-web.md
+++ b/articles/application-auth/current/client-side-web.md
@@ -16,11 +16,13 @@ useCase:
 
 # Authentication for Client-side Web Apps
 
-The Auth0 OAuth 2.0 authentication endpoints support Client-side Web Applications. These applications are also referred to as JavaScript or Single Page Applications.
+The Auth0 OAuth 2.0 authentication endpoints support client-side web applications. These applications are also referred to as JavaScript or Single Page Applications.
 
 ## Overview
 
-Auth0 exposes OAuth 2.0 endpoints for authenticating any user. You can redirect the user from your JavaScript application to these endpoints in the web browser. Auth0 will handle the authentication of the user, and then redirect the user back to the Callback URL, returning an [ID Token](/tokens/id-token) and [Access Token](/tokens/access-token) in the hash fragment of the request.
+Auth0 exposes endpoints that you can use to authenticate users and get their authorization. 
+
+You can redirect the user from your JavaScript application to these endpoints in the web browser. Auth0 will handle the authentication of the user, get their authorization for the resources your app wants to access, and then redirect the user back to a pre-configured callback URL, returning an [ID Token](/tokens/id-token) and [Access Token](/tokens/access-token) in the hash fragment of the request.
 
 ## The Authentication Flow
 

--- a/articles/application-auth/current/client-side-web.md
+++ b/articles/application-auth/current/client-side-web.md
@@ -16,13 +16,11 @@ useCase:
 
 # Authentication for Client-side Web Apps
 
-The Auth0 OAuth 2.0 authentication endpoints support client-side web applications. These applications are also referred to as JavaScript or Single Page Applications.
+You can use the Auth0 Authentication API to create client-side web applications that use [OpenID Connect](/protocols/oidc) and [OAuth 2.0](/protocols/oauth2) to authenticate users and get their authorization to access protected resources.
 
 ## Overview
 
-Auth0 exposes endpoints that you can use to authenticate users and get their authorization. 
-
-You can redirect the user from your JavaScript application to these endpoints in the web browser. Auth0 will handle the authentication of the user, get their authorization for the resources your app wants to access, and then redirect the user back to a pre-configured callback URL, returning an [ID Token](/tokens/id-token) and [Access Token](/tokens/access-token) in the hash fragment of the request.
+Auth0 exposes endpoints that you can use to authenticate users and get their authorization. You can redirect the user from your JavaScript application to these endpoints in the web browser. Auth0 will handle the authentication of the user, get their authorization for the resources your app wants to access, and then redirect the user back to a pre-configured callback URL, returning an [ID Token](/tokens/id-token) and [Access Token](/tokens/access-token) in the hash fragment of the request.
 
 ## The Authentication Flow
 

--- a/articles/application-auth/current/index.md
+++ b/articles/application-auth/current/index.md
@@ -14,7 +14,7 @@ useCase:
 
 Auth0 uses [OpenID Connect](/protocols/oidc) and [OAuth 2.0](/protocols/oauth2) to authenticate users and get their authorization to access protected resources. 
 
-We support common scenarios for mobile, desktop, server-side, or client-side applications.
+We support scenarios for mobile, desktop, server-side, or client-side applications.
 
 You can get more details on implementing these flows by following one of the following links:
 

--- a/articles/application-auth/current/index.md
+++ b/articles/application-auth/current/index.md
@@ -12,7 +12,7 @@ useCase:
 
 # Application Authentication
 
-Auth0 uses [OpenID Connect]() and [OAuth 2.0]() to authenticate users and get their authorization to access protected resources. 
+Auth0 uses [OpenID Connect](/protocols/oidc) and [OAuth 2.0](/protocols/oauth2) to authenticate users and get their authorization to access protected resources. 
 
 We support common scenarios for mobile, desktop, server-side, or client-side applications.
 

--- a/articles/application-auth/current/index.md
+++ b/articles/application-auth/current/index.md
@@ -12,7 +12,9 @@ useCase:
 
 # Application Authentication
 
-Auth0 uses the OAuth 2.0 protocol for authentication and authorization. We support common OAuth 2.0 scenarios for Mobile Applications, Desktop Applications, Server-side web applications or Client-side Web Applications.
+Auth0 uses [OpenID Connect]() and [OAuth 2.0]() to authenticate users and get their authorization to access protected resources. 
+
+We support common scenarios for mobile, desktop, server-side, or client-side applications.
 
 You can get more details on implementing these flows by following one of the following links:
 

--- a/articles/application-auth/current/mobile-desktop.md
+++ b/articles/application-auth/current/mobile-desktop.md
@@ -21,7 +21,7 @@ You can authenticate users of your mobile/desktop applications by:
 * Using one of the [Auth0 SDKs](/libraries), which are client-side libraries that **do not** include a user interface but allow for expanded customization of the authentication behavior and appearance of the login screen;
 * Calling the Auth0 [Authentication API](/api/authentication) endpoints, which allows you to integrate with Auth0 without requiring the user of Auth0's libraries.
 
-This article will cover how to call the Auth0 [Authentication API](/api/authentication) endpoints using [Proof Key for Code Exchange (PKCE)](/api-auth/grant/authorization-code-pkce) during the authentication process.
+This article will cover how to call the Auth0 [Authentication API](/api/authentication) endpoints using [Proof Key for Code Exchange (PKCE)](/api-auth/grant/authorization-code-pkce) during the authentication and authorization process.
 
 If you would like to implement this functionality using either Lock or one of the Auth0 SDKs, please refer to the following resources:
 
@@ -36,13 +36,15 @@ If you would like to implement this functionality using either Lock or one of th
 
 ## Overview
 
-Auth0 exposes OAuth 2.0 endpoints that you can use to authenticate users. You can call these endpoints through an embedded browser in your **native** application. After authentication completes, you can return an [ID Token](/tokens/id-token) that contains the user's profile information.
+Auth0 exposes endpoints that you can use to authenticate users and get their authorization. 
+
+You can call these endpoints through an embedded browser in your **native** application. After authentication completes, you can return an [ID Token](/tokens/id-token) (which contains information about the identity of the user) and an [Access Token](/tokens/access-token).
 
 ::: note
-Instead of following this tutorial, you can use any of Auth0's client libraries. These encapsulate all the logic required and make it easier for your to implement authentication. Please refer to our [Native Quickstarts](/quickstart/native) to get started.
+Instead of following this tutorial, you can use any of Auth0's client libraries. They encapsulate all the logic required and make it easier for your to implement authentication. Please refer to our [Native Quickstarts](/quickstart/native) to get started.
 :::
 
-## Register Your Application
+## Register your application
 
 If you haven't already created a new [Application](/applications) in Auth0, you'll need to do so before implementing your authentication flow. The Auth0 Application maps to your application and allows your application to use Auth0 for authentication purposes.
 

--- a/articles/application-auth/current/server-side-web.md
+++ b/articles/application-auth/current/server-side-web.md
@@ -21,7 +21,7 @@ You can use the Auth0 Authentication API to create server-side web applications 
 
 Auth0 exposes endpoints that you can use to authenticate users and get their authorization. 
 
-You can redirect the user from your web application to these endpoints in the web browser. Auth0 will handle the authentication of the user, and then redirect the user back to a pre-configured URL, returning an authorization code in the query string parameters of the callback URL. This code can then be exchanged for an [ID Token](/tokens/id-token) (which contains information about the identity of the user) and an [Access Token](/tokens/access-token).
+You can redirect the user from your web application to these endpoints in the web browser. Auth0 will handle the authentication of the user, and then redirect the user back to a pre-configured callback URL, returning an authorization code in the query string parameters of the callback URL. This code can then be exchanged for an [ID Token](/tokens/id-token) (which contains information about the identity of the user) and an [Access Token](/tokens/access-token).
 
 ## The Authentication Flow
 

--- a/articles/application-auth/current/server-side-web.md
+++ b/articles/application-auth/current/server-side-web.md
@@ -15,13 +15,13 @@ useCase:
 
 # Authentication for Server-side Web Apps
 
-You can use the Auth0 Authentication API to create server-side web applications that uses OAuth 2.0 authorization to authenticate users.
+You can use the Auth0 Authentication API to create server-side web applications that uses OAuth 2.0 and OpenID Connect to authenticate users and get their authorization to access protected resources.
 
 ## Overview
 
 Auth0 exposes endpoints that you can use to authenticate users and get their authorization. 
 
-You can redirect the user from your web application to these endpoints in the web browser. Auth0 will handle the authentication of the user, and then redirect the user back to a pre-configured URL, returning an authorization code in the query string parameters of the callback URL. This code can then be exchanged for an [ID Token](/tokens/id-token) which contains information about the identity of the user.
+You can redirect the user from your web application to these endpoints in the web browser. Auth0 will handle the authentication of the user, and then redirect the user back to a pre-configured URL, returning an authorization code in the query string parameters of the callback URL. This code can then be exchanged for an [ID Token](/tokens/id-token) (which contains information about the identity of the user) and an [Access Token](/tokens/access-token).
 
 ## The Authentication Flow
 

--- a/articles/application-auth/current/server-side-web.md
+++ b/articles/application-auth/current/server-side-web.md
@@ -19,7 +19,9 @@ You can use the Auth0 Authentication API to create server-side web applications 
 
 ## Overview
 
-Auth0 exposes OAuth 2.0 endpoints for authenticating any user. You can redirect the user from your web application to these endpoints in the web browser. Auth0 will handle the authentication of the user, and then redirect the user back to the `redirect_uri` (also referred to as the Callback URL), returning an authorization `code` in the query string parameters of the Callback URL. This `code` can then be exchanged for an [ID Token](/tokens/id-token) which contains the identity of the user.
+Auth0 exposes endpoints that you can use to authenticate users and get their authorization. 
+
+You can redirect the user from your web application to these endpoints in the web browser. Auth0 will handle the authentication of the user, and then redirect the user back to a pre-configured URL, returning an authorization code in the query string parameters of the callback URL. This code can then be exchanged for an [ID Token](/tokens/id-token) which contains information about the identity of the user.
 
 ## The Authentication Flow
 


### PR DESCRIPTION
Mentions OAuth 2.0 and user authentication in the same sentence and this can be confusing since OAuth 2.0 is actually used for authorization.