### PR TITLE
angular2: don't clear window.location.hash in callback

### DIFF
--- a/articles/quickstart/spa/angular2/_includes/_centralized_login.md
+++ b/articles/quickstart/spa/angular2/_includes/_centralized_login.md
@@ -71,7 +71,6 @@ export class AuthService {
   public handleAuthentication(): void {
     this.auth0.parseHash((err, authResult) => {
       if (authResult && authResult.accessToken && authResult.idToken) {
-        window.location.hash = '';
         this.setSession(authResult);
         this.router.navigate(['/home']);
       } else if (err) {


### PR DESCRIPTION
Clearing window.location.hash on Firefox 61 (presumably to remove the user
hash from the URL) causes a page reload, so the user may observe a spurious
redirection to /home before landing back at /login/callback.  Setting
window.location.hash doesn't seem to trigger a reload on other browsers.

If the intent is to remove the hash from the URL, the following router
navigation to /home should be sufficient without clearing window.location.hash
separately.

https://community.auth0.com/t/auth0-angular-seed-application-does-not-properly-login-on-firefox/8698

This solution was proposed on the community form, and seems to address the
observed behavior.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
