### PR TITLE
Added link to next tutorial from Vue.js Quickstart: 01-Login

### DIFF
--- a/articles/quickstart/spa/vuejs/index.yml
+++ b/articles/quickstart/spa/vuejs/index.yml
@@ -35,6 +35,11 @@ requirements:
 next_steps:
   - path: 01-login
     list:
+    - text: "Part 2: Calling an API using an access token"
+      icon: 345
+      href: "/quickstart/spa/vuejs/03-calling-an-api"
+  - path: 03-calling-an-api
+    list:
     - text: Configure other identity providers
       icon: 345
       href: "/identityproviders"


### PR DESCRIPTION
This PR implements a fix based on community feedback, which was that there was no easy way to navigate to the next part of the quickstart (they didn't spot the menu on the left until later). It was suggested that the next part could be linked at the bottom of the first article, with the links from the first part moved to the second part.

This PR implements this for the Vue.js quickstart.

*01-Login*
<img width="1160" alt="Screenshot 2019-04-25 at 21 48 37" src="https://user-images.githubusercontent.com/766403/56767686-40bdf880-67a4-11e9-9484-9ae60e0b99a1.png">

*03-Calling-an-API*
<img width="1196" alt="Screenshot 2019-04-25 at 21 48 46" src="https://user-images.githubusercontent.com/766403/56767692-49aeca00-67a4-11e9-9e45-4107c9fddb8f.png">
