### PR TITLE
Amendments to the React SPA tutorial inline with the sample

### DIFF
--- a/articles/quickstart/spa/react/02-calling-an-api.md
+++ b/articles/quickstart/spa/react/02-calling-an-api.md
@@ -82,6 +82,7 @@ ReactDOM.render(
   <Auth0Provider
     domain={config.domain}
     client_id={config.clientId}
+    redirect_uri={window.location.origin}
     audience={config.audience},     // NEW - specify the audience value
     onRedirectCallback={onRedirectCallback}
   >

--- a/articles/quickstart/spa/react/_includes/_centralized_login.md
+++ b/articles/quickstart/spa/react/_includes/_centralized_login.md
@@ -147,9 +147,7 @@ const NavBar = () => {
       {!isAuthenticated && (
         <button
           onClick={() =>
-            loginWithRedirect({
-              redirect_uri: window.location.origin
-            })
+            loginWithRedirect({})
           }
         >
           Log in
@@ -200,6 +198,7 @@ ReactDOM.render(
   <Auth0Provider
     domain={config.domain}
     client_id={config.clientId}
+    redirect_uri={window.location.origin}
     onRedirectCallback={onRedirectCallback}
 >
     <App />
@@ -210,7 +209,7 @@ ReactDOM.render(
 serviceWorker.unregister();
 ```
 
-Notice that the `App` component is now wrapped in the `Auth0Provider` component, where the details about the Auth0 domain and client ID are specified.
+Notice that the `App` component is now wrapped in the `Auth0Provider` component, where the details about the Auth0 domain and client ID are specified. The `redirect_uri` prop is also specified here. Doing this here means that you don't need to pass this URI to every call to `loginWithRedirect`, and it keeps the configuration in one place.
 
 Also notice the function `onRedirectCallback`, which tries to route the user to the right place once they have logged in. For example, if the user tries to access a page that requires them to be authenticated, they will be asked to log in. When they return to the application, they will be forwarded to the page they were originally trying to access thanks to this function.
 
@@ -375,7 +374,6 @@ const PrivateRoute = ({ component: Component, path, ...rest }) => {
     const fn = async () => {
       if (!isAuthenticated) {
         await loginWithRedirect({
-          redirect_uri: window.location.origin,
           appState: { targetUrl: path }
         });
       }


### PR DESCRIPTION
There are changes in the sample to refactor the use of the `redirect_uri` prop here: https://github.com/auth0-samples/auth0-react-samples/pull/126

The changes in this PR align with those changes in the sample.