### PR TITLE
Deploy extensions: Added "clients grants" section

### DIFF
--- a/articles/extensions/bitbucket-deploy.md
+++ b/articles/extensions/bitbucket-deploy.md
@@ -175,7 +175,8 @@ __my-client.json__
 See [Management API v2 Docs](https://auth0.com/docs/api/management/v2#!/Clients/post_clients) for more info on allowed attributes for Clients and Client Grants.
 
 ### Deploy Clients Grants
-For each client, you can specify any client grants. For that you must create a JSON file under the `grants` directory.
+
+You can specify the client grants for each client by creating a JSON file in the `grants` directory.
 
 __my-client-api.json__
 ```json

--- a/articles/extensions/bitbucket-deploy.md
+++ b/articles/extensions/bitbucket-deploy.md
@@ -11,7 +11,7 @@ useCase: extensibility-extensions
 
 # Bitbucket Deployments
 
-The **Bitbucket Deployments** extension allows you to deploy [rules](/rules), rules configs, connections, database connection scripts, clients (and client grants), resource servers, hosted pages and email templates from Bitbucket to Auth0. You can configure a Bitbucket repository, keep all of your Rules and Database Connection scripts there, and have them automatically deployed to Auth0 whenever you push changes to your repository.
+The **Bitbucket Deployments** extension allows you to deploy [rules](/rules), rules configs, connections, database connection scripts, clients, client grants, resource servers, hosted pages and email templates from Bitbucket to Auth0. You can configure a Bitbucket repository, keep all of your Rules and Database Connection scripts there, and have them automatically deployed to Auth0 whenever you push changes to your repository.
 
 ## Configure the Extension
 
@@ -54,6 +54,8 @@ Once you have set up the webhook in Bitbucket using the provided information, yo
 
 With each commit you push to your configured Bitbucket repository, the webhook will call the extension to initiate a deployment if changes were made to one of these folders:
 - `clients`
+- `grants`
+- `emails`
 - `resource-servers`
 - `database-connections`
 - `rules-configs`
@@ -161,7 +163,7 @@ __secret_number.json__
 
 ### Deploy Clients
 
-To deploy a client, you must create a JSON file under the `clients` directory of your Bitbucket repository. For each JSON page, you can create a metafile (with the same name - `name.meta.json`) if you want to specify any client grants. Example:
+To deploy a client, you must create a JSON file under the `clients` directory of your Bitbucket repository. Example:
 
 __my-client.json__
 ```json
@@ -170,17 +172,21 @@ __my-client.json__
 }
 ```
 
-__my-client.meta.json__
+See [Management API v2 Docs](https://auth0.com/docs/api/management/v2#!/Clients/post_clients) for more info on allowed attributes for Clients and Client Grants.
+
+### Deploy Clients Grants
+For each client, you can specify any client grants. For that you must create a JSON file under the `grants` directory.
+
+__my-client-api.json__
 ```json
 {
+  "client_id": "my-client",
   "audience": "https://myapp.com/api/v1",
     "scope": [
       "read:users"
     ]
 }
 ```
-
-See [Management API v2 Docs](https://auth0.com/docs/api/management/v2#!/Clients/post_clients) for more info on allowed attributes for Clients and Client Grants.
 
 ### Deploy Resource Servers
 

--- a/articles/extensions/github-deploy.md
+++ b/articles/extensions/github-deploy.md
@@ -185,7 +185,8 @@ __my-client.json__
 See [Management API v2 Docs](https://auth0.com/docs/api/management/v2#!/Clients/post_clients) for more info on allowed attributes for Clients and Client Grants.
 
 ### Deploy Clients Grants
-For each client, you can specify any client grants. For that you must create a JSON file under the `grants` directory.
+
+You can specify the client grants for each client by creating a JSON file in the `grants` directory.
 
 __my-client-api.json__
 ```json

--- a/articles/extensions/github-deploy.md
+++ b/articles/extensions/github-deploy.md
@@ -11,7 +11,7 @@ useCase: extensibility-extensions
 
 # GitHub Deployments
 
