### PR TITLE
Fixed wording in config repo section

### DIFF
--- a/articles/extensions/deploy-cli/guides/incorporate-deploy-cli-into-build-environment.md
+++ b/articles/extensions/deploy-cli/guides/incorporate-deploy-cli-into-build-environment.md
@@ -30,7 +30,7 @@ We recommend that you have a separate Auth0 tenant/account for each environment 
 
 ### Your deploy configuration repository
 
-Your configuration repository should continue a specific set of files based on how you've chosen to import/export your tenant configuration information:
+Your configuration repository should contain a specific set of files based on how you've chosen to import/export your tenant configuration information:
 
 * [Directory Structure](/extensions/deploy-cli/guides/import-export-directory-structure)
 * [YAML File](/extensions/deploy-cli/guides/import-export-yaml-file)


### PR DESCRIPTION
The intro to the Your deploy configuration repository section had the wrong verb. Updated it so that it read correctly.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors
- Please include a short description
- If your PR is a work in progress, title it [DO NOT MERGE]
--->
