### PR TITLE
Export default field names for importing users

### DIFF
--- a/articles/extensions/user-import-export.md
+++ b/articles/extensions/user-import-export.md
@@ -70,7 +70,7 @@ Once you've imported your users, you can manage them individually using the [Use
 ### Export Users
 
 ::: note
-Auth0 uses the [ndjson](http://ndjson.org/) format due to the large size of export files. Before you can import users, you'll need to convert from **ndjson** to **json** using the library of your choice (such as [jq](https://stedolan.github.io/jq/)).
+Auth0 uses the [ndjson](http://ndjson.org/) format due to the large size of export files. Before you can import users, you'll need to convert from **ndjson** to **json** using the library of your choice (such as [jq](https://stedolan.github.io/jq/)). When exporting users intended to later be imported, user field names should be left as their defaults and not mapped to a Column Name.
 :::
 
 To export your existing Auth0 users associated with database connections, select **Export** in the left-hand navigation bar.


### PR DESCRIPTION
Clarify that the default field names should not be mapped to other values with "Column Name" if intending to perform an import with the file that is returned from the export. The default field names are required when performing an import.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors
- Please include a short description
- If your PR is a work in progress, title it [DO NOT MERGE]
--->
