### PR TITLE
Fix Connections index and nav

### DIFF
--- a/articles/connections/identity-providers-enterprise.md
+++ b/articles/connections/identity-providers-enterprise.md
@@ -1,0 +1,18 @@
+---
+title: Enterprise Identity Providers
+description: Learn about enterprise identity providers supported by Auth0.
+topics:
+  - connections
+  - identity-providers
+contentType: 
+    - reference
+useCase:
+  - customize-connections
+  - add-idp
+---
+# Enterprise Identity Providers
+
+Auth0 supports the following enterprise providers out of the box.
+
+<% var enterpriseConnections = cache.find('articles/connections/enterprise', {sort: 'index'}); %>
+<%= include('./_connections', { connections: enterpriseConnections }) %>

--- a/articles/connections/identity-providers-legal.md
+++ b/articles/connections/identity-providers-legal.md
@@ -1,0 +1,18 @@
+---
+title: Legal Identity Providers
+description: Learn about legal identity providers supported by Auth0.
+topics:
+  - connections
+  - identity-providers
+contentType: 
+    - reference
+useCase:
+  - customize-connections
+  - add-idp
+---
+# Legal Identity Providers
+
+Through our partner, Criipto, we offer a growing range of government and bank identities tied to legal persons. If what you need isn't found here, please contact [Criipto](https://criipto.com).
+
+<% var criiptoConnections = cache.find('articles/connections/criipto', {sort: 'index'}); %>
+<%= include('./_connections', { connections: criiptoConnections }) %>

--- a/articles/connections/identity-providers-social.md
+++ b/articles/connections/identity-providers-social.md
@@ -1,0 +1,18 @@
+---
+title: Social Identity Providers
+description: Learn about the social identity providers supported by Auth0.
+topics:
+  - connections
+  - identity-providers
+contentType: 
+    - reference
+useCase:
+  - customize-connections
+  - add-idp
+---
+# Social Identity Providers
+
+Auth0 supports the following social providers out of the box. You can also use any [OAuth2 Authorization Server](/connections/social/oauth2).
+
+<% var socialConnections = cache.find('articles/connections/social', {sort: 'index'}); %>
+<%= include('./_connections', { connections: socialConnections }) %>

--- a/articles/connections/index.md
+++ b/articles/connections/index.md
@@ -1,77 +1,54 @@
 ---
 url: /identityproviders
-description: Auth0 is an identity hub that supports the many authentication providers listed here.
+section: articles
+classes: topic-page
+title: Connections
+description: Learn about connections and types of identity providers supported by Auth0.
 topics:
   - connections
 contentType: 
     - index
-    - reference
 useCase:
   - customize-connections
   - add-idp
 ---
-# Connections
+<div class="topic-page-header">
+  <div data-name="example" class="topic-page-badge"></div>
+  <h1>Connections</h1>
+  <p>Introduction to the various sources of users for applications, including identity providers, databases, and passwordless authentication methods.</p>
+</div>
 
-A connection is the relationship between Auth0 and a source of users. Auth0 sits between your application and its sources of users, which adds a level of abstraction so your application is isolated from any changes to and idiosyncrasies of each source's implementation.
+A connection is the relationship between Auth0 and a source of users, which may include identity providers (such as Google or LinkedIn), databases, or passwordless authentication methods. Auth0 sits between your application and its sources of users, which adds a level of abstraction so your application is isolated from any changes to and idiosyncrasies of each source's implementation.
 
 You can configure any number of connections for your applications to use in the Auth0 Dashboard. To view all the connections that you have configured or create new ones, see [View Connections](/dashboard/guides/connections/view-connections).
 
 By default, Auth0 automatically syncs user profile data with each user login, thereby ensuring that changes made in the connection source are automatically updated in Auth0. You can [optionally disable this synchronization](/dashboard/guides/connections/configure-connection-sync) to allow for updating profile attributes from your application.
 
-# Identity Providers Supported by Auth0
+<ul class="topic-links">
+  <li>
+    <i class="icon icon-budicon-715"></i><a href="/connections/identity-providers-social">Identity Providers Supported by Auth0</a>
 
-An Identity Provider is a server that can provide identity information to other servers. For example, Google is an Identity Provider. If you log in to a site using your Google account, then a Google server will send your identity information to that site.
-
-Auth0 is an identity hub that supports many Identity Providers using various protocols (like <dfn data-key="openid">OpenID Connect (OIDC)</dfn>, <dfn data-key="security-assertion-markup-language">SAML</dfn>, [WS-Federation](/protocols/ws-fed), and more).
-
-Auth0 sits between your app and the Identity Provider that authenticates your users. This adds a level of abstraction so your app is isolated from any changes to and idiosyncrasies of each provider's implementation.
-
-The relationship between Auth0 and any of these authentication providers is referred to as a **connection**. Auth0 supports [Social](#social), [Enterprise](#enterprise), [Database](#database-and-custom-connections) and <dfn data-key="passwordless">[Passwordless](#passwordless)</dfn> connections.
-
-## Social
-
-Auth0 supports the following social providers out of the box. You can also use any [OAuth2 Authorization Server](/connections/social/oauth2).
-
-<% var socialConnections = cache.find('articles/connections/social', {sort: 'index'}); %>
-<%= include('./_connections', { connections: socialConnections }) %>
-
-## Enterprise
-
-<% var enterpriseConnections = cache.find('articles/connections/enterprise', {sort: 'index'}); %>
-<%= include('./_connections', { connections: enterpriseConnections }) %>
-
-## Legal Identities
-
-Through our partner, Criipto, we offer a growing range of government and bank identities tied to legal persons. 
-
-<% var criiptoConnections = cache.find('articles/connections/criipto', {sort: 'index'}); %>
-<%= include('./_connections', { connections: criiptoConnections }) %>
-
-If the one you need isn't found here, we suggest getting in touch with [Criipto](https://criipto.com).
-
-## Database and Custom Connections
+Identity Providers are servers that can provide identity information to other servers. Auth0 supports many Identity Providers using various protocols (like <dfn data-key="openid">[OpenID Connect (OIDC)](/protocols/oidc)</dfn>, <dfn data-key="security-assertion-markup-language">[SAML](/protocols/saml)</dfn>, [WS-Federation](/protocols/ws-fed), and more).
+    <ul>
+      <li>
+        <i class="icon icon-budicon-695"></i><a href="/connections/identity-providers-social">Social Identity Providers</a>
+      </li>
+      <li>
+        <i class="icon icon-budicon-695"></i><a href="/connections/identity-providers-enterprise">Enterprise Identity Providers</a>
+      </li>
+      <li>
+        <i class="icon icon-budicon-695"></i><a href="/connections/identity-providers-legal">Legal Identity Providers</a>
+      </li>
+    </ul>
+  </li>
+  <li>
+      <i class="icon icon-budicon-715"></i><a href="/connections/database">Database and Custom Connections</a>
 
 If you want to create your own user store, instead of using external identity providers like Google or Facebook, you can use a Database Connection. This way you can authenticate users with an email or username and a password. The credentials can be securely stored either in the Auth0 user store or in your own database.
+  </li>
+  <li>
+      <i class="icon icon-budicon-715"></i><a href="/connections/passwordless">Passwordless</a>
 
-You can create any number of custom fields and store this information as part of the `user_metadata`. You can easily import users from a legacy user store, enable or disable sign ups, configure your password policy, or enable <dfn data-key="multifactor-authentication">multi-factor authentication (MFA)</dfn>.
-
-For more details, refer to the [Database Connections](/connections/database) documentation.
-
-## Passwordless
-
-Full documentation on Passwordless authentication can be found at the links below:
-
-<ul>
-<li><a href="/connections/passwordless">Passwordless Authentication Overview</a></li>
-<% cache.find('articles/connections/passwordless', {sort: 'connection'}).forEach(article => { %>
-  <% if (article.connection) { %>
-    <li>
-      <% if (article.public === false) { %>
-        <%- article.connection %>
-      <% } else { %>
-        <a href="<%- article.url %>"><%- article.connection %></a>
-      <% } %>
-    </li>
-  <% } %>
-<% }); %>
+<dfn data-key="passwordless">Passwordless</dfn> connections allow users to log in without the need to remember a password. Instead, users enter their mobile phone number or email address and receive a one-time code or link, which they can then use to log in.
+  </li>
 </ul>

--- a/articles/connections/pass-parameters-to-idps.md
+++ b/articles/connections/pass-parameters-to-idps.md
@@ -8,11 +8,8 @@ useCase:
 ---
 # Pass Parameters to Identity Providers
 
-You can pass provider-specific parameters to an Identity Provider, during authentication.
+You can pass provider-specific parameters to an Identity Provider during authentication. The values can either be static per connection or dynamic per user. Note the following restrictions:
 
-The values can either be static per connection or dynamic per user.
-
-Note the following restrictions:
 - Only [valid OAuth 2.0/OIDC parameters](http://openid.net/specs/openid-connect-core-1_0.html#AuthorizationEndpoint) are accepted.
 - Not all Identity Providers support upstream parameters. Check with the specific Identity Provider before you proceed with your implementation.
 

--- a/articles/connections/passwordless/index.md
+++ b/articles/connections/passwordless/index.md
@@ -141,11 +141,7 @@ When using passwordless authentication with email, users:
 
 ## Implement Passwordless
 
-::: warning
-We strongly recommend implementing passwordless with <dfn data-key="universal-login">[Universal Login](/universal-login)</dfn>, which redirects users to a central domain, through which authentication is performed, before redirecting users back to your application.
-
-If you are building a Native application, which uses device-specific hardware and software, Universal Login is the only way to go.
-:::
+We strongly recommend implementing passwordless with <dfn data-key="universal-login">[Universal Login](/universal-login)</dfn>, which redirects users to a central domain, through which authentication is performed, before redirecting users back to your application. If you are building a Native application, which uses device-specific hardware and software, Universal Login is the only way to go.
 
 Alternatively, you can use an embedded login form with the Lock (with Passwordless) widget. Using [Embedded Login](/login/embedded) with any application type leaves your application vulnerable to cross-origin resource sharing (CORS) attacks and requires the use of [Auth0 Custom Domains](/custom-domains), which is a paid feature.
 

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -208,21 +208,18 @@ articles:
 ## Identity Providers / Connections
 ## ------------------------------------------------------------
 
-  - title: Connections (Identity Providers)
+  - title: Connections
     url: /connections
     children:
 
       - title: Social Identity Providers
-        url: "/connections#social"
-        hidden: true
+        url: "/connections/identity-providers-social"
 
       - title: Enterprise Identity Providers
-        url: "/connections#enterprise"
-        hidden: true
+        url: "/connections/identity-providers-enterprise"
 
       - title: Legal Identity Providers
-        url: "/connections#legal-identities"
-        hidden: true
+        url: "/connections/identity-providers-legal"
       
       - title: Database
         url: /connections/database


### PR DESCRIPTION
Separate Identity Providers into their own pages so they can have sub-nav links. 
Added sub-nav links for Identity Provider sections.
Build index page for Connections section.
Minor edits for typos

https://docs-content-staging-pr-8282.herokuapp.com/docs/connections
