### PR TITLE
Replace rules supported modules with link to auth0-extensions "Can I Require"

### DIFF
--- a/articles/rules/_includes/_supported-modules.md
+++ b/articles/rules/_includes/_supported-modules.md
@@ -1,0 +1,1 @@
+Rules run in a JavaScript sandbox. The sandbox supports the ECMAScript 6 language and a large number of Node.js (version 8+) modules. For a list of supported sandbox modules, check out [Can I require: Auth0 Extensibility](https://auth0-extensions.github.io/canirequire/).

--- a/articles/rules/index.md
+++ b/articles/rules/index.md
@@ -59,4 +59,4 @@ Rules execute in the order shown on the Auth0 Dashboard. If a rule depends on th
 
 For security reasons, your Rules code executes isolated from the code of other Auth0 tenants in a sandbox. 
 
-Within the sandbox, you can access the full power of Node.js with a large number of Node.js modules. For a list of currently supported sandbox modules, see [Node.js Modules Available in Rules](/rules/references/modules)
+<%= include('./_includes/_supported-modules.md') %> 

--- a/articles/rules/references/modules.md
+++ b/articles/rules/references/modules.md
@@ -10,36 +10,4 @@ useCase: extensibility-rules
 
 # Node.js Modules Available in Rules
 
-Rules run in a JavaScript sandbox. The sandbox supports the ECMAScript 6 language and the following Node.js (version 8+) modules and libraries:
-
-| Module | Version |
-|--------|--------:|
-| [async](https://github.com/caolan/async) | ~2.1.2 |
-| [auth0](https://github.com/auth0/node-auth0) | 2.13.0a |
-| [azure_storage](https://github.com/Azure/azure-storage-node) | ~0.9.0 |
-| [bcrypt](https://github.com/ncb000gt/node.bcrypt.js) | ~3.0.0 |
-| [Buffer](http://nodejs.org/docs/v0.10.24/api/buffer.html)
-| [cql](https://github.com/jorgebay/node-cassandra-cql) | ~0.4.4 |
-| [crypto](http://nodejs.org/docs/v0.10.24/api/crypto.html)
-| [ip](https://github.com/keverw/range_check) | 0.3.2 |
-| [jwt](https://github.com/auth0/node-jsonwebtoken) | ~7.1.9 |
-| [knex](http://knexjs.org) | ~0.8.6 |
-| [lodash](https://github.com/lodash/lodash) | ~4.17.10 |
-| [mongodb](https://github.com/mongodb/node-mongodb-native) | ~2.0.33 |
-| [BSON (mongodb)](http://mongodb.github.io/node-mongodb-native/api-bson-generated/bson.html) | 0.3.2 |
-| [Double (mongodb)](http://mongodb.github.io/node-mongodb-native/api-bson-generated/double.html) | |
-| [Long (mongodb)](http://mongodb.github.io/node-mongodb-native/api-bson-generated/long.html) | |
-| [ObjectID (mongodb)](http://mongodb.github.io/node-mongodb-native/api-bson-generated/objectid.html) | |
-| [Timestamp (mongodb)](http://mongodb.github.io/node-mongodb-native/api-bson-generated/timestamp.html) | |
-| [mysql](https://github.com/felixge/node-mysql) | ~2.15.0 |
-| [pbkdf2](https://github.com/davidmurdoch/easy-pbkdf2) | 0.1.1 |
-| [pg](https://github.com/brianc/node-postgres) | 6.1.2 |
-| [pubnub](https://github.com/pubnub/javascript/tree/master/node.js) | 3.7.11 |
-| [q](https://github.com/kriskowal/q) | ~1.1.1 |
-| [querystring](http://nodejs.org/api/querystring.html) | 0.2.0 |
-| [request](https://github.com/mikeal/request) | ~2.81.0 |
-| [uuid](https://github.com/broofa/node-uuid) | ~3.3.2 |
-| [xml2js](https://github.com/Leonidas-from-XIV/node-xml2js) | ~0.4.8 |
-| [xmldom](https://github.com/jindw/xmldom) | ~0.1.19 |
-| [xpath](https://github.com/goto100/xpath) | 0.0.9 |
-| [xtend](https://github.com/Raynos/xtend) | ~4.0.0 |
+<%= include('../_includes/_supported-modules.md') %> 


### PR DESCRIPTION
* Remove incomplete table/listing of supported Node.JS modules on /rules/references/modules
* Create partial with link to https://auth0-extensions.github.io/canirequire/
* Add partial to /rules/references/modules and /rules/