### PR TITLE
NodeJS Quickstart: Logout from Auth0 authorization server

### DIFF
--- a/articles/quickstart/webapp/nodejs/01-login.md
+++ b/articles/quickstart/webapp/nodejs/01-login.md
@@ -16,6 +16,8 @@ github:
 ---
 <%= include('../_includes/_getting_started', { library: 'Node.js', callback: 'http://localhost:3000/callback' }) %>
 
+<%= include('../../../_includes/_logout_url') %>
+
 ## Configure Node.js to use Auth0
 
 ### Create the .env file
@@ -142,9 +144,9 @@ passport.deserializeUser(function (user, done) {
 In this example, following routes are implemented:
 
 * `/login` triggers the authentication by calling Passport's `authenticate` method. The user is then redirected to the tenant login page hosted by Auth0.
-* `/callback`is the route the user is returned to by Auth0 after authenticating. It redirects the user to the profile page (`/user`).
+* `/callback` is the route the user is returned to by Auth0 after authenticating. It redirects the user to the profile page (`/user`).
 * `/user` displays the user's profile.
-* `/logout` closes the local user session and redirects the user again to the root index `/`.
+* `/logout` closes the local user session, logout the user at authorization server and redirects the user again to the root index `/`.
 
 We will use the following routers:
 
@@ -164,6 +166,12 @@ In the authentication step, make sure to pass the `scope` parameter with values 
 var express = require('express');
 var router = express.Router();
 var passport = require('passport');
+var dotenv = require('dotenv');
+var util = require('util');
+var url = require('url');
+var querystring = require('querystring');
+
+dotenv.config();
 
 // Perform the login, after login Auth0 will redirect to callback
 router.get('/login', passport.authenticate('auth0', {
@@ -189,6 +197,22 @@ router.get('/callback', function (req, res, next) {
 // Perform session logout and redirect to homepage
 router.get('/logout', (req, res) => {
   req.logout();
+
+  var returnTo = util.format(
+    '%s://%s:%s',
+    req.protocol,
+    req.hostname,
+    req.connection.localPort
+  );
+  var logoutURL = new URL(
+    util.format('https://%s/logout', process.env.AUTH0_DOMAIN)
+  );
+  var queryString = querystring.stringify({
+    client_id: process.env.AUTH0_CLIENT_ID,
+    returnTo: returnTo
+  });
+  logoutURL.search = queryString;
+
   res.redirect('/');
 });
 
@@ -196,7 +220,7 @@ module.exports = router;
 ```
 
 :::note
-This tutorial implements logout by closing the local user session. After logging out, the user's session in the Auth0 authentication server is still open. For other implementations, please refer to the [logout documentation](/logout). 
+This tutorial implements logout by closing the local user session and the user's session in the Auth0 authentication server as well. For other implementations, please refer to the [logout documentation](/logout).
 :::
 
 ### Middleware to protect routes

--- a/articles/quickstart/webapp/nodejs/01-login.md
+++ b/articles/quickstart/webapp/nodejs/01-login.md
@@ -146,7 +146,7 @@ In this example, following routes are implemented:
 * `/login` triggers the authentication by calling Passport's `authenticate` method. The user is then redirected to the tenant login page hosted by Auth0.
 * `/callback` is the route the user is returned to by Auth0 after authenticating. It redirects the user to the profile page (`/user`).
 * `/user` displays the user's profile.
-* `/logout` closes the local user session, logout the user at authorization server and redirects the user again to the root index `/`.
+* `/logout` logs the user out of Auth0.
 
 We will use the following routers:
 
@@ -220,7 +220,7 @@ module.exports = router;
 ```
 
 :::note
-This tutorial implements logout by closing the local user session and the user's session in the Auth0 authentication server as well. For other implementations, please refer to the [logout documentation](/logout).
+This tutorial implements logout by closing the local user session and the user's Auth0 session as well. For other implementations, please refer to the [logout documentation](/logout).
 :::
 
 ### Middleware to protect routes

--- a/articles/quickstart/webapp/nodejs/01-login.md
+++ b/articles/quickstart/webapp/nodejs/01-login.md
@@ -198,22 +198,21 @@ router.get('/callback', function (req, res, next) {
 router.get('/logout', (req, res) => {
   req.logout();
 
-  var returnTo = util.format(
-    '%s://%s:%s',
-    req.protocol,
-    req.hostname,
-    req.connection.localPort
-  );
+  var returnTo = req.protocol + '://' + req.hostname;
+  var port = req.connection.localPort;
+  if (port !== undefined && port !== 80 && port !== 443) {
+    returnTo += ':' + port;
+  }
   var logoutURL = new URL(
     util.format('https://%s/logout', process.env.AUTH0_DOMAIN)
   );
-  var queryString = querystring.stringify({
+  var searchString = querystring.stringify({
     client_id: process.env.AUTH0_CLIENT_ID,
     returnTo: returnTo
   });
-  logoutURL.search = queryString;
+  logoutURL.search = searchString;
 
-  res.redirect('/');
+  res.redirect(logoutURL);
 });
 
 module.exports = router;


### PR DESCRIPTION
<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors
- Please include a short description
- If your PR is a work in progress, title it [DO NOT MERGE]
--->
Clear session at Auth0 authorization server calling `/v2/logout` endpoint when perform logout.
Sample also updated at: auth0-samples/auth0-nodejs-webapp-sample#44.