### PR TITLE
Add batch size notes to logging extension docs

### DIFF
--- a/articles/extensions/_includes/_batch-size.md
+++ b/articles/extensions/_includes/_batch-size.md
@@ -1,0 +1,16 @@
+### Batch size
+
+When setting your **BATCH_SIZE**, please keep the following information in mind.
+
+During each time frame/window (defined by your chosen **Schedule**), outstanding logs will be batched into groups and sent. The size of each group is determined by the **BATCH_SIZE** value.
+
+In other words, during each window, `NUM_BATCHES` batches of logs will be sent based on the following logic:
+
+```
+IF (NUM_LOGS modulo 100 == 0):
+  NUM_BATCHES = (NUM_LOGS / BATCH_SIZE)
+ELSE:
+  NUM_BATCHES = (NUM_LOGS / BATCH_SIZE) + 1
+```
+
+In the `ELSE` case, the last batch will have < 100 logs.

--- a/articles/extensions/application-insight.md
+++ b/articles/extensions/application-insight.md
@@ -26,6 +26,8 @@ At this point you should set the following configuration variables:
 
  Once you have provided the appropriate values for the above fields, click __Install__ to proceed.
 
+ <%= include('./_includes/_batch-size') %>
+
 ## Retrieve the required information from Application Insights
 
 Let's see how we can retrieve the __AppInsights_Instrumentation_Key__ information.

--- a/articles/extensions/azure-blob-storage.md
+++ b/articles/extensions/azure-blob-storage.md
@@ -33,6 +33,8 @@ At this point you should set the following configuration variables:
 
 Once you have provided this information, click the *Install* button to finish installing the extension.
 
+<%= include('./_includes/_batch-size') %>
+
 ## Retrieve the required information from Azure Portal
 
 We need the following information: Account Name, Account Key, and Container Name. Let's see how we can retrieve these values from Azure Portal.

--- a/articles/extensions/cloudwatch.md
+++ b/articles/extensions/cloudwatch.md
@@ -41,6 +41,8 @@ Extension requires these AWS permissions in order to send logs to CloudWatch:
 
 Once you have provided this information, click the _Install_ button to finish installing the extension.
 
+<%= include('./_includes/_batch-size') %>
+
 ## Use the Extension
 
 You can monitor activity by logging into the extension. There you can find reports on most recent runs. Reports contains amount of logs processed and errors, if any.

--- a/articles/extensions/logentries.md
+++ b/articles/extensions/logentries.md
@@ -27,6 +27,8 @@ At this point you should set the following configuration variables:
 
 Once you have provided this information, click the *Install* button to finish installing the extension.
 
