### PR TITLE
Updating React Native quickstart to use the correct Yarn docs link

### DIFF
--- a/articles/quickstart/native/react-native/00-login.md
+++ b/articles/quickstart/native/react-native/00-login.md
@@ -61,7 +61,7 @@ yarn add --dev react-native-auth0
 ```
 
 ::: note
-For further reference on yarn, check [their official documentation](https://yarnpkg.com/en/package/jest).
+For further reference on yarn, check [their official documentation](https://yarnpkg.com/en/docs).
 :::
 
 ### Link the native module

--- a/articles/quickstart/native/react-native/_includes/_install.md
+++ b/articles/quickstart/native/react-native/_includes/_install.md
@@ -19,7 +19,7 @@ yarn add --dev react-native-auth0
 ```
 
 ::: note
-For further reference on yarn, check [their official documentation](https://yarnpkg.com/en/package/jest).
+For further reference on yarn, check [their official documentation](https://yarnpkg.com/en/docs).
 :::
 
 ### Link the native module


### PR DESCRIPTION
I noticed in [this section of the React Native quickstart](https://auth0.com/docs/quickstart/native/react-native#yarn) that the link to the yarn documentation pointed to the docs related to Jest (the JS testing framework).

It seemed quite confusing, so I updated it to link to the yarn docs homepage 😸 