### PR TITLE
Specify connection type for emails

### DIFF
--- a/articles/email/index.md
+++ b/articles/email/index.md
@@ -12,10 +12,10 @@ useCase: customize-emails
 
 # Emails in Auth0
 
-An Auth0 [Database Connection](/connections/database) provides several emails as a part of it's authentication flow. This includes verification emails, welcome emails, change password emails, and blocked account emails. When you first create your application Auth0 provides a built-in email provider to send emails.
+An Auth0 [Database Connection](/connections/database) provides several emails as a part of its authentication flow, including verification emails, welcome emails, change password emails, and blocked account emails. When you first create your application, Auth0 provides a built-in email provider to send emails.
 
 ::: warning
-Auth0's built-in email provider is not supported for use in a production environment and should be used for testing only and has several restrictions.
+Auth0's built-in email provider is not supported for use in a production environment, should be used for testing only, and has several restrictions.
 :::
 
 * You will not be able to use any of the email customization features. The content of the emails sent for testing will be restricted to format of the existing templates.

--- a/articles/email/index.md
+++ b/articles/email/index.md
@@ -18,6 +18,8 @@ An Auth0 [Database Connection](/connections/database) provides several emails as
 Auth0's built-in email provider is not supported for use in a production environment, should be used for testing only, and has several restrictions.
 :::
 
+Auth0's built-in email provider has these restrictions:
+
 * You will not be able to use any of the email customization features. The content of the emails sent for testing will be restricted to format of the existing templates.
 
 * All emails will be sent from a predefined **from** address (`no-reply@auth0user.net`).

--- a/articles/email/index.md
+++ b/articles/email/index.md
@@ -12,11 +12,11 @@ useCase: customize-emails
 
 # Emails in Auth0
 
-::: warning
-Auth0's built-in email provider is not supported for use in a production environment and should be used for testing only.
-:::
+An Auth0 [Database Connection](/connections/database) provides several emails as a part of it's authentication flow. This includes verification emails, welcome emails, change password emails, and blocked account emails. When you first create your application Auth0 provides a built-in email provider to send emails.
 
-When you first create your application Auth0 provides a built-in email provider to send emails. This includes verification emails, welcome emails, change password emails, and blocked account emails. This is meant to be used for testing purposes only, and has several restrictions:
+::: warning
+Auth0's built-in email provider is not supported for use in a production environment and should be used for testing only and has several restrictions.
+:::
 
 * You will not be able to use any of the email customization features. The content of the emails sent for testing will be restricted to format of the existing templates.
 

--- a/articles/email/index.md
+++ b/articles/email/index.md
@@ -12,7 +12,7 @@ useCase: customize-emails
 
 # Emails in Auth0
 
-An Auth0 [Database Connection](/connections/database) provides several emails as a part of its authentication flow, including verification emails, welcome emails, change password emails, and blocked account emails. When you first create your application, Auth0 provides a built-in email provider to send emails.
+An Auth0 [Database Connection](/connections/database) provides several emails as a part of its authentication flow, including verification emails, welcome emails, change password emails, breached password, and blocked account emails. The **Guardian Enrollment Email** can be sent to users in any connection.
 
 ::: warning
 Auth0's built-in email provider is not supported for use in a production environment, should be used for testing only, and has several restrictions.


### PR DESCRIPTION
This PR makes it clear that email work flows only apply to Database connections