-The **GitHub Deployments** extension allows you to deploy [rules](/rules), rules configs, connections, database connection scripts, clients (and client grants), resource servers, hosted pages and email templates from GitHub to Auth0. You can configure a GitHub repository, keep all your rules and database connection scripts there, and have them automatically deployed to Auth0 each time you push to your repository.
+The **GitHub Deployments** extension allows you to deploy [rules](/rules), rules configs, connections, database connection scripts, clients, client grants, resource servers, hosted pages and email templates from GitHub to Auth0. You can configure a GitHub repository, keep all your rules and database connection scripts there, and have them automatically deployed to Auth0 each time you push to your repository.
 
 ::: note
 You can use the `auth0-deploy-cli` tool to export and import tenant configuration data to a directory structure or a YAML file. For more information, see [Deploy CLI Tool Overview](/extensions/deploy-cli).
@@ -62,6 +62,8 @@ Once you have set up the webhook in GitHub using the provided information, you a
 
 With each commit you push to your configured GitHub repository, the webhook will call the extension to initiate a deployment if changes were made to one of these folders:
 - `clients`
+- `grants`
+- `emails`
 - `resource-servers`
 - `database-connections`
 - `rules-configs`
@@ -171,7 +173,7 @@ __secret_number.json__
 
 ### Deploy Clients
 
-To deploy a client, you must create a JSON file under the `clients` directory of your GitHub repository. For each JSON page, you can create a metafile (with the same name - `name.meta.json`) if you want to specify any client grants. Example:
+To deploy a client, you must create a JSON file under the `clients` directory of your GitHub repository. Example:
 
 __my-client.json__
 ```json
@@ -180,17 +182,21 @@ __my-client.json__
 }
 ```
 
