### PR TITLE
Clarify opaque tokens

### DIFF
--- a/articles/api-auth/tutorials/verify-access-token.md
+++ b/articles/api-auth/tutorials/verify-access-token.md
@@ -19,7 +19,7 @@ When a custom API receives a request with a bearer [Access Token](/tokens/overvi
 At Auth0, an Access Token used for a custom API is formatted as a [JSON Web Token](/jwt) which must be validated before use.
 
 :::note
-If the Access Token you got from Auth0 is not a JWT but an opaque string (like `kPoPMRYrCEoYO6s5`), this means that your implementation follows our legacy pipeline. For info on how to use the latest and more secure pipeline, see our [OIDC Conformant Authentication Adoption Guide](/api-auth/tutorials/adoption#terminology).
+If the Access Token you got from Auth0 is not a JWT but an opaque string (like `kPoPMRYrCEoYO6s5`), this means that the access token was not issued for your custom API as the audience. When requesting a token for your API, make sure to use the `audience` parameter in the authorization or token request with the API identifier as the value of the parameter.
 :::
 
 Validating the token consists of a series of steps, and if any of these fails, then the request **must** be rejected. This document lists all the validations that your API should perform:
@@ -30,7 +30,7 @@ Validating the token consists of a series of steps, and if any of these fails, t
 - Check the Application permissions (scopes)
 
 ::: note
-<a href="https://jwt.io/">JWT.io</a> provides a list of libraries that can do most of the work for you: parse the JWT, verify the signature and the claims.
+<a href="https://jwt.io/">JWT.io</a> provides a list of libraries that can do most of the work for you: parse the JWT, verify the signature and the claims. All of the [backend API quickstarts](/quickstart/backend) use SDKs that perform the JWT validation and parsing.
 :::
 
 ## Parse the JWT


### PR DESCRIPTION
Opaque tokens aren't necessarily non-OIDC-conformant, but simply issued for the `/userinfo` endpoint as the audience.

