### PR TITLE
Updated SAML certificate setup

### DIFF
--- a/articles/protocols/saml/saml-configuration/special-configuration-scenarios/signing-and-encrypting-saml-requests.md
+++ b/articles/protocols/saml/saml-configuration/special-configuration-scenarios/signing-and-encrypting-saml-requests.md
@@ -34,26 +34,21 @@ By default, SAML authentication requests are sent via HTTP-Redirect and use defl
 
 To turn off deflate encoding, you can make a [PATCH call to the Management API's Update a Connection endpoint](/api/management/v2#!/Connections/patch_connections_by_id) and set the `deflate` option to `false`.
 
-```har
+Endpoint: `https://${account.namespace}/api/v2/connections/YOUR_CONNECTION_ID`
+
+Payload: 
+
+```json
 {
-	"method": "PATCH",
-	"url": "https://${account.namespace}/api/v2/connections/YOUR_CONNECTION_ID",
-	"httpVersion": "HTTP/1.1",
-	"cookies": [],
-	"headers": [{
-		"name": "Authorization",
-		"value": "Bearer MGMT_API_ACCESS_TOKEN"
-	}],
-	"queryString": [],
-	"postData": {
-		"mimeType": "application/json",
-		"text": "{ \"name\": \"CONNECTION_NAME\", \"options\": \"{\"validation\": \"object\", \"passwordPolicy\": \"\", \"password_history\": \"object\", \"password_no_personal_info\": \"object\", \"password_dictionary\": \"object\", \"deflate\": \"false\",}\" }"
-	},
-	"headersSize": -1,
-	"bodySize": -1,
-	"comment": ""
+	{ 
+		"options" : {
+			[...], // all the other connection options
+		  "deflate": false
+	}
 }
 ```
+
+**Note**: as always when updating the `options` object for a connection, the whole options object will be overridden, so you need to get first the existing `options` object for the connection and add the new key/value to it.
 
 ### Receive Signed SAML Authentication Responses
 

--- a/articles/protocols/saml/saml-configuration/special-configuration-scenarios/signing-and-encrypting-saml-requests.md
+++ b/articles/protocols/saml/saml-configuration/special-configuration-scenarios/signing-and-encrypting-saml-requests.md
@@ -11,7 +11,7 @@ useCase:
 
 # Special Configuration Scenarios: Signing and Encrypting SAML Requests
 
-To increase the security of your transactions, you can sign or encrypt both your requests and your responses in the SAML protocol. Bellow you will find configurations for specific scenarios, separated under two use cases:
+To increase the security of your transactions, you can sign or encrypt both your requests and your responses in the SAML protocol. In this article you'll find configurations for specific scenarios, separated under two use cases:
 
 - Auth0 as the SAML **service provider** (i.e. a SAML **Connection**)
 - Auth0 as the SAML **identity provider** (i.e. an **Application** configured with the **SAML Web App Addon**)
@@ -34,6 +34,10 @@ By default, SAML authentication requests are sent via HTTP-Redirect and use defl
 
 To turn off deflate encoding, you can make a [PATCH call to the Management API's Update a Connection endpoint](/api/management/v2#!/Connections/patch_connections_by_id) and set the `deflate` option to `false`.
 
+::: note
+Updating the `options` object for a connection overrides the whole `options` object. To keep previous connection options, get the existing `options` object and add new key/values to it.
+:::
+
 Endpoint: `https://${account.namespace}/api/v2/connections/YOUR_CONNECTION_ID`
 
 Payload: 
@@ -48,21 +52,21 @@ Payload:
 }
 ```
 
-**Note**: as always when updating the `options` object for a connection, the whole options object will be overridden, so you need to get first the existing `options` object for the connection and add the new key/value to it.
-
 ### Use a custom certificate to sign requests
 
-By default, Auth0 will use the tenant private key to sign SAML requests (when the **Sign Request** toggle is enabled). You can, however, provide your own private/public key pair to do the signing for requests coming from a specific connection.
+By default, Auth0 uses the tenant private key to sign SAML requests (when the **Sign Request** toggle is enabled). You can also provide your own private/public key pair to sign requests coming from a specific connection.
 
 You can generate your own certificate and private key using this command:
 
-```
+```shell
 openssl req -x509 -nodes -sha256 -days 3650 -newkey rsa:2048 -keyout private_key.key -out certificate.crt
 ```
 
-Changing the key used to sign requests in the connection can't be done directly on the Dashboard UI, so you will have to use the [Update a Connection endpoint](/api/management/v2#!/Connections/patch_connections_by_id) from the Management API v2, and add a `signing_key` property to the `options` object, as shown in the payload example below.
+Changing the key used to sign requests in the connection can't be done on the Dashboard UI, so you will have to use the [Update a Connection endpoint](/api/management/v2#!/Connections/patch_connections_by_id) from the Management API v2, and add a `signing_key` property to the `options` object, as shown in the payload example below.
 
-**Note**: as always when updating the `options` object for a connection, the whole options object will be overridden, so you need to get first the existing `options` object for the connection and add the new key/value to it.
+::: note
+Updating the `options` object for a connection overrides the whole `options` object. To keep previous connection options, get the existing `options` object and add new key/values to it.
+:::
 
 Endpoint: `https://${account.namespace}/api/v2/connections/YOUR_CONNECTION_ID`
 
@@ -87,7 +91,7 @@ See [Working with private and public keys as strings](#working-with-certificates
 
 If Auth0 is the SAML **service provider**, all SAML responses from your identity provider should be signed to indicate it hasn't been tampered with by an unauthorized third-party.
 
-You will then need to configure Auth0 to validate the responses' signatures by:
+You will need to configure Auth0 to validate the responses' signatures by:
 
 * Obtaining a signing certificate from the IdP
 * Loading the certificate from the IdP into your Auth0 Connection (in the Management Dashboard, go to the **Upload Certificate** section for your Connection by navigating to **Connections** -> **Enterprise** -> **SAMLP Identity Provider** -> **Settings**)
@@ -173,7 +177,7 @@ If Auth0 is the SAML **identity provider**, you can use [Rules](/rules) to encry
 
 You'll need to obtain the certificate and the public key from the service provider. If you only got the certificate, you can derive the public key using `openssl`. Assuming that the certificate file is named `certificate.pem` you can do:
 
-```
+```shell
 openssl x509 -in certificate.pem -pubkey -noout > public_key.pem
 ```
 

--- a/articles/protocols/saml/saml-configuration/special-configuration-scenarios/signing-and-encrypting-saml-requests.md
+++ b/articles/protocols/saml/saml-configuration/special-configuration-scenarios/signing-and-encrypting-saml-requests.md
@@ -11,9 +11,16 @@ useCase:
 
 # Special Configuration Scenarios: Signing and Encrypting SAML Requests
 
-To increase the security of your transactions, you can sign or encrypt both your requests and your responses.
+To increase the security of your transactions, you can sign or encrypt both your requests and your responses in the SAML protocol. Bellow you will find configurations for specific scenarios, separated under two use cases:
 
-## Sign the SAML Authentication Request
+- Auth0 as the SAML **service provider** (i.e. a SAML **Connection**)
+- Auth0 as the SAML **identity provider** (i.e. an **Application** configured with the **SAML Web App Addon**)
+
+## Auth0 as the SAML Service Provider
+
+These scenarios apply when Auth0 is the SAML Service Provider, i.e. Auth0 connects to a SAML identity provider by creating a SAML connection.
+
+### Sign the SAML Authentication Request
 
 If Auth0 is the SAML **service provider**, you can sign the authentication request Auth0 sends to the IdP as follows:
 
@@ -21,7 +28,7 @@ If Auth0 is the SAML **service provider**, you can sign the authentication reque
 2. Enable the **Sign Request** toggle.
 3. Download the certificate beneath the **Sign Request** toggle and provide it to the IdP so that it can validate the signature.
 
-### Enable/Disable Deflate Encoding
+#### Enable/Disable Deflate Encoding
 
 By default, SAML authentication requests are sent via HTTP-Redirect and use deflate encoding, which puts the signature in a query parameter.
 
@@ -48,7 +55,30 @@ To turn off deflate encoding, you can make a [PATCH call to the Management API's
 }
 ```
 
-## Sign the SAML Authentication Responses/Assertions
+### Receive Signed SAML Authentication Responses
+
+If Auth0 is the SAML **service provider**, all SAML responses from your identity provider should be signed to indicate it hasn't been tampered with by an unauthorized third-party.
+
+You will then need to configure Auth0 to validate the responses' signatures by:
+
+* Obtaining a signing certificate from the IdP
+* Loading the certificate from the IdP into your Auth0 Connection (in the Management Dashboard, go to the **Upload Certificate** section for your Connection by navigating to **Connections** -> **Enterprise** -> **SAMLP Identity Provider** -> **Settings**)
+
+Auth0 can accept a signed response for the assertion, the response, or both.
+
+### Receive Encrypted SAML Authentication Assertions
+
+If Auth0 is the SAML **service provider**, it may need to receive encrypted assertions from an identity provider. To do this, you must provide Auth0's public key and certificate to the IdP. The IdP encrypts the SAML assertion using the public key and sends it to Auth0, which decrypts it using the private key.
+
+To retrieve the certificate you need to send to your IdP from the [Management Dashboard](${manage_url}), go to **Connections** -> **Enterprise** -> **SAMLP Identity Provider** and click on the **Setup Instructions** button next to the connection.
+
+Navigate to the section titled **Encrypted Assertions** and download the certificate in the format requested by the IdP.
+
+## Auth0 as the SAML Identity Provider
+
+This scenarios apply when Auth0 is the SAML Identity Provider for an application. This is represented in the dashboard by an **Application** that has the SAML Web App Addon enabled.
+
+### Sign the SAML Authentication Responses/Assertions
 
 If Auth0 is the SAML **identity provider**, it can sign responses/assertions with its private key and provide the service provider with the public key/certificate necessary to validate the signature.
 
@@ -63,7 +93,7 @@ Next, you'll need make sure that the SAML assertion is *not* signed (you can sig
 1. In the [Management Dashboard](${manage_url}), navigate to **Applications**. Find the Application you're interested in go to **Addons** > SAML2 WEB APP > Settings.
 2. By default, `signResponse` is true. As such, uncomment this line and set the value to `false`. Your SAML assertion will no longer be signed.
 
-## Receive Signed SAML Authentication Requests
+### Receive Signed SAML Authentication Requests
 
 If Auth0 is the SAML **identity provider**, it can received requests signed with the service provider's private key. Auth0 will then use the service providers' public key/certificate to validate the signature.
 
@@ -78,18 +108,7 @@ The configuration should look like this:
 }
 ```
 
-## Receive Signed SAML Authentication Responses
-
-If Auth0 is the SAML **service provider**, all SAML responses from your identity provider should be signed to indicate it hasn't been tampered with by an unauthorized third-party.
-
-You will then need to configure Auth0 to validate the responses' signatures by:
-
-* Obtaining a signing certificate from the IdP
-* Loading the certificate from the IdP into your Auth0 Connection (in the Management Dashboard, go to the **Upload Certificate** section for your Connection by navigating to **Connections** -> **Enterprise** -> **SAMLP Identity Provider** -> **Settings**)
-
-Auth0 can accept a signed response for the assertion, the response, or both.
-
-## Send Encrypted SAML Authentication Assertions
+### Send Encrypted SAML Authentication Assertions
 
 If Auth0 is the SAML **identity provider**, you can use [Rules](/rules) to encrypt the SAML assertions it sends.
 
@@ -108,10 +127,3 @@ function (user, context, callback) {
 }
 ```
 
-## Receive Encrypted SAML Authentication Assertions
-
-If Auth0 is the SAML **service provider**, it may need to receive encrypted assertions from an identity provider. To do this, you must provide Auth0's public key and certificate to the IdP. The IdP encrypts the SAML assertion using the public key and sends it to Auth0, which decrypts it using the private key.
-
-To retrieve the certificate you need to send to your IdP from the [Management Dashboard](${manage_url}), go to **Connections** -> **Enterprise** -> **SAMLP Identity Provider** and click on the **Setup Instructions** button next to the connection.
-
-Navigate to the section titled **Encrypted Assertions** and download the certificate in the format requested by the IdP.


### PR DESCRIPTION
- Reorganized the **Special Configuration Scenarios: Signing and Encrypting SAML Requests** document to separate Auth0 as IdP and Auth0 as SP scenarios.
- Added instructions on how to provide your own key to sign requests when Auth0 is the SP (i.e. SAML connections).