### PR TITLE
Fix outdated documentation

### DIFF
--- a/articles/quickstart/backend/nodejs/01-authorization.md
+++ b/articles/quickstart/backend/nodejs/01-authorization.md
@@ -19,6 +19,22 @@ useCase: quickstart
 
 ## Validate Access Tokens
 
+### Enable RBAC
+*Important* if you do not enable RBAC, the check scopes will merely validate that the scope itself is configured on the API but will not actually validate whether the user has been granted those permissions. 
+Note to Auth0: It is very easy to get a false positive from the examples given which indicate a route is secured by a scope when it is actully merely validating the user has been authenticated and the scope declared.
+
+* From the Auth0 dashboard select the relevant API (identifier: http://localhost:3001/scaffold)
+* On the RBAC section of the settings Tab:
+  * Enable "Enable RBAC"
+  * Enable "Add Permissions in the Access Token"
+
+### Assign permissions to your user
+* From the Auth0 dashboard select "Users & Roles" > Users
+* Select the User you wish to grant permission for
+* On the permissions tab select "Assign Permissions"
+* Select the API and assign permissions
+* Now when you login as a user without Permission you should receive a 403
+
 ### Install dependencies
 
 This guide shows you how to validate the token using the [express-jwt](https://github.com/auth0/express-jwt) middleware and how to check for appropriate scopes with the [express-jwt-authz](https://github.com/auth0/express-jwt-authz) middleware. 


### PR DESCRIPTION
The documentation is wrong/outdated and the implementation seems dubious (if you were to click disable RBAC by mistake it would open all your routes rather than close them, which seems the wrong way around).  I lost a lot of time on this, it's very confusing.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors
- Please include a short description
- If your PR is a work in progress, title it [DO NOT MERGE]
--->
