### PR TITLE
Removed embedded login link from React quickstart

### DIFF
--- a/articles/quickstart/spa/react/_includes/_centralized_login.md
+++ b/articles/quickstart/spa/react/_includes/_centralized_login.md
@@ -1,4 +1,6 @@
-<%= include('../../_includes/_login_preamble', { library: 'React', embeddedLoginLink: 'https://github.com/auth0-samples/auth0-react-samples/tree/embedded-login/01-Embedded-Login' }) %>
+<!-- markdownlint-disable MD002 MD041 -->
+
+<%= include('../../_includes/_login_preamble', { library: 'React' }) %>
 
 ### Create an Authentication Service
 


### PR DESCRIPTION
This PR removes the link to the Embedded Login sample for the React quickstart, as this sample no longer exists.