### PR TITLE
Update required external connectivity with SMTP

### DIFF
--- a/articles/appliance/infrastructure/ip-domain-port-list.md
+++ b/articles/appliance/infrastructure/ip-domain-port-list.md
@@ -197,7 +197,7 @@ Auth0 strives to keep these IP addresses stable, though this is not a given. Fro
     <td>SMTP</td>
     <td>Outbound</td>
     <td>SMTP Server(s)</td>
-    <td>25/465/587</td>
+    <td>25/587</td>
     <td>Allows sending of emails from the Appliance</td>
     <td>No</td>
   </tr>

--- a/articles/appliance/infrastructure/ip-domain-port-list.md
+++ b/articles/appliance/infrastructure/ip-domain-port-list.md
@@ -193,6 +193,14 @@ Auth0 strives to keep these IP addresses stable, though this is not a given. Fro
     <td>Required by the PSaaS Appliance to resolve host names internal and external to your environment</td>
     <td>Yes</td>
   </tr>
+  <tr>
+    <td>SMTP</td>
+    <td>Outbound</td>
+    <td>SMTP Server(s)</td>
+    <td>25/465/587</td>
+    <td>Allows sending of emails from the Appliance</td>
+    <td>No</td>
+  </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
Very few Appliance customers block outbound access, but some of them do. One customer recently ran into an issue where they weren't able to send emails because the appliance wasn't able to communicate with their SMTP server. They pointed out that SMTP was not on the listed of required connectivity, though it has been required for as long as the Appliance has existed.