### PR TITLE
Added recommended to the Allowed Web Origins note for auth0-spa-js include

### DIFF
--- a/articles/quickstart/spa/_includes/_getting_started.md
+++ b/articles/quickstart/spa/_includes/_getting_started.md
@@ -15,7 +15,14 @@ If you are following along with the sample project you downloaded from the top o
 <% } %>
 
 <% if (typeof showWebOriginInfo !== 'undefined' && showWebOriginInfo === true) { %>
-<%= include('../../../_includes/_web_origins') %>
+  <%= include('../../../_includes/_web_origins') %>
+
+  <% if (typeof webOriginUrl !== 'undefined') { %>
+  ::: note
+  If you are following along with the sample project you downloaded from the top of this page, you should set the **Allowed Web Origins** to `${webOriginUrl}`.
+  :::
+  <% } %>
+
 <% } %>
 
 <% if (typeof new_js_sdk !== 'undefined' && new_js_sdk === true) { %>

--- a/articles/quickstart/spa/angular2/01-login.md
+++ b/articles/quickstart/spa/angular2/01-login.md
@@ -15,6 +15,6 @@ useCase: quickstart
 
 <!-- markdownlint-disable MD034 MD041 -->
 
-<%= include('../_includes/_getting_started', { library: 'Angular 7+', callback: 'http://localhost:3000/callback', showLogoutInfo: true, returnTo: 'http://localhost:3000', showWebOriginInfo: true, new_js_sdk: true }) %>
+<%= include('../_includes/_getting_started', { library: 'Angular 7+', callback: 'http://localhost:3000/callback', showLogoutInfo: true, returnTo: 'http://localhost:3000', webOriginUrl: 'http://localhost:3000', showWebOriginInfo: true, new_js_sdk: true }) %>
 
 <%= include('_includes/_centralized_login') %>

--- a/articles/quickstart/spa/react/01-login.md
+++ b/articles/quickstart/spa/react/01-login.md
@@ -14,6 +14,6 @@ useCase: quickstart
 ---
 <!-- markdownlint-disable MD034 MD041 -->
 
-<%= include('../_includes/_getting_started', { library: 'React', callback: 'http://localhost:3000', returnTo: 'http://localhost:3000', showLogoutInfo: true, showWebOriginInfo: true, new_js_sdk: true }) %>
+<%= include('../_includes/_getting_started', { library: 'React', callback: 'http://localhost:3000', returnTo: 'http://localhost:3000', webOriginUrl: 'http://localhost:3000', showLogoutInfo: true, showWebOriginInfo: true, new_js_sdk: true }) %>
 
 <%= include('_includes/_centralized_login') %>

--- a/articles/quickstart/spa/vanillajs/01-login.md
+++ b/articles/quickstart/spa/vanillajs/01-login.md
@@ -15,6 +15,6 @@ useCase: quickstart
 
 <!-- markdownlint-disable MD034 MD041 -->
 
-<%= include('../_includes/_getting_started', { library: 'JavaScript', callback: 'http://localhost:3000', showLogoutInfo: true, returnTo: 'http://localhost:3000', showWebOriginInfo: true, new_js_sdk: true }) %>
+<%= include('../_includes/_getting_started', { library: 'JavaScript', callback: 'http://localhost:3000', showLogoutInfo: true, returnTo: 'http://localhost:3000', webOriginUrl: 'http://localhost:3000', showWebOriginInfo: true, new_js_sdk: true }) %>
 
 <%= include('_includes/_centralized_login') %>

--- a/articles/quickstart/spa/vuejs/01-login.md
+++ b/articles/quickstart/spa/vuejs/01-login.md
@@ -13,6 +13,8 @@ contentType: tutorial
 useCase: quickstart
 ---
 
-<%= include('../_includes/_getting_started', { library: 'Vue.js', callback: 'http://localhost:3000/callback', returnTo: 'http://localhost:3000', showLogoutInfo: true, showWebOriginInfo: true }) %>
+<!-- markdownlint-disable MD034 MD041 -->
+
+<%= include('../_includes/_getting_started', { library: 'Vue.js', callback: 'http://localhost:3000/callback', returnTo: 'http://localhost:3000', webOriginUrl: 'http://localhost:3000', showLogoutInfo: true, showWebOriginInfo: true }) %>
 
 <%= include('_includes/_centralized_login') %>


### PR DESCRIPTION
This PR adds a note underneath the "Allowed Web Origins" section in the auth0-spa-js include for SPA quickstarts, indicating which URL the reader should use. This is mainly to bring it inline with the paragraphs for Callback URL and Logout URL (which already have such notes), but this has also been raised by a reader through our feedback channel.

This has been added to the Angular, React, Vue and Vanilla JS quickstarts.

![Screenshot 2019-09-04 at 11 37 32](https://user-images.githubusercontent.com/766403/64248916-54bff680-cf0a-11e9-8cbb-2d68f3f78a3a.png)
