### PR TITLE
ACS URLs should go in allowed callback URLs

### DIFF
--- a/articles/protocols/saml/saml-idp-generic.md
+++ b/articles/protocols/saml/saml-idp-generic.md
@@ -34,7 +34,7 @@ In this section you will configure Auth0 to serve as an Identity Provider. You w
     ![SAML Protocol URL](/media/articles/saml/saml-idp-generic/saml-idp-generic2.png)
 1. Scroll back up and click on the **Addons** tab.  Then click on **SAML2 WEB APP**.
     ![SAML2 WEB APP](/media/articles/saml/saml-idp-generic/saml-idp-generic3.png)
-1. In the **Application Callback URL** field, enter the URL of the Service Provider (or application) to which the SAML assertions should be sent after Auth0 has authenticated the user.  
+1. In the **Application Callback URL** field, enter the URL of the Service Provider (or application) to which the SAML assertions should be sent after Auth0 has authenticated the user. This is the Assertion Consumer Service (ACS) URL. If your Service Provider is sending multiple ACS URLs in the SAML Request, you will need to whitelist them by adding them to the Application's **Allowed Callback URLs** setting in Application Settings.
     ![Application Callback URL](/media/articles/saml/saml-idp-generic/saml-idp-generic4.png)
 1.  In the Addon SAML2 Web App popup, click on the **Usage** tab.  This tab will provide you with the information needed to configure the Service Provider application.
     ![Usage](/media/articles/saml/saml-idp-generic/saml-idp-generic5.png)


### PR DESCRIPTION
When acting as SAML IdP i.e Configuring Auth0 Application with a SAML2 Web App Addon, all the URLs should be added to the Application's Allowed Callback URLs otherwise you will receive an error.