### PR TITLE
Typo fix cli doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,7 +117,7 @@ Only use this if the content is brief (one to four lines), if not use the `panel
 
 ```markdown
 ::: note
-  If you need a refresher on the OAuth 2.0 protocol, you can go through our <a href="/protocols/oauth2">OAuth 2.0</a> article.
+If you need a refresher on the OAuth 2.0 protocol, you can go through our <a href="/protocols/oauth2">OAuth 2.0</a> article.
 :::
 ```
 

--- a/articles/integrations/using-auth0-to-secure-a-cli.md
+++ b/articles/integrations/using-auth0-to-secure-a-cli.md
@@ -13,10 +13,10 @@ useCase: integrate-saas-sso
 Authentication in CLI programs is straightforward if the identity provider supports sending credentials, like database connections, SMS passwordless and AD. If the identity provider requires a browser redirect, then the process is slightly more complicated.
 
 ::: note
-   If your identity provider supports sending credentials, then you should use the [Machine-to-Machine (M2M) Flow](/flows/guides/m2m-flow). For details on how to implement this, refer to [Call API Using the Machine-to-Machine (M2M) Flow](/flows/guides/m2m-flow/call-api-using-m2m-flow).
+If your identity provider supports sending credentials, then you should use the [Machine-to-Machine (M2M) Flow](/flows/guides/m2m-flow). For details on how to implement this, refer to [Call API Using the Machine-to-Machine (M2M) Flow](/flows/guides/m2m-flow/call-api-using-m2m-flow).
 :::
 
-Auth0 implements the [Native/Mobile Login Flow](/flows/concepts/mobile-login-flow), which makes use of the [Proof Key for Code Exchange] (https://tools.ietf.org/html/rfc7636) enhancement. This flow makes it easy to add authentication to a CLI while keeping higher standards of security.
+Auth0 implements the [Native/Mobile Login Flow](/flows/concepts/mobile-login-flow), which makes use of the [Proof Key for Code Exchange](https://tools.ietf.org/html/rfc7636) enhancement. This flow makes it easy to add authentication to a CLI while keeping higher standards of security.
 
 ## How the Native/Mobile Login Flow Works
 
@@ -35,11 +35,11 @@ The steps to follow to implement this flow are the following:
 3. __Initiate the Authorization Request__. The regular OAuth 2.0 authorization request, with the caveat that now it includes two parameters: the `code_challenge` and the `code_challenge_method` which should be `S256`. If the authorization is successful, then Auth0 will redirect the browser to the callback with a `code` query parameter: `${account.callback}/?code=123`.
 
 ::: note
-   In order for the CLI to be able to receive the callback and retrieve the code, it needs to implement an HTTP server that corresponds to the allowed callback for the client.
+In order for the CLI to be able to receive the callback and retrieve the code, it needs to implement an HTTP server that corresponds to the allowed callback for the client.
 :::
 
 4. __Exchange the Authorization Code for a Token__. With the `code`, the program then uses the [/oauth/token endpoint](/api/authentication#authorization-code-pkce-) to obtain a token. In this second step, the CLI program adds a `verifier` parameter with the exact same random secret generated in step 1. Auth0 uses this to correlate and verify that the request originates from the same application. If successful, the response is another JSON object, with an ID Token and Access Token. Note that if the `verifier` doesn't match with what was sent in the [/authorize endpoint](/api/authentication#authorization-code-grant-pkce-), the request will fail.
 
 ::: note
-   For implementation details and sample scripts, refer to [Call API Using the Mobile Login Flow](/flows/guides/mobile-login-flow/call-api-using-mobile-login-flow).
+For implementation details and sample scripts, refer to [Call API Using the Mobile Login Flow](/flows/guides/mobile-login-flow/call-api-using-mobile-login-flow).
 :::


### PR DESCRIPTION
https://docs-content-staging-pr-7140.herokuapp.com/docs/integrations/using-auth0-to-secure-a-cli had a broken link due to an errant space. Resolving that, minor style/syntax changes in the doc, and fixing example for the note UI element in CONTRIBUTING to match the standard set by the other elements / other parts of Markdown and having the content within the element left aligned rather than tabbed in.