### PR TITLE
Delegated Admin Custom Field clarifications

### DIFF
--- a/articles/extensions/delegated-admin/v3/hooks/settings.md
+++ b/articles/extensions/delegated-admin/v3/hooks/settings.md
@@ -64,9 +64,9 @@ Beginning with version 3.0 of the Delegated Admin Extension, you can define cust
 
 You may also customize existing fields defined by Auth0, such as email, username, name, and connection.
 
-To utilize custom fields you are required to:
+To utilize custom fields, you must:
   - Add your list of **userFields** to the Settings Query Hook
-  - Implement a Write Hook to ensure `app_metadata` and `user_metadata` are correctly updated
+  - Implement a [Write Hook](/extensions/delegated-admin/v3/hooks/write) to ensure that `app_metadata` and `user_metadata` are correctly updated
 
 Sample schema for **userFields**:
 

--- a/articles/extensions/delegated-admin/v3/hooks/settings.md
+++ b/articles/extensions/delegated-admin/v3/hooks/settings.md
@@ -65,8 +65,9 @@ Beginning with version 3.0 of the Delegated Admin Extension, you can define cust
 You may also customize existing fields defined by Auth0, such as email, username, name, and connection.
 
 To utilize custom fields, you must:
-  - Add your list of **userFields** to the Settings Query Hook
-  - Implement a [Write Hook](/extensions/delegated-admin/v3/hooks/write) to ensure that `app_metadata` and `user_metadata` are correctly updated
+
+- Add your list of **userFields** to the Settings Query Hook
+- Implement a [Write Hook](/extensions/delegated-admin/v3/hooks/write). Custom Fields require the use of the [Write Hook](/extensions/delegated-admin/v3/hooks/write) to properly update `user_metadata` and `app_metadata`. You must [update the user object passed to the callback function](/extensions/delegated-admin/v3/hooks/write#sample-usage) with the `user_metadata` and `app_metadata` from the context (`ctx` object) provided to the hook.
 
 Sample schema for **userFields**:
 

--- a/articles/extensions/delegated-admin/v3/hooks/settings.md
+++ b/articles/extensions/delegated-admin/v3/hooks/settings.md
@@ -64,7 +64,9 @@ Beginning with version 3.0 of the Delegated Admin Extension, you can define cust
 
 You may also customize existing fields defined by Auth0, such as email, username, name, and connection.
 
-To utilize custom fields, you must add your list of **userFields** to the Settings Query Hook.
+To utilize custom fields you are required to:
+  - Add your list of **userFields** to the Settings Query Hook
+  - Implement a Write Hook to ensure `app_metadata` and `user_metadata` are correctly updated
 
 Sample schema for **userFields**:
 

--- a/articles/extensions/delegated-admin/v3/hooks/settings.md
+++ b/articles/extensions/delegated-admin/v3/hooks/settings.md
@@ -135,7 +135,7 @@ userFields: [
     - **edit.validateFunction**: stringified function for validation. Note that this validation function will run on both the server- and client-side. Example: `(function validate(value, values, context, languageDictionary) { if (value...) return 'something went wrong'; return false; }).toString()`
 - **create**: false || object => This describes whether the field shows up on the create dialog.
     - Default: if `false` will not show up on the create page
-    - **create.display**: This will override the default display value
+    - **create.placeholder**: Provide placeholder text to show when input is empty.
     - **create.required**: set to true to fail if it does not have a value.  Default is false.
     - **create.type** **required**: text || select || password
     - **create.component**: InputText || Input Combo || InputMultiCombo || InputSelectCombo

--- a/articles/extensions/delegated-admin/v3/hooks/write.md
+++ b/articles/extensions/delegated-admin/v3/hooks/write.md
@@ -12,13 +12,15 @@ useCase: extensibility-extensions
 ---
 # Delegated Administration Hooks: The Write Hook
 
-Whenever you're creating new users, and you want the newly-created user to be assigned to the same group, department, or vendor as the ones to which you've been assigned, you can configure this behavior using the **Write Hook**.
+The Write Hook will run any time a user is create or updated. For example changing the user's password, changing their email address, updating their profile, and so on.
+
+When using Custom Fields, the user object passed to the callback must be updated to include `user_metadata` and `app_metadata` from the context provided to the hook (`ctx` object). See example below.
+
+Other use cases of the Write Hook could include setting default values for newly created users. For example whenever you're creating new users, and you want the newly-created user to be assigned to the same group, department, or vendor as the ones to which you've been assigned, you can configure this behavior using the **Write Hook**.
 
 ::: warning
 Auth0 only supports user creation with Database Connections.
 :::
-
-The Write Hook will run anytime a user is updated if you are using custom fields. The activities that trigger the Write Hook to run include changing the user's password, changing their email address, updating their profile, and so on.
 
 ## The Hook Contract
 
@@ -29,6 +31,8 @@ The Write Hook will run anytime a user is updated if you are using custom fields
      - **email**: The email address of the user
      - **password**: The password of the user
      - **connection**: The name of the user
+     - **app_metadata**: Included if a Custom Field being modified is saved in `app_metadata`.
+     - **user_metadata**: Included if a Custom Field being modified is saved in `user_metadata`.
    - **userFields**: The user fields array (if specified in the [settings query](#the-settings-query-hook))
    - **method**: Either **create** or **update** depending on whether this is being called as a result of a create or an update call
  - **callback(error, user)**: The callback to which you can return an error and the user object that should be sent to the Management API

--- a/articles/extensions/delegated-admin/v3/hooks/write.md
+++ b/articles/extensions/delegated-admin/v3/hooks/write.md
@@ -12,11 +12,13 @@ useCase: extensibility-extensions
 ---
 # Delegated Administration Hooks: The Write Hook
 
-The Write Hook will run any time a user is create or updated. For example changing the user's password, changing their email address, updating their profile, and so on.
+The Write Hook, which runs anytime you create or update a user, allows you to do things like:
 
-When using Custom Fields, the user object passed to the callback must be updated to include `user_metadata` and `app_metadata` from the context provided to the hook (`ctx` object). See example below.
+* Changing the user's password
+* Changing the user's email address
+* Updating the user's profile
 
-Other use cases of the Write Hook could include setting default values for newly created users. For example whenever you're creating new users, and you want the newly-created user to be assigned to the same group, department, or vendor as the ones to which you've been assigned, you can configure this behavior using the **Write Hook**.
+You can also use the Write Hook to set default values for newly-created users automatically. For example, you might want to automatically assign a user to the same group, department, or vendor as the ones to which you've been assigned.
 
 ::: warning
 Auth0 only supports user creation with Database Connections.
@@ -31,8 +33,8 @@ Auth0 only supports user creation with Database Connections.
      - **email**: The email address of the user
      - **password**: The password of the user
      - **connection**: The name of the user
-     - **app_metadata**: Included if a Custom Field being modified is saved in `app_metadata`.
-     - **user_metadata**: Included if a Custom Field being modified is saved in `user_metadata`.
+     - **app_metadata**: The data that's included if a Custom Field being modified is saved in `app_metadata`.
+     - **user_metadata**: The data that's included if a Custom Field being modified is saved in `user_metadata`.
    - **userFields**: The user fields array (if specified in the [settings query](#the-settings-query-hook))
    - **method**: Either **create** or **update** depending on whether this is being called as a result of a create or an update call
  - **callback(error, user)**: The callback to which you can return an error and the user object that should be sent to the Management API


### PR DESCRIPTION
This PR attempts to make more clear that a Write hook is required to use Custom Fields. It also replaces reference to a `create.display` (which does not exist) with `create.placeholder` (which does exist).