### PR TITLE
[React Native Quickstart Guide] Remove --dev option from yarn install command

### DIFF
--- a/articles/quickstart/native/react-native/00-login.md
+++ b/articles/quickstart/native/react-native/00-login.md
@@ -61,7 +61,7 @@ npm install react-native-auth0 --save
 ### yarn
 
 ```bash
-yarn add --dev react-native-auth0
+yarn add react-native-auth0
 ```
 
 ::: note

--- a/articles/quickstart/native/react-native/_includes/_install.md
+++ b/articles/quickstart/native/react-native/_includes/_install.md
@@ -15,7 +15,7 @@ For more information about npm usage, check [their official documentation](https
 ### yarn
 
 ```bash
-yarn add --dev react-native-auth0
+yarn add react-native-auth0
 ```
 
 ::: note


### PR DESCRIPTION
For yarn, adding a `--dev` flag adds this dependency to `devDependencies`.  Since this dependency is for authentication to be used in a production environment eventually, I think we want to add this as a regular dependency, which is what `yarn add` will do.
