### PR TITLE
broken link to Lock v10 API fixed

### DIFF
--- a/articles/analytics/integrations/_usage.md
+++ b/articles/analytics/integrations/_usage.md
@@ -17,4 +17,4 @@ You will see the following events being logged:
 
 Note that some events that Lock emits like `hash_parsed` are not used for analytics purposes. Also, be aware that some events are only available in newer versions of Lock. If you are using an older version of Lock you will only see some of these events. We suggest upgrading to the latest version of Lock to get the most of the Auth0 Analytics integration.
 
-For more information on the events that are sent see the [Lock API documentation](/libraries/lock/v10/api).
+For more information on the events that are sent see the [Lock API documentation](/libraries/lock/v11/api#on-).


### PR DESCRIPTION
Broken Link to Lock v10 API Documentation [here](https://auth0.com/docs/analytics/integrations/google-analytics#usage).

Changed URL to point to Lock v11's Events emitted: https://auth0.com/docs/libraries/lock/v11/api#on-
