### PR TITLE
QS-61: Added 'api' to 'sample_download_required_data'

### DIFF
--- a/articles/quickstart/spa/vuejs/03-calling-an-api.md
+++ b/articles/quickstart/spa/vuejs/03-calling-an-api.md
@@ -11,6 +11,7 @@ github:
   path: 03-calling-an-api
 sample_download_required_data:
   - client
+  - api
 contentType: tutorial
 useCase: quickstart
 ---


### PR DESCRIPTION
Should fix an issue with the API_IDENTIFIER key not being populated when the associated sample is downloaded.

Context: https://github.com/auth0-samples/auth0-vue-samples/issues/67
