### PR TITLE
Adding a MFA troubleshooting guide

### DIFF
--- a/articles/multifactor-authentication/index.md
+++ b/articles/multifactor-authentication/index.md
@@ -80,3 +80,7 @@ With most MFA factors, upon signup, the end user will be given a recovery code w
 ::: note
 If a recovery code is used, a new recovery code will be provided at that time.
 :::
+
+## Troubleshooting
+
+See the [MFA Troubleshooting Guide](/multifactor-authentication/troubleshooting) for help troubleshooting common end-user issues.

--- a/articles/multifactor-authentication/troubleshooting.md
+++ b/articles/multifactor-authentication/troubleshooting.md
@@ -12,45 +12,58 @@ useCase:
 ---
 # MFA Troubleshooting
 
-Sometimes, issues can arise for users while attempting to authenticate using MFA. This guide is a troubleshooting reference for end-users who are unable to login to your applications via MFA when it is properly configured.
+This guide serves as a troubleshooting reference if you have end-users unable to log in with multi-factor authentication (MFA).
 
 ## Generic issues
 
-### If you do not have your mobile device or it is turned off
+### If you do not have your mobile device, or your mobile device is turned off
 
-If you have lost your device you can finish authentication with the recovery code from when you signed up. After entering your email and password to login, click the link that says "Use the recovery code" to access your account without using your device.
+If you have lost your device, you can finish authentication using the recovery code provided when you first signed up. After entering your email and password to log in, click the **Use the recovery code** link to access your account without using your device.
 
-If you don't have your recovery code you will not be able to login. Contact your system administrator for help accessing your account.
+If you no longer have your recovery code, you will not be able to log in. Contact your system administrator for help accessing your account.
 
-### If you forgot your password
+### If you forget your password
 
-If you forgot your password when you are trying to login, click **Don't remember your password?** underneath the login. Enter your email to receive an email that will contain a link to reset your password.
+If you have forgotten your password, click the **Don't remember your password?** link located underneath the email and password fields. Then, enter your email address to receive an email containing a link you can use to reset your password.
 
-### Transaction expiration
+### If your transaction expires
 
-For all types of multi-factor authentication types there is a five minute expiration. Check the timestamp on the messages to see if it is still valid when trying to login. If it has been longer than five minutes, you will need to try to login again and get a new code or notification.
+When logging in via MFA, there is a five-minute maximum between providing your first and second factors. You can see how much time has elapsed since you logged in using the first factor by checking the timestamp on the messages provided.
 
