### PR TITLE
Fixing snippet for Enable email authenticators

### DIFF
--- a/articles/multifactor-authentication/api/email.md
+++ b/articles/multifactor-authentication/api/email.md
@@ -31,11 +31,12 @@ Start by enabling email authenticators with the [Management API](/api/management
   "method": "PUT",
   "url": "https://${account.namespace}/api/v2/guardian/factors/email",
   "headers": [
-    { "name": "Authorization", "value": "Bearer MANAGEMENT_API_TOKEN" }
+    { "name": "Authorization", "value": "Bearer MANAGEMENT_API_TOKEN" },
+    { "name": "Content-Type", "value": "application/json" }
   ],
   "postData": {
     "mimeType": "application/json",
-    "text": "{\"enabled\":\"true\"}"
+    "text": "{\"enabled\": true }"
   }
 }
 ```


### PR DESCRIPTION
https://docs-content-staging-pr-7739.herokuapp.com/docs/multifactor-authentication/api/email

The code for the snippet was not correct, and copying / pasting the CURL comment did not work. I tried the new one and it works well