### PR TITLE
Update impersonation warning, remove references from unnecessary spots

### DIFF
--- a/articles/_includes/_deprecate-impersonation.md
+++ b/articles/_includes/_deprecate-impersonation.md
@@ -1,3 +1,3 @@
 :::warning
-Impersonation has been deprecated and will not be enabled for customers any longer. The functionality will continue to work for the customers that have it already enabled. If this changes customers will be notified beforehand and given ample time to migrate.
+Impersonation has been deprecated and will not be enabled for customers in the future. The functionality will continue to work for the customers that currently have it enabled. If at some point the impersonation feature is changed or removed from service, customers who currently use it will be notified beforehand and given ample time to migrate.
 :::

--- a/articles/api/management/v1/use-cases.md
+++ b/articles/api/management/v1/use-cases.md
@@ -18,7 +18,6 @@ The features only available in Management API v1 include:
 * [Application Users](#application-users)
 * [Email](#email)
 * [Enterprise Users/Directory Searching](#enterprise-users/directory-searching)
-* [Impersonation](#impersonation)
 * [Rules Configuration](#rules-configuration)
 * [Searching via the PSaaS Appliance](#searching-via-the-auth0-appliance)
 
@@ -52,13 +51,6 @@ Management API v1 allows you to search directly for users authenticated using en
 
 * All users from all enterprise directories:
 GET `/api/enterpriseconnections/users?search={criteria}`
-
-## Impersonation
-
-Management API v1 includes an impersonation endpoint that generates a link that can be used only once to log in as a specific user for troubleshooting purposes.
-
-[`/users/{user_id}/impersonate`](/auth-api#impersonation)
-
 
 ## Rules Configuration
 

--- a/articles/extensions/delegated-admin/v2/manage-users.md
+++ b/articles/extensions/delegated-admin/v2/manage-users.md
@@ -39,11 +39,6 @@ The table below lists the options you can perform on users, as well as informati
         <th>No</th>
     </tr>
     <tr>
-        <th>Sign in as User (Impersonation)</th>
-        <th>Yes</th>
-        <th>No</th>
-    </tr>
-    <tr>
         <th>Block User</th>
         <th>Yes</th>
         <th>Yes</th>

--- a/articles/extensions/delegated-admin/v3/manage-users.md
+++ b/articles/extensions/delegated-admin/v3/manage-users.md
@@ -39,11 +39,6 @@ The table below lists the options you can perform on users, as well as informati
         <th>No</th>
     </tr>
     <tr>
-        <th>Sign in as User (Impersonation)</th>
-        <th>Yes</th>
-        <th>No</th>
-    </tr>
-    <tr>
         <th>Block User</th>
         <th>Yes</th>
         <th>Yes</th>

--- a/articles/users/index.md
+++ b/articles/users/index.md
@@ -39,9 +39,6 @@ useCase:
         <i class="icon icon-budicon-695"></i><a href="/user-profile/normalized/auth0">Normalized User Profiles</a>
       </li>
       <li>
-        <i class="icon icon-budicon-695"></i><a href="/user-profile/user-impersonation">User Impersonation</a>
-      </li>
-      <li>
         <i class="icon icon-budicon-695"></i><a href="/user-profile/user-data-storage">User Data Storage</a>
       </li>
       <li>


### PR DESCRIPTION
Removed mentions of Impersonation from these docs:

* https://auth0-docs-content-pr-6684.herokuapp.com/docs/api/management/v1/use-cases
* https://auth0-docs-content-pr-6684.herokuapp.com/docs/users
* https://auth0-docs-content-pr-6684.herokuapp.com/docs/extensions/delegated-admin/v3/manage-users
* https://auth0-docs-content-pr-6684.herokuapp.com/docs/extensions/delegated-admin/v2/manage-users

Also updated warning copy for future use