### PR TITLE
Fixed incorrect reference to authConfig in VueJS Quickstart sample 03

### DIFF
--- a/articles/quickstart/spa/vuejs/03-calling-an-api.md
+++ b/articles/quickstart/spa/vuejs/03-calling-an-api.md
@@ -88,10 +88,10 @@ Then, modify the `webAuth` creation to include `token` in the response type and 
 // src/auth/authService.js
 
 const webAuth = new auth0.WebAuth({
-  domain: AUTH_CONFIG.domain,
+  domain: authConfig.domain,
   redirectUri: `<%= "${window.location.origin}" %>/callback`,
-  clientID: AUTH_CONFIG.clientId,
-  audience: AUTH_CONFIG.audience,   // add the audience
+  clientID: authConfig.clientId,
+  audience: authConfig.audience,   // add the audience
   responseType: "token id_token",   // request 'token' as well as 'id_token'
   scope: "openid profile email"
 });


### PR DESCRIPTION
This PR fixes an incorrect reference to `authConfig` in a code sample.

This a sample that asks the user to modify a piece of code that was created in the first tutorial, where the variable name is correct.