### PR TITLE
[IPS-479] Return consistent error messages from /co/authenticate to prevent username enumeration

### DIFF
--- a/articles/_includes/_co_authenticate_errors.md
+++ b/articles/_includes/_co_authenticate_errors.md
@@ -12,7 +12,6 @@ The error description is human readable. It **should not be parsed by any code**
 | 401 | unauthorized_client | Cross origin login not allowed. |
 | 400 | unsupported_credential_type | Unknown credential type parameter. |
 | 400 | invalid_request | Unknown realm non-existent-connection. |
-| 403 | access_denied | Invalid user credentials. |
 | 403 | access_denied | Wrong email or password. |
 | 403 | access_denied | Authentication error |
 | 403 | blocked_user | Blocked user |


### PR DESCRIPTION
Remove error message no longer returned during cross-origin authentication.

https://auth0team.atlassian.net/browse/IPS-479
https://github.com/auth0/auth0-server/pull/6254

