### PR TITLE
Removed window.location.hash = '';. It triggered an additional router…

### DIFF
--- a/articles/quickstart/spa/angular2/_includes/_centralized_login.md
+++ b/articles/quickstart/spa/angular2/_includes/_centralized_login.md
@@ -86,7 +86,6 @@ export class AuthService {
   public handleAuthentication(): void {
     this.auth0.parseHash((err, authResult) => {
       if (authResult && authResult.accessToken && authResult.idToken) {
-        window.location.hash = '';
         this.localLogin(authResult);
         this.router.navigate(['/home']);
       } else if (err) {


### PR DESCRIPTION
… event which cancels the subsequent router.navigate call.

Without removing or commenting this line, I was unable to navigate to the login redirect url. It would begin navigating, but then would be interrupted by another router event that was triggered by the hash change. 

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors
- Please include a short description
- If your PR is a work in progress, title it [DO NOT MERGE]
--->
