### PR TITLE
Remove /userinfo audience from Ruby web app quickstart

### DIFF
--- a/snippets/server-platforms/rails/setup.md
+++ b/snippets/server-platforms/rails/setup.md
@@ -7,8 +7,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
     '${account.namespace}',
     callback_path: '/auth/oauth2/callback',
     authorize_params: {
-      scope: 'openid profile',
-      audience: 'https://${account.namespace}/userinfo'
+      scope: 'openid profile'
     }
   )
 end


### PR DESCRIPTION
Associated PR's to remove the same thing from sample repository:

https://github.com/auth0-samples/auth0-rubyonrails-sample/pull/31

