### PR TITLE
remove limit_ui from list

### DIFF
--- a/articles/logs/index.md
+++ b/articles/logs/index.md
@@ -181,7 +181,6 @@ The following table lists the codes associated with the appropriate log events.
 | `gd_user_delete` | User delete | Deleted multi-factor user account. | [User Profile](/users/concepts/overview-user-profile) |
 | `limit_delegation` | Too Many Calls to /delegation | Rate limit exceeded to `/delegation` endpoint | [API Rate Limit Policy](/policies/rate-limits) |
 | `limit_mu` | Blocked IP Address | An IP address is blocked with 100 failed login attempts using different usernames, all with incorrect passwords in 24 hours, or 50 sign-up attempts per minute from the same IP address. | [Anomaly Detection](/anomaly-detection) |
-| `limit_ui` | Too Many Calls to /userinfo | Rate limit exceeded to `/userinfo` endpoint | [API Rate Limit Policy](/policies/rate-limits) |
 | `limit_wc` | Blocked Account | An IP address is blocked with 10 failed login attempts into a single account from the same IP address. | [Anomaly Detection](/anomaly-detection) |
 | `pwd_leak` | Breached password | Someone behind the IP address: `ip` attempted to login with a leaked password. | [Anomaly Detection](/anomaly-detection) |
 | `s` | Success Login | Successful login event. | |


### PR DESCRIPTION
When `/userinfo` gets rate limited, the tenant log event is `api_limit` which is already on the list.

This was changed a while back in `auth0-server`: https://github.com/auth0/auth0-server/commit/2ece8296dc9d684aaa03ff6e134c3faeefc5e928

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors
- Please include a short description
- If your PR is a work in progress, title it [DO NOT MERGE]
--->
