### PR TITLE
Clarifying copy

### DIFF
--- a/articles/users/guides/redirect-users-after-login.md
+++ b/articles/users/guides/redirect-users-after-login.md
@@ -13,7 +13,7 @@ useCase:
 
 To make your login process as easy-to-use and seamless as possible, you'll need to keep track of where you want to route users inside your application once Auth0 redirects users back to your application after authentication. There are two types of URLs:
 
-* **Callback URLs**: During a user's authentication, the `redirect_uri` request parameter is used as a callback URL. This is where your application will receive and process the response from Auth0, and where the users will be redirected, once the authentication is complete.
+* **Callback URLs**: During a user's authentication, the `redirect_uri` request parameter is used as a callback URL. This is where your application will receive and process the response from Auth0, and is often the URL that users will be redirected to once the authentication is complete.
 
   ::: note
   For more information on how the `redirect_uri` works, see [OAuth 2.0](/protocols/oauth2).


### PR DESCRIPTION
Clarifying copy here to indicate that the callback url setting is the redirect for users _most of the time_ rather than definitively, since a couple of lines below we say that it doesn't have to be.