### PR TITLE
Fixing "add roles to tokens" code snippet

### DIFF
--- a/articles/authorization/concepts/sample-use-cases-rules.md
+++ b/articles/authorization/concepts/sample-use-cases-rules.md
@@ -74,8 +74,8 @@ function (user, context, callback) {
   let idTokenClaims = context.idToken || {};
   let accessTokenClaims = context.accessToken || {};
 
-  idTokenClaims['<%= "${namespace}" %>/roles'] = assignedRoles;
-  accessTokenClaims['<%= "${namespace}" %>/roles'] = assignedRoles;
+  idTokenClaims[`<%= "${namespace}" %>/roles`] = assignedRoles;
+  accessTokenClaims[`<%= "${namespace}" %>/roles`] = assignedRoles;
 
   context.idToken = idTokenClaims;
   context.accessToken = accessTokenClaims;


### PR DESCRIPTION
The code snippet is using simple string literals when it should be using template literals.