### PR TITLE
Adding polling with checkSession section

### DIFF
--- a/articles/_includes/_checksession_polling.md
+++ b/articles/_includes/_checksession_polling.md
@@ -1,0 +1,3 @@
+In some multi-application scenarios, where Single Log Out is desired (a user logging out of one application needs to be logged out of other applications), an application can be set up to periodically poll Auth0 using `checkSession()` to see if a session exists. If the session does not exist, you can then log the user out of the application. The same polling method can be used to implement silent authentication for a Single Sign On scenario.
+
+The poll interval between checks to `checkSession()` should be at least 15 minutes between calls to avoid any issues in the future with rate limiting of this call.

--- a/articles/api-auth/tutorials/represent-multiple-apis.md
+++ b/articles/api-auth/tutorials/represent-multiple-apis.md
@@ -152,3 +152,7 @@ The app can then use the Access Token to call the API on behalf of the user.
 After logging in, you can see buttons that allow you to call either of your APIs.
 
 ![SPA Home after Login](/media/articles/api-auth/tutorials/represent-multiple-apis/apis.png)
+
+## Polling checkSession() to attain SSO or SLO
+
+<%= include('../../_includes/_checksession_polling') %>

--- a/articles/api-auth/tutorials/silent-authentication.md
+++ b/articles/api-auth/tutorials/silent-authentication.md
@@ -106,6 +106,10 @@ When the Access Token has expired, silent authentication can be used to retrieve
 
 In the case of single-page applications, the [`checkSession` method from auth0.js](/libraries/auth0js#using-checksession-to-acquire-new-tokens) can be used to perform silent authentication within a hidden iframe, which results in no UX disruption at all.
 
+## Polling with checkSession()
+
+<%= include('../../_includes/_checksession_polling') %>
+
 ### How to implement
 
 Implementation of token renewal will depend on the type of application and framework being used. Sample implementations for some of the common platforms can be found below:

--- a/articles/libraries/auth0js/v9/index.md
+++ b/articles/libraries/auth0js/v9/index.md
@@ -442,6 +442,10 @@ Remember to add the URL where the authorization request originates from, to the 
 If the connection is a social connection and you are using Auth0 dev keys, the `checkSession` call will always return `login_required`.
 :::
 
+### Polling with checkSession()
+
+<%= include('../../../_includes/_checksession_polling') %>
+
 ## Password reset requests
 
 If attempting to set up a password reset functionality, you'll use the `changePassword` method and pass in an "options" object, with a "connection" parameter and an "email" parameter.

--- a/articles/migrations/guides/legacy-lock-api-deprecation.md
+++ b/articles/migrations/guides/legacy-lock-api-deprecation.md
@@ -152,11 +152,9 @@ The `getSSOData()` and `checkSession()` functions should only be used from a Sin
 
 ##### Polling for an existing session
 
-In some multi-application scenarios, where a user logging out of one application needs to be logged out of other applications, an application may have been set up to periodically poll Auth0 using `getSSOData()` to see if a session existed, and if not, log the user out of the application. 
+<%= include('../../_includes/_checksession_polling') %>
 
-Instead of doing this, applications should now use `checkSession()` instead of `getSSOData()`. The `getSSOData()` function performs more work behind the scenes than is needed for this purpose and applications that are not switched to `checkSession()` will suffer a needless performance penalty.
-
-The poll interval between checks to `checkSession()` should be at least 15 minutes between calls to avoid any issues in the future with rate limiting of this call.
+This was previously done with `getSSOData()`. The `getSSOData()` function performs more work behind the scenes than is needed for this purpose and applications that are not switched to `checkSession()` will suffer a needless performance penalty.
 
 #### Web applications
 

--- a/articles/sso/current/single-page-apps.md
+++ b/articles/sso/current/single-page-apps.md
@@ -125,6 +125,10 @@ auth0.checkSession({
 });
 ```
 
+### Polling with checkSession()
+
+<%= include('../../_includes/_checksession_polling') %>
+
 ## Run the sample application
 
 When you run the sample app for the first time, you will not have a valid Access Token. As such, the SSO login process errors when attempting silent authentication.


### PR DESCRIPTION
Adding a polling checkSession() snippet similar to the one formerly present in the Lock Legacy API Migration Guide.

* https://auth0-docs-content-pr-6617.herokuapp.com/docs/migrations/guides/legacy-lock-api-deprecation#polling-for-an-existing-session
* https://auth0-docs-content-pr-6617.herokuapp.com/docs/libraries/auth0js/v9#polling-with-checksession-
* https://auth0-docs-content-pr-6617.herokuapp.com/docs/sso/current/single-page-apps#polling-with-checksession-
* https://auth0-docs-content-pr-6617.herokuapp.com/docs/api-auth/tutorials/silent-authentication#polling-with-checksession-