### PR TITLE
Fix Android Login callback url format

### DIFF
--- a/articles/quickstart/native/android/00-login.md
+++ b/articles/quickstart/native/android/00-login.md
@@ -29,7 +29,7 @@ Edit your `res/values/strings.xml` file as follows:
 <%= include('../../../_includes/_callback_url') %>
 
 ::: note
-If you are following along with the sample project you downloaded from the top of this page, you should set the **Allowed Callback URL** to  'demo://${account.namespace}/android/YOUR_APP_PACKAGE_NAME/callback' }`.
+If you are following along with the sample project you downloaded from the top of this page, you should set the **Allowed Callback URL** to  `demo://${account.namespace}/android/YOUR_APP_PACKAGE_NAME/callback`.
 :::
 
 Replace `YOUR_APP_PACKAGE_NAME` with your application's package name, available as the `applicationId` attribute in the `app/build.gradle` file.


### PR DESCRIPTION
### Briefing
Android Login callback url has some strange format, probably a typo with the back ticks and was looking like this:
![image](https://user-images.githubusercontent.com/241306/51258519-f1885080-1988-11e9-982c-fd40c1d7489d.png)

This only PR fixes that. GitHub is showing a change in the last line of the file that I didn't make 🤔 Please, check if everything is ok 🙂 	

Thanks!
