### PR TITLE
Fix typo referencing .gitignore file

### DIFF
--- a/articles/quickstart/webapp/nodejs/01-login.md
+++ b/articles/quickstart/webapp/nodejs/01-login.md
@@ -33,7 +33,7 @@ AUTH0_CLIENT_SECRET=YOUR_CLIENT_SECRET
 Do not put the `.env` file into source control. Otherwise, your history will contain references to your client secret.
 :::
 
-If you are using git, create a `.gitignorefile` (or edit your existing one, if you have one already) and add `.env` to it. The `.gitignore` file tells source control to ignore the files (or file patterns) you list. Be careful to add `.env` to your `.gitignore` file and commit that change before you add your `.env`.
+If you are using git, create a `.gitignore` file (or edit your existing one, if you have one already) and add `.env` to it. The `.gitignore` file tells source control to ignore the files (or file patterns) you list. Be careful to add `.env` to your `.gitignore` file and commit that change before you add your `.env`.
 
 ```
 # .gitignore


### PR DESCRIPTION
The back tick was in the wrong place.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors
- Please include a short description
- If your PR is a work in progress, title it [DO NOT MERGE]
--->
