### PR TITLE
adds /authorize rate limits [IPS-205]

### DIFF
--- a/articles/policies/rate-limits.md
+++ b/articles/policies/rate-limits.md
@@ -216,6 +216,23 @@ The following Auth0 Authentication API endpoints return rate limit-related heade
     <td>100 requests per second</td>
   </tr>
   <tr>
+    <td rowspan="3">Authentication and authorization</td>
+    <td rowspan="3">/authorize</td>
+    <td>IP</td>
+    <td>Non-Free (*)</td>
+    <td>500 requests per minute</td>
+  </tr>
+  <tr>
+    <td>(any request)</td>
+    <td>Free (*)</td>
+    <td>300 requests per minute</td>
+  </tr>
+  <tr>
+    <td>Session</td>
+    <td>All</td>
+    <td>10 requests per second</td>
+  </tr>
+  <tr>
     <td rowspan="2">User Profile</td>
     <td>/tokeninfo (legacy)</td>
     <td>IP</td>

--- a/updates/2019-03-27.yml
+++ b/updates/2019-03-27.yml
@@ -1,0 +1,8 @@
+changed:
+  -
+    title: "API Rate Limits"
+    tags:
+      - api
+      - ratelimits
+    description: |
+      Updated the [Rate Limit Policy](/rate-limits) to reflect the new limits on the `/authorize` path.


### PR DESCRIPTION
Adds the `/authorize` rate limits to our public docs.

![image](https://user-images.githubusercontent.com/161006/54833968-0e0d7580-4cb7-11e9-9129-4a263f9b4e3a.png)
