### PR TITLE
removed user.logins_count from user object in rules

### DIFF
--- a/articles/rules/references/user-object.md
+++ b/articles/rules/references/user-object.md
@@ -28,7 +28,6 @@ The following properties are available for the `user` object.
 | `user.multifactor` | text | List of the user's enrolled multi-factor providers. |
 | `user.last_ip` | text | IP address associated with the user's last login. |
 | `user.last_login` | date&nbsp;time | Timestamp of when the user last logged in. |
-| `user.logins_count` | integer | Number of times the user has logged in. |
 | `user.name` | text | The user's name. |
 | `user.nickname` | text | The user's nickname. |
 | `user.last_password_reset` | date&nbsp;time | Last time the password was reset or changed. |

--- a/articles/users/references/user-profile-structure.md
+++ b/articles/users/references/user-profile-structure.md
@@ -43,7 +43,6 @@ Auth0 also supports the ability for users to [link their profile to multiple ide
 | `multifactor`   | text    | The list of multi-factor providers in which the user is enrolled. |
 | `last_ip`       | text    | The IP address associated with the user's last login. |
 | `last_login`    | date&nbsp;time   | The timestamp of when the user last logged in. If you are using this property from inside a [Rule](/rules) using the `user` object, its value will be associated with the login that triggered the rule (since rules execute after the actual login). |
-| `logins_count`  | integer | The number of times the user has logged in. If a user is blocked and logs in, the blocked session is counted in `logins_count` and updates the `last_login` value. |
 | `name`          | text     | The user's name. |
 | `nickname`      | text     | The user's nickname. |
 | `last_password_reset` | date&nbsp;time | The last time the password was reset/changed. |


### PR DESCRIPTION
`user.logins_count` is not available in Rules (anymore?).

Users are expected to use `context.stats.loginsCount` to check for number of times a user has logged in: https://auth0.com/docs/rules/references/context-object