### PR TITLE
Change login page for login initiation endpoint

### DIFF
--- a/articles/universal-login/default-login-url.md
+++ b/articles/universal-login/default-login-url.md
@@ -8,7 +8,7 @@ contentType: how-to
 ---
 # Configure Default Login Routes
 
-In certain cases (described below), Auth0 could need to redirect back to the application's login page, using [OIDC Third Party Initiated Login](https://openid.net/specs/openid-connect-core-1_0.html#ThirdPartyInitiatedLogin).
+In certain cases (described below), Auth0 could need to redirect back to the application's login initiation endpoint, using [OIDC Third Party Initiated Login](https://openid.net/specs/openid-connect-core-1_0.html#ThirdPartyInitiatedLogin).
 
 You can configure the URL for the tenant or application login route using a Management API call:
 

--- a/config/redirects.js
+++ b/config/redirects.js
@@ -1342,6 +1342,10 @@ module.exports = [
     to: '/universal-login/custom-error-pages'
   },
   {
+    from: '/hosted-pages/default-login-url',
+    to: '/universal-login/default-login-url'
+  },
+  {
     from: '/connections/database/mysql',
     to: '/connections/database/custom-db'
   },


### PR DESCRIPTION
Changed the wording from "application's login page" to "application's login initiation endpoint" to be more in line with the OIDC spec (will be helpful for searches). It's also more correct in that most apps won't really have a login page, but simply redirect to Auth0.


