### PR TITLE
Adding tip to best practices about not storing credentials in metadata

### DIFF
--- a/articles/best-practices/user-data-storage-best-practices.md
+++ b/articles/best-practices/user-data-storage-best-practices.md
@@ -42,7 +42,7 @@ You can store data points that are read-only to the user in `app_metadata`. Thre
 * **Plan information**: settings that cannot be changed by the user without confirmation from someone with the appropriate authority;
 * **External IDs**: identifying information used to associate users with external accounts.
 
-For a list of fields that *cannot* be stored within `app_metadata`, see [Metadata Field Name Rules](/users/references/metadata-field-name-rules).
+For a list of fields that *cannot* be stored within `app_metadata`, see [Metadata Field Name Rules](/users/references/metadata-field-name-rules). In addition, user credentials such as access tokens, refresh tokens, and additional passwords should not be stored in app_metadata, as these will be visible to any Auth0 dashboard administrator.
 
 When determining where you should store specific pieces of data about your user, here are the general rules of thumb:
 


### PR DESCRIPTION
A number of customers have either inquired about or are actually storing access tokens and refresh tokens in app_metadata or user_metadata. This is not a good practice, as it enables any dashboard administrator to view and copy those tokens. So I am suggesting this update to explicitly state this is not recommended.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors
- Please include a short description
- If your PR is a work in progress, title it [DO NOT MERGE]
--->
