### PR TITLE
Clarify default language of rejection notification

### DIFF
--- a/articles/connections/database/password-strength.md
+++ b/articles/connections/database/password-strength.md
@@ -63,7 +63,7 @@ and on mobile:
 
 
 ::: note
-When a password is rejected, the language of the notification defaults to English. If language customization is required, this should be done via client-side translation.
+If Auth0 rejects a provided password, the notification will display in English. If you would like to display notifications in another language, you will need to do so via client-side translation.
 :::
 
 ## Custom Signup Errors

--- a/articles/connections/database/password-strength.md
+++ b/articles/connections/database/password-strength.md
@@ -61,6 +61,11 @@ and on mobile:
 
 ![Auth0 Lock Password Strength checks on Mobile](/media/articles/connections/database/password-strength/moUbn4XXxR.png)
 
+
+::: note
+When a password is rejected, the language of the notification defaults to English. If language customization is required, this should be done via client-side translation.
+:::
+
 ## Custom Signup Errors
 
 Sign-up errors will return a 400 HTTP status code. The JSON response will contain `code: invalid_password` when the password does not meet the selected password policy criteria.


### PR DESCRIPTION
When a password is rejected, the user will see a window with the reasons for rejection. This information is presented in English. Any customization needs to be done client-side.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
