### PR TITLE
have base ways to integrate include planning include

### DIFF
--- a/articles/architecture-scenarios/_includes/_base-ways-to-integrate.md
+++ b/articles/architecture-scenarios/_includes/_base-ways-to-integrate.md
@@ -1,3 +1,5 @@
 There are many different ways Auth0 can be integrated into the <% if (platform === "b2c") { %>CIAM<% } else { %>B2B IAM<% } %> project architecture. Auth0's flexibility comprehensively supports many different use cases, however keep in mind that not every project requires 100% of the capabilities provided by Auth0.
 
-When you embark on your journey to integrate with Auth0, there are many things for you to consider. Knowing what, when, and how best to implement something will help you focus on completing the necessary tasks at the right time. To help you with this, we've put together some <% if (platform === "b2c") { %>[planning guidance](/media/articles/architecture-scenarios/planning/B2C-Project-Planning.pdf)<% } else { %>[planning guidance](/media/articles/architecture-scenarios/planning/B2B-Project-Planning.pdf)<% } %> that details our recommended strategies.
+When you embark on your journey to integrate with Auth0, there are many things for you to consider. Knowing what, when, and how best to implement something will help you focus on completing the necessary tasks at the right time. 
+
+<%= include('./_planning.md', { platform: platform }) %>


### PR DESCRIPTION
Simple merge to make it less likely to forget a planning link in the future.