### PR TITLE
File paths added for sample code in Android native docs

### DIFF
--- a/articles/quickstart/native/android/_includes/_auth0.md
+++ b/articles/quickstart/native/android/_includes/_auth0.md
@@ -27,6 +27,8 @@ Add manifest placeholders required by the SDK. The placeholders are used interna
 To add the manifest placeholders, add the next line:
 
 ```xml
+// app/build.gradle
+
 apply plugin: 'com.android.application'
 android {
     compileSdkVersion 25

--- a/articles/quickstart/native/android/_includes/_auth0.md
+++ b/articles/quickstart/native/android/_includes/_auth0.md
@@ -27,7 +27,7 @@ Add manifest placeholders required by the SDK. The placeholders are used interna
 To add the manifest placeholders, add the next line:
 
 ```xml
-// app/build.gradle
+<!-- app/build.gradle -->
 
 apply plugin: 'com.android.application'
 android {

--- a/articles/quickstart/native/android/_includes/_auth0.md
+++ b/articles/quickstart/native/android/_includes/_auth0.md
@@ -27,7 +27,7 @@ Add manifest placeholders required by the SDK. The placeholders are used interna
 To add the manifest placeholders, add the next line:
 
 ```xml
-<!-- app/build.gradle -->
+// app/build.gradle
 
 apply plugin: 'com.android.application'
 android {

--- a/articles/quickstart/native/android/_includes/_login.md
+++ b/articles/quickstart/native/android/_includes/_login.md
@@ -65,7 +65,7 @@ You do not need to declare a specific `intent-filter` for your activity, because
 The `AndroidManifest.xml` file should look like this:
 
 ```xml
-// app/src/main/AndroidManifest.xml
+<!-- app/src/main/AndroidManifest.xml -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.auth0.samples">

--- a/articles/quickstart/native/android/_includes/_login.md
+++ b/articles/quickstart/native/android/_includes/_login.md
@@ -65,6 +65,8 @@ You do not need to declare a specific `intent-filter` for your activity, because
 The `AndroidManifest.xml` file should look like this:
 
 ```xml
+// app/src/main/AndroidManifest.xml
+
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.auth0.samples">
 


### PR DESCRIPTION
Add file paths for sample code of `build.gradle` and `AndroidManifest.xml`

Fix #5526 
