### PR TITLE
Fixed follow-on links for React and Angular in SPA Quickstart docs

### DIFF
--- a/articles/quickstart/spa/angular2/index.yml
+++ b/articles/quickstart/spa/angular2/index.yml
@@ -39,7 +39,7 @@ next_steps:
     list:
     - text: "Part 2: Calling an API using an access token"
       icon: 345
-      href: "/quickstart/spa/angular-beta/02-calling-an-api"
+      href: "/quickstart/spa/angular2/02-calling-an-api"
   - path: 02-calling-an-api
     list:
     - text: Configure other identity providers

--- a/articles/quickstart/spa/react/index.yml
+++ b/articles/quickstart/spa/react/index.yml
@@ -40,7 +40,7 @@ next_steps:
     list:
     - text: "Part 2: Calling an API using an access token"
       icon: 345
-      href: "/quickstart/spa/react-beta/02-calling-an-api"
+      href: "/quickstart/spa/react/02-calling-an-api"
   - path: 02-calling-an-api
     list:
     - text: Configure other identity providers


### PR DESCRIPTION
Fixed incorrect links to the second part of the tutorial.