### PR TITLE
Hidden toggle instruction

### DIFF
--- a/articles/extensions/account-link.md
+++ b/articles/extensions/account-link.md
@@ -23,7 +23,7 @@ The extension will create a new **Application** named `auth0-account-link` to us
 
 ## Setup
 
-First, navigate to the [Advanced Settings](${manage_url}/#/tenant/advanced) for your tenant, scroll to the bottom of the page, and click the toggle to enable **Allow ID Tokens for Management API v2 Authentication**.
+First, navigate to the [Advanced Settings](${manage_url}/#/tenant/advanced) for your tenant, scroll to the bottom of the page, and click the toggle to enable **Allow ID Tokens for Management API v2 Authentication**. Note: newly created Tenants will not have this option available, contact [support](https://support.auth0.com/) to make this option available.
 
 ### Changing the Application Name
 


### PR DESCRIPTION
Mention that the **Allow ID Tokens for Management API v2 Authentication** toggle might not be visible.