### PR TITLE
Update Deployment Options doc

### DIFF
--- a/articles/appliance/admin/backing-up-the-appliance-instances.md
+++ b/articles/appliance/admin/backing-up-the-appliance-instances.md
@@ -7,6 +7,7 @@ topics:
 contentType: concept
 useCase: appliance
 applianceId: appliance1
+sitemap: false
 ---
 
 # PSaaS Appliance Administration: Appliance Backups

--- a/articles/appliance/admin/disabling-sign-ups.md
+++ b/articles/appliance/admin/disabling-sign-ups.md
@@ -7,6 +7,7 @@ topics:
 contentType: how-to
 useCase: appliance
 applianceId: appliance3
+sitemap: false
 ---
 
 # PSaaS Appliance Administration: Disabling Sign-Ups

--- a/articles/appliance/admin/federated-access-to-manage.md
+++ b/articles/appliance/admin/federated-access-to-manage.md
@@ -8,6 +8,7 @@ topics:
 contentType: how-to
 useCase: appliance
 applianceId: appliance76
+sitemap: false
 ---
 # Set Up Federated Login to the Manage Dashboard
 

--- a/articles/appliance/admin/importance-of-updates.md
+++ b/articles/appliance/admin/importance-of-updates.md
@@ -8,6 +8,7 @@ topics:
 contentType: concept
 useCase: appliance
 applianceId: appliance75
+sitemap: false
 ---
 # Why You Should Update the PSaaS Appliance Regularly
 

--- a/articles/appliance/admin/index.md
+++ b/articles/appliance/admin/index.md
@@ -9,6 +9,7 @@ topics:
 contentType: index
 useCase: appliance
 applianceId: appliance4
+sitemap: false
 ---
 
 # PSaaS Appliance: Administrator's Manual

--- a/articles/appliance/admin/inviting-coadmins.md
+++ b/articles/appliance/admin/inviting-coadmins.md
@@ -7,6 +7,7 @@ topics:
 contentType: how-to
 useCase: appliance
 applianceId: appliance5
+sitemap: false
 ---
 
 # PSaaS Appliance Administration: Inviting Co-Administrators

--- a/articles/appliance/admin/limiting-ssh-access.md
+++ b/articles/appliance/admin/limiting-ssh-access.md
@@ -8,6 +8,7 @@ topics:
 contentType: concept
 useCase: appliance
 applianceId: appliance6
+sitemap: false
 ---
 
 # PSaaS Appliance Administration: Limiting SSH Access

--- a/articles/appliance/admin/managing-the-dashboard.md
+++ b/articles/appliance/admin/managing-the-dashboard.md
@@ -7,6 +7,7 @@ topics:
 contentType: how-to
 useCase: appliance
 applianceId: appliance7
+sitemap: false
 ---
 
 # PSaaS Appliance Administration: Manage the Dashboard

--- a/articles/appliance/admin/monitoring.md
+++ b/articles/appliance/admin/monitoring.md
@@ -7,6 +7,7 @@ topics:
 contentType: how-to
 useCase: appliance
 applianceId: appliance8
+sitemap: false
 ---
 
 # PSaaS Appliance Administration: Monitoring

--- a/articles/appliance/admin/rate-limiting.md
+++ b/articles/appliance/admin/rate-limiting.md
@@ -7,6 +7,7 @@ topics:
 contentType: how-to
 useCase: appliance
 applianceId: appliance9
+sitemap: false
 ---
 # PSaaS Appliance: Rate Limiting
 

--- a/articles/appliance/admin/updating-the-appliance.md
+++ b/articles/appliance/admin/updating-the-appliance.md
@@ -8,6 +8,7 @@ topics:
 contentType: how-to
 useCase: appliance
 applianceId: appliance10
+sitemap: false
 ---
 # Updating the PSaaS Appliance
 

--- a/articles/appliance/appliance-overview.md
+++ b/articles/appliance/appliance-overview.md
@@ -6,6 +6,7 @@ topics:
 contentType: concept
 useCase: appliance
 applianceId: appliance52
+sitemap: false
 ---
 
 # PSaaS Appliance Overview

--- a/articles/appliance/cli/adding-node-to-backup-role.md
+++ b/articles/appliance/cli/adding-node-to-backup-role.md
@@ -9,6 +9,7 @@ topics:
 contentType: how-to
 useCase: appliance
 applianceId: appliance11
+sitemap: false
 ---
 
 # PSaaS Appliance: Adding a Node to the Backup Role

--- a/articles/appliance/cli/backing-up-the-appliance.md
+++ b/articles/appliance/cli/backing-up-the-appliance.md
@@ -9,6 +9,7 @@ topics:
 contentType: how-to
 useCase: appliance
 applianceId: appliance12
+sitemap: false
 ---
 
 # How to Back Up the PSaaS Appliance Using the CLI

--- a/articles/appliance/cli/configure-cli.md
+++ b/articles/appliance/cli/configure-cli.md
@@ -7,6 +7,7 @@ topics:
 contentType: how-to
 useCase: appliance
 applianceId: appliance13
+sitemap: false
 ---
 
 # Configuring and Using the Auth0 Appliance Command Line Interface

--- a/articles/appliance/cli/index.md
+++ b/articles/appliance/cli/index.md
@@ -9,6 +9,7 @@ topics:
 contentType: how-to
 useCase: appliance
 applianceId: appliance14
+sitemap: false
 ---
 
 # Private SaaS (PSaaS) Appliance Command Line Interface

