### PR TITLE
Add note for changing From address

### DIFF
--- a/articles/connections/passwordless/_includes/_setup-email.md
+++ b/articles/connections/passwordless/_includes/_setup-email.md
@@ -17,6 +17,10 @@ You will need to use your own email provider to be able to modify the `From`, `S
 
 ![Configure Email Passwordless](/media/articles/connections/passwordless/connections-passwordless-email.png)
 
+::: note
+You must change the **From** value to a non **@auth0com** address for your custom email to be sent. Otherwise the default email template will be sent.
+:::
+
 3. Enter any **Authentication Parameters** you would like to include in the generated sign-in link.
 
 4. Adjust settings for your **OTP Expiry** and **OTP Length**, and click **SAVE**.


### PR DESCRIPTION
Trying to deflect support tickets where customers can't figure out why their custom passwordless email is not being used because they left the @auth0.com address in the From field.