-__my-client.meta.json__
+See [Management API v2 Docs](https://auth0.com/docs/api/management/v2#!/Clients/post_clients) for more info on allowed attributes for Clients and Client Grants.
+
+### Deploy Clients Grants
+For each client, you can specify any client grants. For that you must create a JSON file under the `grants` directory.
+
+__my-client-api.json__
 ```json
 {
+  "client_id": "my-client",
   "audience": "https://myapp.com/api/v1",
     "scope": [
       "read:users"
     ]
 }
 ```
-
-See [Management API v2 Docs](https://auth0.com/docs/api/management/v2#!/Clients/post_clients) for more info on allowed attributes for Clients and Client Grants.
 
 ### Deploy Resource Servers
 

--- a/articles/extensions/gitlab-deploy.md
+++ b/articles/extensions/gitlab-deploy.md
@@ -11,7 +11,7 @@ useCase: extensibility-extensions
 
 # GitLab Deployments
 
-The **GitLab Deployments** extension allows you to deploy [rules](/rules), rules configs, connections, database connection scripts, clients (and client grants), resource servers, hosted pages and email templates from GitLab to Auth0. You can configure a GitLab repository, keep all of your scripts there, and have them automatically deployed to Auth0 whenever you push changes to your repository.
+The **GitLab Deployments** extension allows you to deploy [rules](/rules), rules configs, connections, database connection scripts, clients, client grants, resource servers, hosted pages and email templates from GitLab to Auth0. You can configure a GitLab repository, keep all of your scripts there, and have them automatically deployed to Auth0 whenever you push changes to your repository.
 
 ## Configure the Auth0 extension
 
@@ -85,6 +85,8 @@ Once you have set up the webhook in GitLab using the provided information, you a
 
 With each commit you push to your configured GitLab repository, the webhook will call the extension to initiate a deployment if changes were made to one of these folders:
 - `clients`
+- `grants`
+- `emails`
 - `resource-servers`
 - `database-connections`
 - `rules-configs`
@@ -202,7 +204,7 @@ __secret_number.json__
 
 ### Deploy Clients
 
-To deploy a client, you must create a JSON file under the `clients` directory of your GitLab repository. For each JSON page, you can create a metafile (with the same name - `name.meta.json`) if you want to specify any client grants. Example:
+To deploy a client, you must create a JSON file under the `clients` directory of your GitLab repository. Example:
 
 __my-client.json__
 ```json
@@ -211,17 +213,21 @@ __my-client.json__
 }
 ```
 
-__my-client.meta.json__
+See [Management API v2 Docs](https://auth0.com/docs/api/management/v2#!/Clients/post_clients) for more info on allowed attributes for Clients and Client Grants.
+
+### Deploy Clients Grants
+For each client, you can specify any client grants. For that you must create a JSON file under the `grants` directory.
+
+__my-client-api.json__
 ```json
 {
+  "client_id": "my-client",
   "audience": "https://myapp.com/api/v1",
     "scope": [
       "read:users"
     ]
 }
 ```
-
-See [Management API v2 Docs](https://auth0.com/docs/api/management/v2#!/Clients/post_clients) for more info on allowed attributes for Clients and Client Grants.
 
 ### Deploy Resource Servers
 

--- a/articles/extensions/gitlab-deploy.md
+++ b/articles/extensions/gitlab-deploy.md
@@ -216,7 +216,8 @@ __my-client.json__
 See [Management API v2 Docs](https://auth0.com/docs/api/management/v2#!/Clients/post_clients) for more info on allowed attributes for Clients and Client Grants.
 
 ### Deploy Clients Grants
-For each client, you can specify any client grants. For that you must create a JSON file under the `grants` directory.
+
+You can specify the client grants for each client by creating a JSON file in the `grants` directory.
 
 __my-client-api.json__
 ```json

--- a/articles/extensions/visual-studio-team-services-deploy.md
+++ b/articles/extensions/visual-studio-team-services-deploy.md
@@ -220,7 +220,8 @@ __my-client.json__
 See [Management API v2 Docs](https://auth0.com/docs/api/management/v2#!/Clients/post_clients) for more info on allowed attributes for Clients and Client Grants.
 
 ### Deploy Clients Grants
-For each client, you can specify any client grants. For that you must create a JSON file under the `grants` directory.
+
+You can specify the client grants for each client by creating a JSON file in the `grants` directory.
 
 __my-client-api.json__
 ```json

--- a/articles/extensions/visual-studio-team-services-deploy.md
+++ b/articles/extensions/visual-studio-team-services-deploy.md
@@ -10,7 +10,7 @@ useCase: extensibility-extensions
 
 # Visual Studio Team Services Deployments
 
-The **Visual Studio Team Services Deployments** extension allows you to deploy [rules](/rules), rules configs, connections, database connection scripts, clients (and client grants), resource servers, hosted pages and email templates from Visual Studio Team Services to Auth0. You can configure a Visual Studio Team Services project, keep all of your scripts there, and have them automatically deployed to Auth0 whenever you push changes to your project.
+The **Visual Studio Team Services Deployments** extension allows you to deploy [rules](/rules), rules configs, connections, database connection scripts, clients, client grants, resource servers, hosted pages and email templates from Visual Studio Team Services to Auth0. You can configure a Visual Studio Team Services project, keep all of your scripts there, and have them automatically deployed to Auth0 whenever you push changes to your project.
 
 ## Configure the Auth0 Extension
 
@@ -92,6 +92,8 @@ Once you have set up the webhook in Visual Studio Team Services using the provid
 
 With each commit you push to your configured Visual Studio Team Services project, the webhook will call the extension to initiate a deployment if changes were made to one of these folders:
 - `clients`
+- `grants`
+- `emails`
 - `resource-servers`
 - `database-connections`
 - `rules-configs`
@@ -206,7 +208,7 @@ __secret_number.json__
 
 ### Deploy Clients
 
-To deploy a client, you must create a JSON file under the `clients` directory of your Visual Studio Team Services project. For each JSON page, you can create a metafile (with the same name - `name.meta.json`) if you want to specify any client grants. Example:
+To deploy a client, you must create a JSON file under the `clients` directory of your Visual Studio Team Services project. Example:
 
 __my-client.json__
 ```json
@@ -215,17 +217,21 @@ __my-client.json__
 }
 ```
 
-__my-client.meta.json__
+See [Management API v2 Docs](https://auth0.com/docs/api/management/v2#!/Clients/post_clients) for more info on allowed attributes for Clients and Client Grants.
+
+### Deploy Clients Grants
+For each client, you can specify any client grants. For that you must create a JSON file under the `grants` directory.
+
+__my-client-api.json__
 ```json
 {
+  "client_id": "my-client",
   "audience": "https://myapp.com/api/v1",
     "scope": [
       "read:users"
     ]
 }
 ```
-
-See [Management API v2 Docs](https://auth0.com/docs/api/management/v2#!/Clients/post_clients) for more info on allowed attributes for Clients and Client Grants.
 
 ### Deploy Resource Servers
 


### PR DESCRIPTION
Deployment of `client grants` was changed some time ago, yet we forgot to update docs.
Added missing "Clients Grants" section and removed misleading part of "Clients" section.