### PR TITLE
Update user-consent.md scope format description

### DIFF
--- a/articles/api-auth/user-consent.md
+++ b/articles/api-auth/user-consent.md
@@ -72,7 +72,7 @@ Once consent has been given, the user will no longer see the consent dialog on s
 
 ## Scope Descriptions 
 
-By default, the consent page will use the scopes' names to prompt for the user's consent. As shown below, you should define scopes using the **resource_name:action** format.
+By default, the consent page will use the scopes' names to prompt for the user's consent. As shown below, you should define scopes using the **action:resource_name** format.
 
 ![API Scopes](/media/articles/api-auth/consent-scopes.png)
 


### PR DESCRIPTION
This updates user-consent.md to describe the format for consent scopes to be "**action:resource_name**" instead of "**resource_name:action**" in order to make it match the actual usage.

Without this, the textual description suggests to use **resource_name:action** for scope names even though all the examples, such as `read:posts`, use the format **action:resource_name**.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
