### PR TITLE
Wrong information provided

### DIFF
--- a/articles/user-profile/user-profile-structure.md
+++ b/articles/user-profile/user-profile-structure.md
@@ -41,7 +41,7 @@ The following attributes are available on the user profile.
 
 * `last_ip`: The IP address associated with the user's last login.
 
-* `last_login`: The timestamp of when the user last logged in. In case you are this property from inside a [Rule](/rules) using the `user` object, its value will be the one associated with the login that triggered the rule (since rules execute after the actual login).
+* `last_login`: The timestamp of when the user last logged in. In case you want to use this property from inside a [Rule](/rules) using the `user` object, its value will be the one associated with the login that triggered the rule (since rules execute after the actual login).
 
 * `logins_count`: The number of times the user has logged in.
 

--- a/articles/user-profile/user-profile-structure.md
+++ b/articles/user-profile/user-profile-structure.md
@@ -41,6 +41,8 @@ The following attributes are available on the user profile.
 
 * `last_ip`: The IP address associated with the user's last login.
 
+* `last_login`: The timestamp of when the user last logged in.
+
 * `logins_count`: The number of times the user has logged in.
 
 * `name`: The user's name.

--- a/articles/user-profile/user-profile-structure.md
+++ b/articles/user-profile/user-profile-structure.md
@@ -41,8 +41,6 @@ The following attributes are available on the user profile.
 
 * `last_ip`: The IP address associated with the user's last login.
 
-* `last_login`: The timestamp of when the user last logged in. In case you want to use this property from inside a [Rule](/rules) using the `user` object, its value will be the one associated with the login that triggered the rule (since rules execute after the actual login).
-
 * `logins_count`: The number of times the user has logged in.
 
 * `name`: The user's name.


### PR DESCRIPTION
**Description**
* Information provided in the doc is wrong
    * `last_login`property is hidden from the `user` object in the rule. Developers can't use it
