### PR TITLE
Remove unused get_state method

### DIFF
--- a/articles/quickstart/webapp/rails/01-login.md
+++ b/articles/quickstart/webapp/rails/01-login.md
@@ -80,21 +80,7 @@ end
 
 ## Trigger Authentication
 
-Create a helper file called `session_helper.rb`:
-
-```ruby
-# app/helpers/session_helper.rb
-
-module SessionHelper
-  def get_state
-    state = SecureRandom.hex(24)
-    session['omniauth.state'] = state
-    state
-  end
-end
-```
-
-Now, we need a way for users to trigger authentication. Add a link to `/auth/auth0` anywhere in an existing template or use the steps below to generate a homepage in a new app. 
+We need a way for users to trigger authentication. Add a link to `/auth/auth0` anywhere in an existing template or use the steps below to generate a homepage in a new app. 
 
 Run the following command to generate the homepage controller and views:
 


### PR DESCRIPTION
This PR removes the unused `get_state` method from the Rails quickstart. 

I deleted it in my test app and the QS app and everything works fine: state is set in `session['omniauth.state']` and validated on the way back. I modified the `state` value after ULP redirect but before the callback and got the expected “CSRF” error so everything works without that. I don’t see any reference to `get_state` in OmniAuth at all. In OmniAuth-OAuth2, though, it looks like that’s all handled.

Generated:

https://github.com/omniauth/omniauth-oauth2/blob/master/lib/omniauth/strategies/oauth2.rb#L52

Stored:

https://github.com/omniauth/omniauth-oauth2/blob/master/lib/omniauth/strategies/oauth2.rb#L58

Validated:

https://github.com/omniauth/omniauth-oauth2/blob/master/lib/omniauth/strategies/oauth2.rb#L70

Added in 2012:

https://github.com/omniauth/omniauth-oauth2/commit/9029a4a7ac92906f75c25efbde2ab4e102ac3427#diff-1894759d724182a93ca97be91b43a7bc
