### PR TITLE
Clarify recovery when Guardian is uninstalled

### DIFF
--- a/articles/multifactor-authentication/index.md
+++ b/articles/multifactor-authentication/index.md
@@ -83,6 +83,8 @@ If a recovery code is used, a new recovery code will be provided at that time.
 
 If they have lost their recovery code and device, you will need to [reset the user's MFA](/multifactor-authentication/reset-user).
 
+If a user uninstalls then later re-installs Guardian, they may be prompted to enter their recovery code. If the recovery code has been lost, the user can perform a new installation of the app by disabling automatic restoration of their Guardian backup. To do so, the user will need to uninstall Guardian, temporarily disable automatic restoration of backups within their device settings (steps to do so will vary according to the device), then re-install the app. They will then need to add their MFA account(s) to the app as if performing a first-time setup. If automatic backups or automatic restoration are not enabled on the user's device, re-installation of the app will not prompt for a recovery code and the user will be required to add their MFA account(s) as in a first-time setup.
+
 ## Troubleshooting
 
 See the [MFA Troubleshooting Guide](/multifactor-authentication/troubleshooting) for help troubleshooting common end-user issues.


### PR DESCRIPTION
Explain the expected behavior when the Guardian app is uninstalled and later re-installed.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors
- Please include a short description
- If your PR is a work in progress, title it [DO NOT MERGE]
--->
