### PR TITLE
PUBLIC_WT_URL section added to node8 migration doc

### DIFF
--- a/articles/migrations/guides/extensibility-node8.md
+++ b/articles/migrations/guides/extensibility-node8.md
@@ -151,6 +151,11 @@ The login URL for **Users**:
 | Europe | `https://${account.tenant}.eu8.webtask.io/auth0-sso-dashboard/login` |
 | Australia | `https://${account.tenant}.au8.webtask.io/auth0-sso-dashboard/login` |
 
+### All Extensions
+
+Most of the extensions are using `PUBLIC_WT_URL` hidden secret for authorization cause. This secret depends on the runtime version and does not update automatically.
+To update it, you need to save the extension's settings (no changes are necessary). For doing so, after switching runtime to `Node 8`, you need to open the extension's settings in the extensions dashboard (gear icon) and hit `Save`. After that, the extensions gallery will update the `PUBLIC_WT_URL` secret accordingly to the selected runtime.
+
 ## How to ensure a stable migration
 
 As part of the process of introducing Node 8 in our Webtask runtime, we ran a number of tests to determine which modules are not forward-compatible from Node 4 to 8. Most customers _should_ be able to upgrade to Node 8 without any issues.

--- a/articles/migrations/guides/extensibility-node8.md
+++ b/articles/migrations/guides/extensibility-node8.md
@@ -153,8 +153,9 @@ The login URL for **Users**:
 
 ### All Extensions
 
-Most of the extensions are using `PUBLIC_WT_URL` hidden secret for authorization cause. This secret depends on the runtime version and does not update automatically.
-To update it, you need to save the extension's settings (no changes are necessary). For doing so, after switching runtime to `Node 8`, you need to open the extension's settings in the extensions dashboard (gear icon) and hit `Save`. After that, the extensions gallery will update the `PUBLIC_WT_URL` secret accordingly to the selected runtime.
+Most extensions use the `PUBLIC_WT_URL` hidden secret for authorization. This secret depends on the runtime version and does not update automatically.
+
+To update it, you need to save the extension's settings (no changes are necessary). To do so, after switching the runtime to `Node 8`, you need to open the extension's settings in the extensions dashboard (gear icon) and hit `Save`. After that, the extensions gallery will update the `PUBLIC_WT_URL` secret accordingly based on the selected runtime.
 
 ## How to ensure a stable migration
 


### PR DESCRIPTION
Added missing information about extensions migration to node8. See https://auth0team.atlassian.net/projects/ESD/queues/custom/321/ESD-982

Better late than never...