### PR TITLE
Added Auth0 Ruby to SDKs list

### DIFF
--- a/articles/_includes/_libraries_support_sdks.html
+++ b/articles/_includes/_libraries_support_sdks.html
@@ -28,8 +28,8 @@
       <td><div class="label label-primary">Supported</div></td>
     </tr>
     <tr class="light-top-border">
-      <td></td>
-      <td>v3</td>
+      <td><a href="https://github.com/auth0/ruby-auth0">Auth0 Ruby</a></td>
+      <td>v4</td>
       <td><div class="label label-primary">Supported</div></td>
     </tr>
     <tr>


### PR DESCRIPTION
There is a missing SDK name (https://auth0.com/docs/libraries)
![image](https://user-images.githubusercontent.com/373530/47252303-d28a2900-d442-11e8-8e91-27869f747dec.png)

I replaced it with `Auth0 Ruby` and `v4`.

