### PR TITLE
QS API Symfony: Fix port number in download instructions

### DIFF
--- a/articles/quickstart/backend/symfony/download.md
+++ b/articles/quickstart/backend/symfony/download.md
@@ -2,7 +2,7 @@ To run it from the command line:
 
 ```bash
 composer install
-php bin/console server:run 127.0.0.1:301
+php bin/console server:run 127.0.0.1:3010
 ```
 
 ```bash


### PR DESCRIPTION
Fixes #6560.