### PR TITLE
Add include describing how to find Auth0 domain

### DIFF
--- a/articles/connections/social/37signals.md
+++ b/articles/connections/social/37signals.md
@@ -34,6 +34,8 @@ On the next page, select which 37Signals applications you want to access, and en
 
     https://${account.namespace}/login/callback
 
+    <%= include('../_find-auth0-domain-redirects') %>
+
 ![](/media/articles/connections/social/37signals/37signals-register-2.png)
 
 ## 3. Generate your *Client Id* and *Client Secret*

--- a/articles/connections/social/amazon.md
+++ b/articles/connections/social/amazon.md
@@ -48,6 +48,8 @@ and the callback address for your app should be:
 https://${account.namespace}/login/callback
 ```
 
+<%= include('../_find-auth0-domain-redirects') %>
+
 ## 4. Copy your Client Id and Client Secret
 
 Go to your Auth0 Dashboard and select **Connections > Social**, then choose **Amazon**. Copy the `Client Id` and `Client Secret` from the **Web Settings** of your app on Amazon into the fields on this page on Auth0.

--- a/articles/connections/social/auth0-oidc.md
+++ b/articles/connections/social/auth0-oidc.md
@@ -22,6 +22,8 @@ You can use an application on one Auth0 tenant (referred to below as the **OIDC 
 2. Take note of your application's **Client ID** and **Client Secret**. You will need these to create the connection in the Relying Party tenant.
 3. Add the Relying Party tenant's login callback to the list of **Allowed Callback URLs**: `https://${account.namespace}/login/callback`
 
