### PR TITLE
Add rule to integrate RBAC core and DAE roles

### DIFF
--- a/articles/_includes/_rbac_methods.md
+++ b/articles/_includes/_rbac_methods.md
@@ -3,6 +3,6 @@ Currently, we provide two ways of implementing [role-based access control (RBAC)
 * [Authorization Core](/authorization/guides/how-to)
 * [Authorization Extension](/extensions/authorization-extension)
 
-We are expanding our Authorization Core feature set to match the functionality of the Authorization Extension and expect a final release in 2019. Our new core RBAC implementation improves performance and scalability and will eventually provide a more flexible RBAC system than the Authorization Extension.
+We are expanding our Authorization Core feature set to match the functionality of the Authorization Extension and expect a final release in 2020. Our new core RBAC implementation improves performance and scalability and will eventually provide a more flexible RBAC system than the Authorization Extension.
 
 For now, both implement the key features of RBAC and allow you to restrict the custom <dfn data-key="scope">scopes</dfn> defined for an API to those that have been assigned to the user as permissions. For a comparison, see [Authorization Core vs. Authorization Extension](/authorization/concepts/core-vs-extension).

--- a/articles/_includes/_rbac_vs_extensions.md
+++ b/articles/_includes/_rbac_vs_extensions.md
@@ -1,3 +1,5 @@
 ::: warning
-The [Authorization Core](/authorization/guides/how-to) feature set, [Authorization Extension](/extensions/authorization-extension), and [Delegated Administration Extension](/extensions/delegated-admin) are completely separate features. To manage groups, roles, or permissions, you will need to use the feature they were originally created in.
+The [Authorization Core](/authorization/guides/how-to) feature set and[Authorization Extension](/extensions/authorization-extension) are completely separate features. To manage groups, roles, or permissions, you will need to use the feature they were originally created in.
+
+Although the [Delegated Administration Extension](/extensions/delegated-admin) and the [Authorization Core](/authorization/guides/how-to) feature set are completely separate features, you can use the Authorization Core feature set to create and manage roles for the DAE if you use a rule. To learn how, see [Sample Use Cases: Rules with Authorization](/authorization/concepts/sample-use-cases-rules#manage-delegated-administration-extension-roles-using-the-authorization-core-feature-set).
 :::

--- a/articles/authorization/concepts/sample-use-cases-rules.md
+++ b/articles/authorization/concepts/sample-use-cases-rules.md
@@ -39,7 +39,7 @@ function (user, context, callback) {
 }
 ```
 
-If it is weekend, a user will be denied access to the specified application even if they successfully authenticate and have the appropriate privileges.
+If a user attempts to access the application during the weekend, access will be denied, even if they authenticate and have the appropriate privileges.
 
 ## Allow access only to users who are inside the corporate network
 
@@ -60,7 +60,6 @@ function (user, context, callback) {
 ```
 
 If the user is outside the corporate network, they will be denied access even if they successfully authenticate and have the appropriate privileges.
-
 
 ## Add user roles to tokens
 

--- a/articles/authorization/concepts/sample-use-cases-rules.md
+++ b/articles/authorization/concepts/sample-use-cases-rules.md
@@ -18,7 +18,7 @@ useCase:
 ---
 # Sample Use Cases: Rules with Authorization
 
-With rules, you can modify or complement the outcome of the decision made by the pre-configured [authorization policy](/authorization/concepts/policies) to handle more complicated cases than is possible with [role-based access control (RBAC)](/authorization/concepts/rbac) alone. Based on the order in which they run, rules can change the outcome of the authorization decision prior to the permissions being added to the <dfn data-key="access-token">Access Token</dfn>. They can also allow you to customize the content of your tokens.
+With [rules](/rules), you can modify or complement the outcome of the decision made by the pre-configured [authorization policy](/authorization/concepts/policies) to handle more complicated cases than is possible with [role-based access control (RBAC)](/authorization/concepts/rbac) alone. Based on the order in which they run, rules can change the outcome of the authorization decision prior to the permissions being added to the <dfn data-key="access-token">Access Token</dfn>. They can also allow you to customize the content of your tokens.
 
 ## Allow access only on weekdays for a specific application
 
@@ -79,9 +79,34 @@ function (user, context, callback) {
 
   context.idToken = idTokenClaims;
   context.accessToken = accessTokenClaims;
+
   callback(null, user, context);
 }
 
+```
+
+## Manage Delegated Administration Extension roles using the Authorization Core feature set
+
+Although the [Delegated Administration Extension (DAE)](/extensions/delegated-admin) and the Authorization Core feature set are completely separate features, you can use the Authorization Core feature set to create and manage roles for the DAE if you use a rule.
+
+1. [Create DAE roles](/dashboard/guides/roles/create-roles) using the Authorization Core feature set. 
+
+The names of the roles you create must match the names of the [pre-defined DAE roles](/extensions/delegated-admin#assign-roles-to-users).
+
+2. [Assign the DAE roles you created to the appropriate users](/dashboard/guides/users/assign-roles-users) using the Authorization core feature set.
+
+3. Add user roles to the DAE namespace in the ID Token. To do so, add the following rule:
+
+```js
+function (user, context, callback) {
+  const IDTOKEN_ROLES_PROPERTY = 'https://demozero.net/auth0-delegated-admin';
+
+  context.idToken[IDTOKEN_ROLES_PROPERTY] = {
+    roles: (context.authorization || {}).roles
+  };
+
+  callback(null, user, context);
+}
 ```
 
 ## Keep reading

--- a/articles/extensions/delegated-admin/v3/index.md
+++ b/articles/extensions/delegated-admin/v3/index.md
@@ -113,7 +113,7 @@ You will need to add at least one user to your connection. You can do this via t
 
 ### Assign roles to users
 
-<%= include('../_includes/_rbac_vs_extensions') %>
+<%= include('../../../_includes/_rbac_vs_extensions') %>
 
 Auth0 grants the user(s) in your connection access to the Delegated Administration extension based on their <dfn data-key="role">roles</dfn>:
 

--- a/articles/extensions/delegated-admin/v3/index.md
+++ b/articles/extensions/delegated-admin/v3/index.md
@@ -1,5 +1,6 @@
 ---
-description: The Delegated Administration extension allows you to expose the Users dashboard to a group of users, without allowing them access to the dashboard.
+title: Delegated Administration Extension
+description: Learn about Auth0's Delegated Administration Extension, which allows you to expose the Users section of the Auth0 Dashboard to a select group of users without allowing them access to the rest of the Dashboard.
 toc: true
 topics:
   - extensions
@@ -11,11 +12,15 @@ contentType:
 useCase: extensibility-extensions
 ---
 
-# Delegated Administration
+# Delegated Administration Extension
 
-The **Delegated Administration** extension allows you to grant a select group of people administrative permissions to the [Users page](${manage_url}/#/users) without providing access to any other area. This is done by exposing the [Users Dashboard](${manage_url}/#/users) as an Auth0 application.
+::: warning
+This extension requires you to disable the **OIDC Conformant** flag (and for some older tenants, enable the **Legacy User Profile** flag) for your application. Once disabled, you must ensure your application's authentication code is updated as well.
+:::
 
-Follow this tutorial to learn how to expose the Users dashboard to a group of users without allowing them access to the rest of the management dashboard. 
+The **Delegated Administration Extension (DAE)** allows you to grant a select group of people administrative permissions to the [Users page](${manage_url}/#/users) of the Auth0 Dashboard without providing access to any other area. This is done by exposing the [Users area](${manage_url}/#/users) as an Auth0 application.
+
+This tutorial will show you how to expose the Users dashboard to a group of users without allowing them access to the rest of the management dashboard. 
 
 Prior to configuring the extension, you will need to:
 
@@ -70,12 +75,6 @@ Once you've created your application, you'll need to make the following applicat
 
 7. Next, set the **JsonWebToken Signature Algorithm** to `RS256`, and make sure the **OIDC Conformant** toggle is disabled.
 
-::: note
-The **Delegated Administration** extension requires applications to disable the **OIDC Conformant** flag. After turning off **OIDC Conformant** on the dashboard, ensure your application's authentication code is updated as well. 
-
-In some older tenants, you will also need to make sure that the **Legacy User Profile** flag is turned on. 
-:::
-
 ![Change Advanced OAuth Settings](/media/articles/extensions/delegated-admin/oauth-settings.png)
 
 9. Click **Save Changes** to proceed.
@@ -114,7 +113,7 @@ You will need to add at least one user to your connection. You can do this via t
 
 ### Assign roles to users
 
-<%= include('../../../_includes/_rbac_vs_extensions') %>
+<%= include('../_includes/_rbac_vs_extensions') %>
 
 Auth0 grants the user(s) in your connection access to the Delegated Administration extension based on their <dfn data-key="role">roles</dfn>:
 


### PR DESCRIPTION
- Add new rule to sample use cases
- Update include that discusses differences between Authz core, Authz Ext, and DAE.


https://docs-content-staging-pr-8167.herokuapp.com/docs/authorization/concepts/sample-use-cases-rules