### PR TITLE
Adding fully qualified url

### DIFF
--- a/articles/quickstart/backend/django/01-authorization.md
+++ b/articles/quickstart/backend/django/01-authorization.md
@@ -156,7 +156,7 @@ JWT_AUTH = {
     'JWT_PUBLIC_KEY': publickey,
     'JWT_ALGORITHM': 'RS256',
     'JWT_AUDIENCE': '${apiIdentifier}',
-    'JWT_ISSUER': '${account.namespace}',
+    'JWT_ISSUER': 'https://${account.namespace}/',
     'JWT_AUTH_HEADER_PREFIX': 'Bearer',
 }
 ```


### PR DESCRIPTION
Without the fully qualified URL, the token seemed invalid always. I used https://jwt.io to decode the token and then copied the issuer from the decoded value. Now my APIs work

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors
- Please include a short description
- If your PR is a work in progress, title it [DO NOT MERGE]
--->
