### PR TITLE
Update broken link to Access Tokens

### DIFF
--- a/articles/migrations/index.md
+++ b/articles/migrations/index.md
@@ -95,7 +95,7 @@ List of affected endpoints:
 | [POST/api/v2/users/{id}/identities](/api/management/v2#!/Users/post_identities) | [Link user accounts](/link-accounts) from various identity providers |
 | [DELETE /api/v2/users/{id}/identities/{provider}/{user_id}](/api/management/v2#!/Users/delete_provider_by_user_id) | [Unlink user accounts](/link-accounts#unlinking-accounts) |
 
-These endpoints can now accept regular [Access Tokens](/access-token).
+These endpoints can now accept regular [Access Tokens](/tokens/access-token).
 
 The functionality is available and affected users are encouraged to migrate. However the ability to use ID Tokens will not be disabled in the foreseeable future so the mandatory opt-in date for this migration remains open. When this changes, customers will be notified beforehand.
 


### PR DESCRIPTION
Here's the original page: https://auth0.com/docs/migrations

It currently links to https://auth0.com/docs/access-token (404)

I've updated it to point to https://auth0.com/docs/tokens/access-token