### PR TITLE
Fixing a typo in configuration doc

### DIFF
--- a/articles/libraries/lock/v11/configuration.md
+++ b/articles/libraries/lock/v11/configuration.md
@@ -295,7 +295,9 @@ Options for the `window.open` [position and size][windowopen-link] features. Thi
 
 ```js
 var options = {
-  redirect: false,
+  auth: {
+      redirect: false
+  },
   popupOptions: { width: 300, height: 400, left: 200, top: 300 }
 };
 ```


### PR DESCRIPTION
Fixing reference to `redirect` option. 

https://auth0-docs-content-pr-6578.herokuapp.com/docs/libraries/lock/v11/configuration/#popupoptions-object-