### PR TITLE
update default author on quickstarts

### DIFF
--- a/articles/quickstart/config.yml
+++ b/articles/quickstart/config.yml
@@ -1,4 +1,4 @@
 author:
-  name: Andres Aguiar
-  email: andres.aguiar@auth0.com
+  name: Auth0
+  email: support@auth0.com
   community: false


### PR DESCRIPTION
This removes Andres from the default author and puts Auth0 by default