### PR TITLE
Removed short fragment syntax to fix highlight js

### DIFF
--- a/articles/quickstart/spa/react/_includes/_centralized_login.md
+++ b/articles/quickstart/spa/react/_includes/_centralized_login.md
@@ -273,7 +273,7 @@ To display this information to the user, create a new file called `Profile.js` i
 ```jsx
 // src/components/Profile.js
 
-import React from "react";
+import React, { Fragment } from "react";
 import { useAuth0 } from "../react-auth0-wrapper";
 
 const Profile = () => {
@@ -286,13 +286,13 @@ const Profile = () => {
   }
 
   return (
-    <>
+    <Fragment>
       <img src={user.picture} alt="Profile" />
 
       <h2>{user.name}</h2>
       <p>{user.email}</p>
       <code>{JSON.stringify(user, null, 2)}</code>
-    </>
+    </Fragment>
   );
 };
 


### PR DESCRIPTION
The JSX plugin for hightlight.js seems to remove code colouring for [React's short fragment syntax](https://reactjs.org/docs/fragments.html#short-syntax), so I've removed it in favour of the `Fragment` component, which seems to fix it.

Based on customer feedback.

Before:
![image](https://user-images.githubusercontent.com/766403/65869289-0ddee880-e372-11e9-80e0-828acfdf0b47.png)

After:
![image](https://user-images.githubusercontent.com/766403/65869230-f43da100-e371-11e9-944e-f783a4ab143e.png)
