### PR TITLE
update URL

### DIFF
--- a/articles/connections/passwordless/ios-touch-id-swift.md
+++ b/articles/connections/passwordless/ios-touch-id-swift.md
@@ -29,7 +29,7 @@ Touch ID with Auth0 has been deprecated. This document is offered as reference f
 :::
 
 ::: note
-For an alternative approach, using the [Credentials Manager](https://github.com/auth0/Auth0.swift/blob/master/Auth0/CredentialsManager.swift) utility in Auth0.swift, refer to [Touch ID Authentication](/libraries/lock-ios/v2/touchid-authentication).
+For an alternative approach, using the [Credentials Manager](https://github.com/auth0/Auth0.swift/blob/master/Auth0/CredentialsManager.swift) utility in Auth0.swift, refer to [Touch ID Authentication](/libraries/auth0-swift/touchid-authentication).
 :::
 
 <%= include('./_using-lock-ios-touchid', { language: 'swift' }) %>


### PR DESCRIPTION
TouchID for iOS has been deprecated (here: https://auth0.com/docs/connections/passwordless/ios-touch-id-swift), but the suggestion "For an alternative approach, using the Credentials Manager utility in Auth0.swift, refer to Touch ID Authentication (https://auth0.com/docs/libraries/lock-ios/v2/touchid-authentication) does not link to that page but redirects here instead (https://auth0.com/docs/libraries/lock-ios/v2).

The correct link is https://auth0.com/docs/libraries/auth0-swift/touchid-authentication
This PR updates the URL.