### PR TITLE
Update download.md for TLS language

### DIFF
--- a/articles/quickstart/spa/angular2/download.md
+++ b/articles/quickstart/spa/angular2/download.md
@@ -20,3 +20,5 @@ sh exec.sh
 # In Windows' Powershell
 ./exec.ps1
 ```
+
+::: warning Transport Layer Security is required to ensure the confidentiality of access tokens and other sensitive information. Do not use plaintext HTTP for the **Callback URL** or **Allowed Web Origins** in production. :::


### PR DESCRIPTION
The OAuth 2.0 specification requires TLS to ensure that the access token and other sensitive information is not leaked. This PR updates the language to warn our users not to use plaintext http for their production applications.
