### PR TITLE
Update deprecation notices for /delegation endpoint

### DIFF
--- a/articles/_includes/_deprecate-delegation.md
+++ b/articles/_includes/_deprecate-delegation.md
@@ -1,3 +1,3 @@
 ::: warning
-Delegation is a deprecated feature. The functionality will continue to work for the customers that currently have it enabled. If at some point the delegation feature is changed or removed from service, customers who currently use it will be notified beforehand and given ample time to migrate.
+By default, delegation is disabled for tenants without an add-on in use as of 8 June 2017. Legacy tenants who currently use an add-on that requires delegation may continue to use this feature. If delegation functionality is changed or removed from service at some point, customers who currently use it will be notified beforehand and given ample time to migrate.
 :::

--- a/articles/_includes/_deprecate-impersonation.md
+++ b/articles/_includes/_deprecate-impersonation.md
@@ -1,3 +1,3 @@
 ::: warning
-Impersonation has been deprecated and will not be enabled for new customers. The functionality will continue to work for existing customers that currently have it enabled. If at some point the impersonation feature is changed or removed from service, customers who currently use it will be notified beforehand and given ample time to migrate.
+Impersonation has been deprecated and will not be enabled for new customers. The functionality will continue to work for existing customers who currently have it enabled. If at some point the impersonation feature is changed or removed from service, customers who currently use it will be notified beforehand and given ample time to migrate.
 :::

--- a/articles/_includes/_uses-delegation.md
+++ b/articles/_includes/_uses-delegation.md
@@ -1,0 +1,3 @@
+::: warning
+This feature uses delegation. By default, delegation is disabled for tenants without an add-on in use as of 8 June 2017. Legacy tenants who currently use an add-on that requires delegation may continue to use this feature. If delegation functionality is changed or removed from service at some point, customers who currently use it will be notified beforehand and given ample time to migrate.
+:::

--- a/articles/addons/azure-blob-storage.md
+++ b/articles/addons/azure-blob-storage.md
@@ -20,6 +20,8 @@ useCase: integrate-third-party-apps
 
 # Azure Blob Storage Add-on
 
+<%= include('../_includes/_uses-delegation') %>
+
 Here's a sample call to the delegation endpoint to get the Shared Access Signature (SAS):
 
 ```text
@@ -48,7 +50,7 @@ The result of calling the delegation endpoint will be something like:
 }
 ```
 
-You can use the blob SAS token either by appending it to a url directly or by passing it to one of the Azure Storage SDKs.
+You can use the blob SAS token either by appending it to a URL directly or by passing it to one of the Azure Storage SDKs.
 
 ```text
 GET https://{STORAGEACCOUNT}.blob.core.windows.net/mycontainer/myblob.txt?st=2015-01-08T18%3A45%3A14Z&se=2015-01-08T18%3A50%3A14Z&sp=r&sv=2014-02-14&sr=b&sig=13ABC456...

--- a/articles/addons/azure-mobile-services.md
+++ b/articles/addons/azure-mobile-services.md
@@ -24,6 +24,8 @@ description: Learn how to use Auth0 to authenticate and authorize Windows Azure 
 
 # Windows Azure Mobile Services Add-on
 
+<%= include('../_includes/_uses-delegation') %>
+
 ## 1. Create an application
 
 Windows Azure Mobile Services (WAMS) endpoints can be used from anywhere. To configure an app that interacts with WAMS, you can use any of the following tutorials:

--- a/articles/addons/azure-sb.md
+++ b/articles/addons/azure-sb.md
@@ -19,6 +19,8 @@ description: Learn how to use Auth0 to authenticate and authorize Azure Service 
 
 # Azure Service Bus Add-on
 
+<%= include('../_includes/_uses-delegation') %>
+
 Here's a sample call to the delegation endpoint to get the Shared Access Signature (SAS):
 
 ```text

--- a/articles/addons/index.md
+++ b/articles/addons/index.md
@@ -15,6 +15,8 @@ useCase:
 
 # Add-ons
 
+<%= include('../_includes/_uses-delegation') %>
+
 Add-ons are plugins associated with an application registered with Auth0. Usually, they are third-party APIs used by application(s) for which Auth0 generates Access Tokens (e.g., Salesforce, Azure Service Bus, Windows Azure Mobile Services, SAP).
 
 Some typical scenarios for using add-ons include:

--- a/articles/addons/salesforce-sandbox.md
+++ b/articles/addons/salesforce-sandbox.md
@@ -16,6 +16,8 @@ contentType: how-to
 
 # Salesforce (Sandbox) Add-on
 
+<%= include('../_includes/_uses-delegation') %>
+
 Auth0 supports both the __production__ connection to Salesforce and the __Sandbox__, the only difference being the endpoints hosted by Salesforce: `https://login.salesforce.com` and `https://test.salesforce.com`, respectively.
 
 ::: note

--- a/articles/addons/salesforce.md
+++ b/articles/addons/salesforce.md
@@ -16,6 +16,8 @@ contentType: how-to
 
 # Salesforce Add-on
 
+<%= include('../_includes/_uses-delegation') %>
+
 Auth0 supports both the __production__ connection to Salesforce and the __Sandbox__, the only difference being the endpoints hosted by Salesforce: `https://login.salesforce.com` and `https://test.salesforce.com`, respectively.
 
 The integration also supports getting tokens for __Salesforce Community Sites__. For this to work, you need to pass two additional parameters:

--- a/articles/addons/sap-odata.md
+++ b/articles/addons/sap-odata.md
@@ -16,6 +16,8 @@ contentType: how-to
 
 # SAP OData Add-on
 
+<%= include('../_includes/_uses-delegation') %>
+
 ::: warning
 This integration is in <strong>experimental mode</strong>. Contact us if you have questions.
 :::

--- a/articles/api/authentication/legacy/_delegation.md
+++ b/articles/api/authentication/legacy/_delegation.md
@@ -35,7 +35,7 @@ curl --request POST \
 }) %>
 
 ::: warning
