### PR TITLE
Remove userinfo audience from SPA quickstarts

### DIFF
--- a/articles/quickstart/spa/angular2/_includes/_centralized_login.md
+++ b/articles/quickstart/spa/angular2/_includes/_centralized_login.md
@@ -30,7 +30,6 @@ export class AuthService {
     clientID: '${account.clientId}',
     domain: '${account.namespace}',
     responseType: 'token id_token',
-    audience: 'https://${account.namespace}/userinfo',
     redirectUri: 'http://localhost:3000/callback',
     scope: 'openid'
   });

--- a/articles/quickstart/spa/angular2/custom-login-form.md
+++ b/articles/quickstart/spa/angular2/custom-login-form.md
@@ -111,7 +111,6 @@ export class AuthService {
     domain: ${account.namespace},
     clientID: ${account.clientId},
     redirectUri: 'http://localhost:4200/callback',
-    audience: `https://${account.namespace}/userinfo`,
     responseType: 'token id_token'
   });
 

--- a/articles/quickstart/spa/angular2/embedded-login.md
+++ b/articles/quickstart/spa/angular2/embedded-login.md
@@ -44,7 +44,6 @@ export class AuthService {
     auth: {
       redirectUrl: 'http://localhost:3000/callback',
       responseType: 'token id_token',
-      audience: `https://${account.namespace}/userinfo`,
       params: {
         scope: 'openid'
       }

--- a/articles/quickstart/spa/angularjs/_includes/_centralized_login.md
+++ b/articles/quickstart/spa/angularjs/_includes/_centralized_login.md
@@ -57,7 +57,6 @@ In this tutorial, the route is `/callback`, which is implemented in the [Add a C
       clientID: '${account.clientId}',
       domain: '${account.namespace}',
       responseType: 'token id_token',
-      audience: 'https://${account.namespace}/userinfo',
       redirectUri: 'http://localhost:3000/callback',
       scope: 'openid'
     });

--- a/articles/quickstart/spa/aurelia/_includes/_centralized_login.md
+++ b/articles/quickstart/spa/aurelia/_includes/_centralized_login.md
@@ -16,7 +16,6 @@ export class AuthService {
     domain: '${account.namespace}',
     clientID: '${account.clientId}',
     redirectUri: 'http://localhost:3000/callback',
-    audience: 'https://${account.namespace}/userinfo',
     responseType: 'token id_token',
     scope: 'openid'
   });

--- a/articles/quickstart/spa/ember/_includes/_centralized_login.md
+++ b/articles/quickstart/spa/ember/_includes/_centralized_login.md
@@ -24,7 +24,6 @@ export default Service.extend({
       domain: '${account.namespace}',
       clientID: '${account.clientId}',
       redirectUri: 'http://localhost:3000',
-      audience: 'https://${account.namespace}/userinfo',
       responseType: 'token id_token',
       scope: 'openid'
     });

--- a/articles/quickstart/spa/jquery/_includes/_centralized_login.md
+++ b/articles/quickstart/spa/jquery/_includes/_centralized_login.md
@@ -13,7 +13,6 @@ $('document').ready(function() {
     domain: AUTH0_DOMAIN,
     clientID: AUTH0_CLIENT_ID,
     redirectUri: AUTH0_CALLBACK_URL,
-    audience: 'https://' + AUTH0_DOMAIN + '/userinfo',
     responseType: 'token id_token',
     scope: 'openid'
   });

--- a/articles/quickstart/spa/react/_includes/_centralized_login.md
+++ b/articles/quickstart/spa/react/_includes/_centralized_login.md
@@ -23,7 +23,6 @@ export default class Auth {
     domain: '${account.namespace}',
     clientID: '${account.clientId}',
     redirectUri: 'http://localhost:3000/callback',
-    audience: 'https://${account.namespace}/userinfo',
     responseType: 'token id_token',
     scope: 'openid'
   });

--- a/articles/quickstart/spa/vanillajs/_includes/_centralized_login.md
+++ b/articles/quickstart/spa/vanillajs/_includes/_centralized_login.md
@@ -21,7 +21,6 @@ window.addEventListener('load', function() {
     domain: '${account.namespace}',
     clientID: '${account.clientId}',
     responseType: 'token id_token',
-    audience: 'https://${account.namespace}/userinfo',
     scope: 'openid',
     redirectUri: window.location.href
   });

--- a/articles/quickstart/spa/vuejs/_includes/_centralized_login.md
+++ b/articles/quickstart/spa/vuejs/_includes/_centralized_login.md
@@ -27,7 +27,6 @@ export default class AuthService {
     domain: '${account.namespace}',
     clientID: '${account.clientId}',
     redirectUri: 'http://localhost:3000/callback',
-    audience: 'https://${account.namespace}/userinfo',
     responseType: 'token id_token',
     scope: 'openid'
   })


### PR DESCRIPTION
Associated PR's to remove the same thing from sample repositories:

```
// Angular.js
https://github.com/auth0-samples/auth0-angularjs-samples/pull/47
https://github.com/auth0-samples/auth0-angularjs-samples/pull/48

// Angular
https://github.com/auth0-samples/auth0-angular-samples/pull/120
https://github.com/auth0-samples/auth0-angular-samples/pull/121

// React
https://github.com/auth0-samples/auth0-react-samples/pull/94
https://github.com/auth0-samples/auth0-react-samples/pull/95

// Vue.js
https://github.com/auth0-samples/auth0-vue-samples/pull/53
https://github.com/auth0-samples/auth0-vue-samples/pull/54

// jQuery
https://github.com/auth0-samples/auth0-jquery-samples/pull/58
https://github.com/auth0-samples/auth0-jquery-samples/pull/59

// Javascript
https://github.com/auth0-samples/auth0-javascript-samples/pull/51
https://github.com/auth0-samples/auth0-javascript-samples/pull/52

// Aurelia
https://github.com/auth0-community/auth0-aurelia-samples/pull/30

// Ember
https://github.com/auth0-community/auth0-ember-samples/pull/15
```
