### PR TITLE
Corrected path for signing-algorithms

### DIFF
--- a/articles/dashboard/reference/settings-api.md
+++ b/articles/dashboard/reference/settings-api.md
@@ -28,4 +28,4 @@ In the [API](${manage_url}/#/apis) section, locate your API and click on its *Se
 
 - **Allow Offline Access**: When this is enabled, Auth0 will allow applications to ask for <dfn data-key="refresh-token">Refresh Tokens</dfn> for your API.
 
-- **Signing Algorithm**: The algorithm with which to sign the tokens. The available values are `HS256` and `RS256`. When selecting `RS256` (recommended), the token will be signed with your tenant's private key. This value is set when your API is created and cannot be modified afterwards. For more details, visit [Signing Algorithms](/api-auth/concepts/signing-algorithms).
+- **Signing Algorithm**: The algorithm with which to sign the tokens. The available values are `HS256` and `RS256`. When selecting `RS256` (recommended), the token will be signed with your tenant's private key. This value is set when your API is created and cannot be modified afterwards. For more details, visit [Signing Algorithms](/applications/concepts/signing-algorithms).

--- a/articles/dashboard/reference/settings-application.md
+++ b/articles/dashboard/reference/settings-application.md
@@ -87,7 +87,7 @@ Set the OAuth-related settings on this tab:
 
 * By default, all apps/APIs can make a delegation request, but if you want to explicitly grant permissions to selected apps/APIs, you can do so in **Allowed APPs/APIs**.
 
-* Set the algorithm used (**HS256** or **RS256**) for signing your JSON Web Tokens. For more info, see [Signing Algorithms](/api-auth/concepts/signing-algorithms).
+* Set the algorithm used (**HS256** or **RS256**) for signing your JSON Web Tokens. For more info, see [Signing Algorithms](/applications/concepts/signing-algorithms).
 
 * Toggle the **Trust Token Endpoint IP Header** setting; if this is enabled, the `auth0-forwarded-for` is set as trusted and used as a source of end user IP information for protection against brute-force attacks on the token endpoint. This setting is only available for Regular Web Apps and M2M Apps.
 

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -385,7 +385,7 @@ articles:
         children:
 
           - title: Signing Algorithms
-            url: /api-auth/concepts/signing-algorithms
+            url: /applications/concepts/signing-algorithms
 
           - title: Represent Multiple APIs with a Single API
             url: /api-auth/tutorials/represent-multiple-apis


### PR DESCRIPTION
Corrected path in sidebar Configuration > API Configuration > Signing Algorithms
https://docs-content-staging-pr-7944.herokuapp.com/docs/applications/concepts/signing-algorithms

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors
- Please include a short description
- If your PR is a work in progress, title it [DO NOT MERGE]
--->
