### PR TITLE
Correcting parameter passed to parseHash in passwordless docs.

### DIFF
--- a/articles/connections/passwordless/spa-email-code.md
+++ b/articles/connections/passwordless/spa-email-code.md
@@ -125,7 +125,7 @@ The `passwordlessVerify` method will verify the Passwordless transaction, then r
 ```js
 $(document).ready(function() {
   if(window.location.hash){
-    webAuth.parseHash(window.location.hash, function(err, authResult) {
+    webAuth.parseHash({hash: window.location.hash}, function(err, authResult) {
       if (err) {
         return console.log(err);
       } else if (authResult){

--- a/articles/connections/passwordless/spa-email-link.md
+++ b/articles/connections/passwordless/spa-email-link.md
@@ -95,7 +95,7 @@ This will send an email containing the magic link. After clicking the link, the 
 ```js
 //parse hash on page load
 $(document).ready(function(){
-  webAuth.parseHash(window.location.hash, function(err, authResult) {
+  webAuth.parseHash({hash: window.location.hash}, function(err, authResult) {
     if (err) {
       return console.log(err);
     }

--- a/articles/connections/passwordless/spa-sms.md
+++ b/articles/connections/passwordless/spa-sms.md
@@ -131,7 +131,7 @@ The `passwordlessLogin` method will verify the Passwordless transaction, then re
 ```js
 $(document).ready(function() {
   if(window.location.hash){
-    webAuth.parseHash(window.location.hash, function(err, authResult) {
+    webAuth.parseHash({hash: window.location.hash}, function(err, authResult) {
       if (err) {
         return console.log(err);
       } else if (authResult){


### PR DESCRIPTION
The "Using Passwordless Authentication with a one-time code via SMS/email on SPA" documents and the "Using Passwordless Authentication with a Magic Link via email" document were incorrectly indicating to call parseHash in the auth0.WebAuth library by passing the hash as a string as the first parameter.  The function is actually expecting an options object and for the first parameter.  The documentation should therefore actually say {hash: window.location.hash}