### PR TITLE
Update user-consent.md

### DIFF
--- a/articles/api-auth/user-consent.md
+++ b/articles/api-auth/user-consent.md
@@ -120,7 +120,7 @@ Note that this option only allows __verifiable__ first-party applications to ski
 127.0.0.1       myapp.example
 ```
 
-Once you do this, remember to update your application configuration URLs, such as the **Allowed Callback URLs** (found in [Dashboard > Applications > Settings](${manage_url}/#/applications/${account.clientId}/settings)), and the callback URL you configured in your application, to match the updated domain-mapping.
+Similarly, you **cannot** skip consent (even for first-party applications) if `localhost` appears in any domain in the **Allowed Callback URLs** setting (found in [Dashboard > Applications > Settings](${manage_url}/#/applications/${account.clientId}/settings)). Make sure to update **Allowed Callback URLs**, and the callback URL you configured in your application, to match the updated domain-mapping.
 :::
 
 Since third-party applications are assumed to be untrusted, they are not able to skip consent dialogs.


### PR DESCRIPTION
Clarifies that consent cannot be skipped (even for first-party applications) if `localhost` appears in a callback URL. Source: https://community.auth0.com/t/how-do-i-skip-the-consent-page-for-my-api-authorization-flow/6035/6 and https://community.auth0.com/t/how-do-i-skip-the-consent-page-for-my-api-authorization-flow/6035/7.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
