### PR TITLE
Adds error_page.(html|json) to pages dir

### DIFF
--- a/articles/extensions/deploy-cli/guides/import-export-directory-structure.md
+++ b/articles/extensions/deploy-cli/guides/import-export-directory-structure.md
@@ -113,6 +113,8 @@ repository =>
   grants
     grant1.json
   pages
+    error_page.html
+    error_page.json
     login.html
     login.json
     password_reset.html


### PR DESCRIPTION
This was documented in the YAML setup, but not the directory structure setup. I hope this helps.
