### PR TITLE
Updating a bad link + altering HLP terminology

### DIFF
--- a/articles/extensions/bitbucket-deploy.md
+++ b/articles/extensions/bitbucket-deploy.md
@@ -11,7 +11,7 @@ useCase: extensibility-extensions
 
 # Bitbucket Deployments
 
-The **Bitbucket Deployments** extension allows you to deploy [rules](/rules), rules configs, connections, database connection scripts, clients, client grants, resource servers, hosted pages and email templates from Bitbucket to Auth0. You can configure a Bitbucket repository, keep all of your Rules and Database Connection scripts there, and have them automatically deployed to Auth0 whenever you push changes to your repository.
+The **Bitbucket Deployments** extension allows you to deploy [rules](/rules), rules configs, connections, database connection scripts, clients, client grants, resource servers, Universal Login pages and email templates from Bitbucket to Auth0. You can configure a Bitbucket repository, keep all of your Rules and Database Connection scripts there, and have them automatically deployed to Auth0 whenever you push changes to your repository.
 
 ## Configure the Extension
 
@@ -114,9 +114,10 @@ _This will work only for non-Auth0 connections (`strategy !== auth0`); for Auth0
 
 See [Management API v2 Docs](https://auth0.com/docs/api/management/v2#!/Connections/post_connections) for more info on allowed attributes for Connections.
 
-### Deploy Hosted Pages
+### Deploy Universal Login Pages
 
-The supported hosted pages are:
+The supported pages are:
+
 - `error_page`
 - `guardian_multifactor`
 - `login`

--- a/articles/extensions/github-deploy.md
+++ b/articles/extensions/github-deploy.md
@@ -124,9 +124,10 @@ _This will work only for non-Auth0 connections (`strategy !== auth0`); for Auth0
 
 See [Management API v2 Docs](https://auth0.com/docs/api/management/v2#!/Connections/post_connections) for more info on allowed attributes for Connections.
 
-### Deploy Hosted Pages
+### Deploy Universal Login Pages
 
-The supported hosted pages are:
+The supported pages are:
+
 - `error_page`
 - `guardian_multifactor`
 - `login`

--- a/articles/extensions/visual-studio-team-services-deploy.md
+++ b/articles/extensions/visual-studio-team-services-deploy.md
@@ -1,5 +1,5 @@
 ---
-description: The Visual Studio Team Services Deployments extension allows you to deploy Rules, Hosted Pages and Database Connection scripts from Visual Studio Team Services to Auth0.
+description: The Visual Studio Team Services Deployments extension allows you to deploy Rules, Universal Login pages and database connection scripts from Visual Studio Team Services to Auth0.
 topics:
   - extensions
   - vs-team-services-deployments
@@ -10,7 +10,7 @@ useCase: extensibility-extensions
 
 # Visual Studio Team Services Deployments
 
-The **Visual Studio Team Services Deployments** extension allows you to deploy [rules](/rules), rules configs, connections, database connection scripts, clients, client grants, resource servers, hosted pages and email templates from Visual Studio Team Services to Auth0. You can configure a Visual Studio Team Services project, keep all of your scripts there, and have them automatically deployed to Auth0 whenever you push changes to your project.
+The **Visual Studio Team Services Deployments** extension allows you to deploy [rules](/rules), rules configs, connections, database connection scripts, clients, client grants, resource servers, Universal Login pages and email templates from Visual Studio Team Services to Auth0. You can configure a Visual Studio Team Services project, keep all of your scripts there, and have them automatically deployed to Auth0 whenever you push changes to your project.
 
 ## Configure the Auth0 Extension
 
@@ -152,9 +152,10 @@ _This will work only for non-Auth0 connections (`strategy !== auth0`), for Auth0
 
 See [Management API v2 Docs](https://auth0.com/docs/api/management/v2#!/Connections/post_connections) for more info on allowed attributes for Connections.
 
-### Deploy Hosted Pages
+### Deploy Universal Login Pages
 
-The supported hosted pages are:
+The supported pages are:
+
 - `error_page`
 - `guardian_multifactor`
 - `login`

--- a/articles/guides/login/universal-vs-embedded.md
+++ b/articles/guides/login/universal-vs-embedded.md
@@ -54,7 +54,7 @@ Note that if the incoming authentication request uses an external identity provi
 You can deploy your custom login page from an external repository, like [GitHub](/extensions/github-deploy#deploy-hosted-pages), [Bitbucket](/extensions/bitbucket-deploy#deploy-hosted-pages), [GitLab](/extensions/gitlab-deploy#deploy-hosted-pages), or [Visual Studio Team Services](/extensions/visual-studio-team-services-deploy#deployment).
 :::
 
-Our recommendation is to use Universal Login when you use Auth0. The first and foremost reason is security. Using Auth0 hosted pages instead of hosting them externally provides seamless CSRF protection. This helps prevent third-party impersonation or the hijacking of sessions.
+Our recommendation is to use Universal Login when you use Auth0. The first and foremost reason is security. Using Auth0 Universal Login instead of embedding login in your application provides seamless CSRF protection. This helps prevent third-party impersonation or the hijacking of sessions.
 
 ## Embedded login with Auth0
 

--- a/articles/universal-login/guardian.md
+++ b/articles/universal-login/guardian.md
@@ -9,13 +9,13 @@ useCase: customize-hosted-pages
 ---
 # Guardian Multi-factor Login Page
 
-In the [Auth0 Dashboard](${manage_url}/#/guardian_mfa_page), you can enable 2nd factor authentication, using Guardian Multi-factor. You can customize the page that Auth0 displays to your users, allowing you to require MFA on logins which meet certain criteria, or just across the board. For more information on the MFA page, refer to [Hosted Pages > MFA](/hosted-pages/guardian).
+In the [Auth0 Dashboard](${manage_url}/#/guardian_mfa_page), you can enable 2nd factor authentication, using Guardian Multi-factor. You can customize the page that Auth0 displays to your users, allowing you to require MFA on logins which meet certain criteria, or just across the board. For more information on the MFA page, refer to [Universal Login > MFA](/universal-login/guardian).
 
-![Hosted Guardian MFA Page](/media/articles/hosted-pages/guardian.png)
+![Universal Login Guardian MFA Page](/media/articles/hosted-pages/guardian.png)
 
 ## Guardian Login Page HTML Editor
 
-To customize the Guardian Login page, go to [Dashboard > Hosted Pages > Guardian Multi-factor](${manage_url}/#/guardian_mfa_page) and enable the __Customize Guardian Page__ switch.
+To customize the Guardian Login page, go to [Dashboard > Universal Login > Guardian Multi-factor](${manage_url}/#/guardian_mfa_page) and enable the __Customize Guardian Page__ switch.
 
 Once you do that, you'll be able to use the text editor built into the Auth0 Dashboard to change your HTML, style your page using CSS, and alter the JavaScript used to retrieve custom variables. Once you've made your changes, and make sure to click __Save__.
 

--- a/articles/universal-login/version-control.md
+++ b/articles/universal-login/version-control.md
@@ -1,14 +1,14 @@
 ---
-description: How to back up your hosted pages using the Auth0 version control extensions
+description: How to back up your Universal Login pages using the Auth0 version control extensions
 topics:
   - version-control
   - hosted-pages
 contentType: how-to
 useCase: customize-hosted-pages
 ---
-# How to Use Version Control to Manage Your Hosted Pages
+# How to Use Version Control to Manage Your Universal Login Pages
 
-You can use version control software to manage the source code of your hosted pages.
+You can use version control software to manage the source code of your pages.
 To do so, you can use the Auth0-provided extension that works with the version control system you're using:
 
 * [GitLab Extension](/extensions/gitlab-deploy#deploy-hosted-pages)

--- a/config/redirects.js
+++ b/config/redirects.js
@@ -1346,6 +1346,10 @@ module.exports = [
     to: '/universal-login/default-login-url'
   },
   {
+    from: '/hosted-pages/guardian',
+    to: '/universal-login/guardian'
+  },
+  {
     from: '/connections/database/mysql',
     to: '/connections/database/custom-db'
   },


### PR DESCRIPTION
https://docs-content-staging-pr-7271.herokuapp.com/docs/hosted-pages/guardian -> 
https://docs-content-staging-pr-7271.herokuapp.com/docs/universal-login/guardian

Also updated this link wherever it appeared

Also updated "Hosted Pages" terminology wherever it appeared