### PR TITLE
Remove unnecessary dependency

### DIFF
--- a/articles/quickstart/backend/java-spring-security5/01-authorization.md
+++ b/articles/quickstart/backend/java-spring-security5/01-authorization.md
@@ -90,10 +90,6 @@ If you are using Maven, add the Spring dependencies to your `pom.xml` file:
         <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
     <dependency>
-        <groupId>org.springframework.security.oauth.boot</groupId>
-        <artifactId>spring-security-oauth2-autoconfigure</artifactId>
-    </dependency>
-    <dependency>
         <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-oauth2-resource-server</artifactId>
     </dependency>


### PR DESCRIPTION
We had a report that when using the Maven dependencies as provided in this article, the `spring-security-oauth2-autoconfigure` dependency failed to resolve due to missing version information.

Upon further investigation, this dependency is not needed and so can be removed (it is not included in the Gradle dependencies, nor the sample itself).