### PR TITLE
Correct bcrypt magic global version

### DIFF
--- a/articles/migrations/guides/extensibility-node8.md
+++ b/articles/migrations/guides/extensibility-node8.md
@@ -185,7 +185,7 @@ If you are using the following built-in modules (that is, modules that you did n
 | node-cassandra-cql | ^0.4.4 | ^0.5.0 |
 | request | ~2.27.0 | ~2.81.0 |
 | pg | ^4.3.0^* | ^4.5.7 |
-| bcrypt | ~0.8.5^* | ~0.8.7 |
+| bcrypt | ~0.8.5^* | 1.0.3 |
 | xml2json | ~0.10.0^* | ~0.11.2 |
 
 ^* These versions are no longer supported due to incompatibility with Node 8.


### PR DESCRIPTION
Fixes extensibility node8 migration guide to refer to the correct version of `bcryp` (see: https://github.com/auth0/auth0-authz-rules-api/blob/ef07ac81bd537c6699b0b33a0a3a2530e19216f5/package.json#L13)

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors
- Please include a short description
- If your PR is a work in progress, title it [DO NOT MERGE]
--->