-This feature is disabled by default for new tenants as of 8 June 2017. See the [migration notice](/migrations#api-authorization-with-third-party-vendor-apis) for more information.
+By default, this feature is disabled for tenants without an add-on in use as of 8 June 2017. Legacy tenants who currently use an add-on that requires delegation may continue to use this feature. If delegation functionality is changed or removed from service at some point, customers who currently use it will be notified beforehand and given ample time to migrate.
 :::
 
 A delegation token can be obtained and used when an application needs to call the API of an Application Addon, such as Firebase or SAP, registered and configured in Auth0, in the same tenant as the calling program.

--- a/articles/applications/application-settings/_adv-settings.md
+++ b/articles/applications/application-settings/_adv-settings.md
@@ -18,7 +18,7 @@ You can create up to 10 sets of metadata.
 
 Set the OAuth-related settings on this tab:
 
-* By default, all apps/APIs can make a delegation request, but if you want to explicitly grant permissions to selected apps/APIs, you can do so in **Allowed APPs/APIs**.
+* By default, all apps/APIs can make a delegation request, but if you want to explicitly grant permissions to selected apps/APIs, you can do so in **Allowed Apps/APIs**.
 
 * Set the algorithm used (**HS256** or **RS256**) for signing your JSON Web Tokens.
 

--- a/articles/best-practices/application-settings.md
+++ b/articles/best-practices/application-settings.md
@@ -65,9 +65,9 @@ This setting only applies to older tenants, created before Dec 27th 2017. Newer 
 
 ## Restrict Delegation
 
-If you are not using delegation, provide your application's Client ID in the **Allowed Apps / APIs** field to restrict delegation requests. You can find this field in [Applications > Settings > Advanced Settings > OAuth](${manage_url}/#/applications) on the dashboard.
-
 <%= include('../_includes/_deprecate-delegation') %>
+
+If you are not using delegation, provide your application's Client ID in the **Allowed Apps / APIs** field to restrict delegation requests. You can find this field in [Applications > Settings > Advanced Settings > OAuth](${manage_url}/#/applications) on the dashboard.
 
 ### Remove unnecessary grant types
 

--- a/articles/dashboard/guides/applications/set-up-addons.md
+++ b/articles/dashboard/guides/applications/set-up-addons.md
@@ -12,7 +12,7 @@ useCase:
 ---
 # Set Up Add-ons
 
-<%= include('../_includes/_uses-delegation') %>
+<%= include('../../../_includes/_uses-delegation') %>
 
 This guide will show you how to set up an [add-on](/addons) for an application using Auth0's Dashboard.
 

--- a/articles/dashboard/guides/applications/set-up-addons.md
+++ b/articles/dashboard/guides/applications/set-up-addons.md
@@ -12,6 +12,8 @@ useCase:
 ---
 # Set Up Add-ons
 
+<%= include('../_includes/_uses-delegation') %>
+
 This guide will show you how to set up an [add-on](/addons) for an application using Auth0's Dashboard.
 
 1. Navigate to the [Applications](${manage_url}/#/applications) page in the [Auth0 Dashboard](${manage_url}/), and click the name of the Application to view.

--- a/articles/dashboard/reference/settings-application.md
+++ b/articles/dashboard/reference/settings-application.md
@@ -85,7 +85,7 @@ When developing Android apps, you'll provide your **App Package Name** and your 
 
 Set the OAuth-related settings on this tab:
 
-* By default, all apps/APIs can make a delegation request, but if you want to explicitly grant permissions to selected apps/APIs, you can do so in **Allowed APPs/APIs**.
+* By default, all apps/APIs can make a delegation request, but if you want to explicitly grant permissions to selected apps/APIs, you can do so in **Allowed Apps/APIs**.
 
 * Set the algorithm used (**HS256** or **RS256**) for signing your JSON Web Tokens. For more info, see [Signing Algorithms](/applications/concepts/signing-algorithms).
 

--- a/articles/integrations/aws-api-gateway/delegation/_delegation-version-warning.md
+++ b/articles/integrations/aws-api-gateway/delegation/_delegation-version-warning.md
@@ -1,3 +1,5 @@
 ::: version-warning
-Delegation is a deprecated feature. It does not have a sunset date, and users of the feature will be provided with ample notice if a migration ever occurs. However, if you are not already using delegation, please implement custom authorizers instead. Use the drop-down to switch to the custom authorizer docs.
+This feature uses delegation. By default, delegation is disabled for tenants without an add-on in use as of 8 June 2017. If you are not already using delegation, please use the drop-down to learn how to implement custom authorizers instead.
+
+Legacy tenants who currently use an add-on that requires delegation may continue to use this feature. If delegation functionality is changed or removed from service at some point, customers who currently use it will be notified beforehand and given ample time to migrate.
 :::

--- a/articles/integrations/aws/tokens.md
+++ b/articles/integrations/aws/tokens.md
@@ -13,7 +13,7 @@ useCase:
 ---
 # Call AWS APIs and Resources Securely with Tokens
 
-<%= include('../_includes/_uses-delegation') %>
+<%= include('../../_includes/_uses-delegation') %>
 
 Auth0 integrates with the AWS Security Token Service (STS) to obtain an limited-privilege credentials for AWS Identity and Access Management (IAM) users or for users that you authenticate (federated users). These credentials can then be used to call the AWS API of any Auth0-supported [identity provider](/identityproviders).
 

--- a/articles/integrations/aws/tokens.md
+++ b/articles/integrations/aws/tokens.md
@@ -13,9 +13,7 @@ useCase:
 ---
 # Call AWS APIs and Resources Securely with Tokens
 
-::: panel-warning Legacy Grant Types
-As of 8 June 2017, new Auth0 customers cannot add any of the legacy grant types to their applications, which are required for use with the [Delegation endpoint](/api/authentication#get-token-info). Legacy grant types are only available for previous customers while they migrate to new flows, to avoid breaking changes. To find the secure alternative for your case refer to [Secure Alternatives to the Legacy Grant Types](/applications/concepts/grant-types-legacy#secure-alternatives). If you have any questions about which alternative you should use, please contact [Support](${env.DOMAIN_URL_SUPPORT}).
-:::
+<%= include('../_includes/_uses-delegation') %>
 
 Auth0 integrates with the AWS Security Token Service (STS) to obtain an limited-privilege credentials for AWS Identity and Access Management (IAM) users or for users that you authenticate (federated users). These credentials can then be used to call the AWS API of any Auth0-supported [identity provider](/identityproviders).
 

--- a/articles/libraries/lock-android/_includes/_lock-version.md
+++ b/articles/libraries/lock-android/_includes/_lock-version.md
@@ -1,3 +1,3 @@
 ::: version-warning
-This document covers an outdated version of <dfn data-key="lock">Lock</dfn> for Android. We recommend you to [upgrade to v2](/libraries/lock-android/v2/migration-guide)
+This document covers an outdated version of <dfn data-key="lock">Lock</dfn> for Android. We recommend you to [upgrade to v2](/libraries/lock-android/v2/migration-guide).
 :::

--- a/articles/libraries/lock-android/v1/delegation-api.md
+++ b/articles/libraries/lock-android/v1/delegation-api.md
@@ -17,6 +17,8 @@ useCase:
 
 <%= include('../_includes/_lock-version') %>
 
+<%= include('../../../_includes/_deprecate-delegation') %>
+
 After a successful authentication, you can request credentials to access third party apps like Firebase or AWS that are configured in your Auth0 App's Add-On section. In order to do that you need to make a request to our [Delegation API](/auth-api#!#post--delegation) using a valid JWT.
 
 Here's an example

--- a/articles/libraries/lock-android/v1/refresh-jwt-tokens.md
+++ b/articles/libraries/lock-android/v1/refresh-jwt-tokens.md
@@ -18,6 +18,8 @@ useCase:
 
 <%= include('../_includes/_lock-version') %>
 
+<%= include('../../../_includes/_uses-delegation') %>
+
 When an authentication is performed with the `offline_access` <dfn data-key="scope">scope</dfn> included, it will return a <dfn data-key="refresh-token">Refresh Token</dfn> that can be used to request a new JWT token and avoid asking the user for their credentials again.
 
 ::: note

--- a/articles/libraries/lock-android/v2/refresh-jwt-tokens.md
+++ b/articles/libraries/lock-android/v2/refresh-jwt-tokens.md
@@ -15,6 +15,8 @@ useCase:
 ---
 # Lock Android: Refreshing JWT Tokens
 
+<%= include('../../../_includes/_uses-delegation') %>
+
 When an authentication is performed with the `offline_access` <dfn data-key="scope">scope</dfn> included, the returned Credentials will contain a <dfn data-key="refresh-token">Refresh Token</dfn> and an ID Token. Both tokens can be used to request a new <dfn data-key="access-token">Access Token</dfn> and avoid asking the user their credentials again.
 
 We need to store the tokens in a secure storage after a successful authentication. Keep in mind that Refresh Tokens **never expire**. To request a new token you'll need to use `auth0.android`'s `AuthenticationAPIClient`. Don't forget to request the same scope used in the first login call.

--- a/articles/libraries/lock-ios/v1/delegation-api.md
+++ b/articles/libraries/lock-ios/v1/delegation-api.md
@@ -19,6 +19,8 @@ useCase:
 
 <%= include('../_includes/_lock-version-1') %>
 
+<%= include('../../../_includes/_deprecate-delegation') %>
+
 After a successful authentication, you can request credentials to access third party apps like Firebase or AWS that are configured in your Auth0 App's Add-On section. In order to do that you need to make a request to our [Delegation API](/api/authentication/reference#delegation) using a valid JWT.
 
 Here's an example

--- a/articles/libraries/lock-ios/v1/save-and-refresh-jwt-tokens.md
+++ b/articles/libraries/lock-ios/v1/save-and-refresh-jwt-tokens.md
@@ -18,6 +18,8 @@ useCase:
 
 <%= include('../_includes/_lock-version-1') %>
 
+<%= include('../../../_includes/_uses-delegation') %>
+
 When an authentication is performed with the `offline_access` <dfn data-key="scope">scope</dfn> included, it will return a <dfn data-key="refresh-token">Refresh Token</dfn> that can be used to request a new JWT token and avoid asking the user his/her
 credentials again.
 

--- a/articles/libraries/lock-ios/v2/migration.md
+++ b/articles/libraries/lock-ios/v2/migration.md
@@ -284,8 +284,8 @@ Auth0
 
 ### Delegation
 
-Delegation is not available through Lock. It can be implemented via a legacy method in [Auth0.Swift](/libraries/auth0-swift) for tenants which existed prior to June 2017.
-
 <%= include('../../../_includes/_deprecate-delegation') %>
+
+Delegation is not available through Lock. It can be implemented via a legacy method in [Auth0.Swift](/libraries/auth0-swift) for tenants which existed prior to June 2017.
 
 <%= include('../_includes/_roadmap') %>

--- a/articles/tokens/delegation.md
+++ b/articles/tokens/delegation.md
@@ -12,19 +12,17 @@ useCase:
 
 # Delegation Tokens
 
-::: warning
-With [the latest Auth0 authentication pipeline](/api-auth/intro), delegation tokens should not be used to exchange an ID Token issued to one application for a new one issued to a different application, or to get a new ID Token. See the [migration notice](/migrations#api-authorization-with-third-party-vendor-apis) for more information.
-:::
+<%= include('../_includes/_uses-delegation') %>
 
-A delegation token should be obtained and used when an application needs to call the API of an Application Addon, such as Firebase or SAP, registered and configured in Auth0, in the same tenant as the calling program.
+A delegation token should be obtained and used when an application needs to call the API of an Application Add-on, such as Firebase or SAP, registered and configured in Auth0, in the same tenant as the calling program.
 
 Given an existing token, this endpoint will generate a new token signed with the `target` application's secret. This is used to flow the identity of the user from the application to an API.
 
-The type of the delegation token will vary depending on the by provider. For example, if issued for Azure Blob Storage, it will be a SAS (Shared Access Signature). If it is for the Firebase Addon, it will be a JWT.
+The type of the delegation token will vary depending on the by provider. For example, if issued for Azure Blob Storage, it will be an SAS (Shared Access Signature). If it is for the Firebase Add-on, it will be a JWT.
 
 ## How to get a delegation token
 
-The ID Token for an authenticated user can be used with the [Delegation endpoint](/api/authentication#delegation) to request a delegation token for a particular target. The target can be an application Addon configured in Auth0. The Addons for which this can be done are those that are not <dfn data-key="security-assertion-markup-language">SAML</dfn> or WS-Fed Addons and the Addon must be configured in Auth0 with secrets obtained from the Addon service, such as Firebase. Instructions for setting up the secrets are available from the Addon configuration page for each Addon. The secrets are used to sign the delegation token so that the Addon API can validate and trust the token.
+The ID Token for an authenticated user can be used with the [Delegation endpoint](/api/authentication#delegation) to request a delegation token for a particular target. The target can be an application Add-on configured in Auth0. The Add-ons for which this can be done are those that are not <dfn data-key="security-assertion-markup-language">SAML</dfn> or WS-Fed Add-ons and the Add-on must be configured in Auth0 with secrets obtained from the Add-on service, such as Firebase. Instructions for setting up the secrets are available from the Add-on configuration page for each Add-on. The secrets are used to sign the delegation token so that the Add-on API can validate and trust the token.
 
 The delegation endpoint allows the setting of several parameters which will govern the contents of the delegation token, including the `target`, the <dfn data-key="scope">`scope`</dfn>, the API to be called (`api_type`) and an additional free-form area for additional parameters.
 
@@ -32,11 +30,11 @@ See the [Delegation endpoint](/api/authentication#delegation) for more informati
 
 ### Auth0.js Example
 
-For an example on how to get a new token for an addon that you have activated, using __Auth0.js__, refer to [Delegation Token Request](/libraries/auth0js/v7#delegation-token-request). Note that this example is for **version 7** of the __Auth0.js__ library; delegation is **not supported** in version 8 of __Auth0.js__.
+For an example on how to get a new token for an Add-on that you have activated, using __Auth0.js__, refer to [Delegation Token Request](/libraries/auth0js/v7#delegation-token-request). Note that this example is for **version 7** of the __Auth0.js__ library; delegation is **not supported** in version 8 of __Auth0.js__.
 
 ## Validity Period and Termination
 
-The validity period and the ability to revoke a delegation token, varies by individual Addon. The documentation available from the provider of any Addon API should be consulted for further information.
+The validity period and the ability to revoke a delegation token, varies by individual Add-on. The documentation available from the provider of any Add-on API should be consulted for further information.
 
 ## Using Delegation Tokens with Public Applications
 

--- a/articles/tokens/refresh-token/legacy/index.md
+++ b/articles/tokens/refresh-token/legacy/index.md
@@ -14,7 +14,7 @@ useCase:
 # Refresh Token
 
 ::: version-warning
-This document covers an outdated version of the Auth0 authentication pipeline and the way <dfn data-key="refresh-token">Refresh Tokens</dfn> are used. We recommend you use <a href="/tokens/refresh-token">the latest version</a>. For more on the latest authentication pipeline refer to [Introducing OIDC Conformant Authentication](/api-auth/intro).
+This document covers an outdated version of the Auth0 authentication pipeline and the way <dfn data-key="refresh-token">Refresh Tokens</dfn> are used. We recommend you use <a href="/tokens/refresh-token">the latest version</a>.
 :::
 
 A **Refresh Token** is a special kind of token that is used to authenticate a user without them needing to re-authenticate. This is primarily useful for mobile applications that are installed on a device.


### PR DESCRIPTION
Updated deprecation includes, added include references to pages missing them, removed broken link to migrations page.