### PR TITLE
Encourage accesstoken

### DIFF
--- a/articles/libraries/auth0-swift/user-management.md
+++ b/articles/libraries/auth0-swift/user-management.md
@@ -21,7 +21,7 @@ The `link` method accepts two parameters, the primary user id and the secondary 
 
 ```swift
 Auth0
-   .users(token: accessToken)
+   .users(token: "user-scoped access token")
    .link(userId, withOtherUserToken: "another user token")
    .start { result in
       switch result {
@@ -40,7 +40,7 @@ The parameters read, essentially: "Unlink this **secondary user** (with this **p
 
 ```swift
 Auth0
-   .users(token: accessToken)
+   .users(token: "user-scoped access token")
    .unlink(identityId: identifier, provider: provider, fromUserId:userId)
    .start { result in
       switch result {
@@ -60,7 +60,7 @@ Note that when accounts are linked, the secondary account's metadata is not merg
 
 ```swift
 Auth0
-    .users(token: accessToken)
+   .users(token: "user-scoped access token")
     .get(userId, fields: ["user_metadata"], include: true)
     .start { result in
         switch result {
@@ -78,7 +78,7 @@ When updating user metadata, you will create a `userMetadata` object, and then c
 
 ```swift
 Auth0
-    .users(token: accessToken)
+   .users(token: "user-scoped access token")
     .patch("user identifier", userMetadata: ["first_name": "John", "last_name": "Doe"])
     .start { result in
         switch result {

--- a/articles/libraries/auth0-swift/user-management.md
+++ b/articles/libraries/auth0-swift/user-management.md
@@ -21,7 +21,7 @@ The `link` method accepts two parameters, the primary user id and the secondary 
 
 ```swift
 Auth0
-   .users(token: "user token")
+   .users(token: accessToken)
    .link(userId, withOtherUserToken: "another user token")
    .start { result in
       switch result {
@@ -40,7 +40,7 @@ The parameters read, essentially: "Unlink this **secondary user** (with this **p
 
 ```swift
 Auth0
-   .users(token: "user token")
+   .users(token: accessToken)
    .unlink(identityId: identifier, provider: provider, fromUserId:userId)
    .start { result in
       switch result {
@@ -60,7 +60,7 @@ Note that when accounts are linked, the secondary account's metadata is not merg
 
 ```swift
 Auth0
-    .users(token: idToken)
+    .users(token: accessToken)
     .get(userId, fields: ["user_metadata"], include: true)
     .start { result in
         switch result {
@@ -78,7 +78,7 @@ When updating user metadata, you will create a `userMetadata` object, and then c
 
 ```swift
 Auth0
-    .users(token: "user token")
+    .users(token: accessToken)
     .patch("user identifier", userMetadata: ["first_name": "John", "last_name": "Doe"])
     .start { result in
         switch result {

--- a/articles/libraries/auth0-swift/user-management.md
+++ b/articles/libraries/auth0-swift/user-management.md
@@ -60,7 +60,7 @@ Note that when accounts are linked, the secondary account's metadata is not merg
 
 ```swift
 Auth0
-   .users(token: "user-scoped access token")
+    .users(token: "user-scoped access token")
     .get(userId, fields: ["user_metadata"], include: true)
     .start { result in
         switch result {
@@ -78,7 +78,7 @@ When updating user metadata, you will create a `userMetadata` object, and then c
 
 ```swift
 Auth0
-   .users(token: "user-scoped access token")
+    .users(token: "user-scoped access token")
     .patch("user identifier", userMetadata: ["first_name": "John", "last_name": "Doe"])
     .start { result in
         switch result {

--- a/articles/quickstart/native/android/04-user-profile.md
+++ b/articles/quickstart/native/android/04-user-profile.md
@@ -18,7 +18,7 @@ This tutorial shows you how to get and modify the user's profile data with Auth0
 ## Before You Start
 
 ::: note
-Before you continue with this tutorial, make sure that you have completed the [Login](/quickstart/native/android/00-login) and [Session Handling](/quickstart/native/android/03-session-handling) tutorials. To call the API applications, you need a valid Access Token and ID Token.
+Before you continue with this tutorial, make sure that you have completed the [Login](/quickstart/native/android/00-login) and [Session Handling](/quickstart/native/android/03-session-handling) tutorials. To call the API applications, you need a valid Access Token.
 :::
 
 Before launching the login process, you need to make sure the authorization server allows you to read and edit the current user profile. To do that, ask for the `openid profile email read:current_user update:current_user_metadata` scope and the Management API audience, which happens to include the User Info audience as well. Find the snippet in which you initialize the `WebAuthProvider` class. To that snippet, add the line `withScope("openid profile email read:current_user update:current_user_metadata")` and `withAudience(String.format("https://%s/api/v2/", getString(R.string.com_auth0_domain)))`.

--- a/articles/quickstart/native/ios-swift/03-user-sessions.md
+++ b/articles/quickstart/native/ios-swift/03-user-sessions.md
@@ -190,7 +190,7 @@ You can add custom user information in the user metadata section by performing a
 let accessToken = ... // You will need the accessToken from your credentials instance 'credentials.accessToken'
 let profile = ... // the Profile instance you obtained accessing the `/userinfo` endpoint.
 Auth0
-    .users(token: idToken)
+    .users(token: accessToken)
     .patch(profile.sub, userMetadata: ["country": "United Kingdom"])
     .start { result in
         switch result {
@@ -214,7 +214,7 @@ Retrieving the `user_metadata` dictionary:
 let accessToken = ... // You will need the accessToken from your credentials instance 'credentials.accessToken'
 let profile = ... // the Profile instance you obtained accessing the `/userinfo` endpoint.
 Auth0
-    .users(token: idToken)
+    .users(token: accessToken)
     .get(profile.sub, fields: ["user_metadata"], include: true)
     .start { result in
         switch result {

--- a/articles/quickstart/native/ios-swift/03-user-sessions.md
+++ b/articles/quickstart/native/ios-swift/03-user-sessions.md
@@ -190,7 +190,7 @@ You can add custom user information in the user metadata section by performing a
 let accessToken = ... // You will need the accessToken from your credentials instance 'credentials.accessToken'
 let profile = ... // the Profile instance you obtained accessing the `/userinfo` endpoint.
 Auth0
-   .users(token: "user-scoped access token")
+    .users(token: "user-scoped access token")
     .patch(profile.sub, userMetadata: ["country": "United Kingdom"])
     .start { result in
         switch result {
@@ -214,7 +214,7 @@ Retrieving the `user_metadata` dictionary:
 let accessToken = ... // You will need the accessToken from your credentials instance 'credentials.accessToken'
 let profile = ... // the Profile instance you obtained accessing the `/userinfo` endpoint.
 Auth0
-   .users(token: "user-scoped access token")
+    .users(token: "user-scoped access token")
     .get(profile.sub, fields: ["user_metadata"], include: true)
     .start { result in
         switch result {

--- a/articles/quickstart/native/ios-swift/03-user-sessions.md
+++ b/articles/quickstart/native/ios-swift/03-user-sessions.md
@@ -190,7 +190,7 @@ You can add custom user information in the user metadata section by performing a
 let accessToken = ... // You will need the accessToken from your credentials instance 'credentials.accessToken'
 let profile = ... // the Profile instance you obtained accessing the `/userinfo` endpoint.
 Auth0
-    .users(token: accessToken)
+   .users(token: "user-scoped access token")
     .patch(profile.sub, userMetadata: ["country": "United Kingdom"])
     .start { result in
         switch result {
@@ -214,7 +214,7 @@ Retrieving the `user_metadata` dictionary:
 let accessToken = ... // You will need the accessToken from your credentials instance 'credentials.accessToken'
 let profile = ... // the Profile instance you obtained accessing the `/userinfo` endpoint.
 Auth0
-    .users(token: accessToken)
+   .users(token: "user-scoped access token")
     .get(profile.sub, fields: ["user_metadata"], include: true)
     .start { result in
         switch result {


### PR DESCRIPTION
The [Migration Guide](https://auth0.com/docs/migrations/guides/calling-api-with-idtokens) to discourage the use of ID tokens when authorizing some calls to API v2 mentions an as of now open-ended grace period that started March 31, 2018. However, it seems to me that we should update the documentation to encourage use of accessToken over idToken when calling management api.

Even though these are pretty minor, I would definitely would want some one that actually works in the SDK's to review these changes.