--- a/articles/appliance/cli/reconfiguring-ip.md
+++ b/articles/appliance/cli/reconfiguring-ip.md
@@ -8,6 +8,7 @@ topics:
 contentType: how-to
 useCase: appliance
 applianceId: appliance15
+sitemap: false
 ---
 
 # How to Reconfigure IP Addresses Using the Command Line Interface

--- a/articles/appliance/clock.md
+++ b/articles/appliance/clock.md
@@ -7,6 +7,7 @@ topics:
 contentType: how-to
 useCase: appliance
 applianceId: appliance53
+sitemap: false
 ---
 # Time Synchronization
 

--- a/articles/appliance/critical-issue.md
+++ b/articles/appliance/critical-issue.md
@@ -10,6 +10,7 @@ contentType:
     - concept
 useCase: appliance
 applianceId: appliance54
+sitemap: false
 ---
 
 # Critical Support Issue Guidance for Appliance Customers

--- a/articles/appliance/custom-domains/index.md
+++ b/articles/appliance/custom-domains/index.md
@@ -9,6 +9,7 @@ contentType:
     - index
 useCase: appliance
 applianceId: appliance16
+sitemap: false
 ---
 
 # Private SaaS (PSaaS) Appliance: Custom Domains

--- a/articles/appliance/dashboard/activity.md
+++ b/articles/appliance/dashboard/activity.md
@@ -7,6 +7,7 @@ topics:
 contentType: concept
 useCase: appliance
 applianceId: appliance17
+sitemap: false
 ---
 
 # PSaaS Appliance Dashboard: Activity

--- a/articles/appliance/dashboard/cli.md
+++ b/articles/appliance/dashboard/cli.md
@@ -8,6 +8,7 @@ topics:
 contentType: concept
 useCase: appliance
 applianceId: appliance18
+sitemap: false
 ---
 
 # PSaaS Appliance Dashboard: CLI

--- a/articles/appliance/dashboard/index.md
+++ b/articles/appliance/dashboard/index.md
@@ -11,6 +11,7 @@ contentType:
     - concept
 useCase: appliance
 applianceId: appliance19
+sitemap: false
 ---
 
 # Private SaaS (PSaaS) Appliance Management Dashboard

--- a/articles/appliance/dashboard/nodes.md
+++ b/articles/appliance/dashboard/nodes.md
@@ -8,6 +8,7 @@ topics:
 contentType: concept
 useCase: appliance
 applianceId: appliance21
+sitemap: false
 ---
 
 # Auth0 Appliance Dashboard: Nodes

--- a/articles/appliance/dashboard/oss-components.md
+++ b/articles/appliance/dashboard/oss-components.md
@@ -8,6 +8,7 @@ topics:
 contentType: concept
 useCase: appliance
 applianceId: appliance22
+sitemap: false
 ---
 
 # OSS Components

--- a/articles/appliance/dashboard/rate-limiting.md
+++ b/articles/appliance/dashboard/rate-limiting.md
@@ -8,6 +8,7 @@ topics:
 conceptType: concept
 useCase: appliance
 applianceId: appliance23
+sitemap: false
 ---
 
 # Auth0 Appliance Dashboard: Rate Limiting

--- a/articles/appliance/dashboard/settings.md
+++ b/articles/appliance/dashboard/settings.md
@@ -8,6 +8,7 @@ topics:
 contentType: reference
 useCase: appliance
 applianceId: appliance24
+sitemap: false
 ---
 
 # Auth0 Appliance Dashboard: Settings

--- a/articles/appliance/dashboard/tenants.md
+++ b/articles/appliance/dashboard/tenants.md
@@ -8,6 +8,7 @@ topics:
 contentType: reference
 useCase: appliance
 applianceId: appliance25
+sitemap: false
 ---
 
 # PSaaS Appliance Dashboard: Tenants

--- a/articles/appliance/dashboard/troubleshoot.md
+++ b/articles/appliance/dashboard/troubleshoot.md
@@ -8,6 +8,7 @@ topics:
 contentType: reference
 useCase: appliance
 applianceId: appliance26
+sitemap: false
 ---
 
 # PSaaS Appliance Dashboard: Troubleshoot

--- a/articles/appliance/dashboard/updates.md
+++ b/articles/appliance/dashboard/updates.md
@@ -8,6 +8,7 @@ topics:
 contentType: reference
 useCase: appliance
 applianceId: appliance27
+sitemap: false
 ---
 
 # PSaaS Appliance Dashboard: Updates

--- a/articles/appliance/disaster-recovery-raci.md
+++ b/articles/appliance/disaster-recovery-raci.md
@@ -8,6 +8,7 @@ topics:
 contentType: reference
 useCase: appliance
 applianceId: appliance55
+sitemap: false
 ---
 
 <!-- markdownlint-disable MD033 -->

--- a/articles/appliance/disaster-recovery.md
+++ b/articles/appliance/disaster-recovery.md
@@ -7,6 +7,7 @@ topics:
 contentType: concept
 useCase: appliance
 applianceId: appliance56
+sitemap: false
 ---
 
 # PSaaS Appliance: Disaster Recovery

--- a/articles/appliance/extensibility-node8.md
+++ b/articles/appliance/extensibility-node8.md
@@ -12,6 +12,7 @@ contentType:
 toc: true
 useCase: appliance
 applianceId: appliance57
+sitemap: false
 ---
 # PSaaS Appliance Migration Guide: Extensibility and Node 8
 

