### PR TITLE
removing 80 per @sgmeyer

### DIFF
--- a/articles/appliance/infrastructure/ip-domain-port-list.md
+++ b/articles/appliance/infrastructure/ip-domain-port-list.md
@@ -133,7 +133,7 @@ Auth0 strives to keep these IP addresses stable, though this is not a given. Fro
     <td>Updates</td>
     <td>Outbound</td>
     <td>apt-mirror.it.auth0.com (52.8.153.197)</td>
-    <td>80/443</td>
+    <td>443</td>
     <td>Provides update packages for PSaaS Appliance instances</td>
     <td>Yes</td>
   </tr>


### PR DESCRIPTION
sgmeyer [1:51 PM]
We made every effort to remove the need for 80 in favor of 443 for everything we could find.

sgmeyer [1:55 PM]
The outbound 80 access to apt mirror is a bad security thing because we don’t want to download code/dependencies over I’m insecure connection during updates and reconfigurations.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
