### PR TITLE
50 database connection is a Lock limitation

### DIFF
--- a/articles/design/using-auth0-with-multi-tenant-apps.md
+++ b/articles/design/using-auth0-with-multi-tenant-apps.md
@@ -49,7 +49,7 @@ We recommend that you [create multiple Auth0 tenants](https://github.com/auth0/a
 ### Use multiple connections
 
 ::: warning
-[Lock](https://auth0.com/lock) only supports up to 50 Database Connections for each [application](/applications). Enterprise Connections are not affected by this limit.
+[Lock](https://auth0.com/lock) supports a maximum of **50 Database Connections** per [application](/applications). Enterprise Connections are not affected by this limit.
 :::
 
 While using multiple [Connections](/identityproviders) introduces additional layers of complexity, there are several scenarios where this option might make sense:

--- a/articles/design/using-auth0-with-multi-tenant-apps.md
+++ b/articles/design/using-auth0-with-multi-tenant-apps.md
@@ -49,7 +49,7 @@ We recommend that you [create multiple Auth0 tenants](https://github.com/auth0/a
 ### Use multiple connections
 
 ::: warning
-Auth0 enforces a limit of 50 Database Connections for each [application](/applications). Enterprise Connections are not affected by this limit.
+[Lock](https://auth0.com/lock) only supports up to 50 Database Connections for each [application](/applications). Enterprise Connections are not affected by this limit.
 :::
 
 While using multiple [Connections](/identityproviders) introduces additional layers of complexity, there are several scenarios where this option might make sense:


### PR DESCRIPTION
We do not limit the number of database connections per application. The 50 database connection is a limitation of Lock. See the following:

* https://auth0.slack.com/archives/C5YSB7YLQ/p1516749259000226
* https://auth0.slack.com/archives/C0LAJF9KQ/p1495100465517054?thread_ts=1495099323.271959&cid=C0LAJF9KQ

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
