### PR TITLE
Updating docs for legacy lock api removal of service

### DIFF
--- a/articles/_includes/_embedded_login_warning.md
+++ b/articles/_includes/_embedded_login_warning.md
@@ -1,3 +1,3 @@
 ::: warning
-Embedded login for web uses Cross Origin Authentication, which [does not work reliably on all browsers](/cross-origin-authentication#limitations-of-cross-origin-authentication) if you do not [set up a Custom Domain](/custom-domains) **and host your app on the same domain**. The use of Custom Domains with Auth0 is a paid feature. A good alternative is to [migrate to Universal Login](/guides/login/migration-embedded-universal) if you cannot use Custom Domains in your application.
+Embedded login for web uses Cross Origin Authentication. In some browsers [this can be unreliable](/cross-origin-authentication#limitations-of-cross-origin-authentication) if you do not set up a [Custom Domain](/custom-domains) **and host your app on the same domain**. Using Custom Domains with Auth0 is a paid feature. If you cannot use Custom Domains, consider [migrating to Universal Login](/guides/login/migration-embedded-universal).
 :::

--- a/articles/_includes/_embedded_login_warning.md
+++ b/articles/_includes/_embedded_login_warning.md
@@ -1,3 +1,3 @@
 ::: warning
-Embedded login for web uses Cross Origin Authentication, which [does not work reliably on all browsers](/cross-origin-authentication#limitations-of-cross-origin-authentication) if you do not enable [Custom Domains](/custom-domains). The use of Custom Domains is a paid feature. A good alternative is to [migrate to Universal Login](/guides/login/migration-embedded-universal) if you cannot use Custom Domains in your application.
+Embedded login for web uses Cross Origin Authentication, which [does not work reliably on all browsers](/cross-origin-authentication#limitations-of-cross-origin-authentication) if you do not [set up a Custom Domain](/custom-domains) **and host your app on the same domain**. The use of Custom Domains with Auth0 is a paid feature. A good alternative is to [migrate to Universal Login](/guides/login/migration-embedded-universal) if you cannot use Custom Domains in your application.
 :::

--- a/articles/_includes/_version_warning_auth0js.md
+++ b/articles/_includes/_version_warning_auth0js.md
@@ -1,3 +1,3 @@
 ::: version-warning
-This document covers a deprecated version of Auth0.js. We recommend that you [migrate to Auth0.js v9](/libraries/auth0js/v9/migration-guide) as soon as possible.
+This document covers a deprecated version of Auth0.js which uses endpoints that have been removed from service. It will no longer function as expected. We recommend that you [migrate to Auth0.js v9](/libraries/auth0js/v9/migration-guide) as soon as possible.
 :::

--- a/articles/_includes/_version_warning_lock.md
+++ b/articles/_includes/_version_warning_lock.md
@@ -1,3 +1,3 @@
 ::: version-warning
-This document covers a deprecated version of Lock. We recommend that you [migrate to Lock v11](/libraries/lock/v11/migration-guide) as soon as possible.
+This document covers a deprecated version of Lock which uses endpoints that have been removed from service. It will no longer function as expected. We recommend that you [migrate to Lock v11](/libraries/lock/v11/migration-guide) as soon as possible.
 :::

--- a/articles/errors/deprecation-errors.md
+++ b/articles/errors/deprecation-errors.md
@@ -89,8 +89,6 @@ Click on the **TRY** button. If successful, you should see a screen similar to t
 | --- | --- |
 | Either calling the /ssodata directly or using old versions of embedded Lock or Auth0.js SDK to call a function which called the /ssodata endpoint. | [Migrate to Universal Login](/guides/login/migration-embedded-universal) or [migrate to Lock v11 or Auth0.js v9](/migrations#introducing-lock-v11-and-auth0-js-v9). |
 
-## Legacy Lock API notice
+## Legacy Lock API troubleshooting
 
-If you see the warning panel `Your tenant has the Legacy Lock API enabled. Please follow our Deprecation Guide then disable the Legacy Lock API in your advanced settings. The Legacy Lock API will be removed on July 16th, 2018 and your applications will no longer work if you have not fully migrated.` when you login to the Dashboard, it is because you have not turned off the Legacy Lock API switch in your [advanced settings](${manage_url}/#/tenant/advanced). If you are unaffected by the migration, or have completed it, you should be able to turn that setting off and remove the warning.
-
-If you are unsure if you are safely migrated yet, you can follow the [Deprecation Guide](/migrations/guides/legacy-lock-api-deprecation) to be sure.
+For tenant log entries regarding the Legacy Lock API, the referrer as well as information about the SDK being used are returned in the entry, in order to assist with troubleshooting. This information can help narrow down which applications might still be using outdated libraries, and which libraries they are using.

--- a/articles/errors/deprecation-errors.md
+++ b/articles/errors/deprecation-errors.md
@@ -91,4 +91,4 @@ Click on the **TRY** button. If successful, you should see a screen similar to t
 
 ## Legacy Lock API troubleshooting
 
-For tenant log entries regarding the Legacy Lock API, the referrer as well as information about the SDK being used are returned in the entry, in order to assist with troubleshooting. This information can help narrow down which applications might still be using outdated libraries, and which libraries they are using.
+Tenant log entries regarding the Legacy Lock API may include the referrer and information about the SDK used. This information can be used to see if any of your applications use outdated libraries.

--- a/articles/libraries/_includes/_legacy_flows.md
+++ b/articles/libraries/_includes/_legacy_flows.md
@@ -1,5 +1,5 @@
 ### Migrating from legacy authentication flows
 
-The OIDC conformant flows disallow certain practices that were common when developing applications with older versions of the library, like using [Refresh Tokens](tokens/refresh-token), using [ID Tokens](/tokens/id-token) to call APIs, and accessing non-standard claims in the user profile.
+The OIDC conformant flows disallow certain practices that were common when developing applications with older versions of the library, like using [Refresh Tokens](tokens/refresh-token), using [ID Tokens](/tokens/id-token) to call APIs, and [accessing non-standard claims in the user profile](/api-auth/tutorials/adoption/scope-custom-claims).
 
 Follow the steps in the [Migration from Legacy Authentication Flows](guides/migration-legacy-flows) to learn what changes you need to make in your application.

--- a/articles/libraries/auth0js/v9/migration-guide.md
+++ b/articles/libraries/auth0js/v9/migration-guide.md
@@ -19,13 +19,7 @@ useCase:
 
 ## Should I migrate to v9?
 
-Everyone should migrate to v9. All previous versions are deprecated, and will be removed from service July 16, 2018. For applications that use Auth0.js within an Auth0 login page, this migration is recommended; for applications with Auth0.js embedded within them, this migration is mandatory.
-
-::: panel Legacy Lock API Removed from Service
-Previously, the Legacy Lock API (used by deprecated versions of Auth0.js) was planned to be removed from service on April 1, 2018. However, the Removal of Service date was extended to **July 16, 2018** due to a [mitigation of the risks posed by deprecated versions](/cross-origin-authentication/fingerprinting).
-
-As of the week of July 16, 2018, the Legacy Lock API will be disabled. This is a soft removal, so you will have a brief grace period during which you can temporarily re-enable the feature in order to make any necessary changes. See the [soft removal announcement](https://community.auth0.com/t/soft-removal-of-legacy-lock-api/12949) for more details.
-:::
+Everyone should migrate to v9. All previous versions are deprecated, and the deprecated endpoints used by them were removed from service on August 6, 2018. For applications that use Auth0.js within an Auth0 login page, this migration is recommended; for applications with Auth0.js embedded within them, this migration is mandatory.
 
 ## Migration Instructions
 
@@ -55,6 +49,6 @@ You have already migrated to Auth0.js 9 but you still see this error in your log
 Legacy Lock API: This feature is being deprecated. Please refer to our documentation to learn how to migrate your application.
 ```
 
-These deprecation notices most likely originate from a user visiting the [Universal Login page](/hosted-pages/login) directly without initiating the authentication flow from your app. This can happen if a user bookmarks the login page directly. If this happens after **July 16, 2018** the user will not be able to log in. 
+These deprecation notices most likely originate from a user visiting the [Universal Login page](/hosted-pages/login) directly without initiating the authentication flow from your app. This can happen if a user bookmarks the login page directly. After August 6, 2018, these users will not be able to log in. 
 
 Check out the [Deprecation Error Reference](/errors/deprecation-errors) for more information on deprecation related errors.

--- a/articles/libraries/lock/v11/migration-guide.md
+++ b/articles/libraries/lock/v11/migration-guide.md
@@ -20,13 +20,7 @@ useCase:
 
 ## Should I migrate to v11?
 
-Everyone should migrate to v11. All previous versions are deprecated, and the Legacy Lock API was disabled on July 16, 2018. For applications that use Lock within an Auth0 login page, this migration is recommended; for applications with Lock embedded within them, this migration is mandatory.
-
-::: panel Legacy Lock API Removed from Service
-Previously, deprecated Lock versions were planned to be removed from service on April 1, 2018. However, the Removal of Service date was extended to **July 16, 2018** due to a [mitigation of the risks posed by deprecated versions](/cross-origin-authentication/fingerprinting).
-
-As of the week of July 16, 2018, the Legacy Lock API will be disabled. This is a soft removal, so you will have a brief grace period during which you can temporarily re-enable the feature in order to make any necessary changes. See the [soft removal announcement](https://community.auth0.com/t/soft-removal-of-legacy-lock-api/12949) for more details.
-:::
+Everyone should migrate to v11. All previous versions are deprecated, and the Legacy Lock API was removed from service on August 6, 2018. For applications that use Lock within an Auth0 login page, this migration is recommended; for applications with Lock embedded within them, this migration is mandatory.
 
 ## Migration instructions
 
@@ -48,17 +42,9 @@ If you have any questions or concerns, you can discuss them in the [Auth0 Commun
 
 <%= include('../../../_includes/_embedded_login_warning') %>
 
-## Disabling legacy Lock API
-
-After completing the migration to the latest versions, make sure that you turn off the **Legacy Lock API** toggle in the Dashboard. This will make your Auth0 tenant behave as if the legacy API is no longer available. Starting on **July 16, 2018**, this option will be forcibly disabled, so it is recommended you opt-in before that time to verify that your configuration will work correctly.
-
-You can find the setting in the [Advanced section](${manage_url}/#/tenant/advanced) of Tenant Settings.
-
-![Allowed Web Origins](/media/articles/libraries/lock/legacy-lock-api-off.png)
-
 ## Troubleshooting
 
-### Lock takes long to display the login options
+### Lock takes too long to display the login options
 
 If Lock takes a lot of time to display the login options, it could be because the [Allowed Web Origins](/libraries/lock/v11/migration-v10-v11#configure-auth0-for-embedded-login) property is not correctly set.
 
@@ -76,6 +62,6 @@ You have already migrated to Lock 11 but you still see this error in your logs:
 Legacy Lock API: This feature is being deprecated. Please refer to our documentation to learn how to migrate your application.
 ```
 
-These deprecation notices most likely originate from a user visiting the [Universal Login page](/hosted-pages/login) directly without initiating the authentication flow from your app. This can happen if a user bookmarks the login page directly. If this happens after **July 16, 2018** the user will not be able to log in.
+These deprecation notices most likely originate from a user visiting the [Universal Login page](/hosted-pages/login) directly without initiating the authentication flow from your app. This can happen if a user bookmarks the login page directly. After August 6, 2018, these users will not be able to log in.
 
 Check out the [Deprecation Error Reference](/errors/deprecation-errors) for more information on deprecation related errors.

--- a/articles/migrations/guides/legacy-lock-api-deprecation.md
+++ b/articles/migrations/guides/legacy-lock-api-deprecation.md
@@ -11,7 +11,7 @@ useCase:
 ---
 # Legacy Lock API Deprecation
 
-On April 4, 2018, Auth0 [publicly disclosed a vulnerability](https://auth0.com/blog/managing-and-mitigating-security-vulnerabilities-at-auth0/). That vulnerability resulted in the deprecation of two endpoints in the Auth0 API, and the libraries and SDKs which used those endpoints. These endpoints were disabled on **July 16, 2018**, beginning a [brief grace period](https://community.auth0.com/t/soft-removal-of-legacy-lock-api/12949) in which usage of the endpoints could be re-enabled on a per-tenant basis until a migration could be completed. The endpoints have been removed from service as of **August 06, 2018**.
+On April 4, 2018, Auth0 [publicly disclosed a vulnerability](https://auth0.com/blog/managing-and-mitigating-security-vulnerabilities-at-auth0/). That vulnerability resulted in the deprecation of two endpoints in the Auth0 API, and the libraries and SDKs which used those endpoints. These endpoints were disabled on **July 16, 2018**, beginning a [brief grace period](https://community.auth0.com/t/soft-removal-of-legacy-lock-api/12949) in which usage of the endpoints could be re-enabled on a per-tenant basis until a migration could be completed. The endpoints have been removed from service as of **August 6, 2018**.
 
 The purpose of this guide is to help you to select the best migration path for your application(s) if you are impacted by the deprecation. 
 

--- a/articles/migrations/guides/legacy-lock-api-deprecation.md
+++ b/articles/migrations/guides/legacy-lock-api-deprecation.md
@@ -132,7 +132,7 @@ Note also that the [/userinfo response](/api-auth/tutorials/adoption/scope-custo
 
 #### Single Page Applications
 
-If a user navigates to a new page in a Single Page Application, your application may wish to check if a user already has an existing session. In order to do this, you may have directly called the /ssodata endpoint or utilized the `getSSOData()` function in Auth0.js v8 or prior. The /ssodata endpoint is deprecated and was removed from service on **August 06, 2018**. The `getSSOData()` function will continue to work, but will behave differently, and in most cases, can be replaced with use of `checkSession()`.
+If a user navigates to a new page in a Single Page Application, your application may wish to check if a user already has an existing session. In order to do this, you may have directly called the /ssodata endpoint or utilized the `getSSOData()` function in Auth0.js v8 or prior. The /ssodata endpoint is deprecated and was removed from service on **August 6, 2018**. The `getSSOData()` function will continue to work, but will behave differently, and in most cases, can be replaced with use of `checkSession()`.
 
 ::: note
 The `getSSOData()` and `checkSession()` functions should only be used from a Single Page Application

--- a/articles/migrations/guides/legacy-lock-api-deprecation.md
+++ b/articles/migrations/guides/legacy-lock-api-deprecation.md
@@ -11,13 +11,9 @@ useCase:
 ---
 # Legacy Lock API Deprecation
 
-On April 4, 2018, Auth0 [publicly disclosed a vulnerability](https://auth0.com/blog/managing-and-mitigating-security-vulnerabilities-at-auth0/). That vulnerability resulted in the deprecation of two endpoints in the Auth0 API, and the libraries and SDKs which used those endpoints. Due to this vulnerability, those endpoints (and thus, the deprecated versions of the libraries) were removed from service on **July 16, 2018**.
+On April 4, 2018, Auth0 [publicly disclosed a vulnerability](https://auth0.com/blog/managing-and-mitigating-security-vulnerabilities-at-auth0/). That vulnerability resulted in the deprecation of two endpoints in the Auth0 API, and the libraries and SDKs which used those endpoints. These endpoints were disabled on **July 16, 2018**, beginning a [brief grace period](https://community.auth0.com/t/soft-removal-of-legacy-lock-api/12949) in which usage of the endpoints could be re-enabled on a per-tenant basis until a migration could be completed. The endpoints have been removed from service as of **August 06, 2018**.
 
-:::note
-As of the week of July 16, 2018, the Legacy Lock API will be disabled. This is a soft removal, so you will have a brief grace period during which you can temporarily re-enable the feature in order to make any necessary changes. See the [soft removal announcement](https://community.auth0.com/t/soft-removal-of-legacy-lock-api/12949) for more details.
-:::
-
-The purpose of this guide is to help you to select the best migration path for your application(s) if you are impacted by the deprecation notice. 
+The purpose of this guide is to help you to select the best migration path for your application(s) if you are impacted by the deprecation. 
 
 ## Am I affected?
 
@@ -28,14 +24,6 @@ If your applications match any of the following cases, you are affected:
 * Use of /user/ssodata endpoint directly from applications
 
 If you do not use the above libraries and do not specifically call the above endpoints, you are not affected. No libraries which are not specifically named are affected by this vulnerability, or in turn, by the migration.
-
-::: panel-warning Dashboard Warning Banner - Legacy Lock API Enabled
-You may see this warning panel when you log in to the Dashboard: 
-
-_Your tenant has the Legacy Lock API enabled. Please follow our Deprecation Guide then disable the Legacy Lock API in your advanced settings. The Legacy Lock API will be removed on July 16th, 2018 and your applications will no longer work if you have not fully migrated._
-
-This is because you have not turned off the Legacy Lock API switch in your [Advanced Settings](${manage_url}/#/tenant/advanced). If you are not affected by the migration, or have already completed it, turn that setting off to remove the warning.
-:::
 
 ### If you already use Universal Login / Hosted Login Page
 
@@ -61,7 +49,7 @@ If neither of these recommendations (Universal Login or embedded + custom domain
 
 ## What do I do?
 
-All applications _must_ stop using the deprecated endpoints / library versions, as they have been removed from service as of July 16, 2018, and those applications will cease to work correctly. There are two options for migration:
+All applications _must_ stop using the deprecated endpoints / library versions, as they have been removed from service as of August 6, 2018. Applications using those endpoints will no longer function correctly. There are two options for migration:
 
 ### 1. Migrate to Universal Login
 
@@ -144,7 +132,7 @@ Note also that the [/userinfo response](/api-auth/tutorials/adoption/scope-custo
 
 #### Single Page Applications
 
-If a user navigates to a new page in a Single Page Application, your application may wish to check if a user already has an existing session. In order to do this, you may have directly called the /ssodata endpoint or utilized the `getSSOData()` function in auth0.js v8 or prior. The /ssodata endpoint is deprecated and was removed from service on **July 16, 2018**. The `getSSOData()` function will continue to work, but will behave differently, and in most cases, can be replaced with use of `checkSession()`.
+If a user navigates to a new page in a Single Page Application, your application may wish to check if a user already has an existing session. In order to do this, you may have directly called the /ssodata endpoint or utilized the `getSSOData()` function in Auth0.js v8 or prior. The /ssodata endpoint is deprecated and was removed from service on **August 06, 2018**. The `getSSOData()` function will continue to work, but will behave differently, and in most cases, can be replaced with use of `checkSession()`.
 
 ::: note
 The `getSSOData()` and `checkSession()` functions should only be used from a Single Page Application
@@ -189,35 +177,12 @@ The solution for the Kerberos case is to [migrate to Universal Login](#1-migrate
 * Use `getSSOData()` to achieve an automatic login
 * Use Lock and get the **Use Windows Authentication** button (log in with Kerberos).
 
-
 ## Troubleshooting
 
 ### How to tell if you have deprecated usage
 
 Please take a look at the [Deprecation Error Reference](/errors/deprecation-errors) to assist with verifying that your application does, or does not, use deprecated features.
 
-### How to test whether you are ready before the removal of service date
-
-Auth0 has provided a toggle in the tenant settings in the [Dashboard](${manage_url}) to allow customers to turn off the legacy endpoints manually for their tenant ahead of the deprecation deadline of July 16, 2018. Navigate to the tenant settings screen, **Advanced** tab and scroll down to the block of migration toggles.
-
-![Allowed Web Origins](/media/articles/libraries/lock/legacy-lock-api-off.png)
-
-Turn off the **Legacy Lock API** toggle to stop your tenant from being able to use those endpoints. This toggle allows you to test the removal of the deprecated endpoints with the ability to turn them back on if you encounter issues.
-
-::: note
-Tenants created after Dec 27, 2017 were not allowed to begin usage of these deprecated features, and therefore do not have the Legacy Lock API toggle.
-:::
-
 ### Bookmarking the login page
 
 Bookmarking the Universal Login page is not supported. If a user bookmarks the login page and attempts to initiate authentication by going directly to the bookmarked URL instead of starting from the application, the following error message will be shown: `Password login is disabled for clients using externally hosted login pages with oidc_conformant flag set`.
-
-### Fingerprinting error
-
-For any customers who have not quite finished migrating away from the above deprecated features, Auth0 has [implemented a temporary solution](/cross-origin-authentication/fingerprinting) to help mitigate the severity of the issues with the deprecated endpoints. This solution relies on "fingerprinting" checks on the successive calls in an authentication transaction.  
-
-If any authentication requests are being rejected by the fingerprinting solution, they can be identified with the following query against logs:
-
-Description: "Unable to verify transaction consistency"
-
-Customers who have any transactions rejected by the fingerprinting checks should complete their upgrades to resolve the issue.

--- a/articles/migrations/index.md
+++ b/articles/migrations/index.md
@@ -52,31 +52,25 @@ For more information on this migration and the steps you should follow to upgrad
 
 | Severity | Grace Period Start | Mandatory Opt-In|
 | --- | --- | --- |
-| Medium | 2017-12-21 |  2018-07-16 |
+| Medium | 2017-12-21 |  2018-08-06 |
 
-We are continually improving the security of our service. As part of this, we are deprecating some endpoints (/usernamepassword/login and /ssodata) used by Lock.js v8, v9, and v10 and and auth0.js, v6, v7, and v8.
+We are continually improving the security of our service. As part of this effort, we have deprecated the Legacy Lock API, which consists of the /usernamepassword/login and /ssodata endpoints. These endpoints are used by Lock.js v8, v9, and v10 and Auth0.js, v6, v7, and v8, and can also be called directly from applications.
 
-Previously, these endpoints were planned to be removed from service on April 1, 2018. However, the Removal of Service date for those endpoints was extended to **July 16, 2018**.
+As of August 6, 2018, Auth0 has permanently disabled the Legacy Lock API. This removal of service fully mitigates the CSRF vulnerability [disclosed in April 2018](https://auth0.com/blog/managing-and-mitigating-security-vulnerabilities-at-auth0/). This also ends the soft removal grace period that was [first announced on July 16, 2018](https://community.auth0.com/t/auth0-legacy-lock-api-disabled-grace-period-available/12949), meaning the Legacy Lock API can no longer be re-enabled.
 
-Customers are still encouraged to migrate applications to the latest version of Lock 11 and Auth0.js 9 **as soon as possible** in order to ensure that applications continue to function properly.
-
-:::note
-As of the week of July 16, 2018, the Legacy Lock API will be disabled. This is a soft removal, so you will have a brief grace period during which you can temporarily re-enable the feature in order to make any necessary changes. See the [soft removal announcement](https://community.auth0.com/t/soft-removal-of-legacy-lock-api/12949) for more details.
-:::
-
-Please refer to our [Legacy Lock API Deprecation Guide](/migrations/guides/legacy-lock-api-deprecation) for instructions on upgrading your Auth0 implementation!
+If your Legacy Lock API migration has not yet been completed, your users may experience an outage, failed logins, or other adverse effects. You will need to complete your migration in order to restore normal functionality. Refer to the [Legacy Lock API Deprecation Guide](/migrations/guides/legacy-lock-api-deprecation) to determine the correct path for your needs; you may also wish to consult the [Deprecation Error Reference](/errors/deprecation-errors) to identify the source(s) of any errors in your tenant logs. 
 
 #### Am I affected by the change?
 
-If you are currently implementing login in your application with Lock v8, v9, or v10, or Auth0.js v6, v7, or v8, you will be affected by these changes.
+If you are currently implementing login in your application with Lock v8, v9, or v10, or Auth0.js v6, v7, or v8, you are affected by these changes. Additionally, you are affected if your application calls the /usernamepassword/login or /ssodata endpoints directly via the API.
 
-We **recommend** that applications using [Universal Login](/hosted-pages/login) update.
+We **recommend** that applications using [Universal Login](/hosted-pages/login) update the library versions they use inside of the login page.
 
-However, those who are using Lock or Auth0.js embedded within their applications are **required** to update, and applications which still use deprecated versions will cease to work after the removal of service date.
+However, those who are using Lock or Auth0.js embedded within their applications, or are calling the affected API endpoints directly, are **required** to update, and applications which still use deprecated endpoints will cease to function properly after the removal of service date.
 
 Libraries and SDKs not explicitly named here are not affected by this migration.
 
-If you have any questions, create a ticket in our [Support Center](${env.DOMAIN_URL_SUPPORT}).
+If you have any questions, reach out in our [Support Center](${env.DOMAIN_URL_SUPPORT}).
 
 ### Deprecating the usage of ID Tokens on the Auth0 Management API
 


### PR DESCRIPTION
Changing info about deprecation to reflect removal of service

- https://auth0-docs-content-pr-6484.herokuapp.com/docs/migrations#introducing-lock-v11-and-auth0-js-v9 - Lock API section and dates
- https://auth0-docs-content-pr-6484.herokuapp.com/docs/migrations/guides/legacy-lock-api-deprecation - verbiage changes in several places
- https://auth0-docs-content-pr-6484.herokuapp.com/docs/errors/deprecation-errors
- https://auth0-docs-content-pr-6484.herokuapp.com/docs/libraries/lock/v11/migration-guide - notice
- https://auth0-docs-content-pr-6484.herokuapp.com/docs/libraries/auth0js/v9/migration-guide - notice
- https://auth0-docs-content-pr-6484.herokuapp.com/docs/libraries/lock/v10 (deprecated notices changed on several old library references)