### PR TITLE
Fixes Link to Blacklisting Attributes Page

### DIFF
--- a/articles/user-profile/user-profile-structure.md
+++ b/articles/user-profile/user-profile-structure.md
@@ -72,4 +72,4 @@ Most user profile fields are not returned as part of [ID Token](/tokens/id-token
 
 ## Blacklisting user attributes
 
-If there are user fields that should not be stored by Auth0 due to privacy reasons, you can blacklist the attributes you do not want persisting in Auth0 databases. For details on how to do that refer to [Blacklisting User Attributes](/tutorials/blacklisting-attributes).
+If there are user fields that should not be stored by Auth0 due to privacy reasons, you can blacklist the attributes you do not want persisting in Auth0 databases. For details on how to do that refer to [Blacklisting User Attributes](/security/blacklisting-attributes).

--- a/config/redirects.js
+++ b/config/redirects.js
@@ -882,7 +882,7 @@ module.exports = [
   },
   {
     from: '/blacklist-attributes',
-    to: '/tutorials/blacklisting-attributes'
+    to: '/security/blacklisting-attributes'
   },
   {
     from: '/brute-force-protection',


### PR DESCRIPTION
This PR fixes the links from `/tutorials/blacklisting-attributes` to `/security/blacklisting-attributes` and removes the unnecessary redirect from `config/redirects.js`.

The redirect on line [1397](https://github.com/auth0/docs/blob/7e7a7abc5d29f0f235a5bfbde0859ace09d20e0e/config/redirects.js#L1397) in `config/redirects.js` was purposely left in for legacy redirect reasons, but can certainly be removed as well.