### PR TITLE
Update part-2.md

### DIFF
--- a/articles/architecture-scenarios/spa-api/part-2.md
+++ b/articles/architecture-scenarios/spa-api/part-2.md
@@ -158,8 +158,8 @@ function (user, context, callback) {
     return x.indexOf(':') < 0;
   });
 
-  filteredScopes.push(permissions);
-  context.accessToken.scope = filteredScopes.join(' ');
+  var allScopes = filteredScopes.concat(permissions);
+  context.accessToken.scope = allScopes.join(' ');
 
   callback(null, user, context);
 }


### PR DESCRIPTION
I'm surprised, how this could be overlooked, as it makes using multiple permissions per user impossible.
The current implementation of (Access Token Scope) rule is trying to use javascript push function to append array with another array.
Push function, however, should be used to add an item to an array. If we use it to append array with another array, the appending array is automatically converted to a string (thus delimited with a comma).

Given we have  requested scopes: {openid, profile}, and permissions {read:books, write:books}, we end up with the following scope:
scope = "openid profile read:books,write:books"      (notice an extra comma)

To append one array with another, we need to create a new array by using concat function, so I made the following change:

  var allScopes = filteredScopes.concat(permissions);
  context.accessToken.scope = allScopes.join(' ');

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors
- Please include a short description
- If your PR is a work in progress, title it [DO NOT MERGE]
--->
