### PR TITLE
Update logo_name from java to spring

### DIFF
--- a/articles/quickstart/webapp/java-spring-mvc/index.yml
+++ b/articles/quickstart/webapp/java-spring-mvc/index.yml
@@ -1,6 +1,6 @@
 title: Java Spring MVC
 image: /media/platforms/spring.png
-logo_name: java
+logo_name: spring
 author:
   name: Jim Anderson
   email: jim.anderson@auth0.com

--- a/articles/quickstart/webapp/java-spring-security-mvc/index.yml
+++ b/articles/quickstart/webapp/java-spring-security-mvc/index.yml
@@ -1,6 +1,6 @@
 title: Java Spring Security
 image: /media/platforms/spring.png
-logo_name: java
+logo_name: spring
 author:
   name: Jim Anderson
   email: jim.anderson@auth0.com


### PR DESCRIPTION
A pending change to better support images for Quickstarts will map the `logo_name` to the platform to get the proper image. Currently the Spring WebApp Quickstarts specify `java` instead of `spring` for the `logo_name`, which would cause the Java image to be displayed instead of the Spring image (when the docs platform change is made).