### PR TITLE
Add legacy notes to SSO docs

### DIFF
--- a/articles/applications/application-settings/_settings-pt2.md
+++ b/articles/applications/application-settings/_settings-pt2.md
@@ -12,6 +12,6 @@ You can provide up to 100 URLs in the **Allowed Callback URLs**, **Allowed Web O
 
 - **JWT Expiration (seconds)**: The amount of time (in seconds) before the Auth0 ID Token expires. The default value is `36000`, which maps to 10 hours.
 
-- **Use Auth0 instead of the IdP to do <dfn data-key="single-sign-on">Single Sign-on</dfn>**: If enabled, this setting prevents Auth0 from redirecting authenticated users with valid [sessions](/sessions) to the identity provider (such as Facebook, ADFS, and so on).
+- **Use Auth0 instead of the IdP to do <dfn data-key="single-sign-on">Single Sign-on</dfn>**: If enabled, this setting prevents Auth0 from redirecting authenticated users with valid [sessions](/sessions) to the identity provider (such as Facebook, ADFS, and so on). **Legacy tenants only.**
 
 ![Application Settings Page](/media/articles/applications/settings.png)

--- a/articles/connections/social/devkeys.md
+++ b/articles/connections/social/devkeys.md
@@ -38,7 +38,7 @@ The Auth0 developer keys are to be used for testing purposes so there are a few 
 
 2. [Single Sign-on](/sso) will not function properly when using the Auth0 developer keys. The reason for this is that the Auth0 developer applications with all the relevant Identity Providers are configured to call back to the URL `https://login.auth0.com/login/callback` instead of the <dfn data-key="callback">callback URL</dfn> for your own tenant, for example `https://${account.namespace}/login/callback`.
 
-    This results in the SSO cookie not being set on your own tenant domain, so the next time a user authenticates no SSO cookie will be detected, even if you configured your application to **Use Auth0 instead of the Identity Provider to do Single Sign-on**.
+    This results in the SSO cookie not being set on your own tenant domain, so the next time a user authenticates no SSO cookie will be detected, even if you configured your application to **Use Auth0 instead of the Identity Provider to do Single Sign-on** (legacy tenants only).
 
     ::: warning
     If you are using the [New Universal Login Experience](/universal-login), the remaining items on this list are not limitations that apply to you. If you are not using Universal Login, or are using the Classic Experience, read on.

--- a/articles/dashboard/guides/applications/enable-sso-app.md
+++ b/articles/dashboard/guides/applications/enable-sso-app.md
@@ -14,7 +14,7 @@ useCase:
 ---
 # Enable Single Sign-On for Applications
 
-By default, seamless <dfn data-key="single-sign-on">Single Sign-on (SSO)</dfn> is enabled for all new Auth0 tenants; however, legacy tenants may [choose whether to enable this feature at the tenant level](/dashboard/guides/tenants/enable-sso-tenant). If you have not enabled tenant-level SSO, you may enable it per application.
+By default, seamless <dfn data-key="single-sign-on">Single Sign-on (SSO)</dfn> is enabled for all new Auth0 tenants; however, **legacy tenants** may [choose whether to enable this feature at the tenant level](/dashboard/guides/tenants/enable-sso-tenant). If you have not enabled tenant-level SSO, you may enable it per application.
 
 This guide will show you how to enable <dfn data-key="single-sign-on">Single Sign-On (SSO)</dfn> for your application using Auth0's Dashboard.
 

--- a/articles/dashboard/reference/settings-application.md
+++ b/articles/dashboard/reference/settings-application.md
@@ -54,7 +54,7 @@ You can provide up to 100 URLs in the **Allowed Callback URLs**, **Allowed Web O
 
 - **JWT Expiration (seconds)**: The amount of time (in seconds) before the Auth0 ID Token expires. The default value is `36000`, which maps to 10 hours.
 
