### PR TITLE
Save and refresh JWT link

### DIFF
--- a/articles/libraries/lock-ios/v1/use-your-own-ui.md
+++ b/articles/libraries/lock-ios/v1/use-your-own-ui.md
@@ -80,7 +80,7 @@ useCase:
 More details about the parameters you can use check [this wiki page](/libraries/lock-ios/sending-authentication-parameters).
 :::
 
-After that, you may want to save the user's token to be able to use them later, you can find how to do it [here](/libraries/lock-ios/save-and-refresh-jwt-tokens).
+After that, if you want to save the user's token to be able to use it later, you can [do this with Auth0.Swift](/libraries/auth0-swift/save-and-refresh-jwt-tokens).
 
 ## Social Authentication
 

--- a/articles/libraries/lock-ios/v1/use-your-own-ui.md
+++ b/articles/libraries/lock-ios/v1/use-your-own-ui.md
@@ -80,7 +80,7 @@ useCase:
 More details about the parameters you can use check [this wiki page](/libraries/lock-ios/sending-authentication-parameters).
 :::
 
-After that, if you want to save the user's token to be able to use it later, you can [do this with Auth0.Swift](/libraries/auth0-swift/save-and-refresh-jwt-tokens).
+After that, you may want to save the user's token to be able to use them later, you can find how to do it [here](/libraries/lock-ios/save-and-refresh-jwt-tokens).
 
 ## Social Authentication
 

--- a/articles/tokens/index.html
+++ b/articles/tokens/index.html
@@ -117,7 +117,7 @@ useCase:
     </p>
     <ul>
       <li>
-        <i class="icon icon-budicon-695"></i><a href="/libraries/auth0-swift/save-and-refresh-jwt-tokens">Auth0.Swift: Saving and Refreshing JWT Tokens</a>
+        <i class="icon icon-budicon-695"></i><a href="/libraries/lock-ios/save-and-refresh-jwt-tokens">Lock iOS: Saving and Refreshing JWT Tokens</a>
       </li>
       <li>
         <i class="icon icon-budicon-695"></i><a href="/libraries/lock-android/refresh-jwt-tokens">Lock Android: Refreshing JWT Tokens</a>

--- a/articles/tokens/index.html
+++ b/articles/tokens/index.html
@@ -117,7 +117,7 @@ useCase:
     </p>
     <ul>
       <li>
-        <i class="icon icon-budicon-695"></i><a href="/libraries/lock-ios/save-and-refresh-jwt-tokens">Lock iOS: Saving and Refreshing JWT Tokens</a>
+        <i class="icon icon-budicon-695"></i><a href="/libraries/auth0-swift/save-and-refresh-jwt-tokens">Auth0.Swift: Saving and Refreshing JWT Tokens</a>
       </li>
       <li>
         <i class="icon icon-budicon-695"></i><a href="/libraries/lock-android/refresh-jwt-tokens">Lock Android: Refreshing JWT Tokens</a>


### PR DESCRIPTION
https://auth0-docs-content-pr-6585.herokuapp.com/docs/tokens

This is the only place not within the v1 docs from which the doc is linked - changing it to an Auth0-Swift link