-If using SMS, make sure you are not [exceeding rate limits](#sms-rate-limits).
+If more than five minutes has elapsed, you will need to log in again and obtain a new code or notification.
 
-## SMS issues
+If you are requesting SMS messages, make sure you are not [exceeding rate limits](#sms-rate-limits).
 
-### If you did not receive a SMS
+## SMS-related issues
 
-If you did not receive your six digit code via SMS, check that the phone number you entered is correct. If it is the correct number, make sure you have a cellular signal. If you still are not receiving the messages, check with your service provider to confirm that messages are not getting blocked.
+### If you did not receive an SMS message
 
-### SMS Rate Limits
+If you did not receive your six-digit code via SMS, check that the phone number you provided is correct. If it is, make sure you have a cellular signal.
 
-If you attempt to send more than ten SMS to your device within an hour, you will see an error message about a rate limit exception. If you have exceeded the limit of ten, you will need to wait at least an hour from your first SMS send to send another message. Each hour after the first attempt you will gain one more message request maxing out at ten requests.
+If you still are not receiving the messages, check with your service provider to confirm that messages are not getting blocked.
 
-## OTP issues
+### SMS message rate limits
+
+If you attempt to send more than ten SMS messages to your device within one hour, you will see an error message about a rate limit exception.
+
+When you exceed your messaging limit, you'll need to wait at least an hour after your request for your first message before requesting another. You will receive an additional attempt after the passage of each additional hour.
+
+## OTP-related issues
 
 If the 6-digit code in the Guardian or the Google Authenticator app are being rejected for sign in (often with the message `Incorrect Code`), first check that you are selecting the right application from the list in your authenticator app.
 
-If you know you are selecting the correct item, make sure that your mobile device's clock settings are correct. One-time passwords are generated using Coordinated Universal Time (UTC) so your device time must be correct to generate the correct OTP.
+If Guardian or Google Authenticator rejects the six-digit code that you provide and displays the `Incorrect Code` message, check that you are using the correct application from the list of options available in your authenticator app.
 
-* **Android Devices** - Go to the authenticator app's settings, and check to see if there is a setting by which to re-sync the clock.
-* **iOS Devices** - for iOS devices, the time shift can be resolved from device settings. Go to your device's settings, **Date and Time**, and enable **Set Automatically**. If it was already enabled, disable it for a moment and then re-enable it.
+If you've verified that you're selecting the correct application, make sure that your mobile device's clock settings are correct. One-time passwords are generated using Coordinated Universal Time (UTC), so your device's time must be correct for your code to work.
 
-## Duo issues
+To check your clock settings:
 
-For issues/questions specifically regarding Duo, [check the Duo documentation](https://guide.duo.com).
+* **Android Devices** - Go **Settings** > **Date & Time**. Make sure that the box next to **Automatic** is checked.
+
+* **iOS Devices** - Go to  **Settings** > **General** > **Date & Time**. Enable **Set Automatically**. If this setting was already enabled, you can disable it for a moment, then re-enable.
+
+## Duo-related issues
+
+For questions or issues specifically regarding Duo, [see Duo's documentation](https://guide.duo.com).
+
+Android, then tap "Settings." Scroll down to the bottom of the Settings menu, then tap "Date & Time." Tap the box next to "Automatic" to un-check it.

--- a/articles/multifactor-authentication/troubleshooting.md
+++ b/articles/multifactor-authentication/troubleshooting.md
@@ -42,11 +42,11 @@ If you did not receive your six digit code via SMS, check that the phone number 
 
 If you attempt to send more than ten SMS to your device within an hour, you will see an error message about a rate limit exception. If you have exceeded the limit of ten, you will need to wait at least an hour from your first SMS send to send another message. Each hour after the first attempt you will gain one more message request maxing out at ten requests.
 
-## OTP Issues
+## OTP issues
 
 If the 6-digit code in the Guardian or the Google Authenticator app are being rejected for sign in (often with the message `Incorrect Code`), first check that you are selecting the right application from the list in your authenticator app.
 
-If you know you are selecting the correct item, make sure that your mobile device's clock settings are correct. One-time passwords are generated using Coordinated Universal Time(UTC) so your device time must be correct to generate the correct OTP.
+If you know you are selecting the correct item, make sure that your mobile device's clock settings are correct. One-time passwords are generated using Coordinated Universal Time (UTC) so your device time must be correct to generate the correct OTP.
 
 * **Android Devices** - Go to the authenticator app's settings, and check to see if there is a setting by which to re-sync the clock.
 * **iOS Devices** - for iOS devices, the time shift can be resolved from device settings. Go to your device's settings, **Date and Time**, and enable **Set Automatically**. If it was already enabled, disable it for a moment and then re-enable it.

--- a/articles/multifactor-authentication/troubleshooting.md
+++ b/articles/multifactor-authentication/troubleshooting.md
@@ -1,0 +1,56 @@
+---
+title: MFA Troubleshooting for End-Users
+description: Basic troubleshooting of MFA issues for end-users.
+url: /multifactor-authentication/troubleshooting
+toc: true
+topics:
+    - mfa
+contentType:
+  - index
+useCase:
+  - customize-mfa
+---
+# MFA Troubleshooting
+
+Sometimes, issues can arise for users while attempting to authenticate using MFA. This guide is a troubleshooting reference for end-users who are unable to login to your applications via MFA when it is properly configured.
+
+## Generic issues
+
+### If you do not have your mobile device or it is turned off
+
+If you have lost your device you can finish authentication with the recovery code from when you signed up. After entering your email and password to login, click the link that says "Use the recovery code" to access your account without using your device.
+
+If you don't have your recovery code you will not be able to login. Contact your system administrator for help accessing your account.
+
+### If you forgot your password
+
+If you forgot your password when you are trying to login, click **Don't remember your password?** underneath the login. Enter your email to receive an email that will contain a link to reset your password.
+
+### Transaction expiration
+
+For all types of multi-factor authentication types there is a five minute expiration. Check the timestamp on the messages to see if it is still valid when trying to login. If it has been longer than five minutes, you will need to try to login again and get a new code or notification.
+
+If using SMS, make sure you are not [exceeding rate limits](#sms-rate-limits).
+
+## SMS issues
+
+### If you did not receive a SMS
+
+If you did not receive your six digit code via SMS, check that the phone number you entered is correct. If it is the correct number, make sure you have a cellular signal. If you still are not receiving the messages, check with your service provider to confirm that messages are not getting blocked.
+
+### SMS Rate Limits
+
+If you attempt to send more than ten SMS to your device within an hour, you will see an error message about a rate limit exception. If you have exceeded the limit of ten, you will need to wait at least an hour from your first SMS send to send another message. Each hour after the first attempt you will gain one more message request maxing out at ten requests.
+
+## OTP Issues
+
+If the 6-digit code in the Guardian or the Google Authenticator app are being rejected for sign in (often with the message `Incorrect Code`), first check that you are selecting the right application from the list in your authenticator app.
+
+If you know you are selecting the correct item, make sure that your mobile device's clock settings are correct. One-time passwords are generated using Coordinated Universal Time(UTC) so your device time must be correct to generate the correct OTP.
+
+* **Android Devices** - Go to the authenticator app's settings, and check to see if there is a setting by which to re-sync the clock.
+* **iOS Devices** - for iOS devices, the time shift can be resolved from device settings. Go to your device's settings, **Date and Time**, and enable **Set Automatically**. If it was already enabled, disable it for a moment and then re-enable it.
+
+## Duo issues
+
+For issues/questions specifically regarding Duo, [check the Duo documentation](https://guide.duo.com).

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -645,6 +645,9 @@ articles:
           - title: "FAQ"
             url: "/multifactor-authentication/api/faq"
 
+      - title: "MFA Troubleshooting"
+        url: "/multifactor-authentication/troubleshooting"
+
   - title: "Security"
     url: "/security"
     children:


### PR DESCRIPTION
Adding 
https://docs-content-staging-pr-7105.herokuapp.com/docs/multifactor-authentication/troubleshooting

This doc is a guide for end-user MFA troubleshooting, and includes content removed from several old docs as well as some newer details.