--- a/articles/appliance/extensions.md
+++ b/articles/appliance/extensions.md
@@ -10,6 +10,7 @@ contentType:
     - how-to
 useCase: appliance
 applianceId: appliance58
+sitemap: false
 ---
 
 # PSaaS Appliance: Extensions

--- a/articles/appliance/geo-ha/disaster-recovery.md
+++ b/articles/appliance/geo-ha/disaster-recovery.md
@@ -7,6 +7,7 @@ topics:
 contentType: reference
 useCase: appliance
 applianceId: appliance28
+sitemap: false
 ---
 
 <!-- markdownlint-disable MD033 -->

--- a/articles/appliance/geo-ha/dr-overview.md
+++ b/articles/appliance/geo-ha/dr-overview.md
@@ -8,6 +8,7 @@ topics:
 contentType: reference
 useCase: appliance
 applianceId: appliance29
+sitemap: false
 ---
 
 <!-- markdownlint-disable MD033 -->

--- a/articles/appliance/geo-ha/index.md
+++ b/articles/appliance/geo-ha/index.md
@@ -11,6 +11,7 @@ contentType:
     - reference
 useCase: appliance
 applianceId: appliance30
+sitemap: false
 ---
 
 # Private SaaS (PSaaS) Appliance: High Availability Geo Cluster (Geo HA)

--- a/articles/appliance/index.html
+++ b/articles/appliance/index.html
@@ -7,6 +7,7 @@ topics:
     - appliance
 useCase: appliance
 applianceId: appliance59
+sitemap: false
 ---
 
 <div class="topic-page-header">

--- a/articles/appliance/infrastructure/dns.md
+++ b/articles/appliance/infrastructure/dns.md
@@ -8,6 +8,7 @@ topics:
 contentType: reference
 useCase: appliance
 applianceId: appliance31
+sitemap: false
 ---
 
 <!-- markdownlint-disable MD033 -->

--- a/articles/appliance/infrastructure/extensions.md
+++ b/articles/appliance/infrastructure/extensions.md
@@ -9,6 +9,7 @@ contentType:
     - Reference
 useCase: appliance
 applianceId: appliance32
+sitemap: false
 ---
 # Enable Webtasks, Extensions, and User Search
 

--- a/articles/appliance/infrastructure/faq.md
+++ b/articles/appliance/infrastructure/faq.md
@@ -7,6 +7,7 @@ topics:
 contentType: reference
 useCase: appliance
 applianceId: appliance33
+sitemap: false
 ---
 
 # PSaaS Appliance Infrastructure Requirements: Frequently Asked Questions

--- a/articles/appliance/infrastructure/index.md
+++ b/articles/appliance/infrastructure/index.md
@@ -11,6 +11,7 @@ contentType:
     - reference
 useCase: appliance
 applianceId: appliance34
+sitemap: false
 ---
 
 # Private SaaS (PSaaS) Appliance Infrastructure Requirements

--- a/articles/appliance/infrastructure/infrastructure-overview.md
+++ b/articles/appliance/infrastructure/infrastructure-overview.md
@@ -7,6 +7,7 @@ topics:
 contentType: concept
 useCase: appliance
 applianceId: appliance35
+sitemap: false
 ---
 # PSaaS Appliance Deployment Architecture
 

--- a/articles/appliance/infrastructure/installation.md
+++ b/articles/appliance/infrastructure/installation.md
@@ -10,6 +10,7 @@ contentType:
     - how-to
 useCase: appliance
 applianceId: appliance36
+sitemap: false
 ---
 
 <!-- markdownlint-disable MD033 -->

--- a/articles/appliance/infrastructure/internet-restricted-deployment.md
+++ b/articles/appliance/infrastructure/internet-restricted-deployment.md
@@ -4,6 +4,7 @@ description: Operating the PSaaS Appliance in an Internet-Restricted Environment
 contentType: reference
 useCase: appliance
 applianceId: appliance37
+sitemap: false
 ---
 # PSaaS Appliance Deployments with Limited Internet Connectivity
 

--- a/articles/appliance/infrastructure/ip-domain-port-list.md
+++ b/articles/appliance/infrastructure/ip-domain-port-list.md
@@ -10,6 +10,7 @@ topics:
 contentType: reference
 useCase: appliance
 applianceId: appliance38
+sitemap: false
 ---
 
 <!-- markdownlint-disable MD033 -->

--- a/articles/appliance/infrastructure/network.md
+++ b/articles/appliance/infrastructure/network.md
@@ -8,6 +8,7 @@ topics:
 contentType: reference
 useCase: appliance
 applianceId: appliance39
+sitemap: false
 ---
 
 # PSaaS Appliance Infrastructure Requirements: Network

--- a/articles/appliance/infrastructure/security.md
+++ b/articles/appliance/infrastructure/security.md
@@ -8,6 +8,7 @@ topics:
 contentType: reference
 useCase: appliance
 applianceId: appliance40
+sitemap: false
 ---
 
 # PSaaS Appliance Infrastructure Requirements: Security and Access

--- a/articles/appliance/infrastructure/virtual-machines.md
+++ b/articles/appliance/infrastructure/virtual-machines.md
@@ -8,6 +8,7 @@ topics:
 contentType: reference
 useCase: appliance
 applianceId: appliance41
+sitemap: false
 ---
 
 # PSaaS Appliance Infrastructure Requirements: Virtual Machines

