### PR TITLE
Updated Spring Security API Quickstart documentation to use Gradle

### DIFF
--- a/articles/quickstart/backend/java-spring-security/01-authorization.md
+++ b/articles/quickstart/backend/java-spring-security/01-authorization.md
@@ -165,13 +165,13 @@ public class APIController {
 To build and run the project, use the command:
 
 ```bash
-mvn spring-boot:run
+./gradlew bootRun
 ```
 
 or if you are on Windows:
 
 ```bash
-mvn.cmd spring-boot:run
+gradlew.cmd bootRun
 ```
 
 Using a REST client such as Postman or cURL, issue a `GET` request to `http://localhost:3010/api/public`. You should receive the response:

--- a/articles/quickstart/backend/java-spring-security/index.yml
+++ b/articles/quickstart/backend/java-spring-security/index.yml
@@ -36,7 +36,8 @@ github:
   repo: auth0-spring-security-api-sample
 requirements:
   - Java 8 or above
-  - Maven 3.0.x or above
+  - Gradle 5.4.1
+  - Spring Boot 1.5.21
 next_steps:
   - path: 01-authorization
     list:


### PR DESCRIPTION
Spring Security API Sample was updated to use Gradle in [auth0-samples/auth0-spring-security-api-sample/pull/36](https://github.com/auth0-samples/auth0-spring-security-api-sample/pull/36).

This change updates the Quickstart with instructions on building/running using Gradle, not Maven.