### PR TITLE
Update logs query to find User Search v2 usage

### DIFF
--- a/articles/users/search/v3/migrate-search-v2-v3.md
+++ b/articles/users/search/v3/migrate-search-v2-v3.md
@@ -66,8 +66,8 @@ Extension | Version with support for v3 | Considerations
 You can leverage the [logs](/logs) in the [Dashboard](${manage_url}/#/logs) to find calls to the `/api/v2/users` endpoint that use the User Search v2 engine, including calls performed by SDKs. Those logs will help you identify where code changes might be needed in your applications.
 
 Use the following query to retrieve all the logs related to User Search v2: 
-- For Tenants in the **AU** or **EU** regions: `type:w AND description:"The User Search v2 engine is deprecated"`
-- For Tenants in the **US** region: `type:w AND description:*User*Search*v2*`
+- For tenants in the **AU** and **EU** regions: `type:w AND description:"The User Search v2 engine is deprecated"`
+- For tenants in the **US** region: `type:w AND description:*User*Search*v2*`
 
 The logs will provide additional information in the description field, in the following cases:
 

--- a/articles/users/search/v3/migrate-search-v2-v3.md
+++ b/articles/users/search/v3/migrate-search-v2-v3.md
@@ -65,7 +65,7 @@ Extension | Version with support for v3 | Considerations
 
 You can leverage the [logs](/logs) in the [Dashboard](${manage_url}/#/logs) to find calls to the `/api/v2/users` endpoint that use the User Search v2 engine, including calls performed by SDKs. Those logs will help you identify where code changes might be needed in your applications.
 
-Use the following query to retrieve all the logs related to User Search v2: `type:w AND description:"The User Search v2 engine is deprecated"`. The logs will provide additional information in the description field, in the following cases:
+Use the following query to retrieve all the logs related to User Search v2: `type:w AND description:*User*Search*v2*`. The logs will provide additional information in the description field, in the following cases:
 
 - Queries that might produce different results in v3
 - Queries with syntax incompatible with v3

--- a/articles/users/search/v3/migrate-search-v2-v3.md
+++ b/articles/users/search/v3/migrate-search-v2-v3.md
@@ -65,7 +65,11 @@ Extension | Version with support for v3 | Considerations
 
 You can leverage the [logs](/logs) in the [Dashboard](${manage_url}/#/logs) to find calls to the `/api/v2/users` endpoint that use the User Search v2 engine, including calls performed by SDKs. Those logs will help you identify where code changes might be needed in your applications.
 
-Use the following query to retrieve all the logs related to User Search v2: `type:w AND description:*User*Search*v2*`. The logs will provide additional information in the description field, in the following cases:
+Use the following query to retrieve all the logs related to User Search v2: 
+- For Tenants in the **AU** or **EU** regions: `type:w AND description:*User*Search*v2*`
+- For Tenants in the **US** region: `type:w AND description:"The User Search v2 engine is deprecated"`
+
+The logs will provide additional information in the description field, in the following cases:
 
 - Queries that might produce different results in v3
 - Queries with syntax incompatible with v3

--- a/articles/users/search/v3/migrate-search-v2-v3.md
+++ b/articles/users/search/v3/migrate-search-v2-v3.md
@@ -66,8 +66,8 @@ Extension | Version with support for v3 | Considerations
 You can leverage the [logs](/logs) in the [Dashboard](${manage_url}/#/logs) to find calls to the `/api/v2/users` endpoint that use the User Search v2 engine, including calls performed by SDKs. Those logs will help you identify where code changes might be needed in your applications.
 
 Use the following query to retrieve all the logs related to User Search v2: 
-- For Tenants in the **AU** or **EU** regions: `type:w AND description:*User*Search*v2*`
-- For Tenants in the **US** region: `type:w AND description:"The User Search v2 engine is deprecated"`
+- For Tenants in the **AU** or **EU** regions: `type:w AND description:"The User Search v2 engine is deprecated"`
+- For Tenants in the **US** region: `type:w AND description:*User*Search*v2*`
 
 The logs will provide additional information in the description field, in the following cases:
 


### PR DESCRIPTION
The query here doesn't work for me, I have to use wild cards to find relevant logs. 
<img width="883" alt="Screen Shot 2019-04-16 at 9 31 19 AM" src="https://user-images.githubusercontent.com/4720963/56227486-76d3dd80-602a-11e9-93de-f6816eebfafb.png">
<img width="898" alt="Screen Shot 2019-04-16 at 9 30 41 AM" src="https://user-images.githubusercontent.com/4720963/56227487-76d3dd80-602a-11e9-80f3-cadf49f0a7b9.png">
