### PR TITLE
Fix typo "click-jacking" to "clickjacking"

### DIFF
--- a/articles/migrations/guides/clickjacking-protection.md
+++ b/articles/migrations/guides/clickjacking-protection.md
@@ -24,4 +24,4 @@ Even if the potential attack does not entail significant risk, it's a good secur
 
 In a case where you are rendering the login page in an iframe, adding these headers could be a breaking change. Instead of adding these headers for all customers, therefore, Auth0 has added an opt-in for these headers which we strongly recommend you to enable.
 
-You can do this by navigating to [Tenant Settings > Advanced Settings](${manage_url}/#/tenant/advanced), scrolling to 'Migrations', and turning OFF the 'Disable click-jacking protection for Classic Universal Login' setting. This action is not required if you are using the [New Universal Login Experience](/universal-login/new) as those headers are always set.
+You can do this by navigating to [Tenant Settings > Advanced Settings](${manage_url}/#/tenant/advanced), scrolling to 'Migrations', and turning OFF the 'Disable clickjacking protection for Classic Universal Login' setting. This action is not required if you are using the [New Universal Login Experience](/universal-login/new) as those headers are always set.


### PR DESCRIPTION
This PR fixes a typo. To reflect changes in our dashboard I did send a proper PR to the dashboard team as well.