### PR TITLE
Fixing another API link

### DIFF
--- a/articles/flows/guides/device-auth/includes/request-device-code.md
+++ b/articles/flows/guides/device-auth/includes/request-device-code.md
@@ -2,7 +2,7 @@
 
 Once the user has started their device app and wants to authorize the device, you'll need to get a device code. When the user begins their session in their browser-based device, this code will be bound to that session. 
 
-To get the device code, your app must request a code from the [device code URL](/api/authentication#device-code), including the Client ID.
+To get the device code, your app must request a code from the [device code URL](/api/authentication#get-device-code), including the Client ID.
 
 ### Example POST to device code URL
 


### PR DESCRIPTION
Link located here will now go to correct section on API docs instead of just to the top

https://docs-content-staging-pr-7913.herokuapp.com/docs/flows/guides/device-auth/call-api-device-auth#request-device-code