### PR TITLE
Fixed incorrect path for code snippet

### DIFF
--- a/articles/quickstart/spa/vanillajs/_includes/_centralized_login.md
+++ b/articles/quickstart/spa/vanillajs/_includes/_centralized_login.md
@@ -133,7 +133,7 @@ Finally, open the `package.json` file and modify the "scripts" entry to look lik
 
 Next, create a new file in the root of the project alongside `index.html` and `package.json`, called `server.js`. This will be our backend server and will be used to serve the SPA pages.
 
-Open `public/js/app.js` and populate it with the following code:
+Populate `server.js` with the following code:
 
 ```js
 const express = require("express");


### PR DESCRIPTION
Snippet currently refers to `public/js/app.js` whereas it should be `server.js`.