+<%= include('../_find-auth0-domain-redirects') %>
+
 4. Make sure that the **OIDC-Conformant** toggle in the **OAuth** tab under the application's **Advance Settings** is turned **off**.
 
 5. Make sure that the tenant has the **Legacy User Profile** toggle enabled under the **Migrations** section of the [Tenant Advanced Settings](${manage_url}/#/tenant/advanced). If you don't see this toggle for your tenant, please open a support case to request this feature to be enabled.

--- a/articles/connections/social/baidu.md
+++ b/articles/connections/social/baidu.md
@@ -37,6 +37,8 @@ Use the following value for the callback URL:
 
   https://${account.namespace}/login/callback
 
+  <%= include('../_find-auth0-domain-redirects') %>
+
 Select your application on the console, and then click on `API 管理 -> 安全设置`
 
 ![](/media/articles/connections/social/baidu/baidu-register-3.png)

--- a/articles/connections/social/bitbucket.md
+++ b/articles/connections/social/bitbucket.md
@@ -26,6 +26,8 @@ To connect your Auth0 app to Bitbucket, you will need to generate a *Key* and *S
 
 `https://${account.namespace}/login/callback`
 
+<%= include('../_find-auth0-domain-redirects') %>
+
 3. Select the Permissions you want to enable for this connection. At the very least you will need to select the `Account:Email` and `Account:Read` permissions.
 
 4. Click **Save**.

--- a/articles/connections/social/box.md
+++ b/articles/connections/social/box.md
@@ -43,6 +43,8 @@ Enter this URL as the `redirect_uri`:
 
   https://${account.namespace}/login/callback
 
+  <%= include('../_find-auth0-domain-redirects') %>
+
 While on this page, make sure to define the appropriate permission **Scopes** for your app.
 
 ## 3. Copy your *Client Id* and *Client Secret*

--- a/articles/connections/social/docomo.md
+++ b/articles/connections/social/docomo.md
@@ -39,6 +39,8 @@ Access Token lifetime (アクセストークン有効期間 秒) | The lifetime 
 Redirect URI (リダイレクトURI) | The callback url for your application (`https://${account.namespace}/login/callback`)
 Available scopes (利用可能スコープ) | The scopes for the information you are requesting for your app.
 
+<%= include('../_find-auth0-domain-redirects') %>
+
 ![dAccount RP Site Registration](/media/articles/connections/social/docomo/rp-register.png)
 
 When finished, click **Register (登録)**.

--- a/articles/connections/social/dropbox.md
+++ b/articles/connections/social/dropbox.md
@@ -45,6 +45,8 @@ Click **Create your app**:
 On your app's **Settings** page that follows, enter this URL in the **Redirect URIs** field:
 
 `https://${account.namespace}/login/callback`
+
+<%= include('../_find-auth0-domain-redirects') %>
   
 Click **Add**:
 

--- a/articles/connections/social/dwolla.md
+++ b/articles/connections/social/dwolla.md
@@ -31,6 +31,8 @@ Complete the information on this page. Enter the following URL in the **OAuth Re
 
   https://${account.namespace}/login/callback
 
+  <%= include('../_find-auth0-domain-redirects') %>
+
 ![](/media/articles/connections/social/dwolla/dwolla-2.png)
 
 Click **Create application**.

--- a/articles/connections/social/exact.md
+++ b/articles/connections/social/exact.md
@@ -39,7 +39,9 @@ In the `Redirect URI`field, enter this value:
 
     https://${account.namespace}/login/callback
 
-and click **Save**.
+    <%= include('../_find-auth0-domain-redirects') %>
+
+Click **Save**.
 
 ## 3. Get your new app's *Client Id* and *Client Secret*
 

--- a/articles/connections/social/fitbit.md
+++ b/articles/connections/social/fitbit.md
@@ -43,6 +43,8 @@ Log in to the [Fitbit's Developer site](https://dev.fitbit.com), then select **R
 - **Callback URL**- this is the URL called after a request, in this field enter: `https://${account.namespace}/login/callback`
 - **Default Access Type**- the type of access granted to the application
 
+<%= include('../_find-auth0-domain-redirects') %>
+
 When finished, click **Register**.
 
 ## 3. Copy Your New App's *Client ID* and *Client Secret*

--- a/articles/connections/social/github.md
+++ b/articles/connections/social/github.md
@@ -38,6 +38,8 @@ On the [Register a new application](https://github.com/settings/applications/new
 | Application description | The description of your app users will see (Optional) |
 | Authorization callback URL | `https://${account.namespace}/login/callback` |
 
+<%= include('../_find-auth0-domain-redirects') %>
+
 ![](/media/articles/connections/social/github/github-add-app-2.png)
 
 After completing the form click **Register application** to proceed.

--- a/articles/connections/social/goodreads.md
+++ b/articles/connections/social/goodreads.md
@@ -33,6 +33,8 @@ Complete the form then click **Apply for a Developer Key**. Enter this in the `C
 https://${account.namespace}/login/callback
 ```
 
+<%= include('../_find-auth0-domain-redirects') %>
+
 ![Enter information about your app](/media/articles/connections/social/goodreads/goodreads-register-2.png)
 
 ## 3. Get your Consumer Key and Consumer Secret

--- a/articles/connections/social/paypal.md
+++ b/articles/connections/social/paypal.md
@@ -48,6 +48,8 @@ Scroll down to the **Sandbox App Settings** section and **Show** the **Return UR
 
 `https://${account.namespace}/login/callback`
 
+<%= include('../_find-auth0-domain-redirects') %>
+
 ![](/media/articles/connections/social/paypal/sandbox-settings.png)
 
 If you would like to control the scope of access to customer data (such as profile information, email address, home address, and phone number) through Auth0, you need to enable access to this information by selecting the desired attributes under the **Advanced Options**, which becomes available to you if you enable the **Log In with PayPal** feature.

--- a/articles/connections/social/planning-center.md
+++ b/articles/connections/social/planning-center.md
@@ -31,7 +31,9 @@ Complete the form. In the **Authorization callback URLs** field, enter this URL:
 
   https://${account.namespace}/login/callback
 
-and click **Submit**:
+  <%= include('../_find-auth0-domain-redirects') %>
+
+Click **Submit**.
 
 ![](/media/articles/connections/social/planning-center/planning-center-api-2.png)
 

--- a/articles/connections/social/renren.md
+++ b/articles/connections/social/renren.md
@@ -31,6 +31,8 @@ Complete the required information on this page. Enter the following value for th
 
   https://${account.namespace}/login/callback
 
+  <%= include('../_find-auth0-domain-redirects') %>
+
 Click **Create App**.
 
 ![](/media/articles/connections/social/renren/renren-register-2.png)

--- a/articles/connections/social/salesforce.md
+++ b/articles/connections/social/salesforce.md
@@ -35,6 +35,9 @@ Navigate to **Platform Tools > Apps**. Under **App Manager**, click **New Connec
 1. Enter the required basic information (*Connected App Name*, *API Name* and *Contact Email*).
 2. Select **Enable OAuth Settings**  under **API (Enable OAuth Settings)**.
 3. Enter your callback URL: `https://${account.namespace}/login/callback`
+
+<%= include('../_find-auth0-domain-redirects') %>
+
 4. Add *Access your basic information* to the **Selected OAuth Scopes**.
 5. Click **Save**.
 

--- a/articles/connections/social/soundcloud.md
+++ b/articles/connections/social/soundcloud.md
@@ -46,6 +46,8 @@ Once your Auth0 Application has been added to your SoundCloud account, you can g
 
 Be sure to provide the following as your `Redirect URI for Authentication` on the SoundCloud dashboard: `https://${account.namespace}/login/callback`
 
+<%= include('../_find-auth0-domain-redirects') %>
+
 Go to the [Connections > Social](${manage_url}/#/connections/social) section of the Auth0 dashboard and enable **SoundCloud**.
 
 ![](/media/articles/connections/social/soundcloud/social.png)

--- a/articles/connections/social/thecity.md
+++ b/articles/connections/social/thecity.md
@@ -33,6 +33,8 @@ Select __API > Plugin > Create plugin__:
 
 Complete the form using this callback URL: `https://${account.namespace}/login/callback`
 
+<%= include('../_find-auth0-domain-redirects') %>
+
 ![](/media/articles/connections/social/thecity/thecity-register-3.png)
 
 Press __Create__

--- a/articles/connections/social/twitter.md
+++ b/articles/connections/social/twitter.md
@@ -32,6 +32,8 @@ If you're using a [custom domain](/custom-domains), you'll need to add that doma
 
 3. Provide the required information. For the **Callback URL**, enter `https://${account.namespace}/login/callback`. If you're using a [custom domain](/custom-domains), add that domain as another callback URL. 
 
+<%= include('../_find-auth0-domain-redirects') %>
+
     ![Callback URL](/media/articles/connections/social/twitter/twitter-api-2.png)
 
 4. Ensure the **Enabled Sign in with Twitter** option is selected. 

--- a/articles/connections/social/vkontakte.md
+++ b/articles/connections/social/vkontakte.md
@@ -39,6 +39,8 @@ In the **Base domain** field, enter the following:
 
 `${account.namespace}`
 
+<%= include('../_find-auth0-domain-redirects') %>
+
 ![](/media/articles/connections/social/vkontakte/vkontakte-create-app.png)
 
 Click **Connect Site** to create the app.

--- a/articles/connections/social/weibo.md
+++ b/articles/connections/social/weibo.md
@@ -24,6 +24,8 @@ Begin by [registering your Auth0 app with Weibo](https://open.weibo.com/authenti
 
 You will be prompted to provide a callback URL during the registration process. Use `https://${account.namespace}/login/callback`.
 
+<%= include('../_find-auth0-domain-redirects') %>
+
 After the registration process, Weibo provides you with an **appkey** and a corresponding **appkey secret**. Make a note of these values, since you'll need to provide them to Auth0.
 
 ## 2. Create and enable your Auth0 connection

--- a/articles/connections/social/wordpress.md
+++ b/articles/connections/social/wordpress.md
@@ -46,6 +46,8 @@ Complete all the fields on the **Create an Application** screen.
 |**Verification Question** | To confirm you are an actual user performing the request|
 |**Type** | Select **Web** as the client type|
 
+<%= include('../_find-auth0-domain-redirects') %>
+
 After completing the fields, click on the **Create** button.
 
 Then (or if you have previously registered your application) you will see your application listed on your dashboard landing page.

--- a/articles/connections/social/yahoo.md
+++ b/articles/connections/social/yahoo.md
@@ -36,6 +36,8 @@ In the **Callback Domain** field enter:
 
 `https://${account.namespace}`
 
+<%= include('../_find-auth0-domain-redirects') %>
+
 For the **API Permissions** make sure to select at least one user data API:
 
 ![API Permissions](/media/articles/connections/social/yahoo/api-permissions.png)

--- a/articles/connections/social/yammer.md
+++ b/articles/connections/social/yammer.md
@@ -37,6 +37,9 @@ Then click **Register New App**:
 
 Name your app and complete the form.
 For the **Redirect URI**, enter `https://${account.namespace}/login/callback`.
+
+<%= include('../_find-auth0-domain-redirects') %>
+
 Click **Continue**.
 
 ![](/media/articles/connections/social/yammer/yammer-connect-4.png)

--- a/articles/connections/social/yandex.md
+++ b/articles/connections/social/yandex.md
@@ -38,6 +38,8 @@ The callback address for your app should be:
 
   https://${account.namespace}/login/callback
 
+  <%= include('../_find-auth0-domain-redirects') %>
+
 
 Notice that `scopes` in Yandex are defined in this screen. Select what kind of information you are requesting for your app.
 


### PR DESCRIPTION
Per [Docs feedback](https://auth0.slack.com/archives/C090Z5WKB/p1558721638002300). Added include on all social connection docs that reference the callback URL.