### PR TITLE
Fixed broken links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ The following is a set of guidelines for contributing to the Auth0 documentation
 * Read and follow the [Style Guide](STYLEGUIDE.md).
 * Consult the [Words](WORDS.md) document for Auth0 specific spellings and definitions.
 * Always use relative URLs for internal `auth0.com/docs` links. For example, if the absolute path to the document is `https://auth0.com/docs/identityproviders`, use `/identityproviders`. These links will be correctly formatted in the build process.
-* Do not hard code links to Auth0 sites like `docs.auth0.com` or `manage.auth0.com`. Instead, use [Parameter Aliases](#parameter-aliases), such as `${manage_url}`.
+* Do not hard code links to Auth0 sites like `docs.auth0.com` or `manage.auth0.com`. Instead, use [Document Variables](#document-variables), such as `${manage_url}`.
 * Name files with all lowercase using dashes (-) to separate words. If using a date in the file name, it should be in the format YYYY-MM-DD. For example, `this-is-my-file.md` or `this-is-a-title-2015-10-01.md`.
 * Do not store images in external locations like Dropbox, CloudUp, or the Auth0 CDN. Link to images in this repo using a relative path `![ALT_TEXT](/media/folder/image-name.png)`. The image will be uploaded to the CDN and the link will be formatted during the build process. Do not forget to set the alternate text for each image.
 * Keep images to no more than 750 pixels wide.

--- a/articles/errors/deprecation-errors.md
+++ b/articles/errors/deprecation-errors.md
@@ -21,7 +21,7 @@ There are two different ways to search for warning messages showing usage of dep
 
 ### Search logs via the Dashboard
 
-If your application uses a deprecated feature, a Deprecation Notice message will show up in the Logs section of the [Dashboard](/${manage_url}).
+If your application uses a deprecated feature, a Deprecation Notice message will show up in the Logs section of the [Dashboard](${manage_url}/#/).
 
 ::: note
 In order to not overwhelm the logs with repetitive messages, deprecation notes will only be shown once per hour (the first time it occurs within that hour) rather than for each authentication transaction involving the deprecated feature.


### PR DESCRIPTION
Found a broken dashboard link in an article and when I wanted to update it as hacktober practice I found that the CONTRIBUTING file had a wrongly worded broken link regarding the Document Variables, being called Parameter Aliases. I fixed both with proper formatting, double checking with other articles linking to the dashboard too.