### PR TITLE
Quickstart NodeJS: Added note on order of commands

### DIFF
--- a/articles/quickstart/webapp/nodejs/01-login.md
+++ b/articles/quickstart/webapp/nodejs/01-login.md
@@ -85,7 +85,7 @@ passport.use(strategy);
 app.use(passport.initialize());
 app.use(passport.session());
 ```
-Please make sure these last 2 commands are in your code after the application of the express middleware (`app.use(session(sess)`).
+Please make sure these last two commands are in your code after the application of the express middleware (`app.use(session(sess)`).
 
 ### Storing and retrieving user data from the session
 

--- a/articles/quickstart/webapp/nodejs/01-login.md
+++ b/articles/quickstart/webapp/nodejs/01-login.md
@@ -85,6 +85,7 @@ passport.use(strategy);
 app.use(passport.initialize());
 app.use(passport.session());
 ```
+Please make sure these last 2 commands are in your code after the application of the express middleware (`app.use(session(sess)`).
 
 ### Storing and retrieving user data from the session
 


### PR DESCRIPTION
<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
This PR add a note that might save time to NodeJS devs, as they might rearrange the code in the quickstart (As you would expect in an Express app).

Basically if you have `app.use(session(sess));` after the passport initialisation, your application will fail to retrieve the user. 
Now, there might be a bug in the library for this side effect or it might be intended behaviour, but for the scope of the Quickstart I think users should be advised.

