### PR TITLE
Update sample code for connection resolver

### DIFF
--- a/articles/libraries/lock/v11/selecting-the-connection-for-multiple-logins.md
+++ b/articles/libraries/lock/v11/selecting-the-connection-for-multiple-logins.md
@@ -57,7 +57,7 @@ If your application has multiple database connections enabled, Lock needs to kno
 ```
 var options = {
   connectionResolver: function (username, context, cb) {
-    var domain = username.includes('@') && username.split('@')[1];
+    var domain = username.indexOf('@') !== -1 && username.split('@')[1];
     if (domain && domain ==='auth0.com') {
       // If the username is test@auth0.com, the connection used will be the `auth0-users` connection.
       cb({ type: 'database', name: 'auth0-users' });


### PR DESCRIPTION
The previous sample code is using `string.includes()` which is not available in IE; since Lock still supports IE 10/11 this would be a source of issues for customers copying the sample code.

Updated the code to use `string.indexOf` instead.

