### PR TITLE
Fixed broken links

### DIFF
--- a/articles/api/management/v2/tokens.md
+++ b/articles/api/management/v2/tokens.md
@@ -19,9 +19,9 @@ To call an endpoint for test purposes, you can get a token manually using the Da
 
 To call endpoints, you will need to do the following:
 
-* [Create and Authorize a Machine-to-Machine Application](/v2/create-m2m-app). 
-* [Get Access Tokens for Testing](/v2/get-access-tokens-for-test)
-* [Get Access Tokens for Production](/v2/get-access-tokens-for-production)
+* [Create and Authorize a Machine-to-Machine Application](/api/management/v2/create-m2m-app). 
+* [Get Access Tokens for Testing](/api/management/v2/get-access-tokens-for-test)
+* [Get Access Tokens for Production](api/management/v2/get-access-tokens-for-production)
 
 ::: note
 For single page applications (SPAs), you will need to [get an Access Token from the frontend](/v2/get-access-tokens-for-spas).
@@ -30,7 +30,7 @@ For single page applications (SPAs), you will need to [get an Access Token from 
 ## Keep reading
 
 * [Access Tokens](/tokens/overview-access-tokens)
-* [Management API Access Token FAQs](/v2/faq-management-api-access-tokens)
+* [Management API Access Token FAQs](/api/management/v2/faq-management-api-access-tokens)
 * [Changes in Auth0 Management API Tokens](/api/management/v2/tokens-flows)
 * [Calling APIs from a Service](/api-auth/grant/client-credentials)
 * [Ask for Access Tokens for a Client Credentials Grant](/api-auth/config/asking-for-access-tokens)


### PR DESCRIPTION
Closes #6865 

In addition to the 3 links mentioned in the issue I found that the "Management API Access Token FAQs" link in the "Keep reading" section was broken as well.

The URLs had the format `/v2/[article-name]`, which I updated to `/api/management/v2/[article-name]`.
