### PR TITLE
Clarify tenant name policies during deletion

### DIFF
--- a/articles/policies/restore-deleted-tenant.md
+++ b/articles/policies/restore-deleted-tenant.md
@@ -12,12 +12,8 @@ useCase:
 
 # Tenant Restoration Policy
 
-::: note
-If you are considering deleting your tenant, please see our [Resetting/Deleting Tenant](/tutorials/delete-reset-tenant) page for alternative options.
-:::
+**Before you delete your tenant, please see [Resetting/Deleting Tenant](/tutorials/delete-reset-tenant) page for alternative options.**
 
-As explicitly noted during the tenant deletion process, **deleted tenants cannot be restored** at this time.
+**Deleted tenants cannot be restored** and the **tenant name may not be used again** when creating new tenants.
 
-::: note
-If you have deleted your tenant and you require a certain domain or unique domain for branding purposes, we recommend configuring a [custom domain](/custom-domains) for your new tenant.
-:::
+If you've deleted your tenant, and you require the use of a particular domain name, we recommend configuring a [custom domain name](/custom-domains) for your new tenant.

--- a/articles/support/delete-reset-tenant.md
+++ b/articles/support/delete-reset-tenant.md
@@ -18,6 +18,6 @@ Using the [Reset Tenant Extension](https://github.com/auth0-extensions/auth0-res
 
 ## Delete vs. Reset
 
-In some cases, users have opted to delete their tenant to begin with a clean slate. Unfortunately, doing so means that you don't keep your tenant name. Because tenant names have to be unique, they can only used once. As such, we recommend using the Reset Tenant Extension to remove the unwanted items and return your tenant to its initial state, since this means that you do *not* have to start over with a new tenant name.
+In some cases, users have opted to delete their tenant to begin with a clean slate. Unfortunately, doing so means that you don't keep your tenant name. Because tenant names have to be unique, they can only used once (and you will *not* be able to use it for any newly-created tenants in the future). As such, we recommend using the Reset Tenant Extension to remove the unwanted items and return your tenant to its initial state, since this means that you do *not* have to start over with a new tenant name.
 
 <%= include('./_delete-tenant') %>


### PR DESCRIPTION
Make it clear you can never reuse a tenant name no matter what

* https://docs-content-staging-pr-7555.herokuapp.com/docs/policies/restore-deleted-tenant
* https://docs-content-staging-pr-7555.herokuapp.com/docs/support/delete-reset-tenant