+<%= include('./_includes/_batch-size') %>
+
 ## Retrieve the required information from Logentries
 
 In order to acquire the *LOGENTRIES_TOKEN* information, navigate to [Logentries](https://logentries.com) and login to your account or register for a new one. From the menu on the left select *Logs > Add New Log*.

--- a/articles/extensions/loggly.md
+++ b/articles/extensions/loggly.md
@@ -35,6 +35,8 @@ You can find the __Global Client ID__ and __Global Client Secret__ information a
 
 Once you have provided this information, click the *Install* button to finish installing the extension.
 
+<%= include('./_includes/_batch-size') %>
+
 ## Retrieve the required information from Loggly
 
 Let's see how we can retrieve the __Loggly_Customer_Token__ information.

--- a/articles/extensions/logstash.md
+++ b/articles/extensions/logstash.md
@@ -37,6 +37,8 @@ At this point you should set the following configuration variables:
 
 Once you have provided this information, click the _Install_ button to finish installing the extension.
 
+<%= include('./_includes/_batch-size') %>
+
 ### Using extension with ElasticSearch
 
 The extension is sending logs to the logstash instance as they are, including `_id`, which cannot be accepted by ElasticSearch. To fix that, you need rename `_id` to something else. You can do that by adding pipeline with `filter { mutate { rename => { "_id" => "log_id" } } }`.

--- a/articles/extensions/mixpanel.md
+++ b/articles/extensions/mixpanel.md
@@ -41,6 +41,8 @@ Set the following configuration variables:
 
 Once you have provided this information, click the **Install** button to finish installing the extension.
 
+<%= include('./_includes/_batch-size') %>
+
 ## Use your extension
 
 To view all jobs, navigate to [Dashboard > Extensions](${manage_url}/#/extensions), click on the **Installed Extensions** link, and select the **Auth0 Logs to Mixpanel** line. There you can see the alls job and failed jobs. You can also view the logs of these runs.

--- a/articles/extensions/papertrail.md
+++ b/articles/extensions/papertrail.md
@@ -30,22 +30,7 @@ At this point you should set the following configuration variables:
 
 Once you have provided this information, click the *Install* button to finish installing the extension.
 
-### Batch size
-
-When setting your **BATCH_SIZE**, please keep the following information in mind.
-
-During each time frame/window (defined by your chosen **Schedule**), outstanding logs will be batched into groups and sent to Papertrail. The size of each group is determined by the **BATCH_SIZE** value. 
-
-In other words, during each window, `NUM_BATCHES` batches of logs will be sent to Papertrail, based on the following logic:
-
-```
-IF (NUM_LOGS modulo 100 == 0):
-  NUM_BATCHES = (NUM_LOGS / BATCH_SIZE)
-ELSE:
-  NUM_BATCHES = (NUM_LOGS / BATCH_SIZE) + 1
-```
-
-In the `ELSE` case, the last batch will have < 100 logs.
+<%= include('./_includes/_batch-size') %>
 
 ## Retrieve the required information from Papertrail
 

--- a/articles/extensions/segment.md
+++ b/articles/extensions/segment.md
@@ -28,6 +28,8 @@ At this point you should set the following configuration variables:
 
 Once you have provided this information, click the _Install_ button to finish installing the extension.
 
+<%= include('./_includes/_batch-size') %>
+
 ## Use the Extension
 
 You can monitor activity by logging into the extension. There you can find reports on most recent runs. Reports contains amount of logs processed and errors, if any.

--- a/articles/extensions/splunk.md
+++ b/articles/extensions/splunk.md
@@ -32,6 +32,8 @@ At this point you should set the following configuration variables:
 
 Once you have provided this information, click the *Install* button to finish installing the extension.
 
+<%= include('./_includes/_batch-size') %>
+
 ## Retrieve the required information from Splunk
 
 The HTTP Event Collector (HEC) is an endpoint that lets you send application events into Splunk Enterprise using the HTTP or Secure HTTP (HTTPS) protocols. In order to configure a new HTTP Event Collector for Auth0 logs and acquire the URL, Token and Port information, follow the next steps:

--- a/articles/extensions/sumologic.md
+++ b/articles/extensions/sumologic.md
@@ -60,6 +60,8 @@ Once you have provided this information, click the **Install** button to finish 
 
 The integration between Auth0 and Sumo Logic is now in place!
 
+<%= include('./_includes/_batch-size') %>
+
 ## How to view the results
 
 The integration you just setup, created a scheduled job that will be responsible to export the logs.


### PR DESCRIPTION
Add details on how batch sizes are handled by Auth0 when sending logs to a third-party logging tool.

[DOCS-428](https://auth0team.atlassian.net/browse/DOCS-428)

* [Application Insights](https://docs-content-staging-pr-8219.herokuapp.com/docs/extensions/application-insight#batch-size)

* [Azure Blob Storage](https://docs-content-staging-pr-8219.herokuapp.com/docs/extensions/azure-blob-storage#batch-size)
  
* [Cloudwatch](https://docs-content-staging-pr-8219.herokuapp.com/docs/extensions/cloudwatch#batch-size)

* [Logentries](https://docs-content-staging-pr-8219.herokuapp.com/docs/extensions/logentries#batch-size)

* [Loggly](https://docs-content-staging-pr-8219.herokuapp.com/docs/extensions/loggly#batch-size)

* [Logstash](https://docs-content-staging-pr-8219.herokuapp.com/docs/extensions/logstash#batch-size)

* [Mixpanel](https://docs-content-staging-pr-8219.herokuapp.com/docs/extensions/mixpanel#batch-size)

* [Papertrail](https://docs-content-staging-pr-8219.herokuapp.com/docs/extensions/papertrail#batch-size)

* [Segment](https://docs-content-staging-pr-8219.herokuapp.com/docs/extensions/segment#batch-size)

* [Splunk](https://docs-content-staging-pr-8219.herokuapp.com/docs/extensions/splunk#batch-size)

* [Sumologic](https://docs-content-staging-pr-8219.herokuapp.com/docs/extensions/sumologic#batch-size)