### PR TITLE
Adding MFA guardian redirects

### DIFF
--- a/config/redirects.js
+++ b/config/redirects.js
@@ -1930,7 +1930,7 @@ module.exports = [
      to: '/hooks'
    },
    {
-     from: '/multifactor-authentication/yubikey',
+     from: ['/multifactor-authentication/yubikey', 'multifactor-authentication/guardian', 'multifactor-authentication/guardian/user-guide'],
      to: '/multifactor-authentication'
    },
    {

--- a/config/redirects.js
+++ b/config/redirects.js
@@ -1930,7 +1930,7 @@ module.exports = [
      to: '/hooks'
    },
    {
-     from: ['/multifactor-authentication/yubikey', 'multifactor-authentication/guardian', 'multifactor-authentication/guardian/user-guide'],
+     from: ['/multifactor-authentication/yubikey', '/multifactor-authentication/guardian', '/multifactor-authentication/guardian/user-guide'],
      to: '/multifactor-authentication'
    },
    {


### PR DESCRIPTION
https://docs-content-staging-pr-7102.herokuapp.com/docs/multifactor-authentication/guardian

and

https://docs-content-staging-pr-7102.herokuapp.com/docs/multifactor-authentication/guardian/user-guide 

should both now redirect to https://docs-content-staging-pr-7102.herokuapp.com/docs/multifactor-authentication

These links are used elsewhere in the product, and until changed, should redirect away from the old doc rather than 404ing.