### PR TITLE
Fix: scoping storage bug

### DIFF
--- a/articles/quickstart/spa/angular2/04-authorization.md
+++ b/articles/quickstart/spa/angular2/04-authorization.md
@@ -56,7 +56,7 @@ private localLogin(authResult): void {
 // src/app/auth/auth.service.ts
 
 public userHasScopes(scopes: Array<string>): boolean {
-  const grantedScopes = JSON.parse(this._scopes);
+  const grantedScopes = JSON.parse(this._scopes).split(' ');
   return scopes.every(scope => grantedScopes.includes(scope));
 }
 ```

--- a/articles/quickstart/spa/angular2/04-authorization.md
+++ b/articles/quickstart/spa/angular2/04-authorization.md
@@ -56,7 +56,7 @@ private localLogin(authResult): void {
 // src/app/auth/auth.service.ts
 
 public userHasScopes(scopes: Array<string>): boolean {
-  const grantedScopes = JSON.parse(localStorage.getItem('scopes')).split(' ');
+  const grantedScopes = JSON.parse(this._scopes);
   return scopes.every(scope => grantedScopes.includes(scope));
 }
 ```


### PR DESCRIPTION
The quick start stores the scopes correctly in memory in the local login method, but tries to retrieve the scopes through local storage. This change utilizes the scopes from memory to build the `grantedScopes` constant. 

Note: This change has not been tested/validated validated through implementation.