### PR TITLE
Removed unnecessary reference to onRedirectCallback

### DIFF
--- a/articles/quickstart/spa/react/02-calling-an-api.md
+++ b/articles/quickstart/spa/react/02-calling-an-api.md
@@ -83,7 +83,6 @@ ReactDOM.render(
     domain={config.domain}
     client_id={config.clientId}
     audience={config.audience}
-    onRedirectCallback={onRedirectCallback}
   >
     <App />
   </Auth0Provider>,


### PR DESCRIPTION
This line of code is not necessary for the sample described in the docs, and can be removed.