### PR TITLE
Adjusting default login docs

### DIFF
--- a/articles/universal-login/default-login-url.md
+++ b/articles/universal-login/default-login-url.md
@@ -50,7 +50,7 @@ You can also do this using the Management API:
 }
 ```
 
-The `login_url` should point to a route in the application that ends up redirecting to Auth0's `/authorize` endpoint, e.g. `http://yoursite.com/login`.
+The `login_url` should point to a route in the application that ends up redirecting to Auth0's `/authorize` endpoint, e.g. `https://mycompany.org/login`. Note that it requires `https` and it cannot point to `localhost`.
 
 ## Scenarios for redirecting to the default login route
 


### PR DESCRIPTION
- Added 'https' to examples of login URLs and specified that it needs to be https and can't point to localhost