### PR TITLE
Changed "login page" for "login initiation endpoint"

### DIFF
--- a/articles/hosted-pages/default-login-url.md
+++ b/articles/hosted-pages/default-login-url.md
@@ -8,7 +8,7 @@ contentType: how-to
 ---
 # Configure Default Login Routes
 
-In certain cases (described below), Auth0 could need to redirect back to the application's login page, using [OIDC Third Party Initiated Login](https://openid.net/specs/openid-connect-core-1_0.html#ThirdPartyInitiatedLogin).
+In certain cases (described below), Auth0 could need to redirect back to the application's login initiation endpoint, using [OIDC Third Party Initiated Login](https://openid.net/specs/openid-connect-core-1_0.html#ThirdPartyInitiatedLogin).
 
 You can configure the URL for the tenant or application login route using a Management API call:
 


### PR DESCRIPTION
Changed "login page" for "login initiation endpoint", the term used in the OIDC spec, which is more appropriate here (as the application might not have a real "login page").