### PR TITLE
Always use the latest version of the dependency

### DIFF
--- a/articles/quickstart/native/_includes/_ios_dependency_centralized.md
+++ b/articles/quickstart/native/_includes/_ios_dependency_centralized.md
@@ -5,7 +5,7 @@
 If you are using Carthage, add the following to your `Cartfile`:
 
 ```ruby
-github "auth0/Auth0.swift" ~> 1.13
+github "auth0/Auth0.swift"
 ```
 
 Then, run `carthage bootstrap`.
@@ -20,7 +20,7 @@ If you are using [Cocoapods](https://cocoapods.org/), add the following to your 
 
 ```ruby
 use_frameworks!
-pod 'Auth0', '~> 1.13'
+pod 'Auth0'
 ```
 
 Then, run `pod install`.


### PR DESCRIPTION
It's usually easy to forget and update the dependency version when new version of the SDK is released.

By not specifying the version, CocoaPods and Carthage will always use the latest available version.