### PR TITLE
Update Django webapp article

### DIFF
--- a/articles/quickstart/webapp/django/01-login.md
+++ b/articles/quickstart/webapp/django/01-login.md
@@ -178,7 +178,7 @@ LOGIN_REDIRECT_URL = '/dashboard'
 
 ## Trigger Authentication
 
-Add a handler for the `index` view in your `views.py` to render the `index.html` if the user needs to log in. If the user is already logged in, the `dashboard` view will be shown instead.
+Add a handler for the "index" view in your `views.py` to render the `index.html` if the user needs to log in. If the user is already logged in, the "dashboard" view will be shown instead.
 
 ```python
 # auth0login/views.py
@@ -207,7 +207,7 @@ Add a link to `/login/auth0` in the `index.html` template.
 
 ## Display User Information
 
-After the user is logged in, you can access the user information from the `request.user` property. Add a handler for the `/dashboard` endpoint in the `views.py` file. This same view will be displayed when a user that is already logged in tries to visit the `index` view. 
+After the user is logged in, you can access the user information from the `request.user` property. Add a handler for the `/dashboard` endpoint in the `views.py` file. This same "dashboard" view will be displayed when a user that is already logged in tries to visit the "index" view. 
 
 ```python
 # auth0login/views.py

--- a/articles/quickstart/webapp/django/01-login.md
+++ b/articles/quickstart/webapp/django/01-login.md
@@ -89,7 +89,8 @@ Set the `SOCIAL_AUTH_AUTH0_SCOPE` variable with the scopes the application will 
 
 SOCIAL_AUTH_AUTH0_SCOPE = [
     'openid',
-    'profile'
+    'profile',
+    'email
 ]
 ```
 
@@ -120,8 +121,10 @@ class Auth0(BaseOAuth2):
     name = 'auth0'
     SCOPE_SEPARATOR = ' '
     ACCESS_TOKEN_METHOD = 'POST'
+    REDIRECT_STATE = False
     EXTRA_DATA = [
-        ('picture', 'picture')
+        ('picture', 'picture'),
+        ('email', 'email')
     ]
 
     def authorization_url(self):
@@ -145,7 +148,8 @@ class Auth0(BaseOAuth2):
         return {'username': payload['nickname'],
                 'first_name': payload['name'],
                 'picture': payload['picture'],
-                'user_id': payload['sub']}
+                'user_id': payload['sub'],
+                'email': payload['email']}
 ```
 
 ::: note
@@ -174,13 +178,18 @@ LOGIN_REDIRECT_URL = '/dashboard'
 
 ## Trigger Authentication
 
-Add a handler for the `index` view in your `views.py` to render the `index.html`
+Add a handler for the `index` view in your `views.py` to render the `index.html` if the user needs to log in. If the user is already logged in, the `dashboard` view will be shown instead.
 
 ```python
 # auth0login/views.py
+from django.shortcuts import render, redirect
 
 def index(request):
-    return render(request, 'index.html')
+    user = request.user
+    if user.is_authenticated:
+        return redirect(dashboard)
+    else:
+        return render(request, 'index.html')
 ```
 
 Add a link to `/login/auth0` in the `index.html` template.
@@ -198,12 +207,12 @@ Add a link to `/login/auth0` in the `index.html` template.
 
 ## Display User Information
 
-After the user is logged in, you can access the user information from the `request.user` property. Add a handler for the `/dashboard` endpoint in the `views.py` file.
+After the user is logged in, you can access the user information from the `request.user` property. Add a handler for the `/dashboard` endpoint in the `views.py` file. This same view will be displayed when a user that is already logged in tries to visit the `index` view. 
 
 ```python
 # auth0login/views.py
 
-from django.shortcuts import render
+from django.shortcuts import render, redirect
 from django.contrib.auth.decorators import login_required
 import json
 
@@ -214,7 +223,8 @@ def dashboard(request):
     userdata = {
         'user_id': auth0user.uid,
         'name': user.first_name,
-        'picture': auth0user.extra_data['picture']
+        'picture': auth0user.extra_data['picture'],
+        'email': auth0user.extra_data['email'],
     }
 
     return render(request, 'dashboard.html', {


### PR DESCRIPTION
The Django webapp quickstart was not checking for authentication status. It was also missing the `email` scope and sending an unused `redirect_state` value on the redirect_uri query params. This PR fixes all of that.

**Code PR:** https://github.com/auth0-samples/auth0-django-web-app/pull/23