### PR TITLE
Fix links to create-hooks-using-XX

### DIFF
--- a/articles/hooks/guides/use-the-credentials-exchange-extensibility-point.md
+++ b/articles/hooks/guides/use-the-credentials-exchange-extensibility-point.md
@@ -12,7 +12,7 @@ v2: true
 ---
 # Change Scopes and Add Custom Claims to Access Tokens
 
-To use the Credentials Exchange Extensibility Point, you can implement a Hook with either the [Dashboard](/hooks/guides/create-delete-hooks-using-dashboard) or the [Command Line Interface](/hooks/guides/create-delete-hooks-using-cli). 
+To use the Credentials Exchange Extensibility Point, you can implement a Hook with either the [Dashboard](/hooks/guides/create-hooks-using-dashboard) or the [Command Line Interface](/hooks/guides/create-hooks-using-cli). 
 
 For detailed steps on implementing the grant, please refer to [Using Hooks with Client Credentials Grant](/api-auth/tutorials/client-credentials/customize-with-hooks).
 

--- a/articles/hooks/guides/use-the-post-user-registration-extensibility-point.md
+++ b/articles/hooks/guides/use-the-post-user-registration-extensibility-point.md
@@ -14,7 +14,7 @@ For [Database Connections](/connections/database), the `post-user-registration` 
 
 [Hooks](/hooks/concepts/overview-hooks) associated with the `post-user-registration` extensibility point execute asynchronously from the actions that are a part of the Auth0 authentication process.
 
-Implement a [Hook](/hooks/concepts/overview-hooks) using this extensibility point with either the [Dashboard](/hooks/guides/create-delete-hooks-using-dashboard) or the [Command Line Interface](/hooks/guides/create-delete-hooks-using-cli). 
+Implement a [Hook](/hooks/concepts/overview-hooks) using this extensibility point with either the [Dashboard](/hooks/guides/create-hooks-using-dashboard) or the [Command Line Interface](/hooks/guides/create-hooks-using-cli). 
 
 ### Starter code and parameters
 

--- a/articles/hooks/guides/use-the-pre-user-registration-extensibility-point.md
+++ b/articles/hooks/guides/use-the-pre-user-registration-extensibility-point.md
@@ -15,7 +15,7 @@ For [Database Connections](/connections/database), the Pre-User Registration ext
 
 This allows you to implement scenarios such as setting conditional information (in the form of [metadata](/users/concepts/overview-user-metadata) on users that do not exist yet.
 
-Implement a [Hook](/hooks/concepts/overview-hooks) using this extensibility point with either the [Dashboard](/hooks/guides/create-delete-hooks-using-dashboard) or the [Command Line Interface](/hooks/guides/create-delete-hooks-using-cli). 
+Implement a [Hook](/hooks/concepts/overview-hooks) using this extensibility point with either the [Dashboard](/hooks/guides/create-hooks-using-dashboard) or the [Command Line Interface](/hooks/guides/create-hooks-using-cli). 
 
 ## Starter code and parameters
 


### PR DESCRIPTION
<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors
- Please include a short description
- If your PR is a work in progress, title it [DO NOT MERGE]
--->

I updated the followings

These pages have links to `create-**delete-**hooks-using-dashboard` and  `create-**delete-**hooks-using-cli`, but these links are not found.

- https://auth0.com/docs/hooks/guides/use-the-credentials-exchange-extensibility-point
- https://auth0.com/docs/hooks/guides/use-the-pre-user-registration-extensibility-point
- https://auth0.com/docs/hooks/guides/use-the-post-user-registration-extensibility-point

The following pages exist.

- https://auth0.com/docs/hooks/guides/create-hooks-using-dashboard
- https://auth0.com/docs/hooks/guides/create-hooks-using-cli
