### PR TITLE
Needed Change for new review app environment

### DIFF
--- a/prebuild.sh
+++ b/prebuild.sh
@@ -29,17 +29,10 @@ fi
 
 
 echo "Moving content into docs folder"
+rm -rf ./github
 mkdir -p "./docs/"
 shopt -s extglob
 mv !(docs) docs
 shopt -u extglob
 
-git clone ssh://git@github.com/auth0/auth0-docs.git auth0-docs-repo
-
-echo "Moving docs site into root folder"
-shopt -s extglob
-mv auth0-docs-repo/* .
-rm -rf auth0-docs-repo
-shopt -u extglob
-
-echo "Docs site successfully setup."
+git clone ssh://git@github.com/auth0/auth0-docs.git .

--- a/prebuild.sh
+++ b/prebuild.sh
@@ -29,6 +29,7 @@ fi
 
 
 echo "Moving content into docs folder"
+rm -rf ./github
 mkdir -p "./docs/"
 shopt -s extglob
 mv !(docs) docs

--- a/prebuild.sh
+++ b/prebuild.sh
@@ -29,7 +29,6 @@ fi
 
 
 echo "Moving content into docs folder"
-rm -rf ./github
 mkdir -p "./docs/"
 shopt -s extglob
 mv !(docs) docs
@@ -38,9 +37,9 @@ shopt -u extglob
 git clone ssh://git@github.com/auth0/auth0-docs.git auth0-docs-repo
 
 echo "Moving docs site into root folder"
-shopt -s dotglob
+shopt -s extglob
 mv auth0-docs-repo/* .
 rm -rf auth0-docs-repo
-shopt -u dotglob
+shopt -u extglob
 
 echo "Docs site successfully setup."


### PR DESCRIPTION
We were receiving the following error during some of the new review app builds

```
Moving docs site into root folder
mv: cannot move 'auth0-docs-repo/.github' to './.github': Directory not empty
``` 
