### PR TITLE
Clarify 01-Login steps

### DIFF
--- a/articles/api/authentication/_login.md
+++ b/articles/api/authentication/_login.md
@@ -69,13 +69,13 @@ Social connections only support browser-based (passive) authentication because m
 
 1. At the *Configuration* tab, set the fields **Application** (select the application you want to use for the test) and **Connection** (the name of the social connection to use).
 
-1. Copy the **Callback URL** and set it as part of the **Allowed Callback URLs** of your [Application Settings](${manage_url}/#/applications/${account.clientId}/settings).
+1. Copy the **Callback URL** and set it as part of the **Allowed Callback URLs** of your [Application Settings](${manage_url}/#/applications).
 
 1. At the *OAuth2 / OIDC* tab, click **OAuth2 / OIDC Login**.
 
 ### Remarks
 
-- The `redirect_uri` value must be specified as a valid callback URL under your [Application's Settings](${manage_url}/#/applications/${account.clientId}/settings).
+- The `redirect_uri` value must be specified as a valid callback URL under your [Application's Settings](${manage_url}/#/applications).
 
 - If `response_type=token`, after the user authenticates on the provider, it will redirect to your application `callback URL` passing the Access Token and ID Token in the address `location.hash`. This is used for Single Page Apps and also on Native Mobile SDKs.
 
@@ -150,14 +150,14 @@ Use this endpoint for browser based (passive) authentication. It returns a `302`
 
 1. At the *Configuration* tab, set the fields **Application** (select the application you want to use for the test) and **Connection** (the name of the social connection to use).
 
-1. Copy the **Callback URL** and set it as part of the **Allowed Callback URLs** of your [Application Settings](${manage_url}/#/applications/${account.clientId}/settings).
+1. Copy the **Callback URL** and set it as part of the **Allowed Callback URLs** of your [Application Settings](${manage_url}/#/applications).
 
 1. At the *OAuth2 / OIDC* tab, click **OAuth2 / OIDC Login**.
 
 
 ### Remarks
 
-- The `redirect_uri` value must be specified as a valid callback URL under your [Application's Settings](${manage_url}/#/applications/${account.clientId}/settings).
+- The `redirect_uri` value must be specified as a valid callback URL under your [Application's Settings](${manage_url}/#/applications).
 - If `response_type=token`, after the user authenticates, it will redirect to your application `callback URL` passing the Access Token and ID Token in the address `location.hash`. This is used for Single Page Apps and also on Native Mobile SDKs.
 - The main difference between passive and active authentication is that the former happens in the browser through the [Auth0 Login Page](https://${account.namespace}/login) and the latter can be invoked from anywhere (a script, server to server, and so forth).
 - The sample auth0.js script uses the library version 8. If you are using auth0.js version 7, please see this [reference guide](/libraries/auth0js/v7).
@@ -236,7 +236,7 @@ Use this endpoint for passive authentication. It returns a `302` redirect to the
 
 1. At the *Configuration* tab, set the fields **Application** (select the application you want to use for the test) and **Connection** (the name of the social connection to use).
 
-1. Copy the **Callback URL** and set it as part of the **Allowed Callback URLs** of your [Application Settings](${manage_url}/#/applications/${account.clientId}/settings).
+1. Copy the **Callback URL** and set it as part of the **Allowed Callback URLs** of your [Application Settings](${manage_url}/#/applications).
 
 1. At the *OAuth2 / OIDC* tab, click **OAuth2 / OIDC Login**.
 
@@ -244,7 +244,7 @@ Use this endpoint for passive authentication. It returns a `302` redirect to the
 ### Remarks
 
 - If no `connection` is specified, it will redirect to the [Login Page](https://${account.namespace}/login) and show the Login Widget.
-- The `redirect_uri` value must be specified as a valid callback URL under your [Application's Settings](${manage_url}/#/applications/${account.clientId}/settings).
+- The `redirect_uri` value must be specified as a valid callback URL under your [Application's Settings](${manage_url}/#/applications).
 - If `response_type=token`, after the user authenticates, it will redirect to your application `callback URL` passing the Access Token and ID Token in the address `location.hash`. This is used for Single Page Apps and also on Native Mobile SDKs.
 - Additional parameters can be sent that will be passed to the provider.
 - The sample auth0.js script uses the library version 8. If you are using auth0.js version 7, please see this [reference guide](/libraries/auth0js/v7).

--- a/articles/api/authentication/_logout.md
+++ b/articles/api/authentication/_logout.md
@@ -57,7 +57,7 @@ Use this endpoint to logout a user. If you want to navigate the user to a specif
 
 1. At the *Configuration* tab, set the fields **Application** (select the application you want to use for the test) and **Connection** (the name of the social connection to use).
 
-1. Copy the **Callback URL** and set it as part of the **Allowed Logout URLs** of your [Application Settings](${manage_url}/#/applications/${account.clientId}/settings).
+1. Copy the **Callback URL** and set it as part of the **Allowed Logout URLs** of your [Application Settings](${manage_url}/#/applications).
 
 1. At the *Other Flows* tab, click **Logout**, or **Logout (Federated)** to log the user out of the identity provider as well.
 

--- a/articles/api/authentication/_multifactor-authentication.md
+++ b/articles/api/authentication/_multifactor-authentication.md
@@ -104,7 +104,7 @@ If OTP is supported by the user and you don't want to request a different factor
 |:-----------------|:------------|
 | `mfa_token` <br/><span class="label label-danger">Required</span> | The token received from `mfa_required` error. |
 | `client_id` <br/><span class="label label-danger">Required</span> | Your application's Client ID. |
-| `client_secret` | Your application's Client Secret. **Required** when the **Token Endpoint Authentication Method** field at your [Client Settings](${manage_url}/#/clients/${account.clientId}/settings) is `Post` or `Basic`. |
+| `client_secret` | Your application's Client Secret. **Required** when the **Token Endpoint Authentication Method** field at your [Application Settings](${manage_url}/#/applications) is `Post` or `Basic`. |
 | `challenge_type` | A whitespace-separated list of the challenges types accepted by your application. Accepted challenge types are `oob` or `otp`. Excluding this parameter means that your client application accepts all supported challenge types. |
 | `oob_channel` | **(early access users only)** The channel to use for OOB. Can only be provided when `challenge_type` is `oob`. Accepted channel types are `sms` or `auth0`. Excluding this parameter means that your client application will accept all supported OOB channels. |
 | `authenticator_id` | **(early access users only)** The ID of the authenticator to challenge. You can get the ID by querying the list of available authenticators for the user as explained on [List authenticators](#list-authenticators) below. |
@@ -193,7 +193,7 @@ The response is the same as responses for `password` or `http://auth0.com/oauth/
 |:-----------------|:------------|
 | `grant_type` <br/><span class="label label-danger">Required</span> | Denotes the flow you are using. For OTP MFA use  `http://auth0.com/oauth/grant-type/mfa-otp`. |
 | `client_id` <br/><span class="label label-danger">Required</span> | Your application's Client ID. |
-| `client_secret` | Your application's Client Secret. **Required** when the **Token Endpoint Authentication Method** field at your [Client Settings](${manage_url}/#/clients/${account.clientId}/settings) is `Post` or `Basic`. |
+| `client_secret` | Your application's Client Secret. **Required** when the **Token Endpoint Authentication Method** field at your [Application Settings](${manage_url}/#/applications) is `Post` or `Basic`. |
 | `mfa_token` <br/><span class="label label-danger">Required</span> | The `mfa_token` you received from `mfa_required` error. |
 | `otp` <br/><span class="label label-danger">Required</span> | OTP Code provided by the user. |
 
@@ -300,7 +300,7 @@ When the challenge response includes a `binding_method: prompt`, your app needs 
 |:-----------------|:------------|
 | `grant_type` <br/><span class="label label-danger">Required</span> | Denotes the flow you are using. For OTP MFA, use  `http://auth0.com/oauth/grant-type/mfa-oob`. |
 | `client_id` <br/><span class="label label-danger">Required</span> | Your application's Client ID. |
-| `client_secret` | Your application's Client Secret. **Required** when the **Token Endpoint Authentication Method** field at your [Client Settings](${manage_url}/#/clients/${account.clientId}/settings) is `Post` or `Basic`. |
+| `client_secret` | Your application's Client Secret. **Required** when the **Token Endpoint Authentication Method** field at your [Application Settings](${manage_url}/#/applications) is `Post` or `Basic`. |
 | `mfa_token` <br/><span class="label label-danger">Required</span> | The `mfa_token` you received from `mfa_required` error. |
 | `oob_code` <br/><span class="label label-danger">Required</span> | The oob code received from the challenge request. |
 | `binding_code`| A code used to bind the side channel (used to deliver the challenge) with the main channel you are using to authenticate. This is usually an OTP-like code delivered as part of the challenge message. |
@@ -382,7 +382,7 @@ To verify MFA using a recovery code your app must prompt the user for the recove
 |:-----------------|:------------|
 | `grant_type` <br/><span class="label label-danger">Required</span> | Denotes the flow you are using. For OTP MFA use  `http://auth0.com/oauth/grant-type/mfa-otp`. |
 | `client_id` <br/><span class="label label-danger">Required</span> | Your application's Client ID. |
-| `client_secret` | Your application's Client Secret. **Required** when the **Token Endpoint Authentication Method** field at your [Client Settings](${manage_url}/#/clients/${account.clientId}/settings) is `Post` or `Basic`. |
+| `client_secret` | Your application's Client Secret. **Required** when the **Token Endpoint Authentication Method** field at your [Application Settings](${manage_url}/#/applications) is `Post` or `Basic`. |
 | `mfa_token` <br/><span class="label label-danger">Required</span> | The `mfa_token` you received from `mfa_required` error. |
 | `recovery_code` <br/><span class="label label-danger">Required</span> | Recovery code provided by the end-user.
 
@@ -497,7 +497,7 @@ To access this endoint, you must set an [Access Token](/tokens/access-token) at 
 | Parameter        | Description |
 |:-----------------|:------------|
 | `client_id` <br/><span class="label label-danger">Required</span> | Your application's Client ID. |
-| `client_secret` | Your application's Client Secret. **Required** when the **Token Endpoint Authentication Method** field in your [Client Settings](${manage_url}/#/clients/${account.clientId}/settings) is `Post` or `Basic`. |
+| `client_secret` | Your application's Client Secret. **Required** when the **Token Endpoint Authentication Method** field in your [Application Settings](${manage_url}/#/applications) is `Post` or `Basic`. |
 | `authenticator_types` <br/><span class="label label-danger">Required</span> | The type of authenticators supported by the client. Value is an array with values `"otp"` or `"oob"`. |
 | `oob_channel` | The type of OOB channels supported by the client. An array with values `"auth0"` or `"sms"`. Required if `authenticator_types` include `oob`. |
 | `phone_number` | The phone number to use for SMS. Required if `oob_channel` includes `sms`. |

--- a/articles/api/authentication/_passwordless.md
+++ b/articles/api/authentication/_passwordless.md
@@ -215,7 +215,7 @@ Once you have a verification code, use this endpoint to login the user with thei
 
 1. At the *Configuration* tab, set the fields **Application** (select the application you want to use for the test) and **Connection** (use `sms` or `email`).
 
-1. Copy the **Callback URL** and set it as part of the **Allowed Callback URLs** of your [Application Settings](${manage_url}/#/applications/${account.clientId}/settings).
+1. Copy the **Callback URL** and set it as part of the **Allowed Callback URLs** of your [Application Settings](${manage_url}/#/applications).
 
 1. At the *OAuth2 / OIDC* tab, set **Username** to the user's phone number if `connection=sms`, or the user's email if `connection=email`, and **Password** to the user's verification code. Click **Resource Owner Endpoint**.
 

--- a/articles/api/authentication/_saml-sso.md
+++ b/articles/api/authentication/_saml-sso.md
@@ -130,7 +130,7 @@ This endpoint accepts an IdP-Initiated Sign On SAMLResponse from a SAML Identity
 
 1. At the *Configuration* tab, set the field **Application** (select the application you want to use for the test) and **Connection** (the name of the configured identity provider).
 
-1. Copy the **Callback URL** and set it as part of the **Allowed Callback URLs** of your [Application Settings](${manage_url}/#/applications/${account.clientId}/settings).
+1. Copy the **Callback URL** and set it as part of the **Allowed Callback URLs** of your [Application Settings](${manage_url}/#/applications).
 
 1. At the *Other Flows* tab, click **SAML**.
 

--- a/articles/api/authentication/_wsfed-req.md
+++ b/articles/api/authentication/_wsfed-req.md
@@ -44,7 +44,7 @@ This endpoint accepts a WS-Federation request to initiate a login.
 
 1. At the *Configuration* tab, set the field **Application** (select the application you want to use for the test) and **Connection** (the name of the configured identity provider).
 
-1. Copy the **Callback URL** and set it as part of the **Allowed Callback URLs** of your [Application Settings](${manage_url}/#/applications/${account.clientId}/settings).
+1. Copy the **Callback URL** and set it as part of the **Allowed Callback URLs** of your [Application Settings](${manage_url}/#/applications).
 
 1. At the *Other Flows* tab, click **WS-Federation**.
 

--- a/articles/api/authentication/api-authz/_authz-client.md
+++ b/articles/api/authentication/api-authz/_authz-client.md
@@ -59,7 +59,7 @@ This is the OAuth 2.0 grant that regular web apps utilize in order to access an 
 
 1. At the *Configuration* tab, set the **Client** field to the application you want to use for the test.
 
-1. Copy the **Callback URL** and set it as part of the **Allowed Callback URLs** of your [Application Settings](${manage_url}/#/applications/${account.clientId}/settings).
+1. Copy the **Callback URL** and set it as part of the **Allowed Callback URLs** of your [Application Settings](${manage_url}/#/applications).
 
 1. At the *OAuth2 / OIDC* tab, set the fields **Audience** (to the unique identifier of the API you want to access), **Response Type** (set to `code`) and enable the **Audience** switch.
 
@@ -69,7 +69,7 @@ This is the OAuth 2.0 grant that regular web apps utilize in order to access an 
 
 - In order to improve compatibility for applications, Auth0 will now return profile information in a [structured claim format as defined by the OIDC specification](https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims). This means that in order to add custom claims to ID Tokens or Access Tokens, they must conform to a namespaced format to avoid possible collisions with standard OIDC claims. For example, if you choose the namespace `https://foo.com/` and you want to add a custom claim named `myclaim`, you would name the claim `https://foo.com/myclaim`, instead of `myclaim`.
 - Include `offline_access` to the `scope` request parameter to get a Refresh Token from [POST /oauth/token](#authorization-code). Make sure that the **Allow Offline Access** field is enabled in the [API Settings](${manage_url}/#/apis).
-- The `redirect_uri` value must be specified as a valid callback URL under your [Application's Settings](${manage_url}/#/applications/${account.clientId}/settings).
+- The `redirect_uri` value must be specified as a valid callback URL under your [Application's Settings](${manage_url}/#/applications).
 - Silent authentication lets you perform an authentication flow where Auth0 will only reply with redirects, and never with a login page. When an Access Token has expired, silent authentication can be used to retrieve a new one without user interaction, assuming the user's SSO session has not expired.
 
 ### More Information
@@ -131,7 +131,7 @@ This is the OAuth 2.0 grant that mobile apps utilize in order to access an API. 
 
 1. At the *Configuration* tab, set the **Application** field to the app you want to use for the test.
 
-1. Copy the **Callback URL** and set it as part of the **Allowed Callback URLs** of your [Application Settings](${manage_url}/#/applications/${account.clientId}/settings).
+1. Copy the **Callback URL** and set it as part of the **Allowed Callback URLs** of your [Application Settings](${manage_url}/#/applications).
 
 1. At the *OAuth2 / OIDC* tab, set the fields **Audience** (to the unique identifier of the API you want to access), **Response Type** (set to `code`) and enable the **Audience** and **PKCE** switches.
 
@@ -142,7 +142,7 @@ This is the OAuth 2.0 grant that mobile apps utilize in order to access an API. 
 
 - In order to improve compatibility for applications, Auth0 will now return profile information in a [structured claim format as defined by the OIDC specification](https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims). This means that in order to add custom claims to ID Tokens or Access Tokens, they must conform to a namespaced format to avoid possible collisions with standard OIDC claims. For example, if you choose the namespace `https://foo.com/` and you want to add a custom claim named `myclaim`, you would name the claim `https://foo.com/myclaim`, instead of `myclaim`.
 - Include `offline_access` to the `scope` request parameter to get a Refresh Token from [POST /oauth/token](#authorization-code-pkce-). Make sure that the **Allow Offline Access** field is enabled in the [API Settings](${manage_url}/#/apis).
-- The `redirect_uri` value must be specified as a valid callback URL under your [Client's Settings](${manage_url}/#/applications/${account.clientId}/settings).
+- The `redirect_uri` value must be specified as a valid callback URL under your [Application's Settings](${manage_url}/#/applications).
 - Silent authentication lets you perform an authentication flow where Auth0 will only reply with redirects, and never with a login page. When an Access Token has expired, silent authentication can be used to retrieve a new one without user interaction, assuming the user's SSO session has not expired.
 
 
@@ -204,7 +204,7 @@ This is the OAuth 2.0 grant that web apps utilize in order to access an API.
 
 1. At the *Configuration* tab, set the **Application** field to the app you want to use for the test.
 
-1. Copy the **Callback URL** and set it as part of the **Allowed Callback URLs** of your [application Settings](${manage_url}/#/applications/${account.clientId}/settings).
+1. Copy the **Callback URL** and set it as part of the **Allowed Callback URLs** of your [application Settings](${manage_url}/#/applications).
 
 1. At the *OAuth2 / OIDC* tab, set the fields **Audience** (to the unique identifier of the API you want to access), **Response Type** (set to `token`) and enable the **Audience** switch.
 
@@ -213,7 +213,7 @@ This is the OAuth 2.0 grant that web apps utilize in order to access an API.
 
 ### Remarks
 
-- The `redirect_uri` value must be specified as a valid callback URL under your [Application's Settings](${manage_url}/#/applications/${account.clientId}/settings).
+- The `redirect_uri` value must be specified as a valid callback URL under your [Application's Settings](${manage_url}/#/applications).
 - If `response_type=token`, after the user authenticates with the provider, this will redirect them to your application callback URL while passing the `access_token` in the address `location.hash`. This is used for Single Page Apps and on Native Mobile SDKs.
 - The Implicit Grant does not support the issuance of Refresh Tokens. You can use [Silent Authentication](/api-auth/tutorials/silent-authentication) instead.
 - In order to improve compatibility for applications, Auth0 will now return profile information in a [structured claim format as defined by the OIDC specification](https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims). This means that in order to add custom claims to ID Tokens or Access Tokens, they must conform to a namespaced format to avoid possible collisions with standard OIDC claims. For example, if you choose the namespace `https://foo.com/` and you want to add a custom claim named `myclaim`, you would name the claim `https://foo.com/myclaim`, instead of `myclaim`.

--- a/articles/api/authentication/api-authz/_get-token.md
+++ b/articles/api/authentication/api-authz/_get-token.md
@@ -99,7 +99,7 @@ If you have just executed the [Authorization Code Grant](#authorization-code-gra
 
 1. At the *Configuration* tab, set the **Application** field to the application you want to use for the test.
 
-1. Copy the **Callback URL** and set it as part of the **Allowed Callback URLs** of your [Client Settings](${manage_url}/#/clients/${account.clientId}/settings).
+1. Copy the **Callback URL** and set it as part of the **Allowed Callback URLs** of your [Application Settings](${manage_url}/#/applications).
 
 1. At the *OAuth2 / OIDC* tab, set the field **Authorization Code** to the code you retrieved from [Authorization Code Grant](#authorization-code-grant). Click **OAuth2 Code Exchange**.
 
@@ -190,7 +190,7 @@ If you have just executed the [Authorization Code Grant (PKCE)](#authorization-c
 
 1. At the *Configuration* tab, set the **Client** field to the application you want to use for the test.
 
-1. Copy the **Callback URL** and set it as part of the **Allowed Callback URLs** of your [Client Settings](${manage_url}/#/clients/${account.clientId}/settings).
+1. Copy the **Callback URL** and set it as part of the **Allowed Callback URLs** of your [Application Settings](${manage_url}/#/applications).
 
 1. At the *OAuth2 / OIDC* tab, set the field **Authorization Code** to the code you retrieved from [Authorization Code Grant](#authorization-code-grant-pkce-), and the **Code Verifier** to the key. Click **OAuth2 Code Exchange**.
 
@@ -278,7 +278,7 @@ This is the OAuth 2.0 grant that server processes utilize in order to access an 
 
 1. At the *Configuration* tab, set the **Client** field to the application you want to use for the test.
 
-1. Copy the **Callback URL** and set it as part of the **Allowed Callback URLs** of your [Client Settings](${manage_url}/#/clients/${account.clientId}/settings).
+1. Copy the **Callback URL** and set it as part of the **Allowed Callback URLs** of your [Application Settings](${manage_url}/#/applications).
 
 1. At the *OAuth2 / OIDC* tab, click **OAuth2 Client Credentials**.
 
@@ -369,7 +369,7 @@ This is the OAuth 2.0 grant that highly trusted apps use in order to access an A
 |:-----------------|:------------|
 | `grant_type` <br/><span class="label label-danger">Required</span> | Denotes the flow you are using. For Resource Owner Password use  `password`. To add realm support use `http://auth0.com/oauth/grant-type/password-realm`. |
 | `client_id` <br/><span class="label label-danger">Required</span> | Your application's Client ID. |
-| `client_secret` | Your application's Client Secret. **Required** when the **Token Endpoint Authentication Method** field at your [Client Settings](${manage_url}/#/clients/${account.clientId}/settings) is `Post` or `Basic`. |
+| `client_secret` | Your application's Client Secret. **Required** when the **Token Endpoint Authentication Method** field at your [Application Settings](${manage_url}/#/applications) is `Post` or `Basic`. |
 | `audience` | The unique identifier of the target API you want to access. |
 | `username` <br/><span class="label label-danger">Required</span> | Resource Owner's identifier. |
 | `password` <br/><span class="label label-danger">Required</span> | Resource Owner's secret. |
@@ -388,7 +388,7 @@ This is the OAuth 2.0 grant that highly trusted apps use in order to access an A
 
 1. At the *Configuration* tab, set the **Client** field to the application you want to use for the test.
 
-1. Copy the **Callback URL** and set it as part of the **Allowed Callback URLs** of your [Client Settings](${manage_url}/#/clients/${account.clientId}/settings).
+1. Copy the **Callback URL** and set it as part of the **Allowed Callback URLs** of your [Application Settings](${manage_url}/#/applications).
 
 1. At the *OAuth2 / OIDC* tab, set the **Username** and **Password**, and click **Password Grant**.
 
@@ -475,7 +475,7 @@ Use this endpoint to refresh an Access Token using the Refresh Token you got dur
 |:-----------------|:------------|
 | `grant_type` <br/><span class="label label-danger">Required</span> | Denotes the flow you are using. To refresh a token, use  `refresh_token`. |
 | `client_id` <br/><span class="label label-danger">Required</span> | Your application's Client ID. |
-| `client_secret` | Your application's Client Secret. **Required** when the **Token Endpoint Authentication Method** field at your [Client Settings](${manage_url}/#/clients/${account.clientId}/settings) is `Post` or `Basic`. |
+| `client_secret` | Your application's Client Secret. **Required** when the **Token Endpoint Authentication Method** field at your [Application Settings](${manage_url}/#/applications) is `Post` or `Basic`. |
 | `refresh_token` <br/><span class="label label-danger">Required</span> | The Refresh Token to use. |
 
 
@@ -485,7 +485,7 @@ Use this endpoint to refresh an Access Token using the Refresh Token you got dur
 
 1. At the *Configuration* tab, set the **Client** field to the client you want to use for the test.
 
-1. Copy the **Callback URL** and set it as part of the **Allowed Callback URLs** of your [Client Settings](${manage_url}/#/clients/${account.clientId}/settings).
+1. Copy the **Callback URL** and set it as part of the **Allowed Callback URLs** of your [Application Settings](${manage_url}/#/applications).
 
 1. At the *OAuth2 / OIDC* tab, set the field **Refresh Token** to the Refresh Token you have. Click **OAuth2 Refresh Token Exchange**.
 

--- a/articles/api/authentication/api-authz/_revoke-refersh-token.md
+++ b/articles/api/authentication/api-authz/_revoke-refersh-token.md
@@ -64,7 +64,7 @@ Each revocation request invalidates not only the specific token, but all other t
 
 ### Remarks
 
-- For non-confidential applications that cannot keep the Client Secret safe (for example, native apps), the endpoint supports passing no Client Secret but the application itself must have the property `tokenEndpointAuthMethod` set to `none`. You can do this either from the UI ([Dashboard > Applications > Application Settings](${manage_url}/#/applications/${account.clientId}/settings)) or using the [Management API](/api/management/v2#!/Applications/patch_applications_by_id).
+- For non-confidential applications that cannot keep the Client Secret safe (for example, native apps), the endpoint supports passing no Client Secret but the application itself must have the property `tokenEndpointAuthMethod` set to `none`. You can do this either from the UI ([Dashboard > Applications > Application Settings](${manage_url}/#/applications)) or using the [Management API](/api/management/v2#!/Applications/patch_applications_by_id).
 
 ### Error Codes
 

--- a/articles/api/authentication/index.md
+++ b/articles/api/authentication/index.md
@@ -47,10 +47,6 @@ contentType:
 </div>
 
 <div class="api-section" data-section="none">
-  <%= include('./_impersonation') %>
-</div>
-
-<div class="api-section" data-section="none">
   <%= include('./_application-reg') %>
 </div>
 
@@ -72,11 +68,14 @@ contentType:
 <div class="api-section" data-section="legacy">
   <%= include('./legacy/_userinfo') %>
 </div>
-<div class="api-section" data-section="none">
+<div class="api-section" data-section="legacy">
   <%= include('./legacy/_linking') %>
 </div>
 <div class="api-section" data-section="legacy">
   <%= include('./legacy/_delegation') %>
+</div>
+<div class="api-section" data-section="legacy">
+  <%= include('./legacy/_impersonation') %>
 </div>
 <div class="api-section" data-section="legacy">
   <%= include('./legacy/_resource-owner') %>

--- a/articles/api/authentication/legacy/_delegation.md
+++ b/articles/api/authentication/legacy/_delegation.md
@@ -63,7 +63,7 @@ Given an existing token, this endpoint will generate a new token signed with the
 
 1. At the *Configuration* tab, set the **Application** field to the app you want to use for the test.
 
-1. Copy the **Callback URL** and set it as part of the **Allowed Callback URLs** of your [Application Settings](${manage_url}/#/applications/${account.clientId}/settings).
+1. Copy the **Callback URL** and set it as part of the **Allowed Callback URLs** of your [Application Settings](${manage_url}/#/applications).
 
 1. At the *OAuth2 / OIDC* tab, set the fields **ID Token**, **Refresh Token** and **Target Client ID**. Click **Delegation**.
 

--- a/articles/api/authentication/legacy/_impersonation.md
+++ b/articles/api/authentication/legacy/_impersonation.md
@@ -51,15 +51,15 @@ https:/YOUR_DOMAIN/users/IMPERSONATOR_ID/impersonate?&bewit=WFh0MUtm...
 ```
 
 <% var path = '/users/{user_id}/impersonate'; %>
-<%=
-include('../../_includes/_http-method', {
+
+<%= include('../../../_includes/_http-method', {
   "http_badge": "badge-success",
   "http_method": "POST",
   "path": path,
   "link": "#impersonation"
 }) %>
 
-<%= include('../../_includes/_deprecate-impersonation.md') %>
+<%= include('../../../_includes/_deprecate-impersonation.md') %>
 
 Use this endpoint to obtain an impersonation URL to login as another user. Useful for troubleshooting.
 

--- a/articles/api/authentication/legacy/_linking.md
+++ b/articles/api/authentication/legacy/_linking.md
@@ -40,7 +40,7 @@ This endpoint will trigger the login flow to link an existing account with a new
 
 ### Remarks
 
-- The `redirect_uri` value must be specified as a valid callback URL under your [Application's Settings](${manage_url}/#/applications/${account.clientId}/settings).
+- The `redirect_uri` value must be specified as a valid callback URL under your [Application's Settings](${manage_url}/#/applications).
 
 
 ### More Information

--- a/articles/api/authentication/legacy/_login.md
+++ b/articles/api/authentication/legacy/_login.md
@@ -194,7 +194,7 @@ Use this endpoint for API-based (active) authentication. Given the user credenti
 
 1. At the *Configuration* tab, set the fields **Application** (select the application you want to use for the test) and **Connection** (the name of the social connection to use).
 
-1. Copy the **Callback URL** and set it as part of the **Allowed Callback URLs** of your [Application Settings](${manage_url}/#/applications/${account.clientId}/settings).
+1. Copy the **Callback URL** and set it as part of the **Allowed Callback URLs** of your [Application Settings](${manage_url}/#/applications).
 
 1. At the *OAuth2 / OIDC* tab, set **Username** and **Password**. Click **Resource Owner Endpoint**.
 

--- a/articles/api/authentication/legacy/_resource-owner.md
+++ b/articles/api/authentication/legacy/_resource-owner.md
@@ -89,7 +89,7 @@ Given the user's credentials, this endpoint will authenticate the user with the 
 
 1. At the *Configuration* tab, set the **Application** field to the application you want to use for the test, and **Connection** to the name of the connection to use.
 
-1. Copy the **Callback URL** and set it as part of the **Allowed Callback URLs** of your [Application Settings](${manage_url}/#/applications/${account.clientId}/settings).
+1. Copy the **Callback URL** and set it as part of the **Allowed Callback URLs** of your [Application Settings](${manage_url}/#/applications).
 
 1. At the *OAuth2 / OIDC* tab, set the **Username** and **Password**, and click **Resource Owner Endpoint**.
 

--- a/articles/api/management/v2/tokens.md
+++ b/articles/api/management/v2/tokens.md
@@ -24,10 +24,6 @@ In this article we will see how you can do either.
 
 ## Get a token manually
 
-::: warning
-Τhe Management APIv2 token, by default, has a validity of __24 hours__. After that the token will expire and you will have to get a new one. If this doesn't work for you, you can either [change the validity period of the token](#2-get-the-token), or [automate the process](#automate-the-process). Keep in mind that these tokens **cannot be revoked** so long expiration times are **not recommended**.
-:::
-
 Let's see how you can get a token manually. Note, that the first step of the process need to be executed _only_ the first time.
 
 ### 1. Create and Authorize an Application
@@ -56,7 +52,13 @@ If you have multiple apps that should access the Management API, and you need di
 
 A token is automatically generated and displayed at [the API Explorer tab of your Auth0 Management API](${manage_url}/#/apis/management/explorer).
 
-Note, that this token has by default an expiration time of 24 hours (86400 seconds). To change that, update the __Token Expiration (Seconds)__ field and click __Update & Regenerate Token__.
+This token has by default an expiration time of __24 hours__ (86400 seconds). After that the token will expire and you will have to get a new one.
+
+To change that, update the __Token Expiration (Seconds)__ field and click __Update & Regenerate Token__.
+
+:::warning
+These tokens **cannot be revoked** so long expiration times are not recommended. Instead we recommend that you use short expiration times and issue a new one every time you need it.
+:::
 
 ![Test Application](/media/articles/api/tokens/copy-token.png)
 

--- a/articles/connections/database/rate-limits.md
+++ b/articles/connections/database/rate-limits.md
@@ -14,7 +14,7 @@ useCase: customize-connections
 
 For database connections Auth0 limits certain types of repeat login attempts depending on the user account and IP address, some of these limits are set as part of [Anomaly Detection](/anomaly-detection):
 
- - If a user enters their password incorrectly more than 10 times from a single IP address, they will be blocked from logging into that account from that IP address. Auth0 will send an email containing a link to unblock the user to the owner of the database account. This the [Brute Force Protection](/anomaly-detection#brute-force-protection) shield as part of Auth0's Anomaly Detection.
+ - If a user enters their password incorrectly more than 10 times from a single IP address, they will be blocked from logging into that account from that IP address. Auth0 will send an email containing a link to unblock the user to the owner of the database account. This is the [Brute Force Protection](/anomaly-detection#brute-force-protection) shield which is part of Auth0's Anomaly Detection.
 
 - If a user attempts to login 20 times per minute as the same user from the same location, regardless of having the correct credentials, the rate limit will come into effect. When this happens, the user can make 10 attempts per minute. Most endpoints at the moment support this rate limit, and soon all of them will.
 

--- a/articles/dashboard/manage-dashboard-admins.md
+++ b/articles/dashboard/manage-dashboard-admins.md
@@ -38,4 +38,6 @@ Click **Enroll your device now.**
 
 Follow the on-screen instructions to complete your enrollment.
 
+## Support-Only Users
 
+If you want to allow employees of your organization to have access to our [Support Center](https://support.auth0.com), but you don't want to give them complete Administrator access over the tenant or a particular application, you can alternatively add them as Support-Only users. If that's the case, please follow the instructions described in our [Support Options](/support#add-support-only-users) documentation.

--- a/articles/protocols/oauth2/oauth-state.md
+++ b/articles/protocols/oauth2/oauth-state.md
@@ -23,11 +23,13 @@ Your application can use this parameter in order to:
 
 - Restore the previous state of your application.
 
-## Format
+## Format and Limitations
 
 For the most basic cases the **state** parameter should be a [nonce](https://en.wikipedia.org/wiki/Cryptographic_nonce). 
 
 This field can also be a [Base64](https://en.wikipedia.org/wiki/Base64) encoded JSON object that can hold multiple values, [such as a return URL](/tutorials/redirecting-users).
+
+Note that the allowed length for state is not unlimited. If you get the error `414 Request-URI Too Large` try a smaller value.
 
 ## How to use the parameter against CSRF attacks
 

--- a/articles/protocols/oidc/index.md
+++ b/articles/protocols/oidc/index.md
@@ -41,3 +41,6 @@ JWT Tokens contain [claims](/jwt#payload), which are statements (such as name or
 
 The [OpenID Connect specification](https://openid.net/specs/openid-connect-core-1_0.html) defines a set of [standard claims](https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims). The set of standard claims include name, email, gender, birth date, and so on. However, if you want to capture information about a user and there currently isn't a standard claim that best reflects this piece of information, you can create [custom claims and add them to your tokens](/tokens/id-token#add-custom-claims).
 
+:::note
+Watch our 30 minute webinar tutorial [Intro to OpenID Connect](https://auth0.com/resources/webinars/intro-openid-connect) to better understand this protocol, its benefits, and how to integrate it in your app.
+:::

--- a/articles/quickstart/webapp/rails/01-login.md
+++ b/articles/quickstart/webapp/rails/01-login.md
@@ -56,7 +56,7 @@ class Auth0Controller < ApplicationController
     session[:userinfo] = request.env['omniauth.auth']
 
     # Redirect to the URL you want after successful auth
-    redirect_to '/dashboard'
+    redirect_to '/dashboard/show'
   end
 
   def failure
@@ -69,8 +69,8 @@ end
 Replace the generated routes on `routes.rb` with the following:
 
 ```ruby
-get "/auth/oauth2/callback" => "auth0#callback"
-get "/auth/failure" => "auth0#failure"
+get 'auth/oauth2/callback' => 'auth0#callback'
+get '/auth/failure' => 'auth0#failure'
 ```
 
 ## Trigger Authentication
@@ -111,14 +111,13 @@ Create a file called `show.html.erb` to add the template for `show` action. Add 
 
 ```html
 <!-- app/views/home/show.html.erb -->
-
-<section class="jumbotron text-center">
-  <h2><img class="jumbo-thumbnail" src="https://cdn.auth0.com/styleguide/1.0.0/img/badge.svg"></h2>
-  <h1>RoR Auth0 Sample</h1>
-  <p>Step 1 - Login.</p>
-  <a class="btn btn-success btn-lg" href="/auth/auth0">Login</a>
-</section>
+<h2><img src="https://cdn.auth0.com/styleguide/1.0.0/img/badge.svg"></h2>
+<h1>RoR Auth0 Sample</h1>
+<p>Step 1 - Login.</p>
+<a class="btn btn-success btn-lg" href="/auth/auth0">Login</a>
 ```
+
+Alternatively, you can add a link to the `/auth/auth0` path anywhere in an existing template.
 
 ### Check the User's Authentication Status
 
@@ -143,7 +142,7 @@ end
 Use the following command to create the controller for the dashboard view:
 
 ```bash
-rails generate controller dashboard show --skip-template-engine --skip-assets
+rails generate controller dashboard show --skip-assets
 ```
 
 Include the `concern` in the newly-created controller to prevent unauthenticated users from accessing its routes:
@@ -157,6 +156,15 @@ class DashboardController < ApplicationController
   def show
   end
 end
+```
+
+Add the session data for `userinfo` to the dashboard view to see what is returned.
+
+```
+# app/views/dashboard/show.html.erb
+
+<h1>Dashboard#show</h1>
+<%= session[:userinfo].inspect %>
 ```
 
 ### Display Error Descriptions

--- a/articles/tokens/jwt.md
+++ b/articles/tokens/jwt.md
@@ -191,7 +191,7 @@ _Comparison of the length of an encoded JWT and an encoded SAML_
 ## Read More
 
 ::: next-steps
-* [JWT Handbook](https://auth0.com/e-books/jwt-handbook)
+* [JWT Handbook](https://auth0.com/resources/ebooks/jwt-handbook)
 * [10 Things You Should Know About Tokens](https://auth0.com/blog/ten-things-you-should-know-about-tokens-and-cookies/)
 * [Cookies vs Tokens. Getting auth right with Angular.JS](https://auth0.com/blog/angularjs-authentication-with-cookies-vs-token/)
 :::

--- a/snippets/server-platforms/rails/setup.md
+++ b/snippets/server-platforms/rails/setup.md
@@ -5,7 +5,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
     '${account.clientId}',
     'YOUR_CLIENT_SECRET',
     '${account.namespace}',
-    callback_path: "/auth/oauth2/callback",
+    callback_path: '/auth/oauth2/callback',
     authorize_params: {
       scope: 'openid profile',
       audience: 'https://${account.namespace}/userinfo'


### PR DESCRIPTION
A few changes to make this quickstart a little more clear:

- `/dashboard` -> `/dashboard/show` to match the route
- Remove Auth0 styleguide HTML that will not be styled
- Add a note about using that login URL on an existing view
- Remove `--skip-template-engine` from the dashboard controller create command
- Add `session` data output to the dashboard/show view