### PR TITLE
Add namespace format requirement to OIDC conformant breaking changes

### DIFF
--- a/articles/api-auth/tutorials/adoption/oidc-conformant.md
+++ b/articles/api-auth/tutorials/adoption/oidc-conformant.md
@@ -38,6 +38,7 @@ Enabling this flag on an application will have the following effects:
   An OIDC-conformant alternative will be added in future releases.
 * The [`scope` parameter of authentication requests](/api-auth/tutorials/adoption/scope-custom-claims) will comply to the OIDC specification:
     - Custom claims must be namespaced and added to ID Tokens or Access Tokens via rules.
+    - Namespace identifier for custom claims must be a **HTTP** or **HTTPS** URI.
     - Custom scope values can be defined by a [resource server (API)](/api-auth/tutorials/adoption/api-tokens).
 * OIDC-conformant applications cannot be the source or target application of a [delegation request](/api-auth/tutorials/adoption/delegation).
 

--- a/articles/api-auth/tutorials/adoption/oidc-conformant.md
+++ b/articles/api-auth/tutorials/adoption/oidc-conformant.md
@@ -38,7 +38,7 @@ Enabling this flag on an application will have the following effects:
   An OIDC-conformant alternative will be added in future releases.
 * The [`scope` parameter of authentication requests](/api-auth/tutorials/adoption/scope-custom-claims) will comply to the OIDC specification:
     - Custom claims must be namespaced and added to ID Tokens or Access Tokens via rules.
-    - Namespace identifier for custom claims must be an **HTTP** or **HTTPS** URI.
+    - The namespace identifiers for custom claims must be **HTTP** or **HTTPS** URIs.
     - Custom scope values can be defined by a [resource server (API)](/api-auth/tutorials/adoption/api-tokens).
 * OIDC-conformant applications cannot be the source or target application of a [delegation request](/api-auth/tutorials/adoption/delegation).
 

--- a/articles/api-auth/tutorials/adoption/oidc-conformant.md
+++ b/articles/api-auth/tutorials/adoption/oidc-conformant.md
@@ -38,7 +38,7 @@ Enabling this flag on an application will have the following effects:
   An OIDC-conformant alternative will be added in future releases.
 * The [`scope` parameter of authentication requests](/api-auth/tutorials/adoption/scope-custom-claims) will comply to the OIDC specification:
     - Custom claims must be namespaced and added to ID Tokens or Access Tokens via rules.
-    - Namespace identifier for custom claims must be a **HTTP** or **HTTPS** URI.
+    - Namespace identifier for custom claims must be an **HTTP** or **HTTPS** URI.
     - Custom scope values can be defined by a [resource server (API)](/api-auth/tutorials/adoption/api-tokens).
 * OIDC-conformant applications cannot be the source or target application of a [delegation request](/api-auth/tutorials/adoption/delegation).
 

--- a/articles/api-auth/tutorials/adoption/scope-custom-claims.md
+++ b/articles/api-auth/tutorials/adoption/scope-custom-claims.md
@@ -75,7 +75,7 @@ Any non-Auth0 HTTP or HTTPS URL can be used as a namespace identifier, and any n
 `auth0.com`, `webtask.io` and `webtask.run` are Auth0 domains and therefore cannot be used as a namespace identifier.
 :::
 
-This follows a [recommendation from the OIDC specification](https://openid.net/specs/openid-connect-core-1_0.html#AdditionalClaims) stating that custom claim identifiers should be collision-resistant. While this is not mandatory according to the specification, Auth0 will always enforce namespacing when performing OIDC-conformant login flows, meaning that any non-namespaced claims will be silently excluded from tokens.
+This follows a [recommendation from the OIDC specification](https://openid.net/specs/openid-connect-core-1_0.html#AdditionalClaims) stating that custom claim identifiers should be collision-resistant. While this is not mandatory according to the specification, Auth0 will always enforce namespacing when performing OIDC-conformant login flows, meaning that any custom claims without a HTTP or HTTPS namespace will be silently excluded from tokens.
 
 If you need to add custom claims to the Access Token, the same applies but using `context.accessToken` instead.
 

--- a/articles/api-auth/tutorials/adoption/scope-custom-claims.md
+++ b/articles/api-auth/tutorials/adoption/scope-custom-claims.md
@@ -75,7 +75,7 @@ Any non-Auth0 HTTP or HTTPS URL can be used as a namespace identifier, and any n
 `auth0.com`, `webtask.io` and `webtask.run` are Auth0 domains and therefore cannot be used as a namespace identifier.
 :::
 
-This follows a [recommendation from the OIDC specification](https://openid.net/specs/openid-connect-core-1_0.html#AdditionalClaims) stating that custom claim identifiers should be collision-resistant. While this is not mandatory according to the specification, Auth0 will always enforce namespacing when performing OIDC-conformant login flows, meaning that any custom claims without a HTTP or HTTPS namespace will be silently excluded from tokens.
+This follows a [recommendation from the OIDC specification](https://openid.net/specs/openid-connect-core-1_0.html#AdditionalClaims) stating that custom claim identifiers should be collision-resistant. While this is not mandatory according to the specification, Auth0 will always enforce namespacing when performing OIDC-conformant login flows, meaning that any custom claims without HTTP/HTTPS namespaces will be silently excluded from tokens.
 
 If you need to add custom claims to the Access Token, the same applies but using `context.accessToken` instead.
 


### PR DESCRIPTION
This PR adds to the list of OIDC conformant breaking changes the fact that namespaces must be a URI. It also emphasizes this requirement on the custom claims page.