-- **Use Auth0 instead of the IdP to do Single Sign-on**: If enabled, this setting prevents Auth0 from redirecting authenticated users with valid sessions to the identity provider (such as Facebook or ADFS).
+- **Use Auth0 instead of the IdP to do Single Sign-on**: If enabled, this setting prevents Auth0 from redirecting authenticated users with valid sessions to the identity provider (such as Facebook or ADFS). **Legacy tenants only.**
 
 ## Advanced Settings
 

--- a/articles/hosted-pages/login/index.md
+++ b/articles/hosted-pages/login/index.md
@@ -32,7 +32,7 @@ If you want to use <dfn data-key="single-sign-on">Single Sign-on (SSO)</dfn>, yo
 
 This behavior occurs without the need for any modification to the login page itself. This is a simple two step process:
 
-1. Enable SSO for the application in the [Dashboard](${manage_url}) (Go to the Application's Settings, then scroll down to the **Use Auth0 instead of the IdP to do Single Sign-on** setting and toggle it on.
+1. Enable SSO for the application in the [Dashboard](${manage_url}) (Go to the Application's Settings, then scroll down to the **Use Auth0 instead of the IdP to do Single Sign-on** setting (legacy tenants only) and toggle it on.
 1. Use the [authorize endpoint](/api/authentication#authorization-code-grant) with `?prompt=none` for [silent SSO](/api-auth/tutorials/silent-authentication).
 
 ::: note

--- a/articles/integrations/sso/_template.md
+++ b/articles/integrations/sso/_template.md
@@ -148,7 +148,7 @@ On the **Settings** page, configure the following values:
         </tr>
         <% } %>
         <tr>
-            <td>Use Auth0 instead of the IdP to do Single Sign-on (SSO)</td>
+            <td>Use Auth0 instead of the IdP to do Single Sign-on (SSO). **Legacy tenants only.**</td>
             <td>If enabled, Auth0 will handle SSO instead of ${service}.</td>
         </tr>
     </tbody>

--- a/articles/rules/_includes/_context-prop-sso.md
+++ b/articles/rules/_includes/_context-prop-sso.md
@@ -1,4 +1,4 @@
 This object will contain information about the <dfn data-key="single-sign-on">Single Sign-on (SSO)</dfn> transaction (if available)
-- `with_auth0`: when a user signs in with SSO to an application where the `Use Auth0 instead of the IdP to do Single Sign-On` setting is enabled.
+- `with_auth0`: when a user signs in with SSO to an application where the `Use Auth0 instead of the IdP to do Single Sign-On` setting is enabled (only for legacy tenants).
 - `with_dbconn`: an SSO login for a user that logged in through a database connection.
 - `current_clients`: client IDs using SSO.

--- a/articles/security/blacklisting-attributes.md
+++ b/articles/security/blacklisting-attributes.md
@@ -67,7 +67,7 @@ Where:
   - You have performed a redirect via rules
   - Your app is using delegation (and you haven't set `scope = passthrough`)
   - Your app is using impersonation
-  - You have enabled the **Use Auth0 instead of the IdP to do Single Sign-On** setting
+  - You have enabled the **Use Auth0 instead of the IdP to do Single Sign-On** setting (legacy tenants only)
 - For <dfn data-key="security-assertion-markup-language">SAMLP</dfn> connections, if you enable Debug mode, your logs will contain information on the blacklisted attributes
 
 :::panel Working around the limitations


### PR DESCRIPTION
[DOCS-919](https://auth0team.atlassian.net/browse/DOCS-919)

The original task was to remove any and all references to the "Use Auth0 instead of the IdP to do Single Sign-on" toggle, but in the end, I decided AGAINST this. Research through customer notes via Slack and Confluence show that this option  is still available for legacy tenants, and there are major customers who still use/need this feature even if it isn’t available for new tenants. As such, removing this information would be problematic.

I searched through the repo, and if the docs were indicated as being legacy, I left them alone. If they were not, I added markers to all mentions of this toggle as being available for legacy tenant only. 