### PR TITLE
Remove references to admin settings for DUO

### DIFF
--- a/articles/multifactor-authentication/duo/admin-guide.md
+++ b/articles/multifactor-authentication/duo/admin-guide.md
@@ -49,13 +49,7 @@ function (user, context, callback) {
         allowRememberBrowser: false,
 
         // optional. Use some attribute of the profile as the username in DuoSecurity. This is also useful if you already have your users enrolled in Duo.
-        // username: user.nickname,
-
-        // optional. Admin credentials. If you provide an Admin SDK type of credentials. auth0 will update the realname and email in DuoSecurity.
-        // admin: {
-        //  ikey: 'DIAN...NV6UM',
-        //  skey: 'YL8OVzvoeeh...I1uiYrKoHvuzHnSRj'
-        // },
+        // username: user.nickname
       };
     // }
   }

--- a/articles/multifactor-authentication/duo/dev-guide.md
+++ b/articles/multifactor-authentication/duo/dev-guide.md
@@ -45,13 +45,7 @@ function (user, context, callback) {
         allowRememberBrowser: false,
 
         // optional. Use some attribute of the profile as the username in DuoSecurity. This is also useful if you already have your users enrolled in Duo.
-        // username: user.nickname,
-
-        // optional. Admin credentials. If you provide an Admin SDK type of credentials. auth0 will update the realname and email in DuoSecurity.
-        // admin: {
-        //  ikey: 'DIAN...NV6UM',
-        //  skey: 'YL8OVzvoeeh...I1uiYrKoHvuzHnSRj'
-        // },
+        // username: user.nickname
       };
     // }
   }
@@ -101,6 +95,3 @@ If `allowRememberBrowser: true` is set, or if the field is left unset, then user
 
 ### Changing the Username sent to Duo
 To use a specific attribute of the profile as the username in DuoSecurity, uncomment `username: user.nickname` and change it to the attribute you wish to use. This is also useful if you already have your users enrolled in Duo.
-
-### Setting Admin Credentials
-If you provide an Admin SDK type of credentials then Auth0 will update the realname and email in Duo. To do this, replace the `ikey` and `skey` with the integration key and secret key.


### PR DESCRIPTION
Remove references to the `admin` properties for DUO. 

These properties are not being honored any longer, and do not have any effect if set.