### PR TITLE
Remove deprecated quickstart links

### DIFF
--- a/articles/logout/index.md
+++ b/articles/logout/index.md
@@ -40,7 +40,6 @@ For guidance on how to implement logout functionality in your specific type of a
 ### Web Apps
 
 * [ASP.NET (OWIN)](/quickstart/webapp/aspnet-owin/01-login#add-login-and-logout-methods)
-* [ASP.NET (System.Web)](/quickstart/webapp/aspnet#logout)
 * [ASP.NET Core](/quickstart/webapp/aspnet-core/01-login#add-login-and-logout-methods)
 * [Java](/quickstart/webapp/java)
 * [Java Spring MVC](/quickstart/webapp/java-spring-mvc)

--- a/articles/rules/guides/redirect.md
+++ b/articles/rules/guides/redirect.md
@@ -158,7 +158,7 @@ function(user, context, callback) {
     );
 
     context.redirect = {
-      url: `https://example.com/change-pw?token=${token}`
+      url: `<%= "https://example.com/change-pw?token=${token}"%>`
     };
   }
 

--- a/articles/support/matrix.md
+++ b/articles/support/matrix.md
@@ -421,11 +421,6 @@ Auth0 support is limited to the most recent version of the OS listed (unless oth
       <td><div class="label label-primary">Supported</div></td>
     </tr>
     <tr>
-      <td><a href="/quickstart/webapp/aspnet">ASP.NET (System.Web)</a></td>
-      <td class="text-center"><a href="https://github.com/auth0/auth0-aspnet/tree/master/examples/auth0-aspnet-mvc4-sample/"><img src="https://cdn.auth0.com/website/auth0-docs/github-logo.svg"/></a></td>
-      <td><div class="label label-primary">Supported</div></td>
-    </tr>
-    <tr>
       <td><a href="/quickstart/webapp/aspnet-core">ASP.NET Core</a></td>
       <td class="text-center"><a href="https://github.com/auth0-samples/auth0-aspnetcore-mvc-samples"><img src="https://cdn.auth0.com/website/auth0-docs/github-logo.svg"/></a></td>
       <td><div class="label label-primary">Supported</div></td>


### PR DESCRIPTION
The links are currently 404.
Confirmed that they should be removed: https://auth0.slack.com/archives/C9F94RE0K/p1568694057011800 