### PR TITLE
Updated Angular2 quickstart code samples

### DIFF
--- a/articles/quickstart/spa/angular2/_includes/_centralized_login.md
+++ b/articles/quickstart/spa/angular2/_includes/_centralized_login.md
@@ -66,7 +66,6 @@ Make sure that the domain and client ID values are correct for the application t
 import { Injectable } from '@angular/core';
 import createAuth0Client from '@auth0/auth0-spa-js';
 import Auth0Client from '@auth0/auth0-spa-js/dist/typings/Auth0Client';
-import * as config from '../../../auth_config.json';
 import { from, of, Observable, BehaviorSubject, combineLatest, throwError } from 'rxjs';
 import { tap, catchError, concatMap, shareReplay } from 'rxjs/operators';
 import { Router } from '@angular/router';
@@ -218,7 +217,7 @@ Open the `src/app/app.component.ts` file and add the following:
 
 ```ts
 import { Component, OnInit } from '@angular/core';
-import { AuthService } from './auth/auth.service';
+import { AuthService } from './auth.service';
 
 @Component({
   selector: 'app-root',


### PR DESCRIPTION
Documentation doesn't mention a config.json, so source as written does not compile. Also, generating a service via Angular doesn't place code in new folder, so `auth` folder designation does not work since service is created in `app` folder.

