### PR TITLE
Add warning about ULP to Lock Popup mode docs

### DIFF
--- a/articles/libraries/lock/v11/authentication-modes.md
+++ b/articles/libraries/lock/v11/authentication-modes.md
@@ -37,11 +37,14 @@ var lock = new Auth0Lock(
 );
 ```
 
-## Database connections and popup mode
-
 ::: note
 Multifactor authentication does not work in popup mode.
 :::
+
+::: note
+Popup mode does not work with [Universal Login](/hosted-pages/login).
+:::
+
 
 Some Auth0 features such as [SSO](/sso/single-sign-on) between multiple applications depend on users being redirected to Auth0 to set a cookie on `'${account.namespace}'`.
 

--- a/articles/libraries/lock/v11/authentication-modes.md
+++ b/articles/libraries/lock/v11/authentication-modes.md
@@ -45,7 +45,6 @@ Multifactor authentication does not work in popup mode.
 Popup mode does not work with [Universal Login](/hosted-pages/login).
 :::
 
-
 Some Auth0 features such as [SSO](/sso/single-sign-on) between multiple applications depend on users being redirected to Auth0 to set a cookie on `'${account.namespace}'`.
 
 When using popup mode, a popup window will be displayed in order to set this cookie. If prompts are unnecessary, this popup window will be blank and be in a hidden iframe to minimize disruption. The reason for this is that cross-origin requests sent from your application to Auth0 are not be able to set cookies.


### PR DESCRIPTION
Convo about this: https://auth0.slack.com/archives/C9F94RE0K/p1551278274081600?thread_ts=1551269760.081300&cid=C9F94RE0K

Also, removed the heading 'Database connections and popup mode' because it didn't make any sense to have it there. What's under that heading has no relationship to database connections. 