### PR TITLE
Update symfony version

### DIFF
--- a/articles/quickstart/webapp/symfony/index.yml
+++ b/articles/quickstart/webapp/symfony/index.yml
@@ -21,7 +21,7 @@ github:
   branch: master
 requirements:
   - PHP 5.6, 7.0
-  - Symfony 3.*
+  - Symfony 3.3.*
 next_steps:
   - path: 01-login
     list:


### PR DESCRIPTION
Referecing https://github.com/auth0/docs/issues/4746 issue.
If found that the version of the example app is in fact 3.3* https://github.com/auth0-community/auth0-symfony-php-web-app/blob/master/00-Starter-Seed/composer.json#L31  . 
But as example uses greater version than the requirements . Maybe it would be good to update the minimal version in the documentation? In case if there is some breaking changes between 3.* and 3.3
