### PR TITLE
Reorganize code picker display for refresh tokens

### DIFF
--- a/articles/api-auth/tutorials/adoption/refresh-tokens.md
+++ b/articles/api-auth/tutorials/adoption/refresh-tokens.md
@@ -31,15 +31,7 @@ There are some changes to how Refresh Tokens are used in the OIDC-conformant aut
   </div>
   <div class="tab-content">
     <div id="refresh-legacy" class="tab-pane active">
-      <pre class="text hljs"><code>POST /delegation
-Content-Type: 'application/json'
-{
-  "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
-  "client_id": "...",
-  "refresh_token": "...",
-  "scope": "openid profile"
-}
-</code></pre>
+      <pre class="text hljs"></pre>
    </div>
     <div id="refresh-oidc" class="tab-pane">
       <pre class="text hljs"><code>POST /oauth/token
@@ -57,6 +49,15 @@ Content-Type: application/json
    </div>
   </div>
 </div>
+<code>POST /delegation
+Content-Type: 'application/json'
+{
+  "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+  "client_id": "...",
+  "refresh_token": "...",
+  "scope": "openid profile"
+}
+</code>
 
 Please note that Refresh Tokens must be kept confidential in transit and storage, and they should be shared only among the authorization server and the client to whom the Refresh Tokens were issued.
 

--- a/articles/api-auth/tutorials/adoption/refresh-tokens.md
+++ b/articles/api-auth/tutorials/adoption/refresh-tokens.md
@@ -30,7 +30,18 @@ There are some changes to how Refresh Tokens are used in the OIDC-conformant aut
     </ul>
   </div>
   <div class="tab-content">
-    <div id="refresh-oidc" class="tab-pane">
+    <div id="refresh-legacy" class="tab-pane">
+      <pre class="text hljs"><code>POST /delegation
+Content-Type: 'application/json'
+{
+  "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+  "client_id": "...",
+  "refresh_token": "...",
+  "scope": "openid profile"
+}
+</code></pre>
+   </div>
+    <div id="refresh-oidc" class="tab-pane active">
       <pre class="text hljs"><code>POST /oauth/token
 Content-Type: application/json
 {
@@ -43,17 +54,6 @@ Content-Type: application/json
 }
 </code></pre>
 <ul><li>The <code>audience</code> and <code>client_secret</code> parameters are optional. The <code>client_secret</code> is not needed when requesting a <code>refresh_token</code> for a mobile app.</li></ul>
-   </div>
-       <div id="refresh-legacy" class="tab-pane active">
-      <pre class="text hljs"><code>POST /delegation
-Content-Type: 'application/json'
-{
-  "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
-  "client_id": "...",
-  "refresh_token": "...",
-  "scope": "openid profile"
-}
-</code></pre>
    </div>
   </div>
 </div>

--- a/articles/api-auth/tutorials/adoption/refresh-tokens.md
+++ b/articles/api-auth/tutorials/adoption/refresh-tokens.md
@@ -30,9 +30,6 @@ There are some changes to how Refresh Tokens are used in the OIDC-conformant aut
     </ul>
   </div>
   <div class="tab-content">
-    <div id="refresh-legacy" class="tab-pane active">
-      <pre class="text hljs"></pre>
-   </div>
     <div id="refresh-oidc" class="tab-pane">
       <pre class="text hljs"><code>POST /oauth/token
 Content-Type: application/json
@@ -47,9 +44,8 @@ Content-Type: application/json
 </code></pre>
 <ul><li>The <code>audience</code> and <code>client_secret</code> parameters are optional. The <code>client_secret</code> is not needed when requesting a <code>refresh_token</code> for a mobile app.</li></ul>
    </div>
-  </div>
-</div>
-<code>POST /delegation
+       <div id="refresh-legacy" class="tab-pane active">
+      <pre class="text hljs"><code>POST /delegation
 Content-Type: 'application/json'
 {
   "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
@@ -57,7 +53,10 @@ Content-Type: 'application/json'
   "refresh_token": "...",
   "scope": "openid profile"
 }
-</code>
+</code></pre>
+   </div>
+  </div>
+</div>
 
 Please note that Refresh Tokens must be kept confidential in transit and storage, and they should be shared only among the authorization server and the client to whom the Refresh Tokens were issued.
 

--- a/articles/api-auth/tutorials/adoption/refresh-tokens.md
+++ b/articles/api-auth/tutorials/adoption/refresh-tokens.md
@@ -25,8 +25,8 @@ There are some changes to how Refresh Tokens are used in the OIDC-conformant aut
 <div class="code-picker">
   <div class="languages-bar">
     <ul>
-      <li><a href="#refresh-legacy" data-toggle="tab">Legacy (delegation)</a></li>
       <li><a href="#refresh-oidc" data-toggle="tab">OIDC-conformant (token endpoint)</a></li>
+      <li><a href="#refresh-legacy" data-toggle="tab">Legacy (delegation)</a></li>
     </ul>
   </div>
   <div class="tab-content">


### PR DESCRIPTION
Code picker displays current, not legacy approach first now

https://docs-content-staging-pr-7051.herokuapp.com/docs/api-auth/tutorials/adoption/refresh-tokens