### PR TITLE
Update heading for CSRF Attacks

### DIFF
--- a/articles/users/guides/impersonate-users-using-the-dashboard.md
+++ b/articles/users/guides/impersonate-users-using-the-dashboard.md
@@ -33,7 +33,7 @@ Any [Rules](/rules) that you have implemented will run when you impersonate a us
 Impersonation **does not work** with the [API Authorization](/api-auth) features. This means that the `audience` parameter will be ignored, and the [Access Token](/tokens/concepts/overview-access-tokens) returned to applications when using this flow is only valid for requests to [the /userinfo endpoint](/api/authentication#get-user-info). 
 :::
 
-## Login CSRF attack mitigation
+## Impersonation and Login CSRF Attacks
 
 To avoid [Login CSRF attacks](/protocols/oauth2/mitigate-csrf-attacks), the OAuth 2.0 specification recommends that applications use the **state** parameter to make sure that the response they receive matches the authentication request and originates from the same session.
 

--- a/articles/users/guides/impersonate-users-using-the-dashboard.md
+++ b/articles/users/guides/impersonate-users-using-the-dashboard.md
@@ -33,7 +33,7 @@ Any [Rules](/rules) that you have implemented will run when you impersonate a us
 Impersonation **does not work** with the [API Authorization](/api-auth) features. This means that the `audience` parameter will be ignored, and the [Access Token](/tokens/concepts/overview-access-tokens) returned to applications when using this flow is only valid for requests to [the /userinfo endpoint](/api/authentication#get-user-info). 
 :::
 
-## Impersonation and Login CSRF Attacks
+## Impersonation and Login CSRF attacks
 
 To avoid [Login CSRF attacks](/protocols/oauth2/mitigate-csrf-attacks), the OAuth 2.0 specification recommends that applications use the **state** parameter to make sure that the response they receive matches the authentication request and originates from the same session.
 


### PR DESCRIPTION
The prior heading could be misinterpreted as a mitigation section, when it was actually referring to the fact that Impersonation requires an application to *not* check the state parameter which could allow for a successful CSRF login attack.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors
- Please include a short description
- If your PR is a work in progress, title it [DO NOT MERGE]
--->
