### PR TITLE
Wrap certificate at 64 chars to avoid ValueError from cryptography module

### DIFF
--- a/articles/quickstart/backend/django/01-authorization.md
+++ b/articles/quickstart/backend/django/01-authorization.md
@@ -134,10 +134,11 @@ Add code to download the JWKS for your Auth0 domain and create a public key vari
 
 ```python
 # apiexample/settings.py
+import textwrap
 
 jsonurl = request.urlopen("https://${account.namespace}/.well-known/jwks.json")
 jwks = json.loads(jsonurl.read())
-cert = '-----BEGIN CERTIFICATE-----\n' + jwks['keys'][0]['x5c'][0] + '\n-----END CERTIFICATE-----'
+cert = '-----BEGIN CERTIFICATE-----\n' + textwrap.fill(jwks['keys'][0]['x5c'][0], 64) + '\n-----END CERTIFICATE-----'
 
 certificate = load_pem_x509_certificate(str.encode(cert), default_backend())
 publickey = certificate.public_key()


### PR DESCRIPTION
Without wrapping the example fails with:

`ValueError: Unable to load certificate. See https://cryptography.io/en/latest/faq/#why-can-t-i-import-my-pem-file for more details.`

The 64 char requirement is also at https://cryptography.io/en/latest/faq/#why-can-t-i-import-my-pem-file
> all lines, except for the final one, must consist of exactly 64 characters.

Windows 10 with `cryptography==2.7`.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors
- Please include a short description
- If your PR is a work in progress, title it [DO NOT MERGE]
--->
