### PR TITLE
Lock API doc anchor link fixed.

### DIFF
--- a/articles/libraries/lock/v11/api.md
+++ b/articles/libraries/lock/v11/api.md
@@ -12,7 +12,7 @@ useCase:
 ---
 # Lock API Reference
 
-Lock has many methods, features, and configurable options. This reference is designed to direct you to the ones that you need, and discuss how to use them. Click below to go straight the method you're looking for, or just browse! If you're looking for information about events emitted by Lock, they're listed under the [on()](#on-event-callback-) method section!
+Lock has many methods, features, and configurable options. This reference is designed to direct you to the ones that you need, and discuss how to use them. Click below to go straight the method you're looking for, or just browse! If you're looking for information about events emitted by Lock, they're listed under the [on()](#on-) method section!
 
 - [new Auth0Lock](#auth0lock) - Instantiating Lock
 - [getUserInfo()](#getuserinfo-) - Obtaining the profile of a logged in user


### PR DESCRIPTION
Fixed anchor link to correctly point to on() method events.

OLD URL: https://auth0.com/docs/libraries/lock/v11/api#on-event-callback-

NEW one: https://auth0.com/docs/libraries/lock/v11/api#on-
