### PR TITLE
Removed SDK installation instructions from React quickstart intro

### DIFF
--- a/articles/quickstart/spa/react/01-login.md
+++ b/articles/quickstart/spa/react/01-login.md
@@ -14,6 +14,6 @@ useCase: quickstart
 ---
 <!-- markdownlint-disable MD034 MD041 -->
 
-<%= include('../_includes/_getting_started', { library: 'React', callback: 'http://localhost:3000', returnTo: 'http://localhost:3000', webOriginUrl: 'http://localhost:3000', showLogoutInfo: true, showWebOriginInfo: true, new_js_sdk: true }) %>
+<%= include('../_includes/_getting_started', { library: 'React', callback: 'http://localhost:3000', returnTo: 'http://localhost:3000', webOriginUrl: 'http://localhost:3000', showLogoutInfo: true, showWebOriginInfo: true, new_js_sdk: true, show_install_info: false }) %>
 
 <%= include('_includes/_centralized_login') %>

--- a/articles/quickstart/spa/react/_includes/_centralized_login.md
+++ b/articles/quickstart/spa/react/_includes/_centralized_login.md
@@ -261,7 +261,7 @@ export default App;
 This replaces the default content created by `create-react-app` and simply shows the `NavBar` component you created earlier.
 
 :::panel Checkpoint
-At this point, you should be able to go through a complete authentication cycle, logging in and loggin out. Start the application from the terminal using `yarn start` and browse to http://localhost:3000 (if the application does not open automatically). From there, clicking the **Log in** button should redirect you to the Auth0 Login Page where you will be given the opportunity to log in.
+At this point, you should be able to go through the complete authentication flow: logging in and logging out. Start the application from the terminal using `yarn start` and browse to [localhost:3000](http://localhost:3000) (if the application does not open automatically). From there, clicking the **Log in** button should redirect you to the Auth0 login page where you will be given the opportunity to log in.
 
 Once you are logged in, control returns to your application and you should see that the **Log out** button is now visible. Clicking this should log you out of the application and return you to an unauthenticated state.
 :::

--- a/articles/quickstart/spa/react/_includes/_centralized_login.md
+++ b/articles/quickstart/spa/react/_includes/_centralized_login.md
@@ -260,8 +260,11 @@ export default App;
 
 This replaces the default content created by `create-react-app` and simply shows the `NavBar` component you created earlier.
 
-> **Checkpoint**: At this point, you should be able to go through a complete authentication cycle, logging in and loggin out. Start the application from the terminal using `yarn start` and browse to http://localhost:3000 (if the application does not open automatically). From there, clicking the **Log in** button should redirect you to the Auth0 Login Page where you will be given the opportunity to log in.
-> Once you are logged in, control returns to your application and you should see that the **Log out** button is now visible. Clicking this should log you out of the application and return you to an unauthenticated state.
+:::panel Checkpoint
+At this point, you should be able to go through a complete authentication cycle, logging in and loggin out. Start the application from the terminal using `yarn start` and browse to http://localhost:3000 (if the application does not open automatically). From there, clicking the **Log in** button should redirect you to the Auth0 Login Page where you will be given the opportunity to log in.
+
+Once you are logged in, control returns to your application and you should see that the **Log out** button is now visible. Clicking this should log you out of the application and return you to an unauthenticated state.
+:::
 
 ## Read the User Profile
 
@@ -370,7 +373,9 @@ const NavBar = () => {
 export default NavBar;
 ```
 
-> **Checkpoint**: Go ahead and run the project one more time. Now if the user is authenticated and you navigate to the `/profile` page, you will see their profile data. See how this content disappears when you log out.
+:::panel Checkpoint
+Go ahead and run the project one more time. Now if the user is authenticated and you navigate to the `/profile` page, you will see their profile data. See how this content disappears when you log out.
+:::
 
 ## Secure the Profile Page
 
@@ -440,4 +445,6 @@ function App() {
 export default App;
 ```
 
-> **Checkpoint**: Run the project again. Now if the user is not authenticated and you navigate to the `/profile` page through the URL bar in the browser, you will be sent through the authentication flow, and will see the Profile page upon your return.
+:::panel Checkpoint
+Run the project again. Now if the user is not authenticated and you navigate to the `/profile` page through the URL bar in the browser, you will be sent through the authentication flow, and will see the Profile page upon your return.
+:::

--- a/articles/quickstart/spa/react/_includes/_centralized_login.md
+++ b/articles/quickstart/spa/react/_includes/_centralized_login.md
@@ -1,7 +1,5 @@
 <!-- markdownlint-disable MD002 MD041 MD034 -->
 
-<%= include('../../_includes/_login_preamble', { library: 'React' }) %>
-
 ## Create a Sample Application
 
 ::: note
@@ -20,15 +18,16 @@ cd my-app
 
 (npx comes with npm 5.2+ and higher, see [instructions for older npm versions](https://gist.github.com/gaearon/4064d3c23a77c74a3614c498a8bb1c5f))
 
-### Install initial dependencies
+### Install dependencies
 
-After creating a new React app using `create-react-app` install `react-router`, which doesn't come as standard with the boilerplate project. The [Auth0 Client SDK](https://github.com/auth0/auth0-spa-js) should also be added.
-
-Install these two packages using the following command in the terminal:
+Install the following packages using `npm` in the terminal:
 
 ```bash
 npm install react-router-dom @auth0/auth0-spa-js
 ```
+
+- [`@auth0/auth0-spa-js`](https://github.com/auth0/auth0-spa-js) - Auth0's JavaScript SDK for Single Page Applications
+- [`react-router-dom`](https://github.com/ReactTraining/react-router/tree/master/packages/react-router-dom) - React's router package for the browser. This will allow users to navigate between different pages with ease
 
 ### Install the Auth0 React wrapper
 


### PR DESCRIPTION
These have proven to be confusing for the customer, as they are generic
and don't relate to the quickstart tutorial at all. One of the main
pieces of feedback is that they see the import statement but they don't
know which file to put it in.

Installation of the library is repeated further down the tutorial in
context, and more detailed instructions are included as part of the
README on GitHub.

In doing this I also reworded the "Install dependencies" section to call out why the libraries are being installed, for a bit more impact.

- Also removed the "Authenticating with Auth0" include as it's not hugely
required knowledge for the new SDK and just adds fluff.
- Also changes "checkpoint" notes to proper panels