### PR TITLE
Access token docs - correction

### DIFF
--- a/articles/tokens/overview-access-tokens.md
+++ b/articles/tokens/overview-access-tokens.md
@@ -16,10 +16,10 @@ An Access Token is a credential that can be used by an application to access an 
 
 Access Tokens should be used as a **Bearer** credential and transmitted in an HTTP **Authorization** header to the API. 
 
-Depending on how your application needs to use the Access Token, you can do the following:
+Depending on how your application needs to use the Access Token, you can:
 
 * [Set the Access Token format](/tokens/set-access-token-format) to either an opaque string or a JSON web token.
 * [Get Access Tokens](/tokens/get-access-tokens) using any OAuth 2.0-compatible library or you can use one of Auth0's libraries that work with Auth0 endpoints.
-* [Use Access Tokens](/tokens/use-access-tokens) either in server-to-server or customer API interactions.
+* [Use Access Tokens](/tokens/use-access-tokens) either in server-to-server or custom API interactions.
 * [Add Custom Claims](/tokens/add-custom-claims) using [Rules](/rules).
 * [Set an Access Token's lifetime](/tokens/set-access-token-lifetime).


### PR DESCRIPTION
Fixed wording. (Custom APIs, not Customer APIs.)
