### PR TITLE
Update Instagram doc

### DIFF
--- a/articles/connections/social/instagram.md
+++ b/articles/connections/social/instagram.md
@@ -106,18 +106,4 @@ If you have configured everything correctly, you will see the **It works!!!** pa
 
 [Click here to learn more about authentication with Instagram](https://www.instagram.com/developer/authentication/)
 
-## 8. Access Instagram API
-
-Once you successfully authenticate a user, Instagram includes an [Access Token](/tokens/access-token) in the user profile it returns to Auth0. 
-
-You can then use this token to call their API.
-
-In order to get a Instagram Access Token, you have to retrieve the full user's profile, using the Auth0 Management API, and extrach the Access Token from the response. For detailed steps refer to [Call an Identity Provider API](/connections/calling-an-external-idp-api).
-
-Once you have the token you can call the API, following Instagram's documentation.
-
-::: note
-For more information on these tokens, refer to [Identity Provider Access Tokens](/tokens/idp).
-:::
-
 <%= include('../_quickstart-links.md') %>


### PR DESCRIPTION
Instagram does not return an access_token any longer in order to access their API.

Login though looks like it''ll continue to work until 2020.