### PR TITLE
Add disclaimer about support-only users to manage admins doc.

### DIFF
--- a/articles/dashboard/manage-dashboard-admins.md
+++ b/articles/dashboard/manage-dashboard-admins.md
@@ -38,6 +38,6 @@ Click **Enroll your device now.**
 
 Follow the on-screen instructions to complete your enrollment.
 
-# Support-Only Users
+## Support-Only Users
 
-If you want to allow employees of your organization to have access to our [Support Center](https://support.auth0.com), but you don't want to give them complete Administrator access over the tenant or a particular application, you can alternatively add them as Support-Only users. If that's the case, please follow the instructions described [here](https://auth0.com/docs/support#add-support-only-users).
+If you want to allow employees of your organization to have access to our [Support Center](https://support.auth0.com), but you don't want to give them complete Administrator access over the tenant or a particular application, you can alternatively add them as Support-Only users. If that's the case, please follow the instructions described in our [Support Options](/support#add-support-only-users) documentation.

--- a/articles/dashboard/manage-dashboard-admins.md
+++ b/articles/dashboard/manage-dashboard-admins.md
@@ -38,4 +38,6 @@ Click **Enroll your device now.**
 
 Follow the on-screen instructions to complete your enrollment.
 
+# Support-Only Users
 
+If you want to allow employees of your organization to have access to our [Support Center](https://support.auth0.com), but you don't want to give them complete Administrator access over the tenant or a particular application, you can alternatively add them as Support-Only users. If that's the case, please follow the instructions described [here](https://auth0.com/docs/support#add-support-only-users).


### PR DESCRIPTION
When customers are looking for information on how to add a support-only user, they normally end up reading this doc. I've added a disclaimer to the bottom of the document, telling customers where they can find instructions on how to achieve this.