### PR TITLE
Fix broken quickstart link and typo

### DIFF
--- a/articles/universal-login/index.md
+++ b/articles/universal-login/index.md
@@ -28,7 +28,7 @@ For information on the differences between Universal Login and traditional embed
 
 In addition to configuring Universal Login for your tenant's applications, you will also need to set up a connection(s) and set up your application in Auth0's dashboard. You will also need to configure your application's code to call Auth0's `/authorize` endpoint in order to trigger Universal Login, and then to deal with the response.
 
-For step by step instructions on setting up your application to use Universal Login, check out our [Quickstart guides](/docs/quickstart).
+For step by step instructions on setting up your application to use Universal Login, check out our [Quickstart guides](/quickstarts).
 
 ### Simple Customization
 


### PR DESCRIPTION
original points to https://auth0.com/docs/docs/quickstart
now should point to https://auth0.com/docs/quickstarts

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors
- Please include a short description
- If your PR is a work in progress, title it [DO NOT MERGE]
--->