--- a/articles/appliance/instrumentation.md
+++ b/articles/appliance/instrumentation.md
@@ -8,6 +8,7 @@ contentType:
     - how-to
 useCase: appliance
 applianceId: appliance45
+sitemap: false
 ---
 # PSaaS Appliance Monitoring: Instrumentation
 

--- a/articles/appliance/modules.md
+++ b/articles/appliance/modules.md
@@ -8,6 +8,7 @@ topics:
 contentType: reference
 useCase: appliance
 applianceId: appliance60
+sitemap: false
 ---
 
 # Node.js Modules Available in Rules and Custom Database Connections

--- a/articles/appliance/monitoring/authenticated-endpoints.md
+++ b/articles/appliance/monitoring/authenticated-endpoints.md
@@ -8,6 +8,7 @@ topics:
 contentType: how-to
 useCase: appliance
 applianceId: appliance47
+sitemap: false
 ---
 
 # PSaaS Appliance: Authenticated Testing Endpoints

--- a/articles/appliance/monitoring/index.md
+++ b/articles/appliance/monitoring/index.md
@@ -10,6 +10,7 @@ contentType:
 - concept
 useCase: appliance
 applianceId: appliance48
+sitemap: false
 ---
 
 # Monitoring the Private SaaS (PSaaS) Appliance

--- a/articles/appliance/monitoring/testall.md
+++ b/articles/appliance/monitoring/testall.md
@@ -8,6 +8,7 @@ topics:
 contentType: how-to
 useCase: appliance
 applianceId: appliance49
+sitemap: false
 ---
 
 # Using the `testall` Endpoint

--- a/articles/appliance/private-cloud-requirements.md
+++ b/articles/appliance/private-cloud-requirements.md
@@ -9,6 +9,7 @@ topics:
 contentType: reference
 useCase: appliance
 applianceId: appliance61
+sitemap: false
 ---
 # Requirements for the Auth0 Dedicated Cloud Service
 

--- a/articles/appliance/raci.md
+++ b/articles/appliance/raci.md
@@ -7,6 +7,7 @@ topics:
 contentType: reference
 useCase: appliance
 applianceId: appliance62
+sitemap: false
 ---
 
 # PSaaS Appliance: Roles and Responsibilities

--- a/articles/appliance/remote-access-options.md
+++ b/articles/appliance/remote-access-options.md
@@ -7,6 +7,7 @@ topics:
 contentType: reference
 useCase: appliance
 applianceId: appliance63
+sitemap: false
 ---
 # PSaaS Appliance Remote Access Options
 

--- a/articles/appliance/webtasks/dedicated-domains.md
+++ b/articles/appliance/webtasks/dedicated-domains.md
@@ -13,6 +13,7 @@ contentType:
     - how-to
 useCase: appliance
 applianceId: appliance50
+sitemap: false
 ---
 # PSaaS Appliance: Webtask with Dedicated Domains
 

--- a/articles/appliance/webtasks/index.md
+++ b/articles/appliance/webtasks/index.md
@@ -9,6 +9,7 @@ contentType:
     - index
 useCase: appliance
 applianceId: appliance51
+sitemap: false
 ---
 
 # PSaaS Appliance: Webtasks

--- a/articles/getting-started/deployment-models.md
+++ b/articles/getting-started/deployment-models.md
@@ -64,7 +64,7 @@ The following tables describe operational and feature differences between these 
             <th class="info"><strong>Public Facing</strong></th>
             <td>Yes</td>
             <td>Yes</td>
-            <td>Yes; customer hosted is configurable<sup>*</sup>.</td>
+            <td><i>Auth0's Cloud</i>: Yes <br /><i>Customer's AWS Cloud</i>: Configurable<sup>*</sup></td>
         </tr>
         <tr>
             <th class="info"><strong>Updates</strong></th>
@@ -88,17 +88,17 @@ The following tables describe operational and feature differences between these 
             <th class="info"><strong>Service & Uptime Reporting</strong></th>
             <td><a href="https://status.auth0.com">https://status.auth0.com</a><br /><a href="http://uptime.auth0.com">http://uptime.auth0.com</a></td>
             <td>Monitored by Auth0</td>
-            <td>Monitored by Auth0; customer responsible for monitoring if using AWS.</td>
+            <td><i>Auth0's Cloud</i>: Auth0 <br /><i>Customer's AWS Cloud</i>: Customer</td>
         </tr>
         <tr>
             <th class="info"><strong>Infrastructure and Backup Responsibility</strong></th>
             <td>Auth0</td>
             <td>Auth0</td>
-            <td>Auth0 responsible if Auth0 infrastructure used, otherwise Customer is responsible.</td>
+            <td><i>Auth0's Cloud</i>: Auth0 <br /><i>Customer's AWS Cloud</i>: Customer</td>
         </tr>
         <tr>
             <th class="info"><strong>Uptime SLA Provided</strong></th>
-            <td>99.90% <br />No upgrade option available.</td>
+            <td>99.90% <br />No upgrade option available</td>
             <td>99.95% SLA with optional upgrade to 99.99%<sup>**</sup></td>
             <td>99.95% SLA with optional upgrade to 99.99%<sup>**</sup></td>
         </tr>
@@ -183,8 +183,7 @@ The following tables describe operational and feature differences between these 
             <th class="info"><strong>Connecting IP Address Filtering Restrictions</strong></th>
             <td>No</td>
             <td>No</td>
