### PR TITLE
Revise tenant logs migration guide

### DIFF
--- a/articles/logs/migrate-logs-v2-v3.md
+++ b/articles/logs/migrate-logs-v2-v3.md
@@ -19,7 +19,8 @@ Auth0 is proactively migrating customers unaffected by this change, while those 
 Affected customers are those who meet all of the following criteria:
 * With tenants created before or on May 21st, 2019
 * With tenants hosted in Auth0's public cloud in the AU or EU regions
-* Who use the [GET /api/v2/logs](/api/v2#!/Logs/get_logs) or the [GET /api/v2/users/{user_id}/logs](/api/v2#!/Users/get_logs_by_user) endpoint with the parameter `include_totals=true` or the `q` parameter. 
+* Who use the [GET /api/v2/logs](/api/v2#!/Logs/get_logs) or the [GET /api/v2/users/{user_id}/logs](/api/v2#!/Users/get_logs_by_user) endpoint with the parameter `include_totals=true` or the `q` parameter.
+* Who attempt to paginate through more than 1000 results.
 
 The following tenants are NOT affected:
 * Cloud customers in the US region. The US region has already been fully migrated to using Search Engine V3.
@@ -38,10 +39,10 @@ You can search your tenant logs with the following query to check for queries th
 type:depnote AND description:migrate-logs
 ```
 
-These log entries include `feature` and `description` fields that specify what deprecated behavior you're still using.
+These log entries include a `description` field that specifies exactly what deprecated behavior you're still using.
 
 ::: note
-Please note that only one log of the same `type` and `feature` will be generated every 60 minutes. This means even though you may be making multiple calls with deprecated behavior to the impacted endpoints, you will only see one log of each `type`/`feature` combination per hour. This also means you'll need to wait 60 minutes after implementing any changes to your queries before you can consider a lack of new `depnote` logs to mean the deprecated behaviour has been removed from your code.
+Please note that only one log of the same `type` and `description` will be generated every 60 minutes. This means even though you may be making multiple calls with deprecated behavior to the impacted endpoints, you will only see one log for each deprecated bahavior per hour. This also means you'll need to wait 60 minutes after implementing any changes to your queries before you can consider a lack of new `depnote` logs to mean the deprecated behaviour has been removed from your code.
 :::
 
 
@@ -50,7 +51,7 @@ Please note that only one log of the same `type` and `feature` will be generated
 The breaking changes are minor, but you should review your queries to make sure the results you are getting are as expected.
 
 Breaking changes are related to:
-* Pagination: the value of the `totals` field returned in the summary result when calling `GET /api/v2/logs` or `GET /api/v2/users/{user_id}/logs` is changing
+* Pagination: The value of the `totals` field returned in the summary result when calling `GET /api/v2/logs` or `GET /api/v2/users/{user_id}/logs` is changing. There is a limit of 100 logs per request. Additionally, you may only paginate through up to 1,000 search results.
 * Query Syntax: The query syntax when using the `q` parameter in the `GET /api/v2/logs` has minor changes that need to be taken into account
 
 For more details on these changes, see [Logs Search Query Syntax](/logs/query-syntax#search-engine-v3-breaking-changes). 

--- a/articles/logs/migrate-logs-v2-v3.md
+++ b/articles/logs/migrate-logs-v2-v3.md
@@ -12,7 +12,7 @@ useCase:
 # Migrate from Logs Search v2 to v3
 
 To provide our customers with the most reliable and scalable solution, Auth0 has deprecated Tenant Logs Search Engine v2 in favor of v3.
-Auth0 is proactively migrating customers unaffected by this change, while those who are potentially affected are being notified to opt in for v3 during the provided grace period.
+Auth0 is proactively migrating customers unaffected by this change, while those who are potentially affected are being notified to opt-in for v3 during the provided grace period.
 
 ## Am I affected by the migration?
 
@@ -20,10 +20,10 @@ Affected customers are those who meet all of the following criteria:
 * With tenants created before or on May 21st, 2019
 * With tenants hosted in Auth0's public cloud in the AU or EU regions
 * Who use the [GET /api/v2/logs](/api/v2#!/Logs/get_logs) or the [GET /api/v2/users/{user_id}/logs](/api/v2#!/Users/get_logs_by_user) endpoint with the parameter `include_totals=true` or the `q` parameter.
-* Who attempt to paginate through more than 1000 results.
+* Who paginate through more than 1000 results
 
 The following tenants are NOT affected:
-* Cloud customers in the US region. The US region has already been fully migrated to using Search Engine V3.
+* Cloud customers in the US region. The US region has been fully migrated and is already using Search Engine v3.
 * PSaaS customers (Migration for PSaaS customers will begin at a later date).
 * Cloud tenants in the EU and AU regions that:
   * are not using the `GET /api/v2/logs` or `GET /api/v2/users/{user_id}/logs` endpoints of Management API at all.
@@ -31,38 +31,39 @@ The following tenants are NOT affected:
   * are using the `GET /api/v2/logs endpoint` with the by checkpoint method (using `from` parameter).
   * are consuming logs using any of the [Auth0 Logs to External Service Dashboard extensions](/extensions#export-auth0-logs-to-an-external-service) (which use the by checkpoint method).
   
-## How can I check if I've migrated all my queries?
+## How can I check to see if I've migrated all my queries?
 
-You can search your tenant logs with the following query to check for queries that would result in an error after migrating to v3:
+You can search your tenant logs with the following to look for queries that would throw errors after you migrate to v3:
 
 ```
 type:depnote AND description:migrate-logs
 ```
 
-These log entries include a `description` field that specifies exactly what deprecated behavior you're still using.
+These log entries include a `description` field that specifies the deprecated behavior you're using.
 
 ::: note
-Please note that only one log of the same `type` and `description` will be generated every 60 minutes. This means even though you may be making multiple calls with deprecated behavior to the impacted endpoints, you will only see one log for each deprecated bahavior per hour. This also means you'll need to wait 60 minutes after implementing any changes to your queries before you can consider a lack of new `depnote` logs to mean the deprecated behavior has been removed from your code.
-:::
+Auth0 generates only one log of the same **type** and **description** every 60 minutes. No matter how many calls you make using deprecated features to the impacted endpoints, you will still see a single log for *each* deprecated feature each hour.
 
+If you implement changes to your queries, you'll need to allow 60 minutes to elapse before you can conclusively determine that the lack of new `depnote` logs means the deprecated behavior has been removed from your code.
+:::
 
 ## What’s changing?
 
 The breaking changes are minor, but you should review your queries to make sure the results you are getting are as expected.
 
 Breaking changes are related to:
-* Pagination: The value of the `totals` field returned in the summary result when calling `GET /api/v2/logs` or `GET /api/v2/users/{user_id}/logs` is changing. There is a limit of 100 logs per request. Additionally, you may only paginate through up to 1,000 search results.
+* Pagination: The value of the `totals` field returned in the summary result when calling `GET /api/v2/logs` or `GET /api/v2/users/{user_id}/logs` is changing. There is a limit of 100 logs per request, and you may only paginate through a maximum of 1,000 search results
 * Query Syntax: The query syntax when using the `q` parameter in the `GET /api/v2/logs` has minor changes that need to be taken into account
 
 For more details on these changes, see [Logs Search Query Syntax](/logs/query-syntax#search-engine-v3-breaking-changes). 
 
 ## How to Migrate?
 
-After reviewing your queries, you can opt in to Tenant Logs Search Engine v3 via the Dashboard. Go to *Tenant Settings > Advanced*, then scroll down to *Migrations*. Toggle the *Legacy Logs Search V2* switch to off. 
+After reviewing your queries, you can opt-in to Tenant Logs Search Engine v3 via the Dashboard. Go to *Tenant Settings > Advanced*, then scroll down to *Migrations*. Toggle the *Legacy Logs Search V2* switch to off. 
 Toggling this switch to off disables the deprecated logs search engine v2 and forces the use of search engine v3.
 
 ::: note
-If you do not see this option you've already been migrated to v3. No further action is required.
+If you do not see the **Legacy Logs Search V2** toggle, you've already been migrated to v3. No further action is required.
 :::
 
 ![](/media/articles/logs/tenant-logs-migration.png)
@@ -72,4 +73,3 @@ If you need help with the migration, contact us using the [Support Center](https
 ## Keep reading
 * [Tenant Logs Overview](/logs)
 * [Query Syntax](/logs/query-syntax)
-

--- a/articles/logs/migrate-logs-v2-v3.md
+++ b/articles/logs/migrate-logs-v2-v3.md
@@ -16,13 +16,13 @@ Auth0 is proactively migrating customers unaffected by this change, while those 
 
 ## Am I affected by the migration?
 
-Affected customers are those:
+Affected customers are those who meet all of the following criteria:
 * With tenants created before or on May 21st, 2019
 * With tenants hosted in Auth0's public cloud in the AU or EU regions
 * Who use the [GET /api/v2/logs](/api/v2#!/Logs/get_logs) or the [GET /api/v2/users/{user_id}/logs](/api/v2#!/Users/get_logs_by_user) endpoint with the parameter `include_totals=true` or the `q` parameter. 
 
 The following tenants are NOT affected:
-* Cloud customers in the US region who are already using Search Engine V3.
+* Cloud customers in the US region. The US region has already been fully migrated to using Search Engine V3.
 * PSaaS customers (Migration for PSaaS customers will begin at a later date).
 * Cloud tenants in the EU and AU regions that:
   * are not using the `GET /api/v2/logs` or `GET /api/v2/users/{user_id}/logs` endpoints of Management API at all.
@@ -45,6 +45,8 @@ For more details on these changes, see [Logs Search Query Syntax](/logs/query-sy
 After reviewing your queries, you can opt in to Tenant Logs Search Engine v3 via the Dashboard. Go to *Tenant Settings > Advanced*, then scroll down to *Migrations*. Toggle the *Legacy Logs Search V2* switch to off. 
 Toggling this switch to off disables the deprecated logs search engine v2 and forces the use of search engine v3.
 
+::: note If you do not see this option you've already been migrated to v3. No further action is required. :::
+
 ![](/media/articles/logs/tenant-logs-migration.png)
  
 If you need help with the migration, contact us using the [Support Center](https://support.auth0.com/).
@@ -52,3 +54,4 @@ If you need help with the migration, contact us using the [Support Center](https
 ## Keep reading
 * [Tenant Logs Overview](/logs)
 * [Query Syntax](/logs/query-syntax)
+

--- a/articles/logs/migrate-logs-v2-v3.md
+++ b/articles/logs/migrate-logs-v2-v3.md
@@ -40,7 +40,9 @@ type:depnote AND description:migrate-logs
 
 These log entries include `feature` and `description` fields that specify what deprecated behavior you're still using.
 
-::: note Please note that only one log of the same `type` and `feature` will be generated every 60 minutes. This means even though you may be making multiple calls with deprecated behavior to the impacted endpoints, you will only see one log of each `type`/`feature` combination per hour. This also means you'll need to wait 60 minutes after implementing any changes to your queries before you can consider a lack of new `depnote` logs to mean the deprecated behaviour has been removed from your code. :::
+::: note
+Please note that only one log of the same `type` and `feature` will be generated every 60 minutes. This means even though you may be making multiple calls with deprecated behavior to the impacted endpoints, you will only see one log of each `type`/`feature` combination per hour. This also means you'll need to wait 60 minutes after implementing any changes to your queries before you can consider a lack of new `depnote` logs to mean the deprecated behaviour has been removed from your code.
+:::
 
 
 ## What’s changing?
@@ -58,7 +60,9 @@ For more details on these changes, see [Logs Search Query Syntax](/logs/query-sy
 After reviewing your queries, you can opt in to Tenant Logs Search Engine v3 via the Dashboard. Go to *Tenant Settings > Advanced*, then scroll down to *Migrations*. Toggle the *Legacy Logs Search V2* switch to off. 
 Toggling this switch to off disables the deprecated logs search engine v2 and forces the use of search engine v3.
 
-::: note If you do not see this option you've already been migrated to v3. No further action is required. :::
+::: note
+If you do not see this option you've already been migrated to v3. No further action is required.
+:::
 
 ![](/media/articles/logs/tenant-logs-migration.png)
  

--- a/articles/logs/migrate-logs-v2-v3.md
+++ b/articles/logs/migrate-logs-v2-v3.md
@@ -29,6 +29,19 @@ The following tenants are NOT affected:
   * are consuming the logs from the Dashboard Logs section only.
   * are using the `GET /api/v2/logs endpoint` with the by checkpoint method (using `from` parameter).
   * are consuming logs using any of the [Auth0 Logs to External Service Dashboard extensions](/extensions#export-auth0-logs-to-an-external-service) (which use the by checkpoint method).
+  
+## How can I check if I've migrated all my queries?
+
+You can search your tenant logs with the following query to check for queries that would result in an error after migrating to v3:
+
+```
+type:depnote AND description:migrate-logs
+```
+
+These log entries include `feature` and `description` fields that specify what deprecated behavior you're still using.
+
+::: note Please note that only one log of the same `type` and `feature` will be generated every 60 minutes. This means even though you may be making multiple calls with deprecated behavior to the impacted endpoints, you will only see one log of each `type`/`feature` combination per hour. This also means you'll need to wait 60 minutes after implementing any changes to your queries before you can consider a lack of new `depnote` logs to mean the deprecated behaviour has been removed from your code. :::
+
 
 ## What’s changing?
 

--- a/articles/logs/migrate-logs-v2-v3.md
+++ b/articles/logs/migrate-logs-v2-v3.md
@@ -42,7 +42,7 @@ type:depnote AND description:migrate-logs
 These log entries include a `description` field that specifies exactly what deprecated behavior you're still using.
 
 ::: note
-Please note that only one log of the same `type` and `description` will be generated every 60 minutes. This means even though you may be making multiple calls with deprecated behavior to the impacted endpoints, you will only see one log for each deprecated bahavior per hour. This also means you'll need to wait 60 minutes after implementing any changes to your queries before you can consider a lack of new `depnote` logs to mean the deprecated behaviour has been removed from your code.
+Please note that only one log of the same `type` and `description` will be generated every 60 minutes. This means even though you may be making multiple calls with deprecated behavior to the impacted endpoints, you will only see one log for each deprecated bahavior per hour. This also means you'll need to wait 60 minutes after implementing any changes to your queries before you can consider a lack of new `depnote` logs to mean the deprecated behavior has been removed from your code.
 :::
 
 


### PR DESCRIPTION
Updates the Tenant Log migration guide to include information about the `depnote` detailed tenant logs.