### PR TITLE
Remove broken links

### DIFF
--- a/articles/api-auth/tutorials/silent-authentication.md
+++ b/articles/api-auth/tutorials/silent-authentication.md
@@ -109,11 +109,3 @@ The `expires_in` parameter indicates how many seconds the Access Token will be v
 ## Polling with checkSession()
 
 <%= include('../../_includes/_checksession_polling') %>
-
-### How to implement
-
-Implementation of token renewal will depend on the type of application and framework being used. Sample implementations for some of the common platforms can be found below:
-
-* [Plain JavaScript](/quickstart/spa/vanillajs/05-token-renewal)
-* [React](/quickstart/spa/react/05-token-renewal)
-* [Angular](/quickstart/spa/angular2/05-token-renewal)


### PR DESCRIPTION
The quickstarts no longer feature dedicated token renewal stand-alone sections, so we need to remove.

https://docs-content-staging-pr-7856.herokuapp.com/docs/api-auth/tutorials/silent-authentication