### PR TITLE
Added auth0-spa-js installation instructions

### DIFF
--- a/articles/quickstart/spa/_includes/_getting_started.md
+++ b/articles/quickstart/spa/_includes/_getting_started.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable MD041 -->
+
 ::: note
 **New to Auth?** Learn [How Auth0 works](/overview), how it [integrates with Single-Page Applications](/architecture-scenarios/application/spa-api) and which [protocol](/flows/concepts/implicit) it uses.
 :::
@@ -16,4 +18,8 @@ If you are following along with the sample project you downloaded from the top o
 <%= include('../../../_includes/_web_origins') %>
 <% } %>
 
-<%= include('../_includes/_install_auth0js') %>
+<% if (typeof new_js_sdk !== 'undefined' && new_js_sdk === true) { %>
+<%= include('_install_auth0-spa-js') %>
+<% } else { %>
+<%= include('_install_auth0js') %>
+<% } %>

--- a/articles/quickstart/spa/_includes/_install_auth0-spa-js.md
+++ b/articles/quickstart/spa/_includes/_install_auth0-spa-js.md
@@ -1,0 +1,34 @@
+<!-- markdownlint-disable MD002 MD041 -->
+
+## Integrate Auth0 in your Application
+
+### Loading auth0-spa-js
+
+You need the `auth0-spa-js` library to integrate Auth0 into your application.
+You can either install the library locally in your application or load it from CDN.
+
+### Loading via dependencies
+
+Install `auth0-spa-js` using npm or yarn.
+
+```bash
+# installation with npm
+npm install --save @auth0/auth0-spa-js
+
+# installation with yarn
+yarn add @auth0/auth0-spa-js
+```
+
+Once `auth0-spa-js` is installed, reference it using an import statement (if you're using a build system such as [Webpack](https://webpack.js.org/)):
+
+```js
+import createAuth0Client from '@auth0/auth0-spa-js';
+```
+
+### Loading it from CDN
+ 
+If you do not want to use a package manager, you can retrieve `auth0-spa-js` from Auth0's CDN.
+
+```html
+<script src="${auth0spajs_url}"></script>
+```


### PR DESCRIPTION
This PR adds a new include `_install_auth0-spa-js`, which details how to install the `auth0-spa-js` SDK. The instructions are very similar to the `auth0.js` ones.

This include is not currently referred to by any live document as yet (as nothing currently sets the `new_js_sdk` flag in `_getting_started.md`, but will be used by the new SPA Quickstarts when they go live (#7733 and #7769)

`yarn test` has been run, and has been tested manually with current quickstarts to ensure the `auth0.js` instructions are still shown for existing quickstarts.
