### PR TITLE
Update SLA/SLD percentage to match homepage

### DIFF
--- a/articles/support/sld.md
+++ b/articles/support/sld.md
@@ -15,7 +15,7 @@ useCase:
 This document summarizes the key elements of Auth0’s Service Level Agreement. For full details, please see the [Auth0 Service Level Agreement](https://auth0.com/legal).
 :::
 
-The average availability of the Auth0 Platform in each month will be at least 99.90%.
+The average availability of the Auth0 Platform in each month will be at least 99.95%.
 
 ## Availability Credits
 


### PR DESCRIPTION
On your on main landing page, you advertise 99.95% uptime, while the docs list it as 99.90%.

![screen shot 2018-10-23 at 1 59 14 pm](https://user-images.githubusercontent.com/139487/47380711-0e83ef00-d6cc-11e8-9133-9bbb60c3a864.png)

