### PR TITLE
removed the dead-link

### DIFF
--- a/articles/appliance/index.html
+++ b/articles/appliance/index.html
@@ -118,12 +118,6 @@ applianceId: appliance59
     </p>
   </li>
   <li>
-    <i class="icon icon-budicon-715"></i><a href="/appliance/admin/creating-tenants">Automatic Creation of Tenants</a>
-    <p>
-      If your business needs require you to create tenants regularly, you may automate this process in your PSaaS Appliance instances. For example, you might need to create one tenant for each customer or project that goes live.
-    </p>
-  </li>
-  <li>
     <i class="icon icon-budicon-715"></i><a href="/appliance/modules">Node.js Modules Available in Rules and Custom Database Connections for PSaaS Appliance</a>
     <p>
       For security reasons, rules and custom database connections for PSaaS Appliance run in a JavaScript sandbox. You can use the full power of the ECMAScript 5 language and a few selected libraries.

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -1329,6 +1329,7 @@ appliance:
         url: /appliance/cli
       - title: Automatic Tenant Creation
         url: /appliance/admin/creating-tenants
+        hidden: true
       - title: Node Module Availability
         url: /appliance/modules
       - title: Webtasks


### PR DESCRIPTION
Automatic Creating Tenants deadlink removed from the index. This doc is deprecated but the link exists

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors
- Please include a short description
- If your PR is a work in progress, title it [DO NOT MERGE]
--->