-            <td>No when using Auth0 infrastructure; yes if hosted using AWS</td>
-            <td>Yes</td>
+            <td><i>Auth0's Cloud</i>: No <br /><i>Customer's AWS Cloud</i>: Yes</td>
         </tr>
         <tr>
             <th class="info"><strong><a href="/custom-domains">Custom Domains</a></strong></th>
@@ -200,8 +199,8 @@ The following tables describe operational and feature differences between these 
         <tr>
           <th class="info"><strong>MFA</strong></th>
           <td>Yes</td>
-          <td>Available using SMS, Google Authenticator, Duo over TOTP/HOTP, and Push Notification with Guardian SDK.</td>
-          <td>Available using SMS, Google Authenticator, Duo over TOTP/HOTP, and Push Notification with Guardian SDK.</td>
+          <td>Available using SMS, Google Authenticator, Duo over TOTP/HOTP, and Push Notification with Guardian SDK</td>
+          <td>Available using SMS, Google Authenticator, Duo over TOTP/HOTP, and Push Notification with Guardian SDK</td>
         </tr>
     </tbody>
 </table>

--- a/articles/getting-started/deployment-models.md
+++ b/articles/getting-started/deployment-models.md
@@ -13,16 +13,32 @@ useCase:
 ---
 # Auth0 Deployment Models
 
-Auth0 is offered in four deployment models:
+Auth0 is offered in the following deployment models:
 
-- As a **multi-tenant cloud service** running on Auth0's cloud
-- As a **dedicated cloud service** running on Auth0's cloud
-- As a **dedicated cloud service** running on Customer's cloud infrastructure
-- As an **on-premises virtual Private SaaS (PSaaS) Appliance** running on Customer's data centers
+<table class="table">
+<tr>
+    <th>Deployment</th>
+    <th>Description</th>
+</tr>
+<tr>
+    <td>Public Cloud</td>
+    <td>A multi-tenant cloud service running on Auth0's cloud</td>
+</tr>
+<tr>
+    <td>Private Cloud</td>
+    <td>A dedicated cloud service running on Auth0's cloud</td>
+</tr>
+<tr>
+    <td>Managed Private Cloud</td>
+    <td>A dedicated cloud service running on either Auth0's cloud or the customer's AWS cloud infrastructure</td>
+</tr>
+</table>
 
-::: note
-PSaaS Appliance is a managed service that you can use if your organization's requirements prevent you from using a multi-tenant cloud service. To learn more refer to [Private SaaS (PSaaS) Appliance](/appliance).
-:::
+The [Private Cloud and the Managed Private Cloud](/private-cloud) options are managed services that you can use if:
+
+* Your organization's requirements prevent you from using the multi-tenant public cloud service
+* You require an SLA guaranteeing higher uptimes
+* You require a guaranteed level of requests per second
 
 The following tables describe operational and feature differences between these models.
 
@@ -32,15 +48,15 @@ The following tables describe operational and feature differences between these 
     <thead>
         <tr>
             <th class="info"><strong>Where It Runs</strong></th>
-            <th class="info" colspan="2"><strong>Auth0's Infrastructure</strong></th>
-            <th class="info" colspan="2"><strong>Customer's Infrastructure</strong></th>
+            <th class="info"><strong>Auth0's Infrastructure</strong></th>
+            <th class="info"><strong>Auth0's Infrastructure</strong></th>
+            <th class="info"><strong>Auth0's Infrastructure or Customer's AWS Cloud</strong></th>
         </tr>
         <tr>
             <th class="info"><strong>How It Runs</strong></th>
-            <th class="info">Multi-Tenant</th>
-            <th class="info">Dedicated</th>
-            <th class="info">Cloud</th>
-            <th class="info">On-Premises</th>
+            <th class="info">Public Cloud (Multi-Tenant)</th>
+            <th class="info">Private Cloud</th>
+            <th class="info">Managed Private Cloud</th>
         </tr>
     </thead>
     <tbody>
@@ -48,44 +64,78 @@ The following tables describe operational and feature differences between these 
             <th class="info"><strong>Public Facing</strong></th>
             <td>Yes</td>
             <td>Yes</td>
-            <td>Configurable</td>
-            <td>Configurable</td>
+            <td>Yes; customer hosted is configurable<sup>*</sup>.</td>
         </tr>
         <tr>
             <th class="info"><strong>Updates</strong></th>
-            <td>Unscheduled. <br /> Multiple times per day. <br /><br />Staged in two zones.</td>
-            <td>Scheduled with Customer. <br /><br />Monthly, bi-monthly, or quarterly, except critical updates (such as security updates).</td>
-            <td>Scheduled with Customer. <br /><br />Monthly, bi-monthly, or quarterly, except critical updates (such as security updates)</td>
-            <td>Scheduled with Customer. <br /><br />Monthly, bi-monthly, or quarterly, except critical updates (such as security updates)</td>
+            <td>Automatic Updates</td>
+            <td>Automatic Monthly Updates</td>
+            <td>Monthly, bi-monthly, or quarterly as coordinated with Auth0. Excludes critical updates (e.g., security patches), which will be applied as soon as possible</td>
         </tr>
         <tr>
             <th class="info"><strong>Deployment Configurations</strong></th>
             <td>N/A</td>
+            <td>High Availability (HA);<br />High Capacity
             <td>High Availability (HA);<br />Geo HA;<br />High Capacity;<br />Geo HA and High Capacity</td>
