### PR TITLE
Fix broken link to dashboard

### DIFF
--- a/articles/api-auth/tutorials/client-credentials/customize-with-hooks.md
+++ b/articles/api-auth/tutorials/client-credentials/customize-with-hooks.md
@@ -188,7 +188,7 @@ Look into the last two items of the __Payload__. Both have been set by our hook:
 
 ## Manage your Hooks
 
-You can disable, enable, delete or edit hooks using either the Auth0 CLI or the [dashboard]((${manage_url}/#/hooks)). You can also review your logs using the Auth0 CLI. For details, refer to the articles below.
+You can disable, enable, delete or edit hooks using either the Auth0 CLI or the [dashboard](${manage_url}/#/hooks). You can also review your logs using the Auth0 CLI. For details, refer to the articles below.
 
 Use the Dashboard to:
 - [Delete Hooks](/auth0-hooks/dashboard/create-delete)


### PR DESCRIPTION
Here's the original page: https://auth0.com/docs/api-auth/tutorials/client-credentials/customize-with-hooks

It currently links to https://auth0.com/docs/(https://manage.auth0.com#/hooks) (404)

I've updated it to point to https://manage.auth0.com/#/hooks