### PR TITLE
Add Auth0-PHP to Libraries section

### DIFF
--- a/articles/libraries/auth0-php/authentication-api.md
+++ b/articles/libraries/auth0-php/authentication-api.md
@@ -10,9 +10,13 @@ contentType: how-to
 
 # Using the Authentication API with Auth0-PHP
 
-This SDK provides easy-to-implement methods to access the [Authentication API](https://auth0.com/docs/api/authentication). Some common authentication operations are explained below with examples. For additional information and capabilities, please see the methods in the `\Auth0\SDK\API\Authentication` class. Avoid using any methods marked `@deprecated` as they will be removed in the next major version and may not be enabled for your account.
+The Auth0 PHP SDK provides easy-to-implement methods to access the [Authentication API](/api/authentication). In this article, you'll find examples of common authentication operations. For further information, please see the methods in the `\Auth0\SDK\API\Authentication` class.
 
-The examples below assume that you followed the steps in the [Installation and Getting Started sections](/libraries/auth0-php#installation) and are using a `.env` file and loader to store credentials.
+::: warning
+Avoid using any methods marked `@deprecated`. Deprecated methods will be removed in the next major version and may not be enabled for your account.
+:::
+
+The examples below assume you completed the [Installation and Getting Started sections](/libraries/auth0-php#installation) and are using a `.env` file and loader to store credentials.
 
 ## Regular Web App Login Flow
 
@@ -194,7 +198,7 @@ Array
 
 See the [Management API page](/libraries/auth0-php/management-api) for more information on how to use this access token.
 
-## Register a New Database User
+## Register a new database user
 
 Creating a new database user is done using the `/dbconnections/signup` endpoint, [documented here](/api/authentication#signup).
 

--- a/articles/libraries/auth0-php/authentication-api.md
+++ b/articles/libraries/auth0-php/authentication-api.md
@@ -14,11 +14,11 @@ This SDK provides easy-to-implement methods to access the [Authentication API](h
 
 The examples below assume that you followed the steps in the [Installation and Getting Started sections](/libraries/auth0-php#installation) and are using a `.env` file and loader to store credentials.
 
-## Regular Web App Login Flow (Authorization Code grant)
+## Regular Web App Login Flow
 
 An [Authorization Code grant](/api-auth/tutorials/authorization-code-grant) is the basic way to grant users access to your application. This flow is the same one used on the [Basic Use page](/libraries/auth0-php/basic-use#login). If you need more granular control over the login or callback process, this section walks through how to use the Authentication API directly.
 
-First, the user must authenticate with Auth0 to generate the authorization code. This is done by redirecting to the `/authorize` endpoint for your tenant domain. The following code would appear on a page that requires authentication:
+In the example below, we're going to receive the access token in the POST body instead of a URL parameter. First, the user must authenticate with Auth0 to generate the authorization code. This is done by redirecting to the `/authorize` endpoint for your tenant domain. The following code would appear on a page that requires authentication:
 
 ```php
 // auth-required.php
@@ -26,18 +26,11 @@ use Auth0\SDK\API\Authentication;
 use Auth0\SDK\Store\SessionStore;
 use Auth0\SDK\API\Helpers\State\SessionStateHandler;
 
-function is_user_authenticated() {
-    $store = new SessionStore();
-    $userinfo = $store->get('user');
-    return !empty( $userinfo );
-}
-
-if ( ! is_user_authenticated() ) {
-
+if (! isUserAuthenticated()) {
     // Generate and store a state value.
     $session_store = new SessionStore();
     $state_handler = new SessionStateHandler($session_store);
-    $state_value = $state_handler->issue();
+    $state_value   = $state_handler->issue();
 
     $auth0_api = new Authentication(
         getenv('AUTH0_DOMAIN'),
@@ -46,29 +39,47 @@ if ( ! is_user_authenticated() ) {
 
     // Generate the authorize URL.
     $authorize_url = $auth0_api->get_authorize_link(
-        'code', // Response expected by the application.
-        getenv('AUTH0_REDIRECT_URI'), // Callback URL to respond to.
-        null, // Connection to use, null for all.
-        $state_value, // State value to send with the request.
+        // Response expected by the application.
+        'code',
+        // Callback URL to respond to.
+        getenv('AUTH0_REDIRECT_URI'),
+        // Connection to use, null for all.
+        null,
+        // State value to send with the request.
+        $state_value,
         [
-            'response_mode' => 'query', // Respond with the code and state in the URL query.
-            'scope' => 'openid email profile', // Userinfo to allow.
+            // Respond with the code and state in a POST body.
+            'response_mode' => 'form_post',
+            // Userinfo to allow.
+            'scope' => 'openid email profile',
         ]
     );
 
-    header('Location: ' . $authorize_url);
+    header('Location: '.$authorize_url);
     exit;
 }
 
 echo '<h1>Sensitive data!</h1>';
+
+/**
+ * Determine if a user session exists.
+ *
+ * @return boolean
+ */
+function isUserAuthenticated()
+{
+    $store    = new SessionStore();
+    $userinfo = $store->get('user');
+    return ! empty( $userinfo );
+}
 ```
 
 The process above does the following:
 
-1. First we check if there is a persisted user with `is_user_authenticated()`
-1. If not, then we need to log the user in by redirecting to the Universal Login Page.
-1. We need to send a state value with the login request and then verify that value when the code is returned on the callback URL. The `$state_handler->issue()` call above both generates a value and stores it in the PHP session store. This can also be done manually and stored in either the PHP session or cookies.
-1. The `$auth0_api->get_authorize_link()` call builds the correct `/authorize` link with the correct response type (`code` in this case), redirect URI (where in the application we will handle the response, explained below), state (from above), response mode (URL query parameters), and scopes requested.
+1. First, we check if there is a user session with `isUserAuthenticated()`. The implementation here just checks if the SDK has a persisted user. Your application might handle user sessions differently.
+1. If there is no session, then we need to log the user in by redirecting to the Universal Login Page.
+1. We set a state value with the login request and then verify that value when the code is returned on the callback URL. The `$state_handler->issue()` call above both generates a value and stores it in the PHP session store. This can also be done manually and stored in either the PHP session or cookies.
+1. The `$auth0_api->get_authorize_link()` call builds the correct `/authorize` link with the correct response type (`code` in this case), redirect URI (where in the application we will handle the response, explained below), state (from above), response mode (POST body), and scopes requested.
 1. Then we redirect to this URL and wait for a response.
 
 After authentication, the user is redirected to the callback URL, which is handled with the following:
@@ -78,18 +89,22 @@ After authentication, the user is redirected to the callback URL, which is handl
 use Auth0\SDK\API\Authentication;
 use Auth0\SDK\Store\SessionStore;
 use Auth0\SDK\API\Helpers\State\SessionStateHandler;
-use \Auth0\SDK\Exception\ApiException;
-use \GuzzleHttp\Exception\ClientException;
 
-// Look for an authorization code.
-if ( empty( $_GET['code'] ) ) {
+// Handle errors sent back by Auth0.
+if (! empty($_POST['error']) || ! empty($_POST['error_description'])) {
+    printf( '<h1>Error</h1><p>%s</p>', htmlspecialchars( $_GET['error_description'] ) );
+    die();
+}
+
+// Nothing to do.
+if (empty( $_POST['code'] )) {
     die('No authorization code found.');
 }
 
-// Look for and validate the callback state.
+// Validate callback state.
 $session_store = new SessionStore();
 $state_handler = new SessionStateHandler($session_store);
-if ( ! isset( $_GET['state'] ) || ! $state_handler->validate( $_GET['state'] ) ) {
+if (! isset( $_POST['state'] ) || ! $state_handler->validate( $_POST['state'] )) {
     die('Invalid state.');
 }
 
@@ -102,39 +117,35 @@ $auth0_api = new Authentication(
 
 try {
     // Attempt to get an access_token with the code returned and original redirect URI.
-    $code_exchange_result = $auth0_api->code_exchange( $_GET['code'], getenv('AUTH0_REDIRECT_URI') );
-} catch (ClientException $e) {
-    // HTTP error.
-    die( $e->getMessage() );
-} catch (ApiException $e) {
-    // Auth0-PHP SDK error.
+    $code_exchange_result = $auth0_api->code_exchange( $_POST['code'], getenv('AUTH0_REDIRECT_URI') );
+} catch (Exception $e) {
+    // This could be an Exception from the SDK or the HTTP client.
     die( $e->getMessage() );
 }
 
 try {
-    // Attempt to get the user's information with the access_token we received.
+    // Attempt to get an access_token with the code returned and original redirect URI.
     $userinfo_result = $auth0_api->userinfo( $code_exchange_result['access_token'] );
-} catch (ClientException $e) {
-    // HTTP error.
+} catch (Exception $e) {
     die( $e->getMessage() );
 }
 
 $session_store->set('user', $userinfo_result);
-header('Location: /auth-required.php');
+header('Location: /examples/auth-required.php');
 exit;
 ```
 
 Walking through the process in detail:
 
-1. First we look for a non-empty `code` parameter in the URL. In this case we kill the process but this could also redirect to a different page in case this URL is accessed directly.
-1. Next, we check to make sure we have a `state` URL parameter and make sure it matches the same one we generated. This is important to avoid CSRF attacks ([more information](/protocols/oauth2/oauth-state)).
-1. After the state validation, we instantiate an instance of the `Authentication` class with the Domain, Client ID, and, in this case, the Client Secret, which is used with the `code` to obtain an access token.
+1. First, we check for returned errors. Errors returned should have an `error` key containing the error code and an `error_description` key containing human-readable information.
+1. Next, we look for a non-empty `code` parameter in the POST body. In this case we kill the process but this could also redirect to a different page in case this URL is accessed directly.
+1. Now we check to make sure we have a `state` value and make sure it matches the same one we generated. This is important to avoid CSRF attacks ([more information](/protocols/oauth2/oauth-state)).
+1. After the state validation, we instantiate an instance of the `Authentication` class with the Domain, Client ID, and the Client Secret, which is used with the `code` to obtain an access token.
 1. We attempt an exchange with the `$auth0_api->code_exchange()` call, making sure to pass in the same redirect URI we used to request the `code`.
 1. If this succeeds, we know the exchange was successful and we have an access token. We call the `/userinfo` endpoint with this token, which will return an object containing the data we requested in the `scopes` parameter on the authorize URL.
 1. If this last step succeeds, we store the user and redirect back to our sensitive data.
 
-
-## Machine-to-Machine (M2M) Flow (Client Credentials grant)
+## Machine-to-Machine (M2M) Flow
 
 A [Client Credentials grant](/api-auth/tutorials/client-credentials) gives an application access to a specific API based on the scopes set in the dashboard. This is how applications can, for example, make calls to the Management API. Successful authentication will result in an access token being issued for the API requested.
 
@@ -183,9 +194,54 @@ Array
 
 See the [Management API page](/libraries/auth0-php/management-api) for more information on how to use this access token.
 
+## Register a New Database User
+
+Creating a new database user is done using the `/dbconnections/signup` endpoint, [documented here](/api/authentication#signup).
+
+```php
+use Auth0\SDK\API\Authentication;
+
+$auth0_api = new Authentication(
+    getenv('AUTH0_DOMAIN'),
+    getenv('AUTH0_CLIENT_ID')
+);
+
+try {
+    $result = $auth0_api->dbconnections_signup(
+        // A valid email address that does not already exist for the connection.
+        'user@example.com',
+        // Password conforming to the password policy for the connection.
+        'That_Is_1_Strong_Password!',
+        // Database connection name.
+        'Username-Password-Authentication'
+    );
+} catch (Exception $e) {
+    // This could be an Exception from the SDK or the HTTP client.
+    die( $e->getMessage() );
+}
+
+// This will include the user ID and email address.
+var_dump( $result );
+```
+
+If the user creation was successful, you should see the following:
+
+```
+Array
+(
+    [_id] => 'jxuf4clnfz2jo2ugcvrp6hzc'
+    [email_verified] => false
+    [email] => user@example.com
+)
+```
+
+- The `_id` key will contain the user ID for the Connection used. The Auth0 user ID will be this value with `auth0|` pre-pended, like `auth0|jxuf4clnfz2jo2ugcvrp6hzc`.
+- The `email_verified` key will always be `false`.
+- The `email` key will be the same email address that was passed to the endpoint.
+
 ## SSO Logout
 
-Basic logout (covered on the [Basic Use page](/libraries/auth0-php/basic-use#logout)) closes the session in your application but for customers using SSO, it's often necessary to also close the session at Auth0. This means that the next time the user sees an Auth0 login form, they will be required to provide their credentials to log in. This step should be completed **after** the session is close in your application.
+Basic logout (covered on the [Basic Use page](/libraries/auth0-php/basic-use#logout)) closes the session in your application but for customers using SSO, it's often necessary to also close the session at Auth0. This means that the next time the user sees an Auth0 login form, they will be required to provide their credentials to log in. This step should be completed **after** the session is closed in your application.
 
 First, determine where the user should end up after the logout has completed. Save this in the Auth0 Application settings in the "Allowed Logout URLs" field. Also add a `AUTH0_LOGOUT_RETURN_URL` key with this URL as the value in your `.env` file.
 
@@ -203,10 +259,8 @@ $auth0_auth_api = new Authentication(getenv('AUTH0_DOMAIN'));
 
 // Get the Auth0 logout URL to end the Auth0 session.
 $auth0_logout_url = $auth0_auth_api->get_logout_link(
-
-    // This needs to be saved in the "Allowed Logout URLs" field in your Application settings.
+    // Save this in the "Allowed Logout URLs" field in your Application settings.
     getenv('AUTH0_LOGOUT_RETURN_URL'),
-
     // Indicate the specific Application.
     getenv('AUTH0_CLIENT_ID')
 );
@@ -221,6 +275,6 @@ exit;
 * [Auth0-PHP Introduction](/libraries/auth0-php)
 * [Auth0-PHP Basic Use](/libraries/auth0-php/basic-use)
 * [Auth0-PHP Management API](/libraries/auth0-php/management-api)
-* [Auth0-PHP JWT Verification](/libraries/auth0-php/jwt-validation)
+* [Auth0-PHP JWT Validation](/libraries/auth0-php/jwt-validation)
 * [Auth0-PHP Troubleshooting](/libraries/auth0-php/troubleshooting)
 :::

--- a/articles/libraries/auth0-php/authentication-api.md
+++ b/articles/libraries/auth0-php/authentication-api.md
@@ -1,0 +1,226 @@
+---
+section: libraries
+toc: true
+description: Using the Authentication API with Auth0-PHP
+topics:
+  - libraries
+  - php
+contentType: how-to
+---
+
+# Using the Authentication API with Auth0-PHP
+
+This SDK provides easy-to-implement methods to access the [Authentication API](https://auth0.com/docs/api/authentication). Some common authentication operations are explained below with examples. For additional information and capabilities, please see the methods in the `\Auth0\SDK\API\Authentication` class. Avoid using any methods marked `@deprecated` as they will be removed in the next major version and may not be enabled for your account.
+
+The examples below assume that you followed the steps in the [Installation and Getting Started sections](/libraries/auth0-php#installation) and are using a `.env` file and loader to store credentials.
+
+## Regular Web App Login Flow (Authorization Code grant)
+
+An [Authorization Code grant](/api-auth/tutorials/authorization-code-grant) is the basic way to grant users access to your application. This flow is the same one used on the [Basic Use page](/libraries/auth0-php/basic-use#login). If you need more granular control over the login or callback process, this section walks through how to use the Authentication API directly.
+
+First, the user must authenticate with Auth0 to generate the authorization code. This is done by redirecting to the `/authorize` endpoint for your tenant domain. The following code would appear on a page that requires authentication:
+
+```php
+// auth-required.php
+use Auth0\SDK\API\Authentication;
+use Auth0\SDK\Store\SessionStore;
+use Auth0\SDK\API\Helpers\State\SessionStateHandler;
+
+function is_user_authenticated() {
+    $store = new SessionStore();
+    $userinfo = $store->get('user');
+    return !empty( $userinfo );
+}
+
+if ( ! is_user_authenticated() ) {
+
+    // Generate and store a state value.
+    $session_store = new SessionStore();
+    $state_handler = new SessionStateHandler($session_store);
+    $state_value = $state_handler->issue();
+
+    $auth0_api = new Authentication(
+        getenv('AUTH0_DOMAIN'),
+        getenv('AUTH0_CLIENT_ID')
+    );
+
+    // Generate the authorize URL.
+    $authorize_url = $auth0_api->get_authorize_link(
+        'code', // Response expected by the application.
+        getenv('AUTH0_REDIRECT_URI'), // Callback URL to respond to.
+        null, // Connection to use, null for all.
+        $state_value, // State value to send with the request.
+        [
+            'response_mode' => 'query', // Respond with the code and state in the URL query.
+            'scope' => 'openid email profile', // Userinfo to allow.
+        ]
+    );
+
+    header('Location: ' . $authorize_url);
+    exit;
+}
+
+echo '<h1>Sensitive data!</h1>';
+```
+
+The process above does the following:
+
+1. First we check if there is a persisted user with `is_user_authenticated()`
+1. If not, then we need to log the user in by redirecting to the Universal Login Page.
+1. We need to send a state value with the login request and then verify that value when the code is returned on the callback URL. The `$state_handler->issue()` call above both generates a value and stores it in the PHP session store. This can also be done manually and stored in either the PHP session or cookies.
+1. The `$auth0_api->get_authorize_link()` call builds the correct `/authorize` link with the correct response type (`code` in this case), redirect URI (where in the application we will handle the response, explained below), state (from above), response mode (URL query parameters), and scopes requested.
+1. Then we redirect to this URL and wait for a response.
+
+After authentication, the user is redirected to the callback URL, which is handled with the following:
+
+```php
+// auth-required-callback.php
+use Auth0\SDK\API\Authentication;
+use Auth0\SDK\Store\SessionStore;
+use Auth0\SDK\API\Helpers\State\SessionStateHandler;
+use \Auth0\SDK\Exception\ApiException;
+use \GuzzleHttp\Exception\ClientException;
+
+// Look for an authorization code.
+if ( empty( $_GET['code'] ) ) {
+    die('No authorization code found.');
+}
+
+// Look for and validate the callback state.
+$session_store = new SessionStore();
+$state_handler = new SessionStateHandler($session_store);
+if ( ! isset( $_GET['state'] ) || ! $state_handler->validate( $_GET['state'] ) ) {
+    die('Invalid state.');
+}
+
+// Instantiate the Authentication class with the client secret.
+$auth0_api = new Authentication(
+    getenv('AUTH0_DOMAIN'),
+    getenv('AUTH0_CLIENT_ID'),
+    getenv('AUTH0_CLIENT_SECRET')
+);
+
+try {
+    // Attempt to get an access_token with the code returned and original redirect URI.
+    $code_exchange_result = $auth0_api->code_exchange( $_GET['code'], getenv('AUTH0_REDIRECT_URI') );
+} catch (ClientException $e) {
+    // HTTP error.
+    die( $e->getMessage() );
+} catch (ApiException $e) {
+    // Auth0-PHP SDK error.
+    die( $e->getMessage() );
+}
+
+try {
+    // Attempt to get the user's information with the access_token we received.
+    $userinfo_result = $auth0_api->userinfo( $code_exchange_result['access_token'] );
+} catch (ClientException $e) {
+    // HTTP error.
+    die( $e->getMessage() );
+}
+
+$session_store->set('user', $userinfo_result);
+header('Location: /auth-required.php');
+exit;
+```
+
+Walking through the process in detail:
+
+1. First we look for a non-empty `code` parameter in the URL. In this case we kill the process but this could also redirect to a different page in case this URL is accessed directly.
+1. Next, we check to make sure we have a `state` URL parameter and make sure it matches the same one we generated. This is important to avoid CSRF attacks ([more information](/protocols/oauth2/oauth-state)).
+1. After the state validation, we instantiate an instance of the `Authentication` class with the Domain, Client ID, and, in this case, the Client Secret, which is used with the `code` to obtain an access token.
+1. We attempt an exchange with the `$auth0_api->code_exchange()` call, making sure to pass in the same redirect URI we used to request the `code`.
+1. If this succeeds, we know the exchange was successful and we have an access token. We call the `/userinfo` endpoint with this token, which will return an object containing the data we requested in the `scopes` parameter on the authorize URL.
+1. If this last step succeeds, we store the user and redirect back to our sensitive data.
+
+
+## Machine-to-Machine (M2M) Flow (Client Credentials grant)
+
+A [Client Credentials grant](/api-auth/tutorials/client-credentials) gives an application access to a specific API based on the scopes set in the dashboard. This is how applications can, for example, make calls to the Management API. Successful authentication will result in an access token being issued for the API requested.
+
+First, turn on the **Client Credentials** grant on then **Advanced settings > Grant Types** tab on the Application settings page.
+
+Next, authorize the Application for the API being used on the **Machine to Machine Applications** tab on the API's **Settings** page. Make sure all necessary scopes are selected (but no more) and **Update**. Switch back to the **Settings** tab and copy the **Identifier** value. This needs to be added to a `AUTH0_MANAGEMENT_AUDIENCE` key in your `.env` file.
+
+Request an access token for the API using the example below:
+
+```php
+// Example #5
+use \Auth0\SDK\API\Authentication;
+use \Auth0\SDK\Exception\ApiException;
+use \GuzzleHttp\Exception\ClientException;
+
+$auth0_api = new Authentication( getenv('AUTH0_DOMAIN') );
+
+$config = [
+    'client_secret' => getenv('AUTH0_CLIENT_SECRET'),
+    'client_id' => getenv('AUTH0_CLIENT_ID'),
+    'audience' => getenv('AUTH0_MANAGEMENT_AUDIENCE'),
+];
+
+try {
+    $result = $auth0_api->client_credentials($config);
+    echo '<pre>' . print_r($result, true) . '</pre>';
+    die();
+} catch (ClientException $e) {
+    echo 'Caught: ClientException - ' . $e->getMessage();
+} catch (ApiException $e) {
+    echo 'Caught: ApiException - ' . $e->getMessage();
+}
+```
+
+If the grant was successful, you should see the following:
+
+```
+Array
+(
+    [access_token] => eyJ0eXAi...eyJpc3Mi...QoB2c24w
+    [scope] => read:users read:clients ...
+    [expires_in] => 86400
+    [token_type] => Bearer
+)
+```
+
+See the [Management API page](/libraries/auth0-php/management-api) for more information on how to use this access token.
+
+## SSO Logout
+
+Basic logout (covered on the [Basic Use page](/libraries/auth0-php/basic-use#logout)) closes the session in your application but for customers using SSO, it's often necessary to also close the session at Auth0. This means that the next time the user sees an Auth0 login form, they will be required to provide their credentials to log in. This step should be completed **after** the session is close in your application.
+
+First, determine where the user should end up after the logout has completed. Save this in the Auth0 Application settings in the "Allowed Logout URLs" field. Also add a `AUTH0_LOGOUT_RETURN_URL` key with this URL as the value in your `.env` file.
+
+Add the following below your application logout code:
+
+```php
+// logout.php
+use Auth0\SDK\API\Authentication;
+
+// ... application logout
+
+// Setup the Authentication class with required credentials.
+// No API calls are made on instantiation.
+$auth0_auth_api = new Authentication(getenv('AUTH0_DOMAIN'));
+
+// Get the Auth0 logout URL to end the Auth0 session.
+$auth0_logout_url = $auth0_auth_api->get_logout_link(
+
+    // This needs to be saved in the "Allowed Logout URLs" field in your Application settings.
+    getenv('AUTH0_LOGOUT_RETURN_URL'),
+
+    // Indicate the specific Application.
+    getenv('AUTH0_CLIENT_ID')
+);
+
+header('Location: ' . $auth0_logout_url);
+exit;
+```
+
+**Read More**
+
+::: next-steps
+* [Auth0-PHP Introduction](/libraries/auth0-php)
+* [Auth0-PHP Basic Use](/libraries/auth0-php/basic-use)
+* [Auth0-PHP Management API](/libraries/auth0-php/management-api)
+* [Auth0-PHP JWT Verification](/libraries/auth0-php/jwt-validation)
+* [Auth0-PHP Troubleshooting](/libraries/auth0-php/troubleshooting)
+:::

--- a/articles/libraries/auth0-php/authentication-api.md
+++ b/articles/libraries/auth0-php/authentication-api.md
@@ -7,14 +7,17 @@ topics:
   - php
 contentType: how-to
 ---
-
 # Using the Authentication API with Auth0-PHP
 
-The Auth0 PHP SDK provides easy-to-implement methods to access the [Authentication API](/api/authentication). In this article, you'll find examples of common authentication operations. For further information, please see the methods in the `\Auth0\SDK\API\Authentication` class.
+The Auth0 PHP SDK provides you with methods you can use to access the [Authentication API](/api/authentication).
+
+In this article, you'll find examples of common authentication operations. You will find additional information in the methods in the `\Auth0\SDK\API\Authentication` class.
 
 ::: warning
-Avoid using any methods marked `@deprecated`. Deprecated methods will be removed in the next major version and may not be enabled for your account.
+Do not use methods marked as `@deprecated`. Deprecated methods will be removed in the next major version release and will no longer be available.
 :::
+
+## Prerequisites
 
 The examples below assume you completed the [Installation and Getting Started sections](/libraries/auth0-php#installation) and are using a `.env` file and loader to store credentials.
 
@@ -83,7 +86,7 @@ The process above does the following:
 1. First, we check if there is a user session with `isUserAuthenticated()`. The implementation here just checks if the SDK has a persisted user. Your application might handle user sessions differently.
 1. If there is no session, then we need to log the user in by redirecting to the Universal Login Page.
 1. We set a state value with the login request and then verify that value when the code is returned on the callback URL. The `$state_handler->issue()` call above both generates a value and stores it in the PHP session store. This can also be done manually and stored in either the PHP session or cookies.
-1. The `$auth0_api->get_authorize_link()` call builds the correct `/authorize` link with the correct response type (`code` in this case), redirect URI (where in the application we will handle the response, explained below), state (from above), response mode (POST body), and scopes requested.
+1. The `$auth0_api->get_authorize_link()` call builds the correct `/authorize` link with the correct response type (`code` in this case), redirect URI (wherein the application we will handle the response, explained below), state (from above), response mode (POST body), and scopes requested.
 1. Then we redirect to this URL and wait for a response.
 
 After authentication, the user is redirected to the callback URL, which is handled with the following:
@@ -142,11 +145,11 @@ exit;
 Walking through the process in detail:
 
 1. First, we check for returned errors. Errors returned should have an `error` key containing the error code and an `error_description` key containing human-readable information.
-1. Next, we look for a non-empty `code` parameter in the POST body. In this case we kill the process but this could also redirect to a different page in case this URL is accessed directly.
+1. Next, we look for a non-empty `code` parameter in the POST body. In this case, we kill the process, but this could also redirect to a different page in case this URL is accessed directly.
 1. Now we check to make sure we have a `state` value and make sure it matches the same one we generated. This is important to avoid CSRF attacks ([more information](/protocols/oauth2/oauth-state)).
 1. After the state validation, we instantiate an instance of the `Authentication` class with the Domain, Client ID, and the Client Secret, which is used with the `code` to obtain an access token.
 1. We attempt an exchange with the `$auth0_api->code_exchange()` call, making sure to pass in the same redirect URI we used to request the `code`.
-1. If this succeeds, we know the exchange was successful and we have an access token. We call the `/userinfo` endpoint with this token, which will return an object containing the data we requested in the `scopes` parameter on the authorize URL.
+1. If this succeeds, we know the exchange was successful, and we have an access token. We call the `/userinfo` endpoint with this token, which will return an object containing the data we requested in the `scopes` parameter on the authorize URL.
 1. If this last step succeeds, we store the user and redirect back to our sensitive data.
 
 ## Machine-to-Machine (M2M) Flow
@@ -196,11 +199,11 @@ Array
 )
 ```
 
-See the [Management API page](/libraries/auth0-php/management-api) for more information on how to use this access token.
+See the [Management API page](/libraries/auth0-php/management-api) for more information on how to use this Access Token.
 
 ## Register a new database user
 
-Creating a new database user is done using the `/dbconnections/signup` endpoint, [documented here](/api/authentication#signup).
+Creating a new database user is done using the [`/dbconnections/signup` endpoint](/api/authentication#signup).
 
 ```php
 use Auth0\SDK\API\Authentication;
@@ -245,11 +248,11 @@ Array
 
 ## SSO Logout
 
-Basic logout (covered on the [Basic Use page](/libraries/auth0-php/basic-use#logout)) closes the session in your application but for customers using SSO, it's often necessary to also close the session at Auth0. This means that the next time the user sees an Auth0 login form, they will be required to provide their credentials to log in. This step should be completed **after** the session is closed in your application.
+Basic logout (covered on the [Basic Use page](/libraries/auth0-php/basic-use#logout)) closes the session in your application, but for customers using SSO, they also need to close the session at Auth0. This means that the next time the user sees an Auth0 login form, they will be required to provide their credentials to log in. This step should be completed **after** the session is closed in your application.
 
-First, determine where the user should end up after the logout has completed. Save this in the Auth0 Application settings in the "Allowed Logout URLs" field. Also add a `AUTH0_LOGOUT_RETURN_URL` key with this URL as the value in your `.env` file.
+First, determine where the user should end up after the logout has completed. Save this in the Auth0 Application settings in the "Allowed Logout URLs" field. Also, add an `AUTH0_LOGOUT_RETURN_URL` key with this URL as the value in your `.env` file.
 
-Add the following below your application logout code:
+Add the following to your application logout code:
 
 ```php
 // logout.php
@@ -273,7 +276,7 @@ header('Location: ' . $auth0_logout_url);
 exit;
 ```
 
-**Read More**
+### Read More
 
 ::: next-steps
 * [Auth0-PHP Introduction](/libraries/auth0-php)

--- a/articles/libraries/auth0-php/basic-use.md
+++ b/articles/libraries/auth0-php/basic-use.md
@@ -1,0 +1,186 @@
+---
+section: libraries
+toc: true
+description: Auth0-PHP Basic Use
+topics:
+  - libraries
+  - php
+contentType: how-to
+---
+
+# Auth0-PHP Basic Use
+
+The Auth0-PHP SDK comes with a base `Auth0` class that handles common authentication tasks like logging in, logging out, getting user information, and callback processing. These tasks are explained below with examples. For additional information and capabilities, please see the [documentation page for the Authentication API](/libraries/auth0-php/authentication-api).
+
+The examples below assume that you followed the steps in the [Installation and Getting Started sections](/libraries/auth0-php#installation) and are using a `.env` file and loader to store credentials.
+
+### Login
+
+The basic login process in Auth0-PHP uses an [Authentication Code grant](/api-auth/tutorials/authorization-code-grant) combined with Auth0's Universal Login page. In short, that process is:
+
+1. A user requesting access is redirected to the Universal Login Page.
+2. The user authenticates using one of many possible connections: social (Twitter or Facebook); database (email and password); passwordless (email or a mobile device).
+3. The user is redirected back to your application's callback URL with a `code` and `state` parameter if successful or an `error` and `error_description` if not.
+4. If the authentication was successful, the `state` parameter is validated.
+5. If the `state` is valid, the `code` parameter is exchanged with Auth0 for an access token.
+6. If the exchange is successful, the access token is used to call an Auth0 `/userinfo` endpoint, which returns the authenticated user's information.
+7. This information can be used to create an account, to start an application-specific session, or to persist as the user session.
+
+Auth0-PHP handles most of these steps automatically. Your application needs to:
+
+1. Determine a login action (for example: click a link, visit walled content, etc.) and call  `Auth0::login()`
+2. Handle returned errors.
+
+A simple implementation of these steps looks like this:
+
+```php
+// Example #1
+// login.php
+use Auth0\SDK\Auth0;
+use Auth0\SDK\Exception\CoreException;
+use Auth0\SDK\Exception\ApiException;
+
+// Handle errors sent back by Auth0.
+if (! empty($_GET['error']) || ! empty($_GET['error_description'])) {
+    printf( '<h1>Error</h1><p>%s</p>', htmlspecialchars( $_GET['error_description'] ) );
+    die();
+}
+
+// Initialize the Auth0 class with required credentials.
+$auth0 = new Auth0([
+    'domain' => getenv('AUTH0_DOMAIN'),
+    'client_id' => getenv('AUTH0_CLIENT_ID'),
+    'client_secret' => getenv('AUTH0_CLIENT_SECRET'),
+    'redirect_uri' => getenv('AUTH0_REDIRECT_URI'),
+
+    // The scope determines what data is provided by the /userinfo endpoint.
+    // There must be at least one valid scope included here.
+    'scope' => 'openid',
+]);
+
+// If there is a user persisted (PHP session by default), return that.
+// Otherwise, look for a "state" and "code" URL parameter to validate and exchange.
+// If the state validation and code exchange are successful, return the userinfo.
+try {
+    $userinfo = $auth0->getUser();
+} catch ( CoreException $e ) {
+    // Invalid state or session already exists.
+    die( $e->getMessage() );
+} catch ( ApiException $e ) {
+    // Access token not present.
+    die( $e->getMessage() );
+}
+
+// No user information so redirect to the Universal Login Page.
+if (empty($userinfo)) {
+    $auth0->login();
+}
+
+// We either have a persisted user or a successful code exchange.
+var_dump($userinfo);
+
+// This is where a user record in a local database could be retrieved or created.
+// End with a redirect to a new page.
+
+```
+
+In this case, we're using a file `login.php` at the root of our domain (like `https://example.com/login.php`). For this to work properly, we'll need to add this URL to the Auth0 Application's "Allowed Callback URLs" field on the settings page. We'll also need this same value saved in our `.env` file for `AUTH0_REDIRECT_URI`. After that, loading the script above in your browser should:
+
+1. Immediately redirect you to an Auth0 login page for your tenant.
+2. After successfully logging in using any connection, redirect you back to your app.
+3. Display the returned user information:
+
+```
+array(1) { ["sub"]=> string(30) "auth0|4b12v471de68e34446mq7c2v" }
+```
+
+### Profile
+
+Once a user has authenticated, we can use their persisted data to determine whether they are allowed to access sensitive site pages, like a user profile.
+
+Using the example above, we'll add additional [scopes](/api-auth/tutorials/adoption/scope-custom-claims) to make the profile a little more interesting:
+
+```php
+// login.php
+
+// ...
+	'scope' => 'openid email name nickname picture',
+// ...
+```
+
+Once someone has logged in requesting the new user claims, let's redirect to a profile page instead of outputting the user information:
+
+
+```php
+// login.php
+
+//...
+// var_dump($userinfo);
+header('Location: /profile.php');
+
+```
+
+This profile page will return all the data we retrieved from the `/userinfo` endpoint and stored in our session. The data displayed here is controlled by the `scope` parameter we passed to the `Auth0` class. More information on the claims we can pass to `scope` is [here](/api-auth/tutorials/adoption/scope-custom-claims).
+
+
+```php
+// Example #2
+// profile.php
+use Auth0\SDK\Store\SessionStore;
+
+// Get our persistent storage interface to get the stored userinfo.
+$store = new SessionStore();
+$userinfo = $store->get('user');
+
+if ($userinfo) {
+    // The $userinfo keys below will not exist if the user does not have that data.
+    printf(
+        '<h1>Hi %s!</h1>
+        <p><img width="100" src="%s"></p>
+        <p><strong>Contact:</strong> %s %s</p>',
+        isset($userinfo['nickname']) ? strip_tags($userinfo['nickname']) : '[unknown]',
+        isset($userinfo['picture'])
+            ? filter_var($userinfo['picture'], FILTER_SANITIZE_URL)
+            : 'https://www.gravatar.com/avatar',
+        isset($userinfo['email'])
+            ? filter_var($userinfo['email'], FILTER_SANITIZE_EMAIL)
+            : '[unknown]',
+        !empty($userinfo[ 'email_verified' ]) ? '✓' : '✗'
+    );
+} else {
+    echo '<p>Please <a href="login.php">login</a> to view your profile.</p>';
+}
+```
+
+### Logout
+
+In addition to logging in, we also want users to be able to log out. When users log out, they must invalidate their session for the application. For this SDK, that means destroying their persistent user and token data:
+
+```php
+// Example #2
+// logout.php
+use Auth0\SDK\Auth0;
+use Auth0\SDK\API\Authentication;
+
+$auth0 = new Auth0([
+    'domain' => getenv('AUTH0_DOMAIN'),
+    'client_id' => getenv('AUTH0_CLIENT_ID'),
+    'client_secret' => getenv('AUTH0_CLIENT_SECRET'),
+    'redirect_uri' => getenv('AUTH0_REDIRECT_URI'),
+]);
+
+// Log out of the local application.
+$auth0->logout();
+```
+
+If you're using SSO and want this to also end their session at Auth0, see the [SSO Logout section here](/libraries/auth0-php/authentication-api#sso-logout). More information about logging out in general can be found [here](/logout).
+
+**Read More**
+
+::: next-steps
+* [Auth0-PHP Introduction](/libraries/auth0-php)
+* [Auth0-PHP Authentication API](/libraries/auth0-php/authentication-api)
+* [Auth0-PHP Management API](/libraries/auth0-php/management-api)
+* [Auth0-PHP JWT Verification](/libraries/auth0-php/jwt-validation)
+* [Auth0-PHP Troubleshooting](/libraries/auth0-php/troubleshooting)
+:::

--- a/articles/libraries/auth0-php/basic-use.md
+++ b/articles/libraries/auth0-php/basic-use.md
@@ -19,22 +19,21 @@ The examples below assume that you followed the steps in the [Installation and G
 The basic login process in Auth0-PHP uses an [Authentication Code grant](/api-auth/tutorials/authorization-code-grant) combined with Auth0's Universal Login page. In short, that process is:
 
 1. A user requesting access is redirected to the Universal Login Page.
-2. The user authenticates using one of many possible connections: social (Twitter or Facebook); database (email and password); passwordless (email or a mobile device).
-3. The user is redirected back to your application's callback URL with a `code` and `state` parameter if successful or an `error` and `error_description` if not.
-4. If the authentication was successful, the `state` parameter is validated.
-5. If the `state` is valid, the `code` parameter is exchanged with Auth0 for an access token.
+2. The user authenticates using one of [many possible connections](https://auth0.com/docs/identityproviders): social (Google, Twitter, Facebook), database (email and password), passwordless (email, SMS), or enterprise (ActiveDirectory, ADFS, Office 365).
+3. The user is redirected or posted back to your application's callback URL with `code` and `state` values if successful or an `error` and `error_description` if not.
+4. If the authentication was successful, the `state` value is validated.
+5. If the `state` is valid, the `code` value is exchanged with Auth0 for an access token.
 6. If the exchange is successful, the access token is used to call an Auth0 `/userinfo` endpoint, which returns the authenticated user's information.
 7. This information can be used to create an account, to start an application-specific session, or to persist as the user session.
 
 Auth0-PHP handles most of these steps automatically. Your application needs to:
 
-1. Determine a login action (for example: click a link, visit walled content, etc.) and call  `Auth0::login()`
-2. Handle returned errors.
+1. Determine a login action (for example: click a link, visit walled content, etc.) and call  `Auth0\SDK\Auth0::login()`
+2. Handle returned errors, if present, or get the user information with `Auth0\SDK\Auth0::getUser()`
 
 A simple implementation of these steps looks like this:
 
 ```php
-// Example #1
 // login.php
 use Auth0\SDK\Auth0;
 use Auth0\SDK\Exception\CoreException;
@@ -63,10 +62,10 @@ $auth0 = new Auth0([
 // If the state validation and code exchange are successful, return the userinfo.
 try {
     $userinfo = $auth0->getUser();
-} catch ( CoreException $e ) {
+} catch (CoreException $e) {
     // Invalid state or session already exists.
     die( $e->getMessage() );
-} catch ( ApiException $e ) {
+} catch (ApiException $e) {
     // Access token not present.
     die( $e->getMessage() );
 }
@@ -81,7 +80,6 @@ var_dump($userinfo);
 
 // This is where a user record in a local database could be retrieved or created.
 // End with a redirect to a new page.
-
 ```
 
 In this case, we're using a file `login.php` at the root of our domain (like `https://example.com/login.php`). For this to work properly, we'll need to add this URL to the Auth0 Application's "Allowed Callback URLs" field on the settings page. We'll also need this same value saved in our `.env` file for `AUTH0_REDIRECT_URI`. After that, loading the script above in your browser should:
@@ -91,7 +89,7 @@ In this case, we're using a file `login.php` at the root of our domain (like `ht
 3. Display the returned user information:
 
 ```
-array(1) { ["sub"]=> string(30) "auth0|4b12v471de68e34446mq7c2v" }
+array(1) { ["sub"]=> string(30) "strategy|user_id" }
 ```
 
 ### Profile
@@ -124,28 +122,26 @@ This profile page will return all the data we retrieved from the `/userinfo` end
 
 
 ```php
-// Example #2
 // profile.php
 use Auth0\SDK\Store\SessionStore;
 
 // Get our persistent storage interface to get the stored userinfo.
 $store = new SessionStore();
-$userinfo = $store->get('user');
+$user  = $store->get('user');
 
-if ($userinfo) {
+if ($user) {
     // The $userinfo keys below will not exist if the user does not have that data.
     printf(
         '<h1>Hi %s!</h1>
         <p><img width="100" src="%s"></p>
-        <p><strong>Contact:</strong> %s %s</p>',
-        isset($userinfo['nickname']) ? strip_tags($userinfo['nickname']) : '[unknown]',
-        isset($userinfo['picture'])
-            ? filter_var($userinfo['picture'], FILTER_SANITIZE_URL)
-            : 'https://www.gravatar.com/avatar',
-        isset($userinfo['email'])
-            ? filter_var($userinfo['email'], FILTER_SANITIZE_EMAIL)
-            : '[unknown]',
-        !empty($userinfo[ 'email_verified' ]) ? '✓' : '✗'
+        <p><strong>Last update:</strong> %s</p>
+        <p><strong>Contact:</strong> %s %s</p>
+        <p><a href="logout.php">Logout</a></p>',
+        isset($user['nickname']) ? strip_tags($user['nickname']) : '[unknown]',
+        isset($user['picture']) ? filter_var($user['picture'], FILTER_SANITIZE_URL) : 'https://gravatar.com/avatar/',
+        isset($user['updated_at']) ? date('j/m/Y', strtotime($user['updated_at'])) : '[unknown]',
+        isset($user['email']) ? filter_var($user['email'], FILTER_SANITIZE_EMAIL) : '[unknown]',
+        ! empty($user['email_verified']) ? '✓' : '✗'
     );
 } else {
     echo '<p>Please <a href="login.php">login</a> to view your profile.</p>';
@@ -157,23 +153,21 @@ if ($userinfo) {
 In addition to logging in, we also want users to be able to log out. When users log out, they must invalidate their session for the application. For this SDK, that means destroying their persistent user and token data:
 
 ```php
-// Example #2
 // logout.php
 use Auth0\SDK\Auth0;
-use Auth0\SDK\API\Authentication;
 
 $auth0 = new Auth0([
     'domain' => getenv('AUTH0_DOMAIN'),
     'client_id' => getenv('AUTH0_CLIENT_ID'),
     'client_secret' => getenv('AUTH0_CLIENT_SECRET'),
-    'redirect_uri' => getenv('AUTH0_REDIRECT_URI'),
+    'redirect_uri' => getenv('AUTH0_LOGIN_BASIC_CALLBACK_URL'),
 ]);
 
 // Log out of the local application.
 $auth0->logout();
 ```
 
-If you're using SSO and want this to also end their session at Auth0, see the [SSO Logout section here](/libraries/auth0-php/authentication-api#sso-logout). More information about logging out in general can be found [here](/logout).
+If you're using SSO and want to also end their Auth0 session, see the [SSO Logout section here](/libraries/auth0-php/authentication-api#sso-logout). More information about logging out in general can be found [here](/logout).
 
 **Read More**
 
@@ -181,6 +175,6 @@ If you're using SSO and want this to also end their session at Auth0, see the [S
 * [Auth0-PHP Introduction](/libraries/auth0-php)
 * [Auth0-PHP Authentication API](/libraries/auth0-php/authentication-api)
 * [Auth0-PHP Management API](/libraries/auth0-php/management-api)
-* [Auth0-PHP JWT Verification](/libraries/auth0-php/jwt-validation)
+* [Auth0-PHP JWT Validation](/libraries/auth0-php/jwt-validation)
 * [Auth0-PHP Troubleshooting](/libraries/auth0-php/troubleshooting)
 :::

--- a/articles/libraries/auth0-php/basic-use.md
+++ b/articles/libraries/auth0-php/basic-use.md
@@ -10,7 +10,9 @@ contentType: how-to
 
 # Auth0-PHP Basic Use
 
-The Auth0-PHP SDK comes with a base `Auth0` class that handles common authentication tasks like logging in, logging out, getting user information, and callback processing. These tasks are explained below with examples. For additional information and capabilities, please see the [documentation page for the Authentication API](/libraries/auth0-php/authentication-api).
+The Auth0-PHP SDK comes with a base `Auth0` class that handles common authentication tasks like logging in, logging out, getting user information, and callback processing. These tasks are explained below with examples. For additional information on these capabilities and more, please see the [documentation page for the Authentication API](/libraries/auth0-php/authentication-api).
+
+## Prerequisites
 
 The examples below assume that you followed the steps in the [Installation and Getting Started sections](/libraries/auth0-php#installation) and are using a `.env` file and loader to store credentials.
 
@@ -59,7 +61,7 @@ $auth0 = new Auth0([
 
 // If there is a user persisted (PHP session by default), return that.
 // Otherwise, look for a "state" and "code" URL parameter to validate and exchange.
-// If the state validation and code exchange are successful, return the userinfo.
+// If the state validation and code exchange are successful, return `userinfo`.
 try {
     $userinfo = $auth0->getUser();
 } catch (CoreException $e) {
@@ -102,7 +104,7 @@ Using the example above, we'll add additional [scopes](/api-auth/tutorials/adopt
 // login.php
 
 // ...
-	'scope' => 'openid email name nickname picture',
+    'scope' => 'openid email name nickname picture',
 // ...
 ```
 
@@ -115,10 +117,9 @@ Once someone has logged in requesting the new user claims, let's redirect to a p
 //...
 // var_dump($userinfo);
 header('Location: /profile.php');
-
 ```
 
-This profile page will return all the data we retrieved from the `/userinfo` endpoint and stored in our session. The data displayed here is controlled by the `scope` parameter we passed to the `Auth0` class. More information on the claims we can pass to `scope` is [here](/api-auth/tutorials/adoption/scope-custom-claims).
+This profile page will return all the data we retrieved from the `/userinfo` endpoint and stored in our session. The `scope` parameter controls the data displayed here we passed to the `Auth0` class. More information on the claims we can pass to `scope` is [here](/api-auth/tutorials/adoption/scope-custom-claims).
 
 
 ```php
@@ -167,9 +168,9 @@ $auth0 = new Auth0([
 $auth0->logout();
 ```
 
-If you're using SSO and want to also end their Auth0 session, see the [SSO Logout section here](/libraries/auth0-php/authentication-api#sso-logout). More information about logging out in general can be found [here](/logout).
+If you're using SSO and also want to end their Auth0 session, see the [SSO Logout section here](/libraries/auth0-php/authentication-api#sso-logout). More information about logging out, in general, can be found [here](/logout).
 
-**Read More**
+### Read more
 
 ::: next-steps
 * [Auth0-PHP Introduction](/libraries/auth0-php)

--- a/articles/libraries/auth0-php/index.md
+++ b/articles/libraries/auth0-php/index.md
@@ -25,12 +25,127 @@ Check out the [Auth0-PHP repository](https://github.com/auth0/auth0-PHP) on GitH
 
 ## Installation
 
+Auth0-PHP can be installed one of two ways:
 
+### Install With Composer
+
+We recommend installing the SDK with [Composer](https://getcomposer.org/). If you already have Composer [installed globally](https://getcomposer.org/doc/00-intro.md#globally), run the following:
+
+```bash
+$ composer require auth0/auth0-php
+```
+
+Otherwise, [download Composer locally](https://getcomposer.org/doc/00-intro.md#locally) and run:
+
+```bash
+$ php composer.phar require auth0/auth0-php
+```
+
+This will create `composer.json` and `composer.lock` files in the directory where the command was run, along with a vendor folder containing this SDK and its dependencies.
+
+Finally, include the Composer autoload file in your project to use the SDK:
+
+```php
+// index.php
+require __DIR__ . '/vendor/autoload.php';
+use Auth0\SDK\Auth0;
+```
+
+### Install Manually
+
+If your project does not use Composer or you want to maintain the connection to GitHub, Auth0-PHP can be installed manually. This process still requires Composer to download dependencies but does not use it to manage the package.
+
+First, navigate to the directory that should contain the Auth0-PHP library and clone the Github repo:
+
+```bash
+$ cd /path/to/project/
+$ git clone https://github.com/auth0/auth0-PHP.git auth0
+```
+
+Now, [download Composer locally](https://getcomposer.org/download/) and install the dependencies:
+
+```bash
+$ mv ./composer.phar auth0/composer.phar
+$ cd auth0
+$ php composer.phar install
+```
+
+Finally, require the Auth0-PHP autoloader and you're ready to use the SDK:
+
+```php
+// index.php
+require __DIR__ . '/auth0/vendor/autoload.php';
+use Auth0\SDK\Auth0;
+```
+
+## Getting Started
+
+To use the Auth0 Authentication and Management APIs, you'll need a free Auth0 account and an Application:
+
+1. Go to [auth0.com/signup](https://auth0.com/signup) and create your account.
+2. Once you are in the dashboard, go to **Applications**, then **Create Application**.
+3. Give your Application a name, select **Regular Web Application**, then **Create**
+4. Click the **Settings** tab for the required credentials used below. More information about these settings is [here](https://auth0.com/docs/applications/webapps#settings).
+
+The examples in this documentation use [environment variables](https://secure.php.net/manual/en/reserved.variables.environment.php) to store and load sensitive Auth0 credentials (specifically, the Client Secret) from the environment rather than hard-coding them into your application.
+
+The easiest way to use environment variables in your project is to use a library like [PHP Dotenv](https://github.com/josegonzalez/php-dotenv) along with a local `.env` file. Create a `.env` file (make sure this is not accessible publicly and is excluded from version control) and add the following values:
+
+```
+# Auth0 tenant Domain, found in your Application settings
+AUTH0_DOMAIN="tenant.auth0.com"
+
+# Auth0 Client ID, found in your Application settings
+AUTH0_CLIENT_ID="application_client_id"
+
+# Auth0 Client Secret, found in your Application settings
+AUTH0_CLIENT_SECRET="application_client_secret"
+
+# URL to handle the authentication callback
+# Save this URL in the "Allowed Callback URLs" field in the Auth0 dashboard
+AUTH0_REDIRECT_URI="https://yourdomain.com/auth/callback"
+```
+
+The `AUTH0_REDIRECT_URI` value above is a URL for your application that will handle the callback from Auth0. This is used for both successful logins as well as errors. The processing that happens at this URL is covered later in this documentation.
+
+In your application below the Composer autoload `require`, add:
+
+```php
+// ... other use declarations
+use josegonzalez\Dotenv\Loader;
+
+// Setup environment vars
+$Dotenv = new Loader(__DIR__ . '/.env');
+$Dotenv->parse()->putenv(true);
+
+// Get environment variables
+echo 'My Auth0 domain is ' . getenv('AUTH0_DOMAIN');
+```
+
+You can now use the environment variables to instantiate the necessary Auth0-PHP classes:
+
+```php
+// ... setup environment vars.
+// Instantiate the base Auth0 class.
+$auth0 = new Auth0([
+  'domain' => getenv('AUTH0_DOMAIN'),
+  'client_id' => getenv('AUTH0_CLIENT_ID'),
+  'client_secret' => getenv('AUTH0_CLIENT_SECRET'),
+  'redirect_uri' => getenv('AUTH0_REDIRECT_URI'),
+]);
+```
+
+You're now ready to use Auth0-PHP. Use one of the articles below to add authentication to your existing app or one of our quickstarts to build a test application from scratch:
+
+* [Basic PHP application quickstart](https://auth0.com/docs/quickstart/webapp/php/)
+* [PHP API quickstart](https://auth0.com/docs/quickstart/backend/php/)
+
+**Read More**
 
 ::: next-steps
-* [Auth0.Swift Database Authentication](/libraries/auth0-swift/database-authentication)
-* [Auth0.Swift Passwordless Authentication](/libraries/auth0-swift/passwordless)
-* [Auth0.Swift Refresh Tokens](/libraries/auth0-swift/save-and-refresh-jwt-tokens)
-* [Auth0.Swift User Management](/libraries/auth0-swift/user-management)
-* [Auth0.Swift TouchID Authentication](/libraries/auth0-swift/touchid-authentication)
+* [Auth0-PHP Basic Use](/libraries/auth0-php/basic-use)
+* [Auth0-PHP Authentication API](/libraries/auth0-php/authentication-api)
+* [Auth0-PHP Management API](/libraries/auth0-php/management-api)
+* [Auth0-PHP JWT Verification](/libraries/auth0-php/jwt-validation)
+* [Auth0-PHP Troubleshooting](/libraries/auth0-php/troubleshooting)
 :::

--- a/articles/libraries/auth0-php/index.md
+++ b/articles/libraries/auth0-php/index.md
@@ -12,10 +12,10 @@ contentType:
 ---
 # Auth0-PHP
 
-The Auth0 PHP SDK provides straight-forward and tested methods for accessing Authentication and Management API endpoints.
+The Auth0 PHP SDK provides you with methods for accessing Auth0's Authentication and Management API endpoints.
 
 ::: note
-The Auth0-PHP repository is [hosted on GitHub](https://github.com/auth0/auth0-PHP). We appreciate any and all contributions, including bug reports, enhancement proposals, and pull requests.
+The Auth0-PHP repository is [hosted on GitHub](https://github.com/auth0/auth0-PHP). We appreciate all contributions, including bug reports, enhancement proposals, and pull requests.
 :::
 
 ## Requirements
@@ -26,6 +26,9 @@ The Auth0-PHP repository is [hosted on GitHub](https://github.com/auth0/auth0-PH
 ## Installation
 
 Auth0-PHP can be installed one of two ways:
+
+1. With Composer
+2. Manually
 
 ### Install With Composer
 
@@ -53,16 +56,16 @@ use Auth0\SDK\Auth0;
 
 ### Install Manually
 
-If your project does not use Composer or you want to maintain a connection to the Git repo, Auth0-PHP can be installed manually. This process still requires Composer to download dependencies but does not use it to manage the package.
+If your project does not use Composer or you want to maintain a connection to the Git repo, Auth0-PHP can be installed manually. This process still requires Composer to download dependencies, but the process does not use Composer to manage the package.
 
-First, navigate to the directory that should contain the Auth0-PHP library and clone the Github repo:
+First, navigate to the directory that contains the Auth0-PHP library and clone the Github repo:
 
 ```bash
 $ cd /path/to/project/
 $ git clone https://github.com/auth0/auth0-PHP.git auth0
 ```
 
-Now, [download Composer locally](https://getcomposer.org/download/) and install the dependencies:
+[Download Composer](https://getcomposer.org/download/) and install the dependencies:
 
 ```bash
 $ mv ./composer.phar auth0/composer.phar
@@ -88,7 +91,7 @@ To use the Auth0 Authentication and Management APIs, you'll need a free Auth0 ac
 3. Give your Application a name, select **Regular Web Application**, then **Create**
 4. Click the **Settings** tab for the required credentials used below. More information about these settings is [here](https://auth0.com/docs/applications/webapps#settings).
 
-The examples in this documentation use [environment variables](https://secure.php.net/manual/en/reserved.variables.environment.php) to store and load sensitive Auth0 credentials from the environment rather than hard-coding them into your application.
+The examples in this documentation use [environment variables](https://secure.php.net/manual/en/reserved.variables.environment.php) to store and load sensitive Auth0 credentials, eliminating the need for you to hardcode them into your application.
 
 The easiest way to use environment variables in your project is to use a library like [PHP Dotenv](https://github.com/josegonzalez/php-dotenv) along with a local `.env` file. Create a `.env` file (make sure this is not accessible publicly and is excluded from version control) and add the following values:
 
@@ -109,7 +112,7 @@ AUTH0_REDIRECT_URI="https://yourdomain.com/auth/callback"
 
 The `AUTH0_REDIRECT_URI` value above is a URL for your application that will handle the callback from Auth0. This is used for both successful logins as well as errors. The processing that happens at this URL is covered later in this documentation.
 
-In your application below the Composer autoload `require`, add:
+In your application (below the Composer autoload `require`), add:
 
 ```php
 // ... other use declarations
@@ -141,7 +144,7 @@ You are now ready to use Auth0-PHP. Use one of the articles below to add authent
 * [Basic PHP application quickstart](https://auth0.com/docs/quickstart/webapp/php/)
 * [PHP API quickstart](https://auth0.com/docs/quickstart/backend/php/)
 
-**Read More**
+### Read more
 
 ::: next-steps
 * [Auth0-PHP Basic Use](/libraries/auth0-php/basic-use)

--- a/articles/libraries/auth0-php/index.md
+++ b/articles/libraries/auth0-php/index.md
@@ -15,7 +15,7 @@ contentType:
 The Auth0 PHP SDK provides straight-forward and tested methods for accessing Authentication and Management API endpoints.
 
 ::: note
-Check out the [Auth0-PHP repository](https://github.com/auth0/auth0-PHP) on GitHub.
+The Auth0-PHP repository is [hosted on GitHub](https://github.com/auth0/auth0-PHP). We appreciate any and all contributions, including bug reports, enhancement proposals, and pull requests.
 :::
 
 ## Requirements
@@ -53,7 +53,7 @@ use Auth0\SDK\Auth0;
 
 ### Install Manually
 
-If your project does not use Composer or you want to maintain the connection to GitHub, Auth0-PHP can be installed manually. This process still requires Composer to download dependencies but does not use it to manage the package.
+If your project does not use Composer or you want to maintain a connection to the Git repo, Auth0-PHP can be installed manually. This process still requires Composer to download dependencies but does not use it to manage the package.
 
 First, navigate to the directory that should contain the Auth0-PHP library and clone the Github repo:
 
@@ -68,6 +68,7 @@ Now, [download Composer locally](https://getcomposer.org/download/) and install 
 $ mv ./composer.phar auth0/composer.phar
 $ cd auth0
 $ php composer.phar install
+$ rm composer.phar
 ```
 
 Finally, require the Auth0-PHP autoloader and you're ready to use the SDK:
@@ -87,7 +88,7 @@ To use the Auth0 Authentication and Management APIs, you'll need a free Auth0 ac
 3. Give your Application a name, select **Regular Web Application**, then **Create**
 4. Click the **Settings** tab for the required credentials used below. More information about these settings is [here](https://auth0.com/docs/applications/webapps#settings).
 
-The examples in this documentation use [environment variables](https://secure.php.net/manual/en/reserved.variables.environment.php) to store and load sensitive Auth0 credentials (specifically, the Client Secret) from the environment rather than hard-coding them into your application.
+The examples in this documentation use [environment variables](https://secure.php.net/manual/en/reserved.variables.environment.php) to store and load sensitive Auth0 credentials from the environment rather than hard-coding them into your application.
 
 The easiest way to use environment variables in your project is to use a library like [PHP Dotenv](https://github.com/josegonzalez/php-dotenv) along with a local `.env` file. Create a `.env` file (make sure this is not accessible publicly and is excluded from version control) and add the following values:
 
@@ -135,7 +136,7 @@ $auth0 = new Auth0([
 ]);
 ```
 
-You're now ready to use Auth0-PHP. Use one of the articles below to add authentication to your existing app or one of our quickstarts to build a test application from scratch:
+You are now ready to use Auth0-PHP. Use one of the articles below to add authentication to your existing app or one of our quickstarts to build a test application from scratch:
 
 * [Basic PHP application quickstart](https://auth0.com/docs/quickstart/webapp/php/)
 * [PHP API quickstart](https://auth0.com/docs/quickstart/backend/php/)
@@ -146,6 +147,6 @@ You're now ready to use Auth0-PHP. Use one of the articles below to add authenti
 * [Auth0-PHP Basic Use](/libraries/auth0-php/basic-use)
 * [Auth0-PHP Authentication API](/libraries/auth0-php/authentication-api)
 * [Auth0-PHP Management API](/libraries/auth0-php/management-api)
-* [Auth0-PHP JWT Verification](/libraries/auth0-php/jwt-validation)
+* [Auth0-PHP JWT Validation](/libraries/auth0-php/jwt-validation)
 * [Auth0-PHP Troubleshooting](/libraries/auth0-php/troubleshooting)
 :::

--- a/articles/libraries/auth0-php/index.md
+++ b/articles/libraries/auth0-php/index.md
@@ -1,0 +1,36 @@
+---
+section: libraries
+toc: true
+description: How to install, initialize and use Auth0-PHP
+url: /libraries/auth0-php
+topics:
+  - libraries
+  - php
+contentType:
+  - how-to
+  - index
+---
+# Auth0-PHP
+
+The Auth0 PHP SDK provides straight-forward and tested methods for accessing Authentication and Management API endpoints.
+
+::: note
+Check out the [Auth0-PHP repository](https://github.com/auth0/auth0-PHP) on GitHub.
+:::
+
+## Requirements
+
+- PHP 5.5 or later
+- [Composer](https://getcomposer.org/doc/00-intro.md)
+
+## Installation
+
+
+
+::: next-steps
+* [Auth0.Swift Database Authentication](/libraries/auth0-swift/database-authentication)
+* [Auth0.Swift Passwordless Authentication](/libraries/auth0-swift/passwordless)
+* [Auth0.Swift Refresh Tokens](/libraries/auth0-swift/save-and-refresh-jwt-tokens)
+* [Auth0.Swift User Management](/libraries/auth0-swift/user-management)
+* [Auth0.Swift TouchID Authentication](/libraries/auth0-swift/touchid-authentication)
+:::

--- a/articles/libraries/auth0-php/jwt-validation.md
+++ b/articles/libraries/auth0-php/jwt-validation.md
@@ -16,7 +16,6 @@ The decoder can work with both HS256 and RS256 tokens. Both types require the al
 
 Here is an example of a small, URL-based JWT decoder:
 
-
 ```php
 use Auth0\SDK\JWTVerifier;
 use Auth0\SDK\Exception\InvalidTokenException;
@@ -68,7 +67,7 @@ Additional parameters for the `JWTVerifier` configuration array are:
 - **guzzle_options**: Configuration propagated to Guzzle when fetching the JWKs (RS256 only). These options are [documented here](http://docs.guzzlephp.org/en/stable/request-options.html).
 - **secret\_base64\_encoded**: When `true`, it will decode the secret used to verify the token signature. This is only used for HS256 tokens and defaults to `true`. Your Application settings will say whether the Client Secret provided is encoded or not.
 
-**Read More**
+### Read more
 
 ::: next-steps
 * [Auth0-PHP Introduction](/libraries/auth0-php)

--- a/articles/libraries/auth0-php/jwt-validation.md
+++ b/articles/libraries/auth0-php/jwt-validation.md
@@ -10,7 +10,7 @@ contentType: how-to
 
 # Validating JWTs with Auth0-PHP
 
-This SDK also includes an interface to the [Firebase PHP JWT library](https://github.com/firebase/php-jwt), used to decode and verify JSON web tokens (JWT). The `JWTVerifier` class has a single method, `verifyAndDecode()`, which accepts a JWT and either returns a decoded token or throws an error. More information on JWTs and how to build and decode them can be found [here on jwt.io](https://jwt.io/).
+Auth0-PHP includes an interface to the [Firebase PHP JWT library](https://github.com/firebase/php-jwt), used to validate and decode JSON web tokens (JWT). The `JWTVerifier` class has a single method, `verifyAndDecode()`, which accepts a JWT and either returns a decoded token or throws an error. More information on JWTs and how to build and decode them can be found [jwt.io](https://jwt.io/).
 
 The decoder can work with both HS256 and RS256 tokens. Both types require the algorithm and valid audiences to be indicated before processing. Additionally, HS256 tokens require the client secret while RS256 tokens require an authorized issuer. The issuer is used to fetch a JWKs file during the decoding process as well. ([More about signing algorithms here](https://auth0.com/blog/navigating-rs256-and-jwks/).)
 
@@ -18,45 +18,47 @@ Here is an example of a small, URL-based JWT decoder:
 
 
 ```php
-// Example #4
-// decode-jwt.php
 use Auth0\SDK\JWTVerifier;
 use Auth0\SDK\Exception\InvalidTokenException;
 use Auth0\SDK\Exception\CoreException;
 
-// Do we have an ID token?
-if (empty($_GET[ 'id_token' ])) {
-    echo '<code>No "id_token" URL parameter!</code> ';
-    exit;
+if (empty($_GET['id_token'])) {
+    die( 'No `id_token` URL parameter' );
 }
 
-// Do we have a valid algorithm?
-if (empty($_GET[ 'token_alg' ]) || ! in_array($_GET[ 'token_alg' ], [ 'HS256', 'RS256' ])) {
-    echo '<code>Missing or invalid "token_alg" URL parameter!</code> ';
-    exit;
+if (empty($_GET['token_alg']) || ! in_array($_GET['token_alg'], [ 'HS256', 'RS256' ])) {
+    die( 'Missing or invalid `token_alg` URL parameter' );
 }
+
+$idToken  = rawurldecode($_GET['id_token']);
+$tokenAlg = rawurldecode($_GET['token_alg']);
 
 $config = [
-    'supported_algs' => [ $_GET[ 'token_alg' ] ],
-    'client_secret' => getenv('AUTH0_CLIENT_SECRET'),
+    // Array of allowed algorithms; never pass more than what is expected.
+    'supported_algs' => [ $tokenAlg ],
+    // Array of allowed "aud" values.
+    'valid_audiences' => [ getenv('AUTH0_CLIENT_ID') ],
 ];
 
-if ('HS256' === $_GET[ 'token_alg' ]) {
-    $config['client_secret'] = getenv('AUTH0_CLIENT_SECRET');
+if ('HS256' === $tokenAlg) {
+    // HS256 tokens require the Client Secret to decode.
+    $config['client_secret']         = getenv('AUTH0_CLIENT_SECRET');
+    $config['secret_base64_encoded'] = false;
 } else {
-    $config['authorized_iss'] = [ 'https://' . getenv('AUTH0_DOMAIN') . '/' ];
+    // RS256 tokens require a valid issuer.
+    $config['authorized_iss'] = [ 'https://'.getenv('AUTH0_DOMAIN').'/' ];
 }
 
 try {
-    $verifier = new JWTVerifier($config);
-    $decoded_token = $verifier->verifyAndDecode($_GET[ 'id_token' ]);
-    echo '<pre>' . print_r($decoded_token, true) . '</pre>';
+    $verifier      = new JWTVerifier($config);
+    $decoded_token = $verifier->verifyAndDecode($idToken);
+    echo '<pre>'.print_r($decoded_token, true).'</pre>';
 } catch (InvalidTokenException $e) {
-    echo 'Caught: InvalidTokenException - ' . $e->getMessage();
+    echo 'Caught: InvalidTokenException - '.$e->getMessage();
 } catch (CoreException $e) {
-    echo 'Caught: CoreException - ' . $e->getMessage();
+    echo 'Caught: CoreException - '.$e->getMessage();
 } catch (\Exception $e) {
-    echo 'Caught: Exception - ' . $e->getMessage();
+    echo 'Caught: Exception - '.$e->getMessage();
 }
 ```
 

--- a/articles/libraries/auth0-php/jwt-validation.md
+++ b/articles/libraries/auth0-php/jwt-validation.md
@@ -1,0 +1,77 @@
+---
+section: libraries
+toc: true
+description: Validating JWTs with Auth0-PHP
+topics:
+  - libraries
+  - php
+contentType: how-to
+---
+
+# Validating JWTs with Auth0-PHP
+
+This SDK also includes an interface to the [Firebase PHP JWT library](https://github.com/firebase/php-jwt), used to decode and verify JSON web tokens (JWT). The `JWTVerifier` class has a single method, `verifyAndDecode()`, which accepts a JWT and either returns a decoded token or throws an error. More information on JWTs and how to build and decode them can be found [here on jwt.io](https://jwt.io/).
+
+The decoder can work with both HS256 and RS256 tokens. Both types require the algorithm and valid audiences to be indicated before processing. Additionally, HS256 tokens require the client secret while RS256 tokens require an authorized issuer. The issuer is used to fetch a JWKs file during the decoding process as well. ([More about signing algorithms here](https://auth0.com/blog/navigating-rs256-and-jwks/).)
+
+Here is an example of a small, URL-based JWT decoder:
+
+
+```php
+// Example #4
+// decode-jwt.php
+use Auth0\SDK\JWTVerifier;
+use Auth0\SDK\Exception\InvalidTokenException;
+use Auth0\SDK\Exception\CoreException;
+
+// Do we have an ID token?
+if (empty($_GET[ 'id_token' ])) {
+    echo '<code>No "id_token" URL parameter!</code> ';
+    exit;
+}
+
+// Do we have a valid algorithm?
+if (empty($_GET[ 'token_alg' ]) || ! in_array($_GET[ 'token_alg' ], [ 'HS256', 'RS256' ])) {
+    echo '<code>Missing or invalid "token_alg" URL parameter!</code> ';
+    exit;
+}
+
+$config = [
+    'supported_algs' => [ $_GET[ 'token_alg' ] ],
+    'client_secret' => getenv('AUTH0_CLIENT_SECRET'),
+];
+
+if ('HS256' === $_GET[ 'token_alg' ]) {
+    $config['client_secret'] = getenv('AUTH0_CLIENT_SECRET');
+} else {
+    $config['authorized_iss'] = [ 'https://' . getenv('AUTH0_DOMAIN') . '/' ];
+}
+
+try {
+    $verifier = new JWTVerifier($config);
+    $decoded_token = $verifier->verifyAndDecode($_GET[ 'id_token' ]);
+    echo '<pre>' . print_r($decoded_token, true) . '</pre>';
+} catch (InvalidTokenException $e) {
+    echo 'Caught: InvalidTokenException - ' . $e->getMessage();
+} catch (CoreException $e) {
+    echo 'Caught: CoreException - ' . $e->getMessage();
+} catch (\Exception $e) {
+    echo 'Caught: Exception - ' . $e->getMessage();
+}
+```
+
+Additional parameters for the `JWTVerifier` configuration array are:
+
+- **cache**: Receives an instance of `Auth0\SDK\Helpers\Cache\CacheHandler` (Supported `FileSystemCacheHandler` and `NoCacheHandler`). Defaults to `NoCacheHandler` (RS256 only).
+- **guzzle_options**: Configuration propagated to Guzzle when fetching the JWKs (RS256 only). These options are [documented here](http://docs.guzzlephp.org/en/stable/request-options.html).
+- **secret\_base64\_encoded**: When `true`, it will decode the secret used to verify the token signature. This is only used for HS256 tokens and defaults to `true`. Your Application settings will say whether the Client Secret provided is encoded or not.
+
+**Read More**
+
+::: next-steps
+* [Auth0-PHP Introduction](/libraries/auth0-php)
+* [Auth0-PHP Basic Use](/libraries/auth0-php/basic-use)
+* [Auth0-PHP Authentication API](/libraries/auth0-php/authentication-api)
+* [Auth0-PHP Management API](/libraries/auth0-php/management-api)
+* [Auth0-PHP Troubleshooting](/libraries/auth0-php/troubleshooting)
+:::

--- a/articles/libraries/auth0-php/management-api.md
+++ b/articles/libraries/auth0-php/management-api.md
@@ -7,10 +7,9 @@ topics:
   - php
 contentType: how-to
 ---
-
 # Using the Management API with Auth0-PHP
 
-Auht0-PHP also provides a wrapper for the Management API, which is used to perform operations on your Auth0 tenant. Using this API, you can:
+Auht0-PHP provides a wrapper for the Management API, which is used to perform operations on your Auth0 tenant. Using this API, you can:
 
 - Search for and create users
 - Create and update Applications
@@ -19,9 +18,9 @@ Auht0-PHP also provides a wrapper for the Management API, which is used to perfo
 
 ... and much more. See our [documentation](/api/management/v2) for information on what's possible and the examples below for how to authenticate and access this API.
 
-### Authentication
+## Authentication
 
-In order to use the Management API, you must authenticate one of two ways:
+To use the Management API, you must authenticate one of two ways:
 
 - For temporary access or testing, you can [manually generate an API token](/api/management/v2/tokens#get-a-token-manually) and save it in your `.env` file.
 - For extended access, you must create and execute and Client Credentials grant when access is required. This process is detailed on the [Authentication API page](/libraries/auth0-php/authentication-api#regular-web-app-login-flow).
@@ -91,6 +90,8 @@ if (! empty($results)) {
     }
 }
 ```
+
+### Read more
 
 ::: next-steps
 * [Auth0-PHP Introduction](/libraries/auth0-php)

--- a/articles/libraries/auth0-php/management-api.md
+++ b/articles/libraries/auth0-php/management-api.md
@@ -23,8 +23,8 @@ Auht0-PHP also provides a wrapper for the Management API, which is used to perfo
 
 In order to use the Management API, you must authenticate one of two ways:
 
-- For temporary access or testing, you can [manually generate an API token](/api/management/v2/tokens#get-a-token-manually) and save it in your `.env` file
-- For extended access, you can create and execute and Client Credentials grant ([detailed above](#client-credentials-grant)) when access is required
+- For temporary access or testing, you can [manually generate an API token](/api/management/v2/tokens#get-a-token-manually) and save it in your `.env` file.
+- For extended access, you must create and execute and Client Credentials grant when access is required. This process is detailed on the [Authentication API page](/libraries/auth0-php/authentication-api#regular-web-app-login-flow).
 
 Regardless of the method, the token generated must have the scopes required for the operations your app wants to execute. Consult the [API documentation](/api/management/v2) for the scopes required for the specific endpoint you're trying to access.
 
@@ -39,15 +39,17 @@ Now you can authenticate one of the two ways above and use that token to perform
 ```php
 use Auth0\SDK\API\Management;
 
-$access_token = getenv('AUTH0_MANAGEMENT_API_TOKEN');
-if ( empty( $access_token ) ) {
-	// See "Client Credentials Grant" above
-	$access_token = get_access_token();
+if ( 'test' === getenv('APPLICATION_ENVIRONMENT') ) {
+    // Use a temporary testing token.
+    $access_token = getenv('AUTH0_MANAGEMENT_API_TOKEN');
+} else {
+    // See Authentication API page to implement this function.
+    $access_token = getManagementAccessToken();
 }
 $mgmt_api = new Management( $access_token, getenv('AUTH0_DOMAIN') );
 ```
 
-The `Management` class stores access to endpoints as properties of its instances. The best way to see what endpoints are covered is to read through the `\Auth0\SDK\API\Management::__construct()` method.
+The `Management` class stores access to endpoints as properties of its instances. The best way to see what endpoints are covered is to read through the `\Auth0\SDK\API\Management` constructor method.
 
 ### Example - Search Users by Email
 
@@ -94,6 +96,6 @@ if (! empty($results)) {
 * [Auth0-PHP Introduction](/libraries/auth0-php)
 * [Auth0-PHP Basic Use](/libraries/auth0-php/basic-use)
 * [Auth0-PHP Authentication API](/libraries/auth0-php/authentication-api)
-* [Auth0-PHP JWT Verification](/libraries/auth0-php/jwt-verification)
+* [Auth0-PHP JWT Validation](/libraries/auth0-php/jwt-validation)
 * [Auth0-PHP Troubleshooting](/libraries/auth0-php/troubleshooting)
 :::

--- a/articles/libraries/auth0-php/management-api.md
+++ b/articles/libraries/auth0-php/management-api.md
@@ -1,0 +1,99 @@
+---
+section: libraries
+toc: true
+description: Using the Management API with Auth0-PHP
+topics:
+  - libraries
+  - php
+contentType: how-to
+---
+
+# Using the Management API with Auth0-PHP
+
+Auht0-PHP also provides a wrapper for the Management API, which is used to perform operations on your Auth0 tenant. Using this API, you can:
+
+- Search for and create users
+- Create and update Applications
+- Retrieve log entries
+- Manage rules
+
+... and much more. See our [documentation](/api/management/v2) for information on what's possible and the examples below for how to authenticate and access this API.
+
+### Authentication
+
+In order to use the Management API, you must authenticate one of two ways:
+
+- For temporary access or testing, you can [manually generate an API token](/api/management/v2/tokens#get-a-token-manually) and save it in your `.env` file
+- For extended access, you can create and execute and Client Credentials grant ([detailed above](#client-credentials-grant)) when access is required
+
+Regardless of the method, the token generated must have the scopes required for the operations your app wants to execute. Consult the [API documentation](/api/management/v2) for the scopes required for the specific endpoint you're trying to access.
+
+To grant the scopes needed:
+
+1. Go to [APIs](https://manage.auth0.com/#/apis) > Auth0 Management API > **Machine to Machine Applications** tab.
+2. Find your Application and authorize it.
+3. Click the arrow to expand the row and select the scopes required.
+
+Now you can authenticate one of the two ways above and use that token to perform operations:
+
+```php
+use Auth0\SDK\API\Management;
+
+$access_token = getenv('AUTH0_MANAGEMENT_API_TOKEN');
+if ( empty( $access_token ) ) {
+	// See "Client Credentials Grant" above
+	$access_token = get_access_token();
+}
+$mgmt_api = new Management( $access_token, getenv('AUTH0_DOMAIN') );
+```
+
+The `Management` class stores access to endpoints as properties of its instances. The best way to see what endpoints are covered is to read through the `\Auth0\SDK\API\Management::__construct()` method.
+
+### Example - Search Users by Email
+
+This endpoint is documented [here](/api/management/v2#!/Users/get_users).
+
+```php
+$results = $mgmt_api->users->search([
+    'q' => 'josh'
+]);
+
+if (! empty($results)) {
+    echo '<h2>User Search</h2>';
+    foreach ($results as $datum) {
+        printf(
+            '<p><strong>%s</strong> &lt;%s&gt; - %s</p>',
+            !empty($datum['nickname']) ? $datum['nickname'] : 'No nickname',
+            !empty($datum['email']) ? $datum['email'] : 'No email',
+            $datum['user_id']
+        );
+    }
+}
+```
+
+### Example - Get All Clients
+
+This endpoint is documented [here](/api/management/v2#!/Clients/get_clients).
+
+```php
+$results = $mgmt_api->clients->getAll();
+
+if (! empty($results)) {
+    echo '<h2>Get All Clients</h2>';
+    foreach ($results as $datum) {
+        printf(
+            '<p><strong>%s</strong> - %s</p>',
+            $datum['name'],
+            $datum['client_id']
+        );
+    }
+}
+```
+
+::: next-steps
+* [Auth0-PHP Introduction](/libraries/auth0-php)
+* [Auth0-PHP Basic Use](/libraries/auth0-php/basic-use)
+* [Auth0-PHP Authentication API](/libraries/auth0-php/authentication-api)
+* [Auth0-PHP JWT Verification](/libraries/auth0-php/jwt-verification)
+* [Auth0-PHP Troubleshooting](/libraries/auth0-php/troubleshooting)
+:::

--- a/articles/libraries/auth0-php/troubleshooting.md
+++ b/articles/libraries/auth0-php/troubleshooting.md
@@ -1,0 +1,30 @@
+---
+section: libraries
+toc: true
+description: Troubleshooting the Auth0-PHP SDK
+topics:
+  - libraries
+  - php
+contentType: how-to
+---
+
+# Troubleshooting Auth0-PHP
+
+> I'm getting an "Invalid State" exception when trying to log in.
+
+[State validation](https://auth0.com/docs/protocols/oauth2/oauth-state) was added in 5.1.0 for improved security. By default, this uses session storage and will happen automatically if you are using a combination of `Auth0::login()` and any method which calls `Auth0::exchange()` in your callback.
+
+If you need to use a different storage method, implement your own [StateHandler](https://github.com/auth0/auth0-PHP/blob/master/src/API/Helpers/State/StateHandler.php) and set it using the `state_handler` config key when you initialize an `Auth0` instance.
+
+If you are using `Auth0::exchange()` and a method other than `Auth0::login()` to generate the Authorize URL, you can disable automatic state validation by setting the `state_handler` key to `false` when you initialize the `Auth0` instance. It is **highly recommended** to implement state validation, either automatically or otherwise.
+
+> I am getting `curl error 60: SSL certificate problem: self-signed certificate in certificate chain` on Windows
+
+This is a common issue with latest PHP versions under **Windows OS** (related to an incompatibility between windows and openssl CAs database).
+
+1. Download this CA database `https://curl.haxx.se/ca/cacert.pem` to `c:/cacert.pem`.
+2. Edit your php.ini and add `openssl.cafile=c:/cacert.pem`. (It should point to the file you downloaded.)
+
+> My host does not allow using Composer
+
+This SDK uses Composer for maintaining dependencies (required external PHP libraries). If Composer is not allowed or installed on your host, install Composer locally, follow the installation instructions there, then upload your entire application, vendor folder included, to your host.

--- a/articles/libraries/auth0-php/troubleshooting.md
+++ b/articles/libraries/auth0-php/troubleshooting.md
@@ -36,5 +36,5 @@ This SDK uses Composer for maintaining dependencies (required external PHP libra
 * [Auth0-PHP Basic Use](/libraries/auth0-php/basic-use)
 * [Auth0-PHP Authentication API](/libraries/auth0-php/authentication-api)
 * [Auth0-PHP Management API](/libraries/auth0-php/management-api)
-* [Auth0-PHP JWT Verification](/libraries/auth0-php/jwt-validation)
+* [Auth0-PHP JWT Validation](/libraries/auth0-php/jwt-validation)
 :::

--- a/articles/libraries/auth0-php/troubleshooting.md
+++ b/articles/libraries/auth0-php/troubleshooting.md
@@ -28,3 +28,13 @@ This is a common issue with latest PHP versions under **Windows OS** (related to
 > My host does not allow using Composer
 
 This SDK uses Composer for maintaining dependencies (required external PHP libraries). If Composer is not allowed or installed on your host, install Composer locally, follow the installation instructions there, then upload your entire application, vendor folder included, to your host.
+
+**Read More**
+
+::: next-steps
+* [Auth0-PHP Introduction](/libraries/auth0-php)
+* [Auth0-PHP Basic Use](/libraries/auth0-php/basic-use)
+* [Auth0-PHP Authentication API](/libraries/auth0-php/authentication-api)
+* [Auth0-PHP Management API](/libraries/auth0-php/management-api)
+* [Auth0-PHP JWT Verification](/libraries/auth0-php/jwt-validation)
+:::

--- a/articles/libraries/auth0-php/troubleshooting.md
+++ b/articles/libraries/auth0-php/troubleshooting.md
@@ -7,8 +7,9 @@ topics:
   - php
 contentType: how-to
 ---
+# Troubleshooting Issues When Using the Auth0-PHP Library
 
-# Troubleshooting Auth0-PHP
+The following is a list of issues you might see when using the Auth0-PHP library and how you might troubleshoot these issues.
 
 > I'm getting an "Invalid State" exception when trying to log in.
 
@@ -20,7 +21,7 @@ If you are using `Auth0::exchange()` and a method other than `Auth0::login()` to
 
 > I am getting `curl error 60: SSL certificate problem: self-signed certificate in certificate chain` on Windows
 
-This is a common issue with latest PHP versions under **Windows OS** (related to an incompatibility between windows and openssl CAs database).
+This is a common issue with the latest PHP versions under **Windows OS** (it is related to an incompatibility between Windows and OpenSSL CA's database).
 
 1. Download this CA database `https://curl.haxx.se/ca/cacert.pem` to `c:/cacert.pem`.
 2. Edit your php.ini and add `openssl.cafile=c:/cacert.pem`. (It should point to the file you downloaded.)
@@ -29,7 +30,7 @@ This is a common issue with latest PHP versions under **Windows OS** (related to
 
 This SDK uses Composer for maintaining dependencies (required external PHP libraries). If Composer is not allowed or installed on your host, install Composer locally, follow the installation instructions there, then upload your entire application, vendor folder included, to your host.
 
-**Read More**
+### Read more
 
 ::: next-steps
 * [Auth0-PHP Introduction](/libraries/auth0-php)

--- a/articles/libraries/index.md
+++ b/articles/libraries/index.md
@@ -7,7 +7,7 @@ topics:
   - libraries
   - lock
   - auth0js
-contentType: 
+contentType:
     - index
     - concept
 ---
@@ -24,7 +24,7 @@ contentType:
 
 <%= include('../_includes/_embedded_login_warning') %>
 
-## Lock 
+## Lock
 
 ### Lock documentation
 
@@ -60,6 +60,9 @@ contentType:
   </li>
   <li>
     <i class="icon icon-budicon-715"></i><a href="https://auth0.github.io/node-auth0/"> Node-Auth0</a>
+  </li>
+  <li>
+    <i class="icon icon-budicon-715"></i><a href="https://auth0.com/docs/libraries/auth0-php"> Auth0-PHP</a>
   </li>
 </ul>
 


### PR DESCRIPTION
Big PR here ... this moves all the SDK documentation from the [repo README](https://github.com/auth0/auth0-PHP/blob/master/README.md) to the docs site [Libraries section](https://auth0.com/docs/libraries#sdk-documentation). Specifically:

- Created 6 new pages:
  * Auth0-PHP Introduction
  * Auth0-PHP Basic Use
  * Auth0-PHP Authentication API
  * Auth0-PHP Management API
  * Auth0-PHP Troubleshooting
  * Auth0-PHP JWT Validation
- Moved in the documentation from the README (after a thorough review) and updated the code samples
- Added a few additional tasks

Once this is merged, I'll put through the change on the SDK repo ([auth0/auth0-php#312](https://github.com/auth0/auth0-PHP/pull/312)).