### PR TITLE
Update calling API for security language

### DIFF
--- a/articles/quickstart/spa/angular2/03-calling-an-api.md
+++ b/articles/quickstart/spa/angular2/03-calling-an-api.md
@@ -81,7 +81,8 @@ interface IApiResponse {
 // ...
 export class PingComponent {
 
-  API_URL: string = 'http://<your-application-domain>/api';
+  // Security note: API uses https to avoid bearer token leakage
+  API_URL: string = 'https://<your-application-domain>/api';
   message: string;
 
   constructor(public auth: AuthService, private http: HttpClient) {}


### PR DESCRIPTION
This PR adds a note in the sample code to call out the necessity of using https and sets the API_URL sample code to an https scheme. Alternative wording is welcome.