### PR TITLE
Provide warning on TLS usage

### DIFF
--- a/articles/quickstart/spa/angular2/05-token-renewal-download.md
+++ b/articles/quickstart/spa/angular2/05-token-renewal-download.md
@@ -18,3 +18,5 @@ You can also run it from a [Docker](https://www.docker.com) image with the follo
 # In Linux / macOS         In Windows' Powershell
 sh exec.sh                 ./exec.ps1
 ```
+
+::: warning Transport Layer Security is required to ensure the confidentiality of access tokens and other sensitive information. Do not use plaintext HTTP for the **Callback URL** or **Allowed Web Origins** in production.  :::


### PR DESCRIPTION
The OAuth 2 and OIDC specification both rely upon Transport Layer Security. This PR creates a warning for the user to ensure that our customers are not using plaintext HTTP for their production applications. The use of http in the sample application is to help in starting development.