### PR TITLE
IUM-272: Update signup endpoint documentation

### DIFF
--- a/articles/api/authentication/_sign-up.md
+++ b/articles/api/authentication/_sign-up.md
@@ -90,7 +90,7 @@ This endpoint only works for database connections.
 | `password` <br/><span class="label label-danger">Required</span> | The user's desired password. |
 | `connection` <br/><span class="label label-danger">Required</span> | The name of the database configured to your client. |
 | `username` | The user's username. Only valid if the connection requires a username. |
-| `given_name` | The user's user given name(s). |
+| `given_name` | The user's given name(s). |
 | `family_name` | The user's family name(s). |
 | `name` | The user's full name. |
 | `nickname` | The user's nickname. |

--- a/articles/api/authentication/_sign-up.md
+++ b/articles/api/authentication/_sign-up.md
@@ -8,6 +8,12 @@ Content-Type: application/json
   "email": "EMAIL",
   "password": "PASSWORD",
   "connection": "CONNECTION",
+  "username": "johndoe",
+  "given_name": "John",
+  "family_name": "Doe",
+  "name": "John Doe",
+  "nickname": "johnny",
+  "picture": "http://example.org/jdoe.png"
   "user_metadata": { plan: 'silver', team_id: 'a111' }
 }
 ```
@@ -16,7 +22,7 @@ Content-Type: application/json
 curl --request POST \
   --url 'https://${account.namespace}/dbconnections/signup' \
   --header 'content-type: application/json' \
-  --data '{"client_id":"${account.clientId}", "email":"test.account@signup.com", "password":"PASSWORD", "connection":"CONNECTION", "user_metadata":{ "plan": "silver", "team_id": "a111" }}'
+  --data '{"client_id":"${account.clientId}", "email":"test.account@signup.com", "password":"PASSWORD", "connection":"CONNECTION", "username": "johndoe", "given_name": "John", "family_name": "Doe", "name": "John Doe", "nickname": "johnny", "picture": "http://example.org/jdoe.png", "user_metadata":{ "plan": "silver", "team_id": "a111" }}'
 ```
 
 ```javascript
@@ -33,6 +39,12 @@ curl --request POST \
     connection: 'CONNECTION', 
     email: 'EMAIL', 
     password: 'PASSWORD',
+    username: "johndoe",
+    given_name: "John",
+    family_name: "Doe",
+    name: "John Doe",
+    nickname: "johnny",
+    picture: "http://example.org/jdoe.png",
     user_metadata: { plan: 'silver', team_id: 'a111' }
   }, function (err) { 
     if (err) return alert('Something went wrong: ' + err.message); 
@@ -48,7 +60,12 @@ curl --request POST \
   "_id": "58457fe6b27...",
   "email_verified": false,
   "email": "test.account@signup.com",
-  "user_metadata":{"plan":"silver","team_id":"a111"}
+  "username": "johndoe",
+  "given_name": "John",
+  "family_name": "Doe",
+  "name": "John Doe",
+  "nickname": "johnny",
+  "picture": "http://example.org/jdoe.png"
 }
 ```
 
@@ -72,6 +89,12 @@ This endpoint only works for database connections.
 | `email` <br/><span class="label label-danger">Required</span> | The user's email address. |
 | `password` <br/><span class="label label-danger">Required</span> | The user's desired password. |
 | `connection` <br/><span class="label label-danger">Required</span> | The name of the database configured to your client. |
+| `username` | The user's username. Only valid if the connection requires a username. |
+| `given_name` | The user's user given name(s). |
+| `family_name` | The user's family name(s). |
+| `name` | The user's full name. |
+| `nickname` | The user's nickname. |
+| `picture` | A URI pointing to the user's picture. |
 | `user_metadata` | The [user metadata](/users/concepts/overview-user-metadata) to be associated with the user. If set, the field must be an object containing no more than ten properties. Property names can have a maximum of 100 characters, and property values must be strings of no more than 500 characters. |
 
 ### Test with Postman


### PR DESCRIPTION
Documentation for the updatable root attributes feature on the `POST /dbconnections/signup` endpoint.

- Added the new updatable root attributes field.
- Removed the user_metadata from the response (it's not being returned).
- Added the username field.

![Screen Shot 2019-03-29 at 16 44 57](https://user-images.githubusercontent.com/44579600/55258607-19761900-5242-11e9-8937-1274c9fdedd6.png)
![Screen Shot 2019-03-29 at 16 45 12](https://user-images.githubusercontent.com/44579600/55258612-1da23680-5242-11e9-9541-f84b2a2f34e3.png)
![Screen Shot 2019-03-29 at 16 45 18](https://user-images.githubusercontent.com/44579600/55258614-1f6bfa00-5242-11e9-87a5-c6c6a9636639.png)
![Screen Shot 2019-03-29 at 16 45 26](https://user-images.githubusercontent.com/44579600/55258617-209d2700-5242-11e9-9c78-aee6592e11a3.png)

