### PR TITLE
Fix API link in Authz how-to

### DIFF
--- a/articles/authorization/guides/how-to.md
+++ b/articles/authorization/guides/how-to.md
@@ -19,7 +19,7 @@ The core Authorization features of Auth0 allow for [role-based access control (R
 
 To use the core functionality most efficiently, you should do the following:
 
-1. [Register API with Auth0](/architecture-scenarios/mobile-api/part-2#create-the-api)
+1. [Register API with Auth0](/getting-started/set-up-api)
 2. [Define permissions for API](/dashboard/guides/apis/add-permissions-apis)
 3. [Create roles](/dashboard/guides/roles/create-roles)
 4. [Assign roles to users](/dashboard/guides/users/assign-roles-users)


### PR DESCRIPTION
Per concierge issue. Link was a temporary placeholder until we pulled the separate doc out. Was only supposed to be referring to a section of the doc, but it appears it was confusing. Separate doc has now been pulled out, so I linked to it instead.
