### PR TITLE
Update silent authentication documentation

### DIFF
--- a/articles/api-auth/tutorials/silent-authentication.md
+++ b/articles/api-auth/tutorials/silent-authentication.md
@@ -93,7 +93,7 @@ If any of these errors are returned, the user must be redirected to the Auth0 lo
 Please review [our notes on token renewal for Safari users](/api-auth/token-renewal-in-safari).
 :::
 
-Since Single Page Applications can not request or use [Refresh Tokens](https://auth0.com/docs/tokens/refresh-token/current) to renew an expired token, a silent authentication request can be used instead to get new tokens as long as the user still has a valid session at Auth0.
+Since Single Page Applications cannot request or use [Refresh Tokens](https://auth0.com/docs/tokens/refresh-token/current) to renew an expired token, a silent authentication request can be used instead to get new tokens as long as the user still has a valid session at Auth0.
 
 
 The [`checkSession` method from auth0.js](/libraries/auth0js#using-checksession-to-acquire-new-tokens) uses a silent token request in combination with `response_mode=web_message` so that the request happens in a hidden iframe. Auth0.js handles the result processing (either the token or the error code) and passes the information through a callback function provided by the application. This results in no UX disruption (no page refresh or lost state).

--- a/articles/api-auth/tutorials/silent-authentication.md
+++ b/articles/api-auth/tutorials/silent-authentication.md
@@ -58,7 +58,7 @@ For example, when using the [Implicit Flow](/api-auth/grant/implicit) (`response
 
 ```text
 GET ${account.callback}
-    ?id_token=...&
+    #id_token=...&
     access_token=...&
     state=...&
     expires_in=...
@@ -72,12 +72,10 @@ If the user was not logged in via SSO or their SSO session had expired, Auth0 wi
 
 ```
 GET https://your_callback_url/
-    ?error=ERROR_CODE&
+    #error=ERROR_CODE&
     error_description=ERROR_DESCRIPTION&
     state=...
 ```
-
-When using the [Authorization Code Grant](/api-auth/grant/authorization-code), the error response parameters are returned in the query string. When using the [Implicit Grant](/api-auth/grant/implicit), they are returned in the hash fragment instead.
 
 The possible values for `ERROR_CODE` are defined by the [OpenID Connect specification](https://openid.net/specs/openid-connect-core-1_0.html#AuthError):
 

--- a/articles/api-auth/tutorials/silent-authentication.md
+++ b/articles/api-auth/tutorials/silent-authentication.md
@@ -14,11 +14,9 @@ useCase:
 
 <%= include('../../_includes/_pipeline2') %>
 
-There are two main participants involved in a [single sign-on (SSO)](/sso) scenario: an Authorization Server (Auth0), and multiple applications.
+The OpenID Connect protocol supports a `prompt=none` parameter on the authentication request that allows applications to indicate that the authorization server must not display any user interaction (such as authentication, consent or MFA). Auth0 will either return the requested response back to the application or return an error if the user is not already authenticated, or some type of consent or prompt is required before proceeding.
 
-For privacy reasons, applications cannot query Auth0 directly to determine if a user has logged in via SSO. This means that users must be redirected to Auth0 for SSO authentication.
-
-However, redirecting users away from your application is usually considered disruptive and should be avoided, from a UX perspective. **Silent authentication** lets you perform an authentication flow where Auth0 will only reply with redirects, and never with a login page.
+This flow can be used by Single Page Applications to renew tokens as explained below.
 
 ## Initiate a Silent Authentication request
 
@@ -28,22 +26,25 @@ For example:
 
 ```text
 GET https://${account.namespace}/authorize
-    ?response_type=code&
+    ?response_type=id_token token&
     client_id=...&
     redirect_uri=...&
     state=...&
     scope=openid...&
+    nonce=...&
+    audience=...&
+    response_mode=...&
     prompt=none
 ```
 
 ::: note
-  The specific parameters on the authentication request will depend on what kind of application is authenticating (<a href="/api/authentication#authorization-code-grant">regular web application</a>, <a href="/api/authentication#implicit-grant">single page app</a>), and so forth).
+  The specific parameters on the authentication request will depend on the specific needs of the application.
 :::
 
-The `prompt=none` parameter will cause Auth0 to immediately redirect to the specified `redirect_uri` (callback URL) with two possible responses:
+The `prompt=none` parameter will cause Auth0 to immediately send a result to the specified `redirect_uri` (callback URL) using the specified `response_mode` with one of two possible responses:
 
-* A successful authentication response if the user was already logged in via SSO
-* An error response if the user is not logged in via SSO and therefore cannot be silently authenticated
+* A successful authentication response if the user already has a valid session in Auth0 and consent or other prompts are needed.
+* An error response if the user doesn't have a valid session or some interactive prompt is required.
 
 ::: note
 Any applicable [rules](/rules) will be executed as part of the silent authentication process.
@@ -51,13 +52,14 @@ Any applicable [rules](/rules) will be executed as part of the silent authentica
 
 ### Successful authentication response
 
-If the user was already logged in via SSO, Auth0 will respond exactly as if the user had authenticated manually through the SSO login page.
+If the user was already logged in into Auth0 and no other interactive prompts are required, Auth0 will respond exactly as if the user had authenticated manually through the login page.
 
-For example, when using the [Authorization Code Grant](/api-auth/grant/authorization-code) (`response_type=code`, used for regular web applications), Auth0 will respond with an authorization code that can be exchanged for an ID Token and optionally an Access Token:
+For example, when using the [Implicit Flow](/api-auth/grant/implicit) (`response_type=id_token token`, used for single page applications), Auth0 will respond with the requested tokens:
 
 ```text
 GET ${account.callback}
-    ?code=...&
+    ?id_token=...&
+    access_token=...&
     state=...&
     expires_in=...
 ```
@@ -91,6 +93,12 @@ If any of these errors are returned, the user must be redirected to the Auth0 lo
 Please review [our notes on token renewal for Safari users](/api-auth/token-renewal-in-safari).
 :::
 
+Since Single Page Applications can not request or use [Refresh Tokens](https://auth0.com/docs/tokens/refresh-token/current) to renew an expired token, a silent authentication request can be used instead to get new tokens as long as the user still has a valid session at Auth0.
+
+
+The [`checkSession` method from auth0.js](/libraries/auth0js#using-checksession-to-acquire-new-tokens) uses a silent token request in combination with `response_mode=web_message` so that the request happens in a hidden iframe. Auth0.js handles the result processing (either the token or the error code) and passes the information through a callback function provided by the application. This results in no UX disruption (no page refresh or lost state).
+
+### Access Token expiration
 Access Tokens are opaque to applications. This means that applications are unable to inspect the contents of Access Tokens to determine their expiration date.
 
 There are two options to determine when an Access Token expires:
@@ -101,10 +109,6 @@ There are two options to determine when an Access Token expires:
 In the case of the [Implicit Grant](/api-auth/grant/implicit), the `expires_in` parameter is returned by Auth0 as a hash parameter following a successful authentication. For the [Authorization Code Grant](/api-auth/grant/code), it is returned to the backend server when performing the authorization code exchange.
 
 The `expires_in` parameter indicates how many seconds the Access Token will be valid for, and can be used to anticipate expiration of the Access Token.
-
-When the Access Token has expired, silent authentication can be used to retrieve a new one without user interaction, assuming the user's SSO session has not expired.
-
-In the case of single-page applications, the [`checkSession` method from auth0.js](/libraries/auth0js#using-checksession-to-acquire-new-tokens) can be used to perform silent authentication within a hidden iframe, which results in no UX disruption at all.
 
 ## Polling with checkSession()
 

--- a/articles/api-auth/tutorials/silent-authentication.md
+++ b/articles/api-auth/tutorials/silent-authentication.md
@@ -91,7 +91,7 @@ If any of these errors are returned, the user must be redirected to the Auth0 lo
 Please review [our notes on token renewal for Safari users](/api-auth/token-renewal-in-safari).
 :::
 
-Since Single Page Applications cannot request or use [Refresh Tokens](https://auth0.com/docs/tokens/refresh-token/current) to renew an expired token, a silent authentication request can be used instead to get new tokens as long as the user still has a valid session at Auth0.
+Since Single Page Applications cannot request or use Refresh Tokens to renew an expired token, a silent authentication request can be used instead to get new tokens as long as the user still has a valid session at Auth0.
 
 
 The [`checkSession` method from auth0.js](/libraries/auth0js#using-checksession-to-acquire-new-tokens) uses a silent token request in combination with `response_mode=web_message` so that the request happens in a hidden iframe. Auth0.js handles the result processing (either the token or the error code) and passes the information through a callback function provided by the application. This results in no UX disruption (no page refresh or lost state).

--- a/articles/api-auth/tutorials/silent-authentication.md
+++ b/articles/api-auth/tutorials/silent-authentication.md
@@ -38,7 +38,7 @@ GET https://${account.namespace}/authorize
 ```
 
 ::: note
-  The specific parameters on the authentication request will depend on the specific needs of the application.
+  The individual parameters on the authentication request will depend on the specific needs of the application.
 :::
 
 The `prompt=none` parameter will cause Auth0 to immediately send a result to the specified `redirect_uri` (callback URL) using the specified `response_mode` with one of two possible responses:


### PR DESCRIPTION
Clarified some concepts. 
Removed SSO references.
Removed confusing references to code authorization flow as the silent token request is mostly targeted at SPA using the implicit flow.
Moved Access Token expiration to its own subsection.

