### PR TITLE
Update user_metadata warning

### DIFF
--- a/articles/_includes/_metadata_on_signup_warning.md
+++ b/articles/_includes/_metadata_on_signup_warning.md
@@ -1,0 +1,3 @@
+::: note
+When setting the `user_metadata` field using the Authentication API's [Signup endpoint](/api/authentication?javascript#signup), you are limited a maximum of 10 `String` fields and 500 characters.
+:::

--- a/articles/_includes/_metadata_on_signup_warning.md
+++ b/articles/_includes/_metadata_on_signup_warning.md
@@ -1,3 +1,3 @@
 ::: note
-When setting the `user_metadata` field using the Authentication API's [Signup endpoint](/api/authentication?javascript#signup), you are limited a maximum of 10 `String` fields and 500 characters.
+When setting the `user_metadata` field using the Authentication API's [Signup endpoint](/api/authentication?javascript#signup), you are limited to a maximum of 10 `String` fields and 500 characters.
 :::

--- a/articles/metadata/apis.md
+++ b/articles/metadata/apis.md
@@ -21,9 +21,7 @@ In this article, we will cover how you can create and update metadata using the 
 
 When you use the Authentication API's [Signup endpoint](/api/authentication?shell#signup), you can create a new Database Connection user and set the `user_metadata` field.
 
-::: note
-When setting the `user_metadata` field using the Authentication API's [Signup endpoint](/api/authentication?javascript#signup), you are limited a maximum of 10 fields and 500 characters.
-:::
+<%= include('../_includes/_metadata_on_signup_warning') %>
 
 ## Management API
 

--- a/articles/metadata/index.md
+++ b/articles/metadata/index.md
@@ -190,7 +190,7 @@ The following fields may not be stored in the `app_metadata` field:
 
 Currently, Auth0 limits the total size of your user metadata to **16 MB**. However, when using Rules and/or the Management Dashboard, your metadata limits may be lower.
 
-When setting the `user_metadata` field with the [Authentication API Signup endpoint](/api/authentication?javascript#signup), your metadata is limited to a maximum of 10 fields and 500 characters.
+<%= include('../_includes/_metadata_on_signup_warning') %>
 
 ## Using Lock to Manage Metadata
 


### PR DESCRIPTION
This PR updates the warning regarding setting `user_metadata` when calling the `/dbconnections/signup` endpoint to specifically mention the values can only be of type `String`.