### PR TITLE
Added link to the FAQ on various docs

### DIFF
--- a/articles/libraries/_includes/_spa_js_faq.md
+++ b/articles/libraries/_includes/_spa_js_faq.md
@@ -1,0 +1,5 @@
+<!-- markdownlint-disable MD041 -->
+
+::: note
+If you encounter some problems or errors when using the new JavaScript SDK, please [check out the FAQ](https://github.com/auth0/auth0-spa-js/blob/master/FAQ.md) to see if your issue is covered there.
+:::

--- a/articles/libraries/auth0-spa-js/index.md
+++ b/articles/libraries/auth0-spa-js/index.md
@@ -10,11 +10,15 @@ contentType:
   - index
 ---
 
+<!-- markdownlint-disable MD041 -->
+
 # Auth0 Single Page Application SDK
 
 The Auth0 Single Page Application (SPA) SDK is a new JavaScript library designed to secure SPAs with best practices and less code. It implements [Universal Login](/universal-login) and the [Authorization Code Grant Flow with PKCE](/api-auth/tutorials/authorization-code-grant-pkce). The Auth0 SPA SDK handles grant and protocol details, manages token expiration and renewal, and it stores and caches tokens for you.
 
 You can find the source code [on Github](https://github.com/auth0/auth0-spa-js) and the full API documentation [here](https://auth0.github.io/auth0-spa-js/).
+
+<%= include('../_includes/_spa_js_faq.md') %>
 
 ## Installation
 

--- a/articles/quickstart/spa/_includes/_install_auth0-spa-js.md
+++ b/articles/quickstart/spa/_includes/_install_auth0-spa-js.md
@@ -32,3 +32,5 @@ If you do not want to use a package manager, you can retrieve `auth0-spa-js` fro
 ```html
 <script src="${auth0spajs_url}"></script>
 ```
+
+<%= include('../../../libraries/_includes/_spa_js_faq') %>


### PR DESCRIPTION
This PR adds a note to a few docs to point the user to the [SPA JS FAQ page](https://github.com/auth0/auth0-spa-js/blob/master/FAQ.md) should they encounter a problem.

Added to:

* All SPA quickstarts that use auth0-spa-js
* The auth0-spa-js library docs