### PR TITLE
Fix broken includes reference

### DIFF
--- a/articles/connections/social/exact.md
+++ b/articles/connections/social/exact.md
@@ -35,11 +35,11 @@ Enter your app name:
 
 ![](/media/articles/connections/social/exact/exact-register-3.png)
 
-In the `Redirect URI`field, enter your <dfn data-key="callback">callback URL</dfn>:
+In the `Redirect URI` field, enter your <dfn data-key="callback">callback URL</dfn>:
 
     https://${account.namespace}/login/callback
 
-    <%= include('../_find-auth0-domain-redirects') %>
+  <%= include('../_find-auth0-domain-redirects') %>
 
 Click **Save**.
 


### PR DESCRIPTION
## Description
This page is broken because the includes is indented as a codeblock, rendering the panel inside of a codeblock and then trying to tag the definition inside of this, causing a chain of events that the page is unable to recover from.

Fixing the indentation, fixes the issue.