### PR TITLE
remove duplicate redirect rules link

### DIFF
--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -380,9 +380,6 @@ articles:
       - title: "Cache Expensive Resources"
         url: "/rules/guides/cache-resources"
 
-      - title: "Redirect Rules"
-        url: "/rules/guides/redirect"
-
       - title: "Debug Rules"
         url: "/rules/guides/debug"
 


### PR DESCRIPTION
There's already this one:
```
- title: "Redirect Users from Rules"
        url: "/rules/guides/redirect"
```

This removes "Redirect Rules" from the sidebar because it's duplicate.
https://auth0.com/docs/rules/guides/redirect