### PR TITLE
Fixing a broken link + adding a redirect

### DIFF
--- a/articles/users/references/user-profile-structure.md
+++ b/articles/users/references/user-profile-structure.md
@@ -83,7 +83,7 @@ Auth0 also supports the ability for users to [link their profile to multiple ide
 Most user profile fields are not returned as part of [ID Token](/tokens/id-token), nor are they included in the response from the [/userinfo endpoint](/api/authentication#get-user-info) of the Authentication API. To retrieve user datails from these fields you will need to utilize one of the [User endpoints](/api/management/v2#!/Users/get_users) of the Management API. For more information on the endpoints you can use to retrieve users, see [User Search Best Practices](/best-practices/search-best-practices).
 
 ::: panel Blacklist user attributes
-If there are user fields that should not be stored by Auth0 due to privacy reasons, you can blacklist the attributes you do not want persisting in Auth0 databases. For details, see [Blacklist User Attributes](/security/blacklist-user-attributes).
+If there are user fields that should not be stored by Auth0 due to privacy reasons, you can blacklist the attributes you do not want persisting in Auth0 databases. For details, see [Blacklist User Attributes](/security/blacklisting-attributes).
 :::
 
 ## Keep reading

--- a/config/redirects.js
+++ b/config/redirects.js
@@ -893,7 +893,7 @@ module.exports = [
     to: '/libraries/lock/v11/selecting-the-connection-for-multiple-logins'
   },
   {
-    from: '/blacklist-attributes',
+    from: ['/blacklist-attributes', '/security/blacklist-user-attributes'],
     to: '/security/blacklisting-attributes'
   },
   {


### PR DESCRIPTION
Redirecting 
https://docs-content-staging-pr-7064.herokuapp.com/docs/security/blacklist-user-attributes to 
https://docs-content-staging-pr-7064.herokuapp.com/docs/security/blacklisting-attributes

And fixing link here: https://docs-content-staging-pr-7064.herokuapp.com/docs/users/references/user-profile-structure