### PR TITLE
Remove inaccurate statement from Renew Token doc for Safari 

### DIFF
--- a/articles/api-auth/token-renewal-in-safari.md
+++ b/articles/api-auth/token-renewal-in-safari.md
@@ -27,7 +27,7 @@ By default, ITP is active. You can determine if the Safari version you are using
 Enabling ITP causes the browser to behave as if you had disabled third-party cookies in the browser: **checkSession()** is unable to access the current user's session, which makes it impossible to obtain a new token without displaying anything to the user.
 
 This is akin to the way OpenID Connect uses iframes for handling [sessions]
-(/sessions) in single-page applications (SPAs). Auth0 is working with [OpenID Connect AB/Connect Working Group](http://openid.net/wg/connect/) to determine if this issue can be addressed at the standards level.
+(/sessions) in single-page applications (SPAs).
 
 ## Solution
 

--- a/articles/api-auth/token-renewal-in-safari.md
+++ b/articles/api-auth/token-renewal-in-safari.md
@@ -26,8 +26,7 @@ By default, ITP is active. You can determine if the Safari version you are using
 
 Enabling ITP causes the browser to behave as if you had disabled third-party cookies in the browser: **checkSession()** is unable to access the current user's session, which makes it impossible to obtain a new token without displaying anything to the user.
 
-This is akin to the way OpenID Connect uses iframes for handling [sessions]
-(/sessions) in single-page applications (SPAs).
+This is akin to the way OpenID Connect uses iframes for handling [sessions](/sessions) in single-page applications (SPAs).
 
 ## Solution
 
@@ -37,7 +36,7 @@ You can work around the issues posed by ITP by using Auth0's [custom domains](/c
 
 ## ITP Debug Mode
 
-[Safari Technology Preview](https://developer.apple.com/safari/technology-preview/) offers an "Intelligent Tracking Prevention Debug Mode" that you can use to troubleshoot ITP issues. You can find instructions on how to debug ITP on [this blog post from WebKit](https://webkit.org/blog/8387/itp-debug-mode-in-safari-technology-preview-62/). 
+[Safari Technology Preview](https://developer.apple.com/safari/technology-preview/) offers an "Intelligent Tracking Prevention Debug Mode" that you can use to troubleshoot ITP issues. You can find instructions on how to debug ITP on [this blog post from WebKit](https://webkit.org/blog/8387/itp-debug-mode-in-safari-technology-preview-62/).
 
 **NOTE**: The instructions mention how to permanently classify a custom domain as having tracking abilites for testing purposes. In later versions of Safari Technology Preview, though, the domain to store the User Defaults for this setting changed from `com.apple.SafariTechnologyPreview` to `com.apple.WebKit.Networking`. If you are having trouble with the commands mentioned in the instructions, try these:
 


### PR DESCRIPTION
This PR removes a line that no longer applies, per a Slack conversation.