### PR TITLE
Fix anchors in application-type links 

### DIFF
--- a/articles/libraries/_includes/_embedded_sso.md
+++ b/articles/libraries/_includes/_embedded_sso.md
@@ -2,9 +2,9 @@
 
 Apps with embedded login must meet two criteria in order to have SSO.
 
-1. Both of the applications attempting SSO must be [first-party applications](/applications/application-types#first-party-application). SSO with third party applications will not work.
+1. Both of the applications attempting SSO must be [first-party applications](/applications/application-types#first-party-applications). SSO with third party applications will not work.
 1. They need to make use of [custom domains](/custom-domains) and have both the applications which intend to have SSO as well as the Auth0 tenant on the same domain. Traditionally, Auth0 domains are in the format `foo.auth0.com`, but custom domains allow you to use the same domain for each of the applications in question as well as your Auth0 tenant, preventing the risk of CSRF attacks.
 
 ::: note
-Our recommendation is to use [Universal Login](/hosted-pages/login) instead of setting up SSO in embedded login scenarios. Universal Login is the most reliable and stable way to perform SSO, and is the only way to do so if you must use multiple domains for your applications, or use [third-party applications](/applications/application-types#third-party-application).
+Our recommendation is to use [Universal Login](/hosted-pages/login) instead of setting up SSO in embedded login scenarios. Universal Login is the most reliable and stable way to perform SSO, and is the only way to do so if you must use multiple domains for your applications, or use [third-party applications](/applications/application-types#third-party-applications).
 :::


### PR DESCRIPTION
Both links to first- and third party applications were missing an `s` (see target [here](https://github.com/auth0/docs/blob/master/articles/applications/application-types.md#first-party-applications)).
