### PR TITLE
Fix bias in randomString()

### DIFF
--- a/articles/api-auth/tutorials/nonce.md
+++ b/articles/api-auth/tutorials/nonce.md
@@ -23,7 +23,7 @@ For more information on where to include the nonce, see [How to Implement the Im
 
 ## Generate a cryptographically random nonce
 
-[Modern browsers](http://caniuse.com/#feat=cryptography) can use the [Web Crypto API](https://www.w3.org/TR/WebCryptoAPI/) to generate cryptographically secure random strings for use as nonces.
+One way to generate a cryptographically random nonce is to use a tool like [Nano ID](https://github.com/ai/nanoid) or similar. This does require you to bundle the tool with your JavaScript code, however. If that's not possible, you can take advantage of the fact that [modern browsers](http://caniuse.com/#feat=cryptography) can use the [Web Crypto API](https://www.w3.org/TR/WebCryptoAPI/) to generate cryptographically secure random strings for use as nonces.
 
 ```js
 function randomString(length) {

--- a/articles/api-auth/tutorials/nonce.md
+++ b/articles/api-auth/tutorials/nonce.md
@@ -27,14 +27,24 @@ For more information on where to include the nonce, see [How to Implement the Im
 
 ```js
 function randomString(length) {
-    var bytes = new Uint8Array(length);
-    var random = window.crypto.getRandomValues(bytes);
-    var result = [];
     var charset = '0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._~'
-    random.forEach(function (c) {
-        result.push(charset[c % charset.length]);
-    });
-    return result.join('');
+    result = ''
+
+    while (length > 0) {
+        var bytes = new Uint8Array(16);
+        var random = window.crypto.getRandomValues(bytes);
+
+        random.forEach(function(c) {
+            if (length == 0) {
+                return;
+            }
+            if (c < charset.length) {
+                result += charset[c];
+                length--;
+            }
+        });
+    }
+    return result;
 }
 ```
 


### PR DESCRIPTION
Charset `[c % charset.length]` technically works for mapping a random value to a character. But by using the modulo operator, a possible bias in introduced. In this case, with the length of the `charset` being 65, the last 4 characters are chosen less often than the others. 

Another possible solution for removing the bias, is using a `charset` of length 64. However, this is very error-prone because a user could easily change the `charset`.

Note: as long as the used nonce is long enough, using the biased implementation won't easily cause any vulnerabilities. However, the name of the function and the accompanying text suggest it can be used to generate a secure random strings, which is not true.
