### PR TITLE
Swap catches in Laravel middlewares

### DIFF
--- a/articles/quickstart/backend/laravel/01-authorization.md
+++ b/articles/quickstart/backend/laravel/01-authorization.md
@@ -169,9 +169,9 @@ class CheckJWT
 
             \Auth::login($user);
 
-        } catch (CoreException $e) {
-            return response()->json(["message" => $e->getMessage()], 401);
         } catch (InvalidTokenException $e) {
+            return response()->json(["message" => $e->getMessage()], 401);
+        } catch (CoreException $e) {
             return response()->json(["message" => $e->getMessage()], 401);
         }
 
@@ -284,9 +284,9 @@ class CheckScope
 
                 \Auth::login($user);
             }
-        } catch (CoreException $e) {
-            return response()->json(["message" => $e->getMessage()], 401);
         } catch (InvalidTokenException $e) {
+            return response()->json(["message" => $e->getMessage()], 401);
+        } catch (CoreException $e) {
             return response()->json(["message" => $e->getMessage()], 401);
         }
 


### PR DESCRIPTION
As `Auth0\SDK\Exception\InvalidTokenException` extends `Auth0\SDK\Exception\CoreException`, currently the `catch (InvalidTokenException $e)` block will never be reached because
all `InvalidTokenException`s will be caught in the `catch (CoreException $e)` block instead.

Swapping them around allows handling `InvalidTokenException` separately from all other `CoreException`s.

Edit: Accompanying PR for the sample Laravel API project is auth0-samples/auth0-laravel-api-samples#18.