### PR TITLE
Update User search v2 note with service end date

### DIFF
--- a/articles/users/search/v2/index.md
+++ b/articles/users/search/v2/index.md
@@ -16,7 +16,7 @@ useCase:
 # User Search
 
 ::: version-warning
-User search v2 has been deprecated as of **June 6th 2018**. Tenants created after this date will not have the option of using it. We recommend that you use [User Search v3](/users/search/v3) instead.
+User search v2 has been deprecated as of **June 6th 2018**. Tenants created after this date will not have the option of using it. We recommend that you use [User Search v3](/users/search/v3) instead. User search v2 will be removed from service on November 13th 2018.
 :::
 
 Auth0 allows you, as an administrator, to search for users using [Lucene Query Syntax](http://www.lucenetutorial.com/lucene-query-syntax.html).


### PR DESCRIPTION
https://auth0.com/docs/users/search/v3#migrate-from-search-engine-v2-to-v3

The migration guide says this API will be removed on November 13 2018. Is the migration guide out of date or this page?

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->
