### PR TITLE
Updated to point to custom domain docs

### DIFF
--- a/articles/connector/troubleshooting.md
+++ b/articles/connector/troubleshooting.md
@@ -155,4 +155,4 @@ Approximately once a day (though this frequency might vary under certain circums
 
 ### Receive a "postUrl is required" error
 
-This is usually thrown if additional configuration for custom domains have not been made. See [the custom domains documentation](https://auth0.com/docs/custom-domains/additional-configuration#configure-ad-ldap-connections) for more info.
+This is usually thrown if additional configuration for custom domains have not been made. See [the custom domains documentation](/custom-domains/additional-configuration#configure-ad-ldap-connections) for more info.

--- a/articles/connector/troubleshooting.md
+++ b/articles/connector/troubleshooting.md
@@ -155,4 +155,4 @@ Approximately once a day (though this frequency might vary under certain circums
 
 ### Receive a "postUrl is required" error
 
-This is usually thrown if a custom domain is configured for your tenant, but the `PROVISIONING_TICKET` in the `config.json` still uses the Auth0 tenant domain. Try changing the `PROVISIONING_TICKET` URL to use your custom domain.
+This is usually thrown if additional configuration for custom domains have not been made. See [the custom domains documentation](https://auth0.com/docs/custom-domains/additional-configuration#configure-ad-ldap-connections) for more info.


### PR DESCRIPTION
The workaround for this is already documented in the custom domains documentation - pointing to the existing docs instead of repeating the same workaround.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors
- Please include a short description
- If your PR is a work in progress, title it [DO NOT MERGE]
--->