-            <td>High Availability (HA);<br />Geo HA;<br />High Capacity;<br />Geo HA and High Capacity</td>
-            <td>High Availability (HA);<br />Geo HA;<br />High Capacity;<br />Geo HA and High Capacity</td>
+        </tr>
+        <tr>
+            <th class="info"><strong>Isolated Non-Production Environment</strong></th>
+            <td>No</td>
+            <td>Yes</td>
+            <td>Yes</td>
         </tr>
         <tr>
             <th class="info"><strong>Service & Uptime Reporting</strong></th>
             <td><a href="https://status.auth0.com">https://status.auth0.com</a><br /><a href="http://uptime.auth0.com">http://uptime.auth0.com</a></td>
             <td>Monitored by Auth0</td>
-            <td>Monitored by Customer</td>
-            <td>Monitored by Customer</td>
+            <td>Monitored by Auth0; customer responsible for monitoring if using AWS.</td>
+        </tr>
+        <tr>
+            <th class="info"><strong>Infrastructure and Backup Responsibility</strong></th>
+            <td>Auth0</td>
+            <td>Auth0</td>
+            <td>Auth0 responsible if Auth0 infrastructure used, otherwise Customer is responsible.</td>
         </tr>
         <tr>
             <th class="info"><strong>Uptime SLA Provided</strong></th>
-            <td>Yes</td>
-            <td>Yes</td>
-            <td>Limited to PSaaS Appliance*</td>
-            <td>Limited to PSaaS Appliance*</td>
+            <td>99.90% <br />No upgrade option available.</td>
+            <td>99.95% SLA with optional upgrade to 99.99%<sup>**</sup></td>
+            <td>99.95% SLA with optional upgrade to 99.99%<sup>**</sup></td>
+        </tr>
+        <tr>
+            <th class="info"><strong>Requests per Second</strong></th>
+            <td>No guaranteed rates</td>
+            <td>500 requests per second with optional upgrade to 1500 requests per second</td>
+            <td>500 requests per second with optional upgrade to 1500 requests per second</td>
+        </tr>
+        <tr>
+            <th class="info"><strong>Data Residency</strong></th>
+            <td>Not applicable</td>
+            <td>Region of Choice<sup>***</sup> <sup>****</sup></td>
+            <td>Region of Choice<sup>***</sup></td>
+        </tr>
+        <tr>
+            <th class="info"><strong>PCI Compliance</strong></th>
+            <td>No</td>
+            <td>Add-on available</td>
+            <td>Add-on available</td>
         </tr>
         <tr>
             <th class="info"><strong>Support Channels & Levels</strong></th>
-            <td colspan="4">Same across all models</td>
+            <td>Same across all models</td>
+            <td>Same across all models</td>
+            <td>Same across all models</td>
         </tr>
     </tbody>
 </table>
