### PR TITLE
OPEX-252 Updating date information in logs docs

### DIFF
--- a/articles/logs/query-syntax.md
+++ b/articles/logs/query-syntax.md
@@ -71,17 +71,6 @@ The question mark character (`?`), is currently not supported.
 
 For example, to find all logs for users whose usernames start with `john`, use `q=user_name:john*`:
 
-## Dates
-
-A date will always be converted to a zeroed-out state if all values are provided; if `2018-12-18` is provided, it will be converted to `2018-12-18T00:00:00.000Z` internally. Below are some more examples of how various date formats will be converted.
-
-Example | Converted Value
---------|----------------
-`2018-12-18` | `2018-12-18T00:00:00.000Z`
-`2018-12` | `2018-12-01T00:00:00.000Z`
-`2018-12-18T12:22` | `2018-12-18T12:22:00.000Z`
-`2018-12-18T15:23:48.123Z` | `2018-12-18T15:23:48.123Z`
-
 ## Ranges
 
 You can use ranges in your log search queries. For inclusive ranges use square brackets: `[min TO max]`, and for exclusive ranges use curly brackets: `{min TO max}`.
@@ -104,7 +93,7 @@ Search for all logs with a type starting with "s" | `type:s*`
 Search for user names that start with "jane" and end with "smith" | `user_name:jane*smith`
 Search for all logs in December 2018 | `date:[2018-12 TO 2018-01-01}`
 Search for all logs from December 10, 2018 forward | `date:[2018-12-10 TO *]`
-Search for all logs from January 1, 2019 at 1AM, up till, but not including till January 1, 2019 at 12:23:45 | `date:[2019-01-01T01:00:00 TO 2019-01-01T12:23:45}`
+Search for all logs from January 1, 2019 at 1AM, until, but not including January 1, 2019 at 12:23:45 | `date:[2019-01-01T01:00:00 TO 2019-01-01T12:23:45}`
 
 ## Limitations
 
@@ -124,4 +113,3 @@ While the query syntax described in this article is compliant with both the old 
 * The details field is not searcheable anymore, only the [list of searcheable fields](/logs/query-syntax#searchable-fields) can be used for search and sort.
 * Log fields are not tokenized like in v2, so `description:rule` will not match a description with value `Create a rule` nor `Update a rule` like in v2. Instead, use `description:*rule`. See [wildcards](/logs/query-syntax#wildcards) and [exact matching](/logs/query-syntax#exact-matching).
 * The .raw field extension is no longer supported and must be removed. In v3, fields match the whole value that is provided and are not tokenized as they were in v2 without the .raw suffix.
-* Ranges for dates for which the exact time is not provided, will behave differently than with v2. For example, the following query `q=date:[2018-12-18 TO 2018-12-19]` will return logs from the start of 2018-12-18 *till the end of day of* 2019-12-19 on search engine v2, but it in v3, as all dates that don't include the time will be filled with zeros, it will return logs from the first millisecond of 2018-12-18 (2018-12-18T00:00:00.000Z) *till, and including, the first millisecond* of 2018-12-19T00:00:00.000Z, which means that all logs except for the first millisecond of 2018-12-19 will *not* be included. In order to include the desired date, either the time should be provided or one more day should be added to the range, i.e. `q=date:[2018-12-18 TO 2018-12-20}`. Since our logs only allow searching to nanosecond precision, it is helpful to start with an inclusive datetime `[` and end with

--- a/updates/2019-04-12.yml
+++ b/updates/2019-04-12.yml
@@ -1,0 +1,10 @@
+changed:
+  -
+    title: "Logs - Query Syntax"
+    tags:
+      - logs
+      - log-management
+      - search
+      - query-syntax
+    description: |
+      Updated the [Logs Query Syntax](/logs/query-syntax) to remove temporary limits on the date functionality.


### PR DESCRIPTION
We had some temporary information regarding the behavior of dates in log
search to account for some broken behavior between v2 and v3. This
behavior has since been corrected and is now back to the way it was.

The docs have been updated to reflect this change.