### PR TITLE
Remove link to non-existent jumpstart page

### DIFF
--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -1078,9 +1078,6 @@ articles:
       - title: "Private SaaS Management Workshop"
         url: "/services/private-saas-management"
 
-      - title: "Jumpstart"
-        url: "/services/jumpstart"
-
 apis:
 
   - title: "Overview"


### PR DESCRIPTION
Some time ago we removed pages referencing the now deprecated Jumpstart program, but one link was left behind and it's now leading to a 404 page.