### PR TITLE
Add note about auth0-notifications domain blacklisting

### DIFF
--- a/articles/_includes/_email-domain-blacklist.md
+++ b/articles/_includes/_email-domain-blacklist.md
@@ -1,3 +1,3 @@
 ::: warning
-Auth0 blacklists certain "false" domains commonly used during testing. Use real email addresses to avoid disruption or domain is blacklisted errors.
+Auth0 blacklists certain "false" domains commonly used during testing. Use real email addresses to avoid disruption or `domain is blacklisted` errors.
 :::

--- a/articles/_includes/_email-domain-blacklist.md
+++ b/articles/_includes/_email-domain-blacklist.md
@@ -1,0 +1,3 @@
+::: warning
+Auth0 blacklists certain "false" domains commonly used during testing. Use real email addresses to avoid disruption or domain is blacklisted errors.
+:::

--- a/articles/dev-lifecycle/local-testing-and-development.md
+++ b/articles/dev-lifecycle/local-testing-and-development.md
@@ -42,6 +42,4 @@ Because Auth0's main identity protocol is [OpenID Connect](/protocols), Auth0 ne
 
 If you want to test your local application and do not want the emails (creation, validation, etc.) to be delivered to the actual email address of the users your application creates or validates, Auth0 recommends using a custom email provider. For example, a service like [Mailtrap](https://mailtrap.io/signin) or your own custom SMTP server implementation can apply whatever logic you require to trap the emails. This ensures that users do not receive emails but you can access them for validation and troubleshooting. 
 
-::: warning
-We suggest establishing real email addresses for quality assurance purposes and using these addresses when testing. Since we blacklist certain "false" domains that are commonly used to test, this will help you avoid disruption and the accompanying error in your logs stating that `the domain is blacklisted`.
-:::
+<%= include('../../_includes/_email-domain-blacklist') %>

--- a/articles/dev-lifecycle/local-testing-and-development.md
+++ b/articles/dev-lifecycle/local-testing-and-development.md
@@ -41,3 +41,7 @@ Because Auth0's main identity protocol is [OpenID Connect](/protocols), Auth0 ne
 ## Divert emails for testing
 
 If you want to test your local application and do not want the emails (creation, validation, etc.) to be delivered to the actual email address of the users your application creates or validates, Auth0 recommends using a custom email provider. For example, a service like [Mailtrap](https://mailtrap.io/signin) or your own custom SMTP server implementation can apply whatever logic you require to trap the emails. This ensures that users do not receive emails but you can access them for validation and troubleshooting. 
+
+::: warning
+We suggest establishing real email addresses for quality assurance purposes and using these addresses when testing. This will help you avoid disruption caused by the blacklisting of certain "false" domains that are commonly used to test.
+:::

--- a/articles/dev-lifecycle/local-testing-and-development.md
+++ b/articles/dev-lifecycle/local-testing-and-development.md
@@ -43,5 +43,5 @@ Because Auth0's main identity protocol is [OpenID Connect](/protocols), Auth0 ne
 If you want to test your local application and do not want the emails (creation, validation, etc.) to be delivered to the actual email address of the users your application creates or validates, Auth0 recommends using a custom email provider. For example, a service like [Mailtrap](https://mailtrap.io/signin) or your own custom SMTP server implementation can apply whatever logic you require to trap the emails. This ensures that users do not receive emails but you can access them for validation and troubleshooting. 
 
 ::: warning
-We suggest establishing real email addresses for quality assurance purposes and using these addresses when testing. This will help you avoid disruption caused by the blacklisting of certain "false" domains that are commonly used to test.
+We suggest establishing real email addresses for quality assurance purposes and using these addresses when testing. Since we blacklist certain "false" domains that are commonly used to test, this will help you avoid disruption and the accompanying error in your logs stating that `the domain is blacklisted`.
 :::

--- a/articles/dev-lifecycle/local-testing-and-development.md
+++ b/articles/dev-lifecycle/local-testing-and-development.md
@@ -42,4 +42,4 @@ Because Auth0's main identity protocol is [OpenID Connect](/protocols), Auth0 ne
 
 If you want to test your local application and do not want the emails (creation, validation, etc.) to be delivered to the actual email address of the users your application creates or validates, Auth0 recommends using a custom email provider. For example, a service like [Mailtrap](https://mailtrap.io/signin) or your own custom SMTP server implementation can apply whatever logic you require to trap the emails. This ensures that users do not receive emails but you can access them for validation and troubleshooting. 
 
-<%= include('../../_includes/_email-domain-blacklist') %>
+<%= include('../_includes/_email-domain-blacklist') %>

--- a/articles/email/testing.md
+++ b/articles/email/testing.md
@@ -21,6 +21,10 @@ You can either:
 
 Once you have either your own SMTP server set up or a test service available, you can provide its credentials the way you typically would for a [custom email provider](/email/providers#configure-a-custom-smtp-server-for-sending-email).
 
+::: warning
+We suggest establishing real email addresses for quality assurance purposes and using these addresses when testing. This will help you avoid disruption caused by the blacklisting of certain "false" domains that are commonly used to test.
+:::
+
 ## Resources to Consider
 
 ::: next-steps
@@ -29,8 +33,4 @@ Once you have either your own SMTP server set up or a test service available, yo
 * [Haraka](https://haraka.github.io/)
 * [MailTrap](https://mailtrap.io/)
 * [smtp4dev](https://smtp4dev.codeplex.com/)
-:::
-
-::: warning
-We suggest establishing real email addresses for quality assurance purposes and using these addresses when testing. This will help you avoid disruption caused by the blacklisting of certain "false" domains that are commonly used to test.
 :::

--- a/articles/email/testing.md
+++ b/articles/email/testing.md
@@ -21,9 +21,7 @@ You can either:
 
 Once you have either your own SMTP server set up or a test service available, you can provide its credentials the way you typically would for a [custom email provider](/email/providers#configure-a-custom-smtp-server-for-sending-email).
 
-::: warning
-We suggest establishing real email addresses for quality assurance purposes and using these addresses when testing. Since we blacklist certain "false" domains that are commonly used to test, this will help you avoid disruption and the accompanying error in your logs stating that `the domain is blacklisted`.
-:::
+<%= include('../../_includes/_email-domain-blacklist') %>
 
 ## Resources to Consider
 

--- a/articles/email/testing.md
+++ b/articles/email/testing.md
@@ -21,7 +21,7 @@ You can either:
 
 Once you have either your own SMTP server set up or a test service available, you can provide its credentials the way you typically would for a [custom email provider](/email/providers#configure-a-custom-smtp-server-for-sending-email).
 
-<%= include('../../_includes/_email-domain-blacklist') %>
+<%= include('../_includes/_email-domain-blacklist') %>
 
 ## Resources to Consider
 

--- a/articles/email/testing.md
+++ b/articles/email/testing.md
@@ -30,3 +30,7 @@ Once you have either your own SMTP server set up or a test service available, yo
 * [MailTrap](https://mailtrap.io/)
 * [smtp4dev](https://smtp4dev.codeplex.com/)
 :::
+
+::: warning
+We suggest establishing real email addresses for quality assurance purposes and using these addresses when testing. This will help you avoid disruption caused by the blacklisting of certain "false" domains that are commonly used to test.
+:::

--- a/articles/email/testing.md
+++ b/articles/email/testing.md
@@ -22,7 +22,7 @@ You can either:
 Once you have either your own SMTP server set up or a test service available, you can provide its credentials the way you typically would for a [custom email provider](/email/providers#configure-a-custom-smtp-server-for-sending-email).
 
 ::: warning
-We suggest establishing real email addresses for quality assurance purposes and using these addresses when testing. This will help you avoid disruption caused by the blacklisting of certain "false" domains that are commonly used to test.
+We suggest establishing real email addresses for quality assurance purposes and using these addresses when testing. Since we blacklist certain "false" domains that are commonly used to test, this will help you avoid disruption and the accompanying error in your logs stating that `the domain is blacklisted`.
 :::
 
 ## Resources to Consider


### PR DESCRIPTION
Adding notes about domain blacklisting while testing emails.

See Slack conversation here:
https://auth0.slack.com/archives/C02FE2CTZ/p1546902975067900
