### PR TITLE
Delegation warning updates

### DIFF
--- a/articles/_includes/_deprecate-delegation.md
+++ b/articles/_includes/_deprecate-delegation.md
@@ -1,0 +1,3 @@
+::: warning
+Delegation is a deprecated feature. The functionality will continue to work for the customers that currently have it enabled. If at some point the delegation feature is changed or removed from service, customers who currently use it will be notified beforehand and given ample time to migrate.
+:::

--- a/articles/api-auth/intro.md
+++ b/articles/api-auth/intro.md
@@ -175,6 +175,8 @@ For more information, refer to [Resource Owner Password Credentials exchange](/a
 
 ### Delegation
 
+<%= include('../_includes/_deprecate-delegation') %>
+
 [Delegation](/api/authentication#delegation) is used for many operations:
 - Exchanging an ID Token issued to one application for a new one issued to a different application
 - Using a Refresh Token to obtain a fresh ID Token

--- a/articles/api-auth/tutorials/adoption/_index.md
+++ b/articles/api-auth/tutorials/adoption/_index.md
@@ -9,6 +9,5 @@
   - [Resource Owner Password Credentials exchange](/api-auth/tutorials/adoption/password)
   - [Client Credentials exchange](/api-auth/tutorials/adoption/client-credentials) (only available in new pipeline)
 * [Refresh Tokens](/api-auth/tutorials/adoption/refresh-tokens)
-* [Delegation (deprecated)](/api-auth/tutorials/adoption/delegation)
 * [Passwordless authentication](/api-auth/passwordless)
 * [List of breaking changes for OIDC-conformant applications](/api-auth/tutorials/adoption/oidc-conformant)

--- a/articles/api-auth/tutorials/adoption/api-tokens.md
+++ b/articles/api-auth/tutorials/adoption/api-tokens.md
@@ -96,7 +96,7 @@ The scope parameter in the OIDC-conformant pipeline determines:
 
 If you have multiple apps calling an API under a single client ID, you should represent each application with a single Auth0 application, each of which can interact with the resource server representing the API on which these apps depend.
 
-Similarly, if you use [delegation to exchange tokens obtained by one application for tokens for a different application](/tokens/delegation), you should also be using a multi-application solution, each authenticating to the same resource server.
+Similarly, if you use delegation to exchange tokens obtained by one application for tokens for a different application, you should also be using a multi-application solution, each authenticating to the same resource server.
 
 If your applications do not depend on external APIs and you just need to authenticate users, you do not need to define a resource server/API as long as the ID Tokens are:
 

--- a/articles/api-auth/tutorials/adoption/delegation.md
+++ b/articles/api-auth/tutorials/adoption/delegation.md
@@ -12,6 +12,8 @@ useCase:
 
 # Delegation and the OIDC-conformant pipeline
 
+<%= include('../../../_includes/_deprecate-delegation') %>
+
 <%= include('./_about.md') %>
 
 [Delegation](/api/authentication#delegation) is used for many operations, depending on your particular use case:

--- a/articles/api-auth/tutorials/adoption/refresh-tokens.md
+++ b/articles/api-auth/tutorials/adoption/refresh-tokens.md
@@ -20,7 +20,7 @@ There are some changes to how Refresh Tokens are used in the OIDC-conformant aut
 * Using the [implicit grant](/api-auth/tutorials/adoption/implicit) for authentication will no longer return Refresh Tokens.
   Use [silent authentication](/api-auth/tutorials/silent-authentication) (such as `prompt=none`) instead.
 * Refresh Tokens should only be used by [confidential applications](/applications/application-types#confidential-applications). However, they can also be used by Native (public) applications to obtain Refresh Tokens for mobile apps. 
-* The `/delegation` endpoint is considered deprecated. To obtain new tokens from a Refresh Token, the `/oauth/token` endpoint should be used instead:
+* The `/delegation` endpoint is deprecated. To obtain new tokens from a Refresh Token, the `/oauth/token` endpoint should be used instead:
 
 <div class="code-picker">
   <div class="languages-bar">

--- a/articles/best-practices/application-settings.md
+++ b/articles/best-practices/application-settings.md
@@ -67,7 +67,7 @@ This setting only applies to older tenants, created before Dec 27th 2017. Newer 
 
 If you are not using delegation, provide your application's Client ID in the **Allowed Apps / APIs** field to restrict delegation requests. You can find this field in [Applications > Settings > Advanced Settings > OAuth](${manage_url}/#/applications) on the dashboard.
 
-Delegation is a deprecated feature and new applications should not use it.
+<%= include('../_includes/_deprecate-delegation') %>
 
 ### Remove unnecessary grant types
 

--- a/articles/integrations/aws-api-gateway/delegation/_delegation-version-warning.md
+++ b/articles/integrations/aws-api-gateway/delegation/_delegation-version-warning.md
@@ -1,0 +1,3 @@
+::: version-warning
+Delegation is a deprecated feature. It does not have a sunset date, and users of the feature will be provided with ample notice if a migration ever occurs. However, if you are not already using delegation, please implement custom authorizers instead. Use the drop-down to switch to the custom authorizer docs.
+:::

--- a/articles/integrations/aws-api-gateway/delegation/index.md
+++ b/articles/integrations/aws-api-gateway/delegation/index.md
@@ -11,12 +11,9 @@ contentType:
 useCase:
   - secure-an-api
 ---
-
 # Build a Serverless Application Using Token-Based Authentication with AWS API Gateway and Lambda
 
-::: version-warning
-Delegation is considered deprecated in Auth0. Please integrate Auth0 using custom authorizers. Use the drop-down to switch to these docs.
-:::
+<%= include('./_delegation-version-warning') %>
 
 With AWS, you can create powerful, serverless, highly scalable APIs and applications through AWS Lambda, Amazon API Gateway, and a JavaScript application.
 

--- a/articles/integrations/aws-api-gateway/delegation/part-1.md
+++ b/articles/integrations/aws-api-gateway/delegation/part-1.md
@@ -11,9 +11,7 @@ useCase:
 ---
 # AWS API Gateway Tutorial
 
-::: version-warning
-Delegation is considered deprecated in Auth0. Please integrate Auth0 using custom authorizers. Use the drop-down to switch to these docs.
-:::
+<%= include('./_delegation-version-warning') %>
 
 ## Step 1 - Set up the Amazon API Gateway
 

--- a/articles/integrations/aws-api-gateway/delegation/part-2.md
+++ b/articles/integrations/aws-api-gateway/delegation/part-2.md
@@ -11,9 +11,7 @@ useCase:
 ---
 # AWS API Gateway Tutorial
 
-::: version-warning
-Delegation is considered deprecated in Auth0. Please integrate Auth0 using custom authorizers. Use the drop-down to switch to these docs.
-:::
+<%= include('./_delegation-version-warning') %>
 
 ## Step 2 - Secure and Deploy the Amazon API Gateway
 

--- a/articles/integrations/aws-api-gateway/delegation/part-3.md
+++ b/articles/integrations/aws-api-gateway/delegation/part-3.md
@@ -11,9 +11,7 @@ useCase:
 ---
 # AWS API Gateway Tutorial
 
-::: version-warning
-Delegation is considered deprecated in Auth0. Please integrate Auth0 using custom authorizers. Use the drop-down to switch to these docs.
-:::
+<%= include('./_delegation-version-warning') %>
 
 ## Step 3 - Build the Application
 

--- a/articles/integrations/aws-api-gateway/delegation/part-4.md
+++ b/articles/integrations/aws-api-gateway/delegation/part-4.md
@@ -11,9 +11,7 @@ useCase:
 ---
 # AWS API Gateway Tutorial
 
-::: version-warning
-Delegation is considered deprecated in Auth0. Please integrate Auth0 using custom authorizers. Use the drop-down to switch to these docs.
-:::
+<%= include('./_delegation-version-warning') %>
 
 ## Step 4 - Use Multiple Roles with Amazon API Gateway
 

--- a/articles/integrations/aws-api-gateway/delegation/part-5.md
+++ b/articles/integrations/aws-api-gateway/delegation/part-5.md
@@ -11,9 +11,7 @@ useCase:
 ---
 # AWS API Gateway Tutorial
 
-::: version-warning
-Delegation is considered deprecated in Auth0. Please integrate Auth0 using custom authorizers. Use the drop-down to switch to these docs.
-:::
+<%= include('./_delegation-version-warning') %>
 
 ## Step 5 - Use Identity Tokens to Flow Identity
 

--- a/articles/libraries/auth0js/v8/migration-guide.md
+++ b/articles/libraries/auth0js/v8/migration-guide.md
@@ -200,6 +200,8 @@ In [auth0.js v7](/libraries/auth0js/v7#refresh-token), the `renewIdToken()` and 
 
 ## Delegation
 
+<%= include('../../../_includes/_deprecate-delegation') %>
+
 Delegation is now done via the `delegation` method, which takes an `options` object containing the following potential parameters:
 
 * __client_id__ (required): a string; the Auth0 application identifier

--- a/articles/libraries/lock-android/v2/delegation-api.md
+++ b/articles/libraries/lock-android/v2/delegation-api.md
@@ -15,6 +15,8 @@ useCase:
 ---
 # Lock Android: Delegation API
 
+<%= include('../../../_includes/_deprecate-delegation') %>
+
 After a successful authentication, you can request credentials to access third party apps like Firebase or AWS that are configured in your Auth0 App's Add-On section. In order to do that you need to make a request to our [Delegation API](/api/authentication/reference#delegation) using a valid JWT.
 
 Here's an example

--- a/articles/libraries/lock-ios/v2/migration.md
+++ b/articles/libraries/lock-ios/v2/migration.md
@@ -284,6 +284,8 @@ Auth0
 
 ### Delegation
 
-Delegation is not available through Lock. It can be implemented via a legacy method in [Auth0.Swift](/libraries/auth0-swift) for tenants which existed prior to June 2017, but delegation is deprecated and not recommended for most use cases. See the [migrations notice](/migrations#api-authorization-with-third-party-vendor-apis) for more details.
+Delegation is not available through Lock. It can be implemented via a legacy method in [Auth0.Swift](/libraries/auth0-swift) for tenants which existed prior to June 2017.
+
+<%= include('../../../_includes/_deprecate-delegation') %>
 
 <%= include('../_includes/_roadmap') %>


### PR DESCRIPTION
Making delegation notices more consistent, first PR, possibly more later.

https://auth0-docs-content-pr-6834.herokuapp.com/docs/integrations/aws-api-gateway/delegation

https://auth0-docs-content-pr-6834.herokuapp.com/docs/api-auth/intro

And quite a few others. Those two ^ show the two includes (one version-warning for aws docs, one regular included warning panel for all other docs).