### PR TITLE
updated links to status page

### DIFF
--- a/articles/best-practices/operations.md
+++ b/articles/best-practices/operations.md
@@ -25,7 +25,7 @@ Also, make sure to [configure and customize the templates](/email/templates) for
 
 ## Subscribe to updates on the Auth0 status page
 
-Head over to the [Auth0 status page](http://status.auth0.com/) and sign up for notifications. If there are any Auth0 outages, you or your support staff will be notified.
+Head over to the [Auth0 status page](https://status.auth0.com/) and sign up for notifications. If there are any Auth0 outages, you or your support staff will be notified.
 
 ## Store custom code in a source code repository
 

--- a/articles/getting-started/deployment-models.md
+++ b/articles/getting-started/deployment-models.md
@@ -67,7 +67,7 @@ The following tables describe operational and feature differences between these 
         </tr>
         <tr>
             <th class="info"><strong>Service & Uptime Reporting</strong></th>
-            <td><a href="http://status.auth0.com">http://status.auth0.com</a><br /><a href="http://uptime.auth0.com">http://uptime.auth0.com</a></td>
+            <td><a href="https://status.auth0.com">https://status.auth0.com</a><br /><a href="http://uptime.auth0.com">http://uptime.auth0.com</a></td>
             <td>Monitored by Auth0</td>
             <td>Monitored by Auth0 and Customer's tools</td>
             <td>Monitored by Auth0 and Customer's tools</td>

--- a/articles/monitoring/how-to-monitor-auth0.md
+++ b/articles/monitoring/how-to-monitor-auth0.md
@@ -14,7 +14,7 @@ useCase:
 
 # Monitor Auth0
 
-If you are using the public cloud version of Auth0, we recommend subscribing to [Auth0 Status](http://status.auth0.com) for notifications regarding Auth0 service availability. The Auth0 DevOps team uses [Auth0 Status](http://status.auth0.com) for reports on current incidents.
+If you are using the public cloud version of Auth0, we recommend subscribing to [Auth0 Status](https://status.auth0.com) for notifications regarding Auth0 service availability. The Auth0 DevOps team uses [Auth0 Status](https://status.auth0.com) for reports on current incidents.
 
 Current and historical uptime is available at [Auth0 Uptime](http://uptime.auth0.com).
 

--- a/articles/onboarding/enterprise-support.md
+++ b/articles/onboarding/enterprise-support.md
@@ -81,9 +81,9 @@ To speed resolution, please check the following before logging an issue:
 * Is the issue experienced by all users or just a few?
   * All? - Could be a service or configuration issue
     * Check status of Auth0 service
-      * Americas: (http://status.auth0.com)
-      * EU Region: (http://status.eu.auth0.com)
-      * APAC Region: (http://status.au.auth0.com)
+      * Americas: (https://status.auth0.com)
+      * EU Region: (https://status.auth0.com/?region=EU)
+      * APAC Region: (https://status.auth0.com/?region=AU)
       * You can subscribe to updates via the button on those pages
     * Check authentication services (connections) are up and reachable
     * Check application components - make sure they are functioning


### PR DESCRIPTION
Replaced `http` with `https` and fixed links to region-specific pages. All previous region-specific urls redirected to the **US** region.