### PR TITLE
Add Google+ deprecation notice

### DIFF
--- a/articles/migrations/guides/google-plus-deprecation.md
+++ b/articles/migrations/guides/google-plus-deprecation.md
@@ -1,0 +1,22 @@
+---
+title: Google+ API Deprecation
+description: Information on the Google+ API deprecation and Google Social Connection changes.
+toc: false
+contentType:
+  - how-to
+useCase:
+  - add-login
+  - migrate
+---
+
+# Google+ API Deprecation
+
+On March 7th, 2019, [Google deprecated the Google+ service and APIs](https://developers.google.com/+/api-shutdown). As part of this change [Google+ scopes](https://developers.google.com/+/scopes-shutdown) are no longer valid.
+
+We've updated [Google Social Connections](/connections/social/google) to reflect these changes.
+
+## What's changed?
+
+The `https://www.googleapis.com/auth/plus.me` scope, labeled as **Google+** on the Auth0 Dashboard and `google_plus` in the Management API, has been removed from Google Social Connections.
+
+The removal of the Google+ scope does not change the user profile response from the API. However, it will limit the actions you can perform with the access token on Google APIs. So you may need to update your application code to accomodate these API changes.

--- a/articles/migrations/index.md
+++ b/articles/migrations/index.md
@@ -36,6 +36,10 @@ Current migrations are listed below, newest first.
 
 For migrations that have already been enabled for all customers, see [Past Migrations](/migrations/past-migrations).
 
+### Google+ API deprecation
+
+On March 7th, 2019, Google deprecated the Google+ service and related APIs. We've updated Google Social Connections to reflect these changes. For for more information, check out [Google+ API Deprecation](/migrations/guides/google-plus-deprecation).
+
 ### Facebook Login and Graph API
 
 The latest version of Facebook Login and the Facebook Graph API change what permissions and fields can be requested. We've updated Facebook connections to reflect these changes. For for more information, check out [Changes to Facebook Login and Graph API](/migrations/guides/facebook-graph-api-deprecation).


### PR DESCRIPTION
[Demo: Google+ API Deprecation](https://docs-content-staging-pr-7419.herokuapp.com/docs/migrations/guides/google-plus-deprecation)