### PR TITLE
Fix typo in Ionic QS

### DIFF
--- a/articles/quickstart/native/ionic3/01-login.md
+++ b/articles/quickstart/native/ionic3/01-login.md
@@ -27,7 +27,6 @@ If you are following along with the sample project you downloaded from the top o
 # replace YOUR_PACKAGE_ID with your app package ID
 YOUR_PACKAGE_ID://${account.namespace}/cordova/YOUR_PACKAGE_ID/callback
 ```
-:::
 
 Replace `YOUR_APP_PACKAGE_NAME` with your application's package name, available as the `applicationId` attribute in the `app/build.gradle` file.
 ```bash


### PR DESCRIPTION
### Briefing
There are three colons showing up in the quickstarts that don't make sense.

I don't know if any of the preceding or the following blocks were meant to have `:::note` or similar, so maybe the fix is to add them, anyway this PR removes the dangling colons.

Feel free to close if this is not appropriate, this is how it's looking in current QS:
![image](https://user-images.githubusercontent.com/241306/51258964-f4377580-1989-11e9-88e8-de1625834fc7.png)


