### PR TITLE
Bumped react-native min version QS-247

### DIFF
--- a/articles/quickstart/native/react-native/index.yml
+++ b/articles/quickstart/native/react-native/index.yml
@@ -30,7 +30,7 @@ github:
   org: auth0-samples
   repo: auth0-react-native-sample
 requirements:
-  - React Native 0.59.10
+  - React Native 2.0.1
   - NodeJS 10.16
 next_steps:
   - path: 00-login

--- a/articles/quickstart/native/react-native/index.yml
+++ b/articles/quickstart/native/react-native/index.yml
@@ -30,7 +30,8 @@ github:
   org: auth0-samples
   repo: auth0-react-native-sample
 requirements:
-  - React Native 2.0.1
+  - React Native 0.60.4
+  - React Native Cli 2.0.1
   - NodeJS 10.16
 next_steps:
   - path: 00-login

--- a/articles/quickstart/native/react-native/index.yml
+++ b/articles/quickstart/native/react-native/index.yml
@@ -31,7 +31,6 @@ github:
   repo: auth0-react-native-sample
 requirements:
   - React Native 0.60.4
-  - React Native Cli 2.0.1
   - NodeJS 10.16
 next_steps:
   - path: 00-login


### PR DESCRIPTION
There was an outdated minimum requirement for react-native

--- [QuickStart | React-native] minimum requirements are not the same as the project