### PR TITLE
Remove google authenticator customization

### DIFF
--- a/articles/multifactor-authentication/google-auth/dev-guide.md
+++ b/articles/multifactor-authentication/google-auth/dev-guide.md
@@ -52,10 +52,6 @@ function (user, context, callback) {
 
 When you have finished editing the code snippet based on the requirements of your app, click **Save**.
 
-::: panel Screen customization
-The Google Authenticator widget inherits from the Guardian widget. To customize the Google Authenticator screen, [customize the Guardian screen](/multifactor-authentication/administrator/customizing-widget) in your [tenant settings](${manage_url}/#/tenant).
-:::
-
 ### Configuring Google Authenticator for Select Users
 
 You may choose to enable Google Authenticator only for select users. Within the Customize MFA code snippet, you may include the conditions for Google Authenticator is enabled.


### PR DESCRIPTION
This PR removes the inaccurate note about being able to customize the google authenticator MFA screen.

The google-authenticator just renders a static template so it's not customizable, whereas guardian does actually render the template from the Dashboard editor.