-<p>* See "PSaaS Appliance" section in <a href="https://auth0.com/legal">Service Level Description</a>.</p>
+
+<sup>*</sup>Access to the Managed Private Cloud can be restricted to customer's private subnets.
+
+<sup>**</sup>See the **PSaaS Appliance** section the Auth0 [Service Level Description](https://auth0.com/legal).
+
+<sup>***</sup>Deployments to China are currently unavailable.
+
+<sup>****</sup>If you need to meet data sovereignty requirements, Auth0 supports Private Cloud deployments in the following regions USA, Europe, Australia, Canada, and Japan. Otherwise, the Private Cloud can be supported in other regions (excepting China).
 
 ## Feature Differences
 
@@ -93,99 +143,57 @@ The following tables describe operational and feature differences between these 
     <thead>
         <tr>
             <th class="info"><strong>Where It Runs</strong></th>
-            <th class="info" colspan="2"><strong>Auth0's Infrastructure</strong></th>
-            <th class="info" colspan="2"><strong>Customer's Infrastructure</strong></th>
-        </tr>
-        <tr>
-            <th class="info"><strong>How It Runs</strong></th>
-            <th class="info">Multi-Tenant</th>
-            <th class="info">Dedicated</th>
-            <th class="info">Cloud</th>
-            <th class="info">On-Premises</th>
+            <th class="info"><strong>Public Cloud (Multi-Tenant)</strong></th>
+            <th class="info"><strong>Private Cloud</strong></th>
+            <th class="info"><strong>Managed Private Cloud</strong></th>
         </tr>
     </thead>
     <tbody>
         <tr>
-            <th class="info"><strong>SSO Lifetime</strong></th>
-            <td>Default Settings</td>
-            <td>Configurable</td>
-            <td>Configurable</td>
-            <td>Configurable</td>
-        </tr>
-        <tr>
             <th class="info"><strong>User Search</strong></th>
-            <td>V3</td>
-            <td>V2</td>
-            <td>V2</td>
-            <td>V2</td>
+            <td><a href="/users/search/v3">v3</a></td>
+            <td><a href="/users/search/v2">v2</a></td>
+            <td><a href="/users/search/v2">v2</a></td>
         </tr>
         <tr>
             <th class="info"><strong>Tenant Log Search</strong></th>
-            <td>Lucene queries</td>
-            <td>Simple attribute search</td>
-            <td>Simple attribute search</td>
-            <td>Simple attribute search</td>
-        </tr>
-        <tr>
-            <th class="info"><strong>Log Retention</strong></th>
-            <td>Up to 30 days (depends on subscription plan)</td>
-            <td>Limited to 30 days</td>
-            <td>Limited to 30 days</td>
-            <td>Limited to 30 days</td>
+            <td><a href="/logs/query-syntax#search-engine-v3-breaking-changes">v3</a></td>
+            <td><a href="/logs/query-syntax">v1</a></td>
+            <td><a href="/logs/query-syntax">v1</a></td>
         </tr>
         <tr>
             <th class="info"><strong>Code Sandbox</strong></th>
-            <td>Webtask (Javascript and C#)</td>
-            <td>Webtask or in-process</td>
-            <td>Webtask or in-process</td>
-            <td>Webtask or in-process</td>
+            <td>Webtask (Node.js version 8 and C#)</td>
+            <td>Webtask (Node.js version 8)</td>
+            <td>Webtask (Node.js version 8)</td>
         </tr>
         <tr>
             <th class="info"><strong>Webtask</strong></th>
             <td>Multi-Tenant</td>
-            <td>Dedicated (Fixed NPM modules)</td>
-            <td>Dedicated (Fixed NPM modules)</td>
-            <td>On-Premises (Fixed NPM modules)</td>
+            <td>Dedicated</td>
+            <td>Dedicated</td>
         </tr>
         <tr>
             <th class="info"><strong>Anomaly Detection</strong></th>
             <td>Brute Force and Breached Passwords</td>
             <td>Brute Force</td>
             <td>Brute Force</td>
-            <td>Brute Force</td>
-        </tr>
-        <tr>
-            <th class="info"><strong>Extensions</strong></th>
-            <td>Yes</td>
-            <td>Yes <sup>*</sup></td>
-            <td>Yes <sup>*</sup></td>
-            <td>Yes <sup>*</sup></td>
-        </tr>
-        <tr>
-            <th class="info"><strong>Geolocation</strong></th>
-            <td>Yes</td>
-            <td>Yes</td>
-            <td>Yes</td>
-            <td>Yes</td>
         </tr>
         <tr>
             <th class="info"><strong>Connecting IP Address Filtering Restrictions</strong></th>
             <td>No</td>
             <td>No</td>
-            <td>Yes</td>
+            <td>No when using Auth0 infrastructure; yes if hosted using AWS</td>
             <td>Yes</td>
         </tr>
         <tr>
             <th class="info"><strong><a href="/custom-domains">Custom Domains</a></strong></th>
             <td>Yes</td>
-            <td><a href="/appliance/custom-domains">Yes</a><sup>**</sup></td>
-            <td><a href="/appliance/custom-domains">Yes</a><sup>**</sup></td>
-            <td><a href="/appliance/custom-domains">Yes</a><sup>**</sup></td> 
-        </tr>
+            <td>Yes<sup>*</sup></td>
+            <td>Yes<sup>*</sup></td>
         <tr>
             <th class="info"><strong>Shared Resources Among Multiple Customers</strong></th>
             <td>Yes</td>
-            <td>No</td>
             <td>No</td>
             <td>No</td>
         </tr>
@@ -194,27 +202,8 @@ The following tables describe operational and feature differences between these 
           <td>Yes</td>
           <td>Available using SMS, Google Authenticator, Duo over TOTP/HOTP, and Push Notification with Guardian SDK.</td>
           <td>Available using SMS, Google Authenticator, Duo over TOTP/HOTP, and Push Notification with Guardian SDK.</td>
-          <td>Available using SMS, Google Authenticator, Duo over TOTP/HOTP, and Push Notification with Guardian SDK.</td>
-        </tr>
-        <tr>
-          <th class="info"><strong>Lock</strong></th>
-          <td>Yes</td>
-          <td>Yes</td>
-          <td>Yes</td>
-          <td>Yes <sup>***</sup></td>
-        </tr>
-        <tr>
-          <th class="info"><strong>Internet Restricted</strong></th>
-          <td>No</td>
-          <td>No</td>
-          <td>No</td>
-          <td>Optional <sup>***</sup></td>
         </tr>
     </tbody>
 </table>
 
-<sup>*</sup>See the [PSaaS Appliance: Extensions page](/appliance/extensions) to learn more about configuring extensions with the PSaaS Appliance.
-
-<sup>**</sup>See [PSaaS Appliance Custom Domains](/appliance/custom-domains) for details. If your PSaaS Appliance is hosted in the Auth0 Private Cloud, see [Private Cloud Requirements](/appliance/private-cloud-requirements).
-
-<sup>***</sup>You may choose to [operate the PSaaS Appliance in an Internet-restricted environment](/appliance/infrastructure/internet-restricted-deployment) (except during [update periods](/appliance/infrastructure/ip-domain-port-list#external-connectivity)).
+<sup>*</sup>See [Custom Domains](/appliance/custom-domains) and [Private Cloud Requirements](/appliance/private-cloud-requirements) for details.

--- a/articles/private-cloud/index.md
+++ b/articles/private-cloud/index.md
@@ -1,14 +1,12 @@
 ---
-url: /enterprise/private-cloud/overview
-section: enterprise
-description: Overview of the Private Cloud deployment option
+section: private-cloud
+description: Overview of the Private Cloud deployment options
 classes: topic-page
 topics:
-    - enterprise
     - private-cloud
     - managed-private-cloud
 contentType: concept
-useCase: enterprise
+useCase: private-cloud
 ---
 <div class="topic-page-header">
   <div data-name="example" class="topic-page-badge"></div>

--- a/config/cards.yml
+++ b/config/cards.yml
@@ -94,21 +94,11 @@
       forceFullReload: true
 
 - id: "appliance"
-  title: "PSaaS Appliance"
+  title: "Private Cloud"
   icon: "icon-budicon-359"
   color: "pink"
   description: "Deploying and managing a private instance of Auth0."
-  url: "/appliance"
-  articles:
-
-    - title: "PSaaS Appliance Planning"
-      url: "/appliance/appliance-overview"
-
-    - title: Administrator's Manual
-      url: /appliance/admin
-
-    - title: Onboarding Process
-      url: /onboarding/appliance-sprint
+  url: "/private-cloud"
 
 - id: "extensibility"
   title: "Extensibility"

--- a/config/redirects.js
+++ b/config/redirects.js
@@ -2078,4 +2078,10 @@ module.exports = [
       from: '/integrations/using-auth0-as-an-identity-provider-with-github-enterprise',
       to: '/protocols/saml/saml-apps/github-server'
     },
+    {
+      from: '/enterprise/private-cloud/overview',
+      to: '/private-cloud'
+    }
+
+    
 ];

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -252,114 +252,16 @@ articles:
           - title: "Enable RBAC for APIs"
             url: "/authorization/guides/dashboard/enable-rbac"
 
-  - title: "Appliance"
-    url: "/appliance"
+  - title: "Private Cloud"
+    url: "/private-cloud"
     children:
-      - title: "Support"
-        url: "/appliance/critical-issue"
-        children:
-          - title: Critical Issue
-            url: /appliance/critical-issue
-          - title: Enterprise Support
-            url: /onboarding/enterprise-support
-
-      - title: PSaaS Appliance Planning
-        url: /appliance/appliance-overview
-        children:
-          - title: Overview
-            url: /appliance/appliance-overview
-
-          - title: Geographic High-Availability
-            url: /appliance/geo-ha
-            children:
-              - title: Disaster Recovery
-                url: /appliance/geo-ha/disaster-recovery
-
-          - title: Infrastructure Requirements
-            url: /appliance/infrastructure
-            children:
-              - title: Installation Process
-                url: /appliance/infrastructure/installation
-              - title: Infrastructure Overview
-                url: /appliance/infrastructure/infrastructure-overview
-              - title: Webtasks and Web Extensions
-                url: /appliance/infrastructure/extensions
-
-              - title: Virtual Machines
-                url: /appliance/infrastructure/virtual-machines
-              - title: Network
-                url: /appliance/infrastructure/network
-              - title: IP/Domain and Port List
-                url: /appliance/infrastructure/ip-domain-port-list
-              - title: Security and Access
-                url: /appliance/infrastructure/security
-
-          - title: Roles and Responsibilities
-            url: /appliance/raci
-
-          - title: Customer Onboarding
-            url: /onboarding/appliance-sprint
-
-          - title: Private Cloud Requirements
-            url: /appliance/private-cloud-requirements
-
-      - title: "PSaaS Appliance Administration"
-        url: "/appliance/admin"
-        children:
-          - title: Administrator's Manual
-            url: /appliance/admin
-            children:
-              - title: Managing the Dashboard
-                url: /appliance/admin/managing-the-dashboard
-              - title: Disabling Sign-ups
-                url: /appliance/admin/disabling-sign-ups
-              - title: Inviting Co-Administrators
-                url: /appliance/admin/inviting-coadmins
-              - title: Appliance Backups
-                url: /appliance/admin/backing-up-the-appliance-instances
-              - title: Monitoring
-                url: /appliance/admin/monitoring
-              - title: Updating
-                url: /appliance/admin/updating-the-appliance
-
-          - title: Dashboard/Configuration Area
-            url: /appliance/dashboard
-            children:
-              - title: Troubleshoot
-                url: /appliance/dashboard/troubleshoot
-            
-          - title: Monitoring
-            url: /appliance/monitoring
-            children:
-              - title: Instrumentation
-                url: /appliance/instrumentation
-              - title: Testall endpoint
-                url: /appliance/monitoring/testall
-              - title: Authenticated testing endpoints
-                url: /appliance/monitoring/authenticated-endpoints
-            
-          - title: Command-Line Interface Tools
-            url: /appliance/cli
-          - title: Automatic Tenant Creation
-            url: /appliance/admin/creating-tenants
-            hidden: true
-          - title: Node Module Availability
-            url: /appliance/modules
-          - title: Webtasks
-            url: /appliance/webtasks
-          - title: Extensions
-            url: /appliance/extensions
-          - title: Disaster Recovery
-            url: /appliance/disaster-recovery
-            children:
-              - title: Roles and Responsibilities
-                url: /appliance/disaster-recovery-raci
-          - title: Migrating to Node.js v8
-            url: /appliance/extensibility-node8
-          - title: Release Notes
-            url: https://auth0.com/changelog/appliance
-            external: true
-            forceFullReload: true
+      - title: Enterprise Support
+        url: /onboarding/enterprise-support
+        
+      - title: Release Notes
+        url: https://auth0.com/changelog/appliance
+        external: true
+        forceFullReload: true
 
   - title: "Connections"
     url: "/connections"


### PR DESCRIPTION
* [Deployment Models](https://docs-content-staging-pr-7417.herokuapp.com/docs/getting-started/deployment-models)
* Redirect: [/docs/enterprise/private-cloud/overview](https://docs-content-staging-pr-7417.herokuapp.com/docs/enterprise/private-cloud/overview) to [/docs/private-cloud](https://docs-content-staging-pr-7417.herokuapp.com/docs/private-cloud)
* Removed /appliance and sundry from sitemap and prevent such docs from being crawled by search engines
* Added new /private-cloud folder
* Removed Appliance navigation (sidebar and cards) - URLs are still active, however