### PR TITLE
Fix URL construction on Node QS

### DIFF
--- a/articles/quickstart/webapp/nodejs/01-login.md
+++ b/articles/quickstart/webapp/nodejs/01-login.md
@@ -203,7 +203,7 @@ router.get('/logout', (req, res) => {
   if (port !== undefined && port !== 80 && port !== 443) {
     returnTo += ':' + port;
   }
-  var logoutURL = new URL(
+  var logoutURL = new url.URL(
     util.format('https://%s/v2/logout', process.env.AUTH0_DOMAIN)
   );
   var searchString = querystring.stringify({


### PR DESCRIPTION
For compatibility with older Node versions than 10, we need to use a different constructor for URL

https://nodejs.org/docs/latest-v8.x/api/url.html

Code is already updated.