### PR TITLE
Rename Spring Security API QS to Spring Security 4

### DIFF
--- a/articles/quickstart/backend/java-spring-security/index.yml
+++ b/articles/quickstart/backend/java-spring-security/index.yml
@@ -1,4 +1,4 @@
-title: Spring Security Java API
+title: Spring Security 4 Java API
 thirdParty: false
 author:
   name: Luciano Balmaceda


### PR DESCRIPTION
This should help better differentiate between the two Spring Security API Quickstarts.

![image](https://user-images.githubusercontent.com/276225/62388534-26be4f80-b523-11e9-8f2f-b89d54c12c27.png)
