### PR TITLE
removed duplicated sentence

### DIFF
--- a/articles/users/references/metadata-field-name-rules.md
+++ b/articles/users/references/metadata-field-name-rules.md
@@ -92,7 +92,6 @@ The following fields may not be stored in the `app_metadata` field:
 Currently, Auth0 limits the total size of your user metadata to **16 MB**. However, when using Rules and/or the Management Dashboard, your metadata limits may be lower.
 
 When setting the `user_metadata` field with the [Authentication API Signup endpoint](/api/authentication?javascript#signup), your metadata is limited to a maximum of 10 fields and 500 characters.
-Currently, Auth0 limits the total size of your user metadata to **16 MB**. However, when using Rules and/or the Management Dashboard, your metadata limits may be lower.
 
 <%= include('../../_includes/_metadata_on_signup_warning') %>
 


### PR DESCRIPTION
the following sentence is listed twice in the same section: 

> Currently, Auth0 limits the total size of your user metadata to 16 MB. However, when using Rules and/or the Management Dashboard, your metadata limits may be lower.

This PR removes the second instance. 