### PR TITLE
deploy-extensions: deploy pages section fix

### DIFF
--- a/articles/extensions/_includes/_use-default-error.md
+++ b/articles/extensions/_includes/_use-default-error.md
@@ -1,0 +1,3 @@
+::: note
+The `error_page` cannot be enabled/disabled. To use the default error page, remove the content of `error_page.html`.
+:::

--- a/articles/extensions/bitbucket-deploy.md
+++ b/articles/extensions/bitbucket-deploy.md
@@ -132,17 +132,21 @@ The supported pages are:
 To deploy a page, you must create an HTML file under the `pages` directory of your Bitbucket repository. For each HTML page, you need to create a JSON file (with the same name) that will be used to mark the page as enabled or disabled. For example, to deploy an `error_page`, you would create two files:
 
 ```text
-your-bitbucket-repo/pages/error_page.html
-your-bitbucket-repo/pages/error_page.json
+your-bitbucket-repo/pages/password_reset.html
+your-bitbucket-repo/pages/password_reset.json
 ```
 
-To enable the page, the `error_page.json` would contain the following:
+To enable the page, the `password_reset.json` would contain the following:
 
 ```json
 {
   "enabled": true
 }
 ```
+
+::: note
+`error_page` cannot be enabled/disabled. If you want to use default error page - you should remove content of `error_page.html`
+:::
 
 ### Deploy Rules
 

--- a/articles/extensions/bitbucket-deploy.md
+++ b/articles/extensions/bitbucket-deploy.md
@@ -118,7 +118,7 @@ __facebook.json__
 
 _This will work only for non-Auth0 connections (`strategy !== auth0`); for Auth0 connections, use `database-connections`._
 
-See [Management API v2 Docs](https://auth0.com/docs/api/management/v2#!/Connections/post_connections) for more info on allowed attributes for Connections.
+For more info on the allowed attributes for connections, see the [Post Connections endpoint] (/api/management/v2#!/Connections/post_connections).
 
 ### Deploy Universal Login Pages
 
@@ -145,7 +145,7 @@ To enable the page, the `password_reset.json` would contain the following:
 ```
 
 ::: note
-`error_page` cannot be enabled/disabled. If you want to use default error page - you should remove content of `error_page.html`
+The `error_page` cannot be enabled/disabled. To use the default error page, remove the content of `error_page.html`.
 :::
 
 ### Deploy Rules

--- a/articles/extensions/bitbucket-deploy.md
+++ b/articles/extensions/bitbucket-deploy.md
@@ -129,7 +129,7 @@ The supported pages are:
 - `login`
 - `password_reset`
 
-To deploy a page, you must create an HTML file under the `pages` directory of your Bitbucket repository. For each HTML page, you need to create a JSON file (with the same name) that will be used to mark the page as enabled or disabled. For example, to deploy an `error_page`, you would create two files:
+To deploy a page, you must create an HTML file under the `pages` directory of your Bitbucket repository. For each HTML page, you need to create a JSON file (with the same name) that will be used to mark the page as enabled or disabled. For example, to deploy a `password_reset`, you would create two files:
 
 ```text
 your-bitbucket-repo/pages/password_reset.html

--- a/articles/extensions/bitbucket-deploy.md
+++ b/articles/extensions/bitbucket-deploy.md
@@ -144,9 +144,7 @@ To enable the page, the `password_reset.json` would contain the following:
 }
 ```
 
-::: note
-The `error_page` cannot be enabled/disabled. To use the default error page, remove the content of `error_page.html`.
-:::
+<%= include('./_includes/_use-default-error') %>
 
 ### Deploy Rules
 

--- a/articles/extensions/github-deploy.md
+++ b/articles/extensions/github-deploy.md
@@ -142,17 +142,21 @@ The supported pages are:
 To deploy a page, you must create an HTML file under the `pages` directory of your GitHub repository. For each HTML page, you need to create a JSON file (with the same name) that will be used to mark the page as enabled or disabled. For example, to deploy an `error_page`, you would create two files:
 
 ```text
-your-github-repo/pages/error_page.html
-your-github-repo/pages/error_page.json
+your-bitbucket-repo/pages/password_reset.html
+your-bitbucket-repo/pages/password_reset.json
 ```
 
-To enable the page, the `error_page.json` would contain the following:
+To enable the page, the `password_reset.json` would contain the following:
 
 ```json
 {
   "enabled": true
 }
 ```
+
+::: note
+`error_page` cannot be enabled/disabled. If you want to use default error page - you should remove content of `error_page.html`
+:::
 
 ### Deploy rules
 

--- a/articles/extensions/github-deploy.md
+++ b/articles/extensions/github-deploy.md
@@ -154,9 +154,7 @@ To enable the page, the `password_reset.json` would contain the following:
 }
 ```
 
-::: note
-`error_page` cannot be enabled/disabled. If you want to use default error page - you should remove content of `error_page.html`
-:::
+<%= include('./_includes/_use-default-error') %>
 
 ### Deploy rules
 

--- a/articles/extensions/github-deploy.md
+++ b/articles/extensions/github-deploy.md
@@ -139,7 +139,7 @@ The supported pages are:
 - `login`
 - `password_reset`
 
-To deploy a page, you must create an HTML file under the `pages` directory of your GitHub repository. For each HTML page, you need to create a JSON file (with the same name) that will be used to mark the page as enabled or disabled. For example, to deploy an `error_page`, you would create two files:
+To deploy a page, you must create an HTML file under the `pages` directory of your GitHub repository. For each HTML page, you need to create a JSON file (with the same name) that will be used to mark the page as enabled or disabled. For example, to deploy a `password_reset`, you would create two files:
 
 ```text
 your-bitbucket-repo/pages/password_reset.html

--- a/articles/extensions/gitlab-deploy.md
+++ b/articles/extensions/gitlab-deploy.md
@@ -161,7 +161,7 @@ The supported hosted pages are:
 - `login`
 - `password_reset`
 
-To deploy a page, you must create an HTML file under the `pages` directory of your GitLab repository. For each HTML page, you need to create a JSON file (with the same name) that will be used to mark the page as enabled or disabled. For example, to deploy an `error_page`, you would create two files:
+To deploy a page, you must create an HTML file under the `pages` directory of your GitLab repository. For each HTML page, you need to create a JSON file (with the same name) that will be used to mark the page as enabled or disabled. For example, to deploy a `password_reset`, you would create two files:
 
 ```text
 your-bitbucket-repo/pages/password_reset.html

--- a/articles/extensions/gitlab-deploy.md
+++ b/articles/extensions/gitlab-deploy.md
@@ -176,9 +176,7 @@ To enable the page, the `password_reset.json` would contain the following:
 }
 ```
 
-::: note
-`error_page` cannot be enabled/disabled. If you want to use default error page - you should remove content of `error_page.html`
-:::
+<%= include('./_includes/_use-default-error') %>
 
 ### Deploy rules
 

--- a/articles/extensions/gitlab-deploy.md
+++ b/articles/extensions/gitlab-deploy.md
@@ -164,17 +164,21 @@ The supported hosted pages are:
 To deploy a page, you must create an HTML file under the `pages` directory of your GitLab repository. For each HTML page, you need to create a JSON file (with the same name) that will be used to mark the page as enabled or disabled. For example, to deploy an `error_page`, you would create two files:
 
 ```text
-your-gitlab-repo/pages/error_page.html
-your-gitlab-repo/pages/error_page.json
+your-bitbucket-repo/pages/password_reset.html
+your-bitbucket-repo/pages/password_reset.json
 ```
 
-To enable the page, the `error_page.json` would contain the following:
+To enable the page, the `password_reset.json` would contain the following:
 
 ```json
 {
   "enabled": true
 }
 ```
+
+::: note
+`error_page` cannot be enabled/disabled. If you want to use default error page - you should remove content of `error_page.html`
+:::
 
 ### Deploy rules
 

--- a/articles/extensions/visual-studio-team-services-deploy.md
+++ b/articles/extensions/visual-studio-team-services-deploy.md
@@ -182,9 +182,7 @@ To enable the page, the `password_reset.json` would contain the following:
 }
 ```
 
-::: note
-`error_page` cannot be enabled/disabled. If you want to use default error page - you should remove content of `error_page.html`
-:::
+<%= include('./_includes/_use-default-error') %>
 
 ### Deploy Rules
 

--- a/articles/extensions/visual-studio-team-services-deploy.md
+++ b/articles/extensions/visual-studio-team-services-deploy.md
@@ -167,7 +167,7 @@ The supported pages are:
 - `login`
 - `password_reset`
 
-To deploy a page, you must create an HTML file under the `pages` directory of your Visual Studio Team Services project. For each HTML page, you need to create a JSON file (with the same name) that will be used to mark the page as enabled or disabled. For example, to deploy an `error_page`, you would create two files:
+To deploy a page, you must create an HTML file under the `pages` directory of your Visual Studio Team Services project. For each HTML page, you need to create a JSON file (with the same name) that will be used to mark the page as enabled or disabled. For example, to deploy a `password_reset`, you would create two files:
 
 ```text
 your-bitbucket-repo/pages/password_reset.html

--- a/articles/extensions/visual-studio-team-services-deploy.md
+++ b/articles/extensions/visual-studio-team-services-deploy.md
@@ -170,17 +170,22 @@ The supported pages are:
 To deploy a page, you must create an HTML file under the `pages` directory of your Visual Studio Team Services project. For each HTML page, you need to create a JSON file (with the same name) that will be used to mark the page as enabled or disabled. For example, to deploy an `error_page`, you would create two files:
 
 ```text
-your-project/pages/error_page.html
-your-project/pages/error_page.json
+your-bitbucket-repo/pages/password_reset.html
+your-bitbucket-repo/pages/password_reset.json
 ```
 
-To enable the page, the `error_page.json` would contain the following:
+To enable the page, the `password_reset.json` would contain the following:
 
 ```json
 {
   "enabled": true
 }
 ```
+
+::: note
+`error_page` cannot be enabled/disabled. If you want to use default error page - you should remove content of `error_page.html`
+:::
+
 ### Deploy Rules
 
 To deploy a rule, you must first create a JavaScript file under the `rules` directory of your Visual Studio Team Services project. Each Rule must be in its own JavaScript file.


### PR DESCRIPTION
For some reason we did use the only page, that cannot be enabled/disabled, as an example for `enabled` flag. Fixed that and added note about `error_page` inability to be `enabled`.