### PR TITLE
Fix claim namespace in article to match sample

### DIFF
--- a/articles/quickstart/webapp/aspnet-core-v1_1/03-authorization.md
+++ b/articles/quickstart/webapp/aspnet-core-v1_1/03-authorization.md
@@ -48,7 +48,7 @@ function (user, context, callback) {
   user.app_metadata.roles = roles;
   auth0.users.updateAppMetadata(user.user_id, user.app_metadata)
     .then(function() {
-      context.idToken['https://example.com/roles'] = user.app_metadata.roles;
+      context.idToken['https://schemas.quickstarts.com/roles'] = user.app_metadata.roles;
       callback(null, user, context);
     })
     .catch(function (err) {
@@ -59,7 +59,7 @@ function (user, context, callback) {
 
 Update the code to check for your own email domain, or match the condition according to your needs. Notice that you can also set more roles other than `admin` and `user`, or customize the whole rule as you please.
 
-This quickstart uses `https://schemas.quickstarts.com` for the claim namespace, but it is suggested that you use a namespace related to your own Auth0 tenant for your claims, e.g `https://schemas.YOUR_TENANT_NAME.com`.
+This quickstart uses `https://schemas.quickstarts.com/roles` for the claim namespace, but it is suggested that you use a namespace related to your own Auth0 tenant for your claims, e.g `https://schemas.YOUR_TENANT_NAME.com`.
 
 ::: note
 For more information on custom claims please see [User profile claims and scope](/api-auth/tutorials/adoption/scope-custom-claims).

--- a/articles/quickstart/webapp/aspnet-core/03-authorization.md
+++ b/articles/quickstart/webapp/aspnet-core/03-authorization.md
@@ -53,7 +53,7 @@ function (user, context, callback) {
   user.app_metadata.roles = roles;
   auth0.users.updateAppMetadata(user.user_id, user.app_metadata)
     .then(function() {
-      context.idToken['https://example.com/roles'] = user.app_metadata.roles;
+      context.idToken['https://schemas.quickstarts.com/roles'] = user.app_metadata.roles;
       callback(null, user, context);
     })
     .catch(function (err) {
@@ -68,7 +68,7 @@ Update the code to check for your own email domain, or match your custom conditi
 You can define more roles other than `admin` and `user`, or customize the whole rule, depending on your product requirements.
 :::
 
-This quickstart guide uses `https://schemas.quickstarts.com` for the claim namespace. We recommend that you use a namespace related to your own Auth0 tenant for your claims, for example, `https://schemas.YOUR_TENANT_NAME.com`.
+This quickstart guide uses `https://schemas.quickstarts.com/roles` for the claim namespace. We recommend that you use a namespace related to your own Auth0 tenant for your claims, for example, `https://schemas.YOUR_TENANT_NAME.com`.
 
 ::: note
 For more information on custom claims, read [User profile claims and scope](/api-auth/tutorials/adoption/scope-custom-claims).

--- a/articles/quickstart/webapp/aspnet-owin/03-authorization.md
+++ b/articles/quickstart/webapp/aspnet-owin/03-authorization.md
@@ -48,7 +48,7 @@ function (user, context, callback) {
   user.app_metadata.roles = roles;
   auth0.users.updateAppMetadata(user.user_id, user.app_metadata)
     .then(function() {
-      context.idToken['https://example.com/roles'] = user.app_metadata.roles;
+      context.idToken['https://schemas.quickstarts.com/roles'] = user.app_metadata.roles;
       callback(null, user, context);
     })
     .catch(function (err) {
@@ -59,7 +59,7 @@ function (user, context, callback) {
 
 Update the code to check for your own email domain, or match the condition according to your needs. Notice that you can also set more roles other than `admin` and `user`, or customize the whole rule as you please.
 
-This quickstart uses `https://schemas.quickstarts.com` for the claim namespace, but it is suggested that you use a namespace related to your own Auth0 tenant for your claims, e.g. `https://schemas.YOUR_TENANT_NAME.com`
+This quickstart uses `https://schemas.quickstarts.com/roles` for the claim namespace, but it is suggested that you use a namespace related to your own Auth0 tenant for your claims, e.g. `https://schemas.YOUR_TENANT_NAME.com`.
 
 ## Restrict an action based on a user's roles
 


### PR DESCRIPTION
The .NET authorization samples demonstrate using a Rule to assign roles, but the article Rule code snippet does not use the same claim namespace as the code sample.

This PR fixes that so that the rule snippet will work when used with the sample.
