### PR TITLE
Fix broken link in rules/current/management-api.md

### DIFF
--- a/articles/rules/current/management-api.md
+++ b/articles/rules/current/management-api.md
@@ -46,5 +46,5 @@ For a filtered list of available libraries that can be set as required, check th
 :::
 
 ::: note
-The Access Token for the Management API, which is available through `auth0.accessToken`, is limited to the `read:users` and `update:users` scopes. If you require a broader range of scopes, you can [Get Access Tokens for Production](/api/management/v2/tokens/get-access-tokens-for-production) to request a token using the Client Credentials Grant.
+The Access Token for the Management API, which is available through `auth0.accessToken`, is limited to the `read:users` and `update:users` scopes. If you require a broader range of scopes, you can [Get Access Tokens for Production](/api/management/v2/get-access-tokens-for-production) to request a token using the Client Credentials Grant.
 :::


### PR DESCRIPTION
Changed the Link in Line 49 from https://auth0.com/docs/api/management/v2/tokens/get-access-tokens-for-production to https://auth0.com/docs/api/management/v2/get-access-tokens-for-production