### PR TITLE
Adding custom error pages liquid syntax variables names [DO NOT MERGE]

### DIFF
--- a/articles/hosted-pages/custom-error-pages.md
+++ b/articles/hosted-pages/custom-error-pages.md
@@ -63,6 +63,14 @@ If you use the API instead, use the `PATCH /api/v2/tenants/settings` endpoint. U
 
 ### Render a custom error page
 
+** Mark: ToDo **
+
+You can customise your error page by rendering following fields:
+
+* Error : the code corresponding to the error that occurred; Liquid tag: {{error}}
+* Error Description : a description of the error that occurred; Liquid tag: {{error_description}}
+* ...
+
 To provide the appropriate HTML, pass in a string containing the appropriate Liquid syntax to the `html` element:
 
 ```har

--- a/articles/hosted-pages/custom-error-pages.md
+++ b/articles/hosted-pages/custom-error-pages.md
@@ -63,13 +63,15 @@ If you use the API instead, use the `PATCH /api/v2/tenants/settings` endpoint. U
 
 ### Render a custom error page
 
-** Mark: ToDo **
+You can render your custom error page with Liquid syntax using following variables:
 
-You can customise your error page by rendering following fields:
-
-* Error : the code corresponding to the error that occurred; Liquid tag: {{error}}
-* Error Description : a description of the error that occurred; Liquid tag: {{error_description}}
-* ...
+* `{client_id}`
+* `{connection}`
+* `{lang}`
+* `{error}`
+* `{error_description}`
+* `{tracking}`
+* `{logo_url}`
 
 To provide the appropriate HTML, pass in a string containing the appropriate Liquid syntax to the `html` element:
 

--- a/articles/hosted-pages/custom-error-pages.md
+++ b/articles/hosted-pages/custom-error-pages.md
@@ -63,7 +63,7 @@ If you use the API instead, use the `PATCH /api/v2/tenants/settings` endpoint. U
 
 ### Render a custom error page
 
-You can render your custom error page with Liquid syntax using following variables:
+You can render your custom error page with Liquid syntax using the following variables:
 
 * `{client_id}`
 * `{connection}`


### PR DESCRIPTION
**Short description** 

We do offer our developers list of liquid syntax variables that they can use for email templates but we have no such thing for custom error pages.

https://auth0.com/docs/hosted-pages/custom-error-pages#render-a-custom-error-page

**Link to community forum issue**

https://community.auth0.com/t/custom-error-page-liquid-syntax-variables/17213/3

**Notes**

Not sure of those liquid syntax variables names that apply here, so whoever will review it please help me add such list to this article: https://auth0.com/docs/hosted-pages/custom-error-pages#render-a-custom-error-page
