### PR TITLE
QS SPA Vanilla JS: Fix callback URL in download instructions

### DIFF
--- a/articles/quickstart/spa/vanillajs/download.md
+++ b/articles/quickstart/spa/vanillajs/download.md
@@ -2,7 +2,7 @@ To run the sample follow these steps:
 
 1) Set the **Callback URL** in the [Application Settings](${manage_url}/#/applications/${account.clientId}/settings) to
 ```text
-http://localhost:3000/callback
+http://localhost:3000
 ```
 2) Make sure [Node.JS LTS](https://nodejs.org/en/download/) is installed and execute the following commands in the sample's directory:
 ```bash


### PR DESCRIPTION
Fixes #6543 
