### PR TITLE
Fix typos in docs files

### DIFF
--- a/articles/appliance/cli/backing-up-the-appliance.md
+++ b/articles/appliance/cli/backing-up-the-appliance.md
@@ -31,7 +31,7 @@ Please be aware that we use the following sample values throughout this document
 
 * IP address of the node on the replica set to be backed up: `192.168.1.186`. Generically, the node may also be referred to as `<target node>`.
 * Password used for encryption: `Passw0rd`.
-* The replica set connection string: `a0/a0-1:27017,a0-2:27017,a0-3:27017`
+* The replica set connection string: `a0/a0-1:27017,a0-2:27017,a0-3:27017`.
 
 ## Generate a New Backup
 
@@ -47,7 +47,7 @@ For example, if you were to run the above command using the provided sample valu
 a0cli -t 192.168.1.186 backup --password Passw0rd
 ```
 
-If the command successfully begins the backup process, you will see the message, "Backup in progress."
+If the command successfully begins the backup process, you will see the message, "Backup in progress" :
 
 ![](/media/articles/appliance/cli/backup-in-progress.png)
 
@@ -65,10 +65,10 @@ To do this, you can use the `backup-sensitive` command, which works the same way
 
 The full instructions (along with the commands you'll need to run) are as follows:
 
-1. Request a backup: `a0cli -t node_IP_address backup-sensitive --password 0therPassw0rd`
-2. Check the status of a backup: `a0cli -t node_IP_address backup-sensitive-status`
-3. Retrieve backup of sensitive information: `a0cli -t node_IP_address backup-sensitive-retrieve`
-4. Delete the sensitive backup from the node: `a0cli -t node_IP_address backup-sensitive-delete`
+1. Request a backup: `a0cli -t node_IP_address backup-sensitive --password 0therPassw0rd`;
+2. Check the status of a backup: `a0cli -t node_IP_address backup-sensitive-status`;
+3. Retrieve backup of sensitive information: `a0cli -t node_IP_address backup-sensitive-retrieve`;
+4. Delete the sensitive backup from the node: `a0cli -t node_IP_address backup-sensitive-delete`.
 
 ## Check the Status of the Backup
 

--- a/articles/appliance/cli/backing-up-the-appliance.md
+++ b/articles/appliance/cli/backing-up-the-appliance.md
@@ -47,7 +47,7 @@ For example, if you were to run the above command using the provided sample valu
 a0cli -t 192.168.1.186 backup --password Passw0rd
 ```
 
-If the command successfully begins the backup process, you will see the message, "Backup in progress" :
+If the command successfully begins the backup process, you will see the message, "Backup in progress."
 
 ![](/media/articles/appliance/cli/backup-in-progress.png)
 

--- a/articles/appliance/geo-ha/disaster-recovery.md
+++ b/articles/appliance/geo-ha/disaster-recovery.md
@@ -76,7 +76,7 @@ The following table details some of the ways in which the Geographic High-Availa
         </tr>
         <tr>
             <td>Connection between the Global Load Balancer and the Primary Site Unavailable</td>
-            <td>All requests are routed to the secondary site, but the secondary nodes continue to use data on the primary site</td>
+            <td>All requests are routed to the secondary site, but the secondary nodes continue to use data on the primary site.</td>
             <td>Some performance degradation due to cross-geography data requests.</td>
         </tr>
         <tr>
@@ -101,7 +101,7 @@ The following table details some of the ways in which the Geographic High-Availa
 
 To test the Geographic High-Availability PSaaS Appliance (GEO HA) failover/failback procedure, you should:
 
-1. Take all nodes in the primary data center offline.
+1. Take all nodes in the primary data center offline;
 2. Run tests against the global load balancer to ensure that traffic gets rerouted to the secondary site.
 
 GEO HA does not support having both the primary and secondary sites disconnected and active at the same time. Because the data layer is arranged in one stretched cluster, the cluster only permits one data node to act as primary.

--- a/articles/appliance/infrastructure/extensions.md
+++ b/articles/appliance/infrastructure/extensions.md
@@ -19,7 +19,7 @@ Beginning with version `8986`, the PSaaS Appliance supports extensions. This is 
 Some of the [Extensions](/extensions) available to users of the Auth0 public cloud are unavailable in the PSaaS Appliance. As such, these do not appear as options in the PSaaS Appliance's Dashboard.
 :::
 
-Beginning with version `10755`, the PSaaS Appliance supports User Search using Elasticsearch. This allows you to use extensions that require User Search, including the [Delegated Administration extension](/extensions/delegated-admin)
+Beginning with version `10755`, the PSaaS Appliance supports User Search using Elasticsearch. This allows you to use extensions that require User Search, including the [Delegated Administration extension](/extensions/delegated-admin).
 
 ## Requirements for Enabling User Search
 
@@ -55,7 +55,7 @@ Your Development and/or Production environments must meet the following requirem
 
 Once you have met the requirements for enabling Webtasks, submit a Support ticket to request that Auth0:
 
-* Configure Webtasks (including switching your sandbox mode to `auth0-sandbox`)
+* Configure Webtasks (including switching your sandbox mode to `auth0-sandbox`);
 * Update your PSaaS Appliance to version `8986`. Auth0 will work with you to upgrade your Development environment first, so that you can test the changes. Afterwards, Auth0 will coordinate the Production upgrade.
 
 ## Dedicated Domains

--- a/articles/appliance/infrastructure/internet-restricted-deployment.md
+++ b/articles/appliance/infrastructure/internet-restricted-deployment.md
@@ -43,9 +43,9 @@ You may, however, restrict server-side access to the Management Dashboard.
 
 To properly render the Dashboard, it accesses the following sites:
 
-* **cdn.auth0.com**: resources loaded from this CDN are well-known and include CSS, JavaScript, and images
-* **fonts.googleapis.com**: resources loaded include CSS and font files
-* **s.gravatar.com** and **i2.wp.com**: resources include user profile images loaded from WordPress' Gravatar service
+* **cdn.auth0.com**: resources loaded from this CDN are well-known and include CSS, JavaScript, and images.
+* **fonts.googleapis.com**: resources loaded include CSS and font files.
+* **s.gravatar.com** and **i2.wp.com**: resources include user profile images loaded from WordPress' Gravatar service.
 * **fast.fonts.net**: resources include CSS files for font support.
 
 ### Multi-factor Authentication (MFA)

--- a/articles/appliance/infrastructure/security.md
+++ b/articles/appliance/infrastructure/security.md
@@ -24,7 +24,7 @@ You need to create and install a unique SSL certificate for each PSaaS Appliance
 
 The SSL Certificate:
 
-* must be created by a public certificate authority. They cannot be self-signed.
+* must be created by a public certificate authority. They cannot be self-signed;
 * may be a wildcard *or* a multi-domain (SAN) certificate;
 * must contain all required DNS/domain names, including those for the:
     * Management Dashboard;


### PR DESCRIPTION
**Description of the change**: Fixes typos and punctuation in the backing-up-the-appliance.md, disaster-recovery.md, extensions.md, internet-restricted-deployment.md and security.md files.