### PR TITLE
Fixed incorrect use of tenant vs namespace across the SPA quickstarts

### DIFF
--- a/articles/quickstart/spa/_includes/_calling_api_create_backend.md
+++ b/articles/quickstart/spa/_includes/_calling_api_create_backend.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable MD002 MD041 -->
+
 ## Create the Backend API
 
 For this example, you'll create an [Express](https://expressjs.com/) server that acts as the backend API. This API will expose an endpoint to validate incoming ID Tokens before returning a response.
@@ -25,12 +27,12 @@ const app = express();
 
 // Set up Auth0 configuration
 const authConfig = {
-  domain: "${account.tenant}",
+  domain: "${account.namespace}",
   audience: "${apiIdentifier}"
 };
 
 // Define middleware that validates incoming bearer tokens
-// using JWKS from ${account.tenant}
+// using JWKS from ${account.namespace}
 const checkJwt = jwt({
   secret: jwksRsa.expressJwtSecret({
     cache: true,

--- a/articles/quickstart/spa/_includes/_calling_api_modify_backend.md
+++ b/articles/quickstart/spa/_includes/_calling_api_modify_backend.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable MD002 MD041 -->
+
 ## Modify the Backend API
 
 For this tutorial, let's modify the API to include a new endpoint that expects an Access Token to be supplied.
@@ -60,7 +62,7 @@ Finally, modify the `authConfig` object to include your `audience` value:
 
 ```js
 const authConfig = {
-  domain: "${account.tenant}",
+  domain: "${account.namespace}",
   clientID: "${account.clientId}",
   audience: "${apiIdentifier}"
 };

--- a/articles/quickstart/spa/angular2/02-calling-an-api.md
+++ b/articles/quickstart/spa/angular2/02-calling-an-api.md
@@ -93,7 +93,7 @@ Modify the `src/app/auth.service.ts` file so that the `audience` value is config
 ```js
 // Auth0 application configuration
 config = {
-  domain: "${account.tenant}",
+  domain: "${account.namespace}",
   client_id: "${account.clientId}",
   redirect_uri: `<%= "${window.location.origin}" %>/callback`,
   audience: "${apiIdentifier}" // NEW - add in the audience value

--- a/articles/quickstart/spa/angular2/_includes/_centralized_login.md
+++ b/articles/quickstart/spa/angular2/_includes/_centralized_login.md
@@ -77,7 +77,7 @@ export class AuthService {
 
   // Auth0 application configuration
   config = {
-    domain: "${account.tenant}",
+    domain: "${account.namespace}",
     client_id: "${account.clientId}",
     redirect_uri: `<%= "${window.location.origin}" %>/callback`
   };

--- a/articles/quickstart/spa/react/02-calling-an-api.md
+++ b/articles/quickstart/spa/react/02-calling-an-api.md
@@ -69,7 +69,7 @@ To specify the audience, open `src/auth_config.json` and add a new key called `a
 
 ```json
 {
-  "domain": "${account.tenant}",
+  "domain": "${account.namespace}",
   "clientId": "${account.clientId}",
   "audience": "${apiIdentifier}"
 }

--- a/articles/quickstart/spa/react/_includes/_centralized_login.md
+++ b/articles/quickstart/spa/react/_includes/_centralized_login.md
@@ -217,7 +217,7 @@ Next, create a new file `auth_config.json` in the `src` folder, and populate it 
 
 ```json
 {
-  "domain": "${account.tenant}",
+  "domain": "${account.namespace}",
   "clientId": "${account.clientId}"
 }
 ```

--- a/articles/quickstart/spa/vanillajs/02-calling-an-api.md
+++ b/articles/quickstart/spa/vanillajs/02-calling-an-api.md
@@ -71,7 +71,7 @@ Next, open the `auth_config.json` file and modify the data so that the `audience
 
 ```json
 {
-  "domain": "${account.tenant}",
+  "domain": "${account.namespace}",
   "clientId": "${account.clientId}",
   "audience": "${apiIdentifier}"
 }

--- a/articles/quickstart/spa/vanillajs/_includes/_centralized_login.md
+++ b/articles/quickstart/spa/vanillajs/_includes/_centralized_login.md
@@ -78,7 +78,7 @@ Create an `auth_config.json` in the root of the project. The values from `domain
 
 ```json
 {
-  "domain": "${account.tenant}",
+  "domain": "${account.namespace}",
   "clientId": "${account.clientId}"
 }
 ```

--- a/articles/quickstart/spa/vuejs/03-calling-an-api.md
+++ b/articles/quickstart/spa/vuejs/03-calling-an-api.md
@@ -16,6 +16,8 @@ contentType: tutorial
 useCase: quickstart
 ---
 
+<!-- markdownlint-disable MD002 MD041 -->
+
 Most single-page apps use resources from data APIs. You may want to restrict access to those resources, so that only authenticated users with sufficient privileges can access them. Auth0 lets you manage access to these resources using [API Authorization](/api-auth).
 
 This tutorial shows you how to create a simple API using [Express](https://expressjs.com) that validates incoming JSON Web Tokens. You will then see how to call this API using an Access Token granted by the Auth0 authorization server.
@@ -77,7 +79,7 @@ First of all, open `auth_config.json` in the root of the project and make sure t
 
 ```json
 {
-  "domain": "${account.tenant}",
+  "domain": "${account.namespace}",
   "clientId": "${account.clientId}",
   "audience": "${apiIdentifier}"
 }

--- a/articles/quickstart/spa/vuejs/_includes/_centralized_login.md
+++ b/articles/quickstart/spa/vuejs/_includes/_centralized_login.md
@@ -45,7 +45,7 @@ To provide the values for `clientID`, `callbackUrl`, and `domain`, create a new 
 
 ```json
 {
-  "domain": "${account.tenant}",
+  "domain": "${account.namespace}",
   "clientId": "${account.clientId}"
 }
 ```


### PR DESCRIPTION
The SPA quickstarts currently use `account.tenant` to write out the user's tenant domain name, whereas it should be `account.namespace`. This PR corrects that error.