### PR TITLE
Update use-the-post-user-registration-extensibility-point.md

### DIFF
--- a/articles/hooks/guides/use-the-post-user-registration-extensibility-point.md
+++ b/articles/hooks/guides/use-the-post-user-registration-extensibility-point.md
@@ -25,7 +25,7 @@ The parameters listed in the comment at the top of the code indicate the Auth0 o
 ```js
 /**
 @param {object} user - The user being created
-@param {string} user.id - user id
+@param {string} user.id - user id (user GUID without "auth0|" database prefix)
 @param {string} user.tenant - Auth0 tenant name
 @param {string} user.username - user name
 @param {string} user.email - email


### PR DESCRIPTION
Clarify that `user.id` is actually the GUID without the `auth0` provider since only database connections can be used with this hook.

Example:
`user.id` that is passed to the hook is `5d8b1128fe2e260e0d96e369` and not `auth0|5d8b1128fe2e260e0d96e369` which is a misconception.

Please see discussion here: https://community.auth0.com/t/post-registration-hook-get-full-user-id/31392

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors
- Please include a short description
- If your PR is a work in progress, title it [DO NOT MERGE]
--->
