### PR TITLE
Ium 473  filter duplicate users

### DIFF
--- a/articles/users/guides/bulk-user-imports.md
+++ b/articles/users/guides/bulk-user-imports.md
@@ -47,7 +47,7 @@ Create a request that contains the following parameters:
 |-----------|-------------|
 | `users` | [File in JSON format](/users/references/bulk-import-database-schema-examples#file-example) that contains the users to import. |
 | `connection_id` | ID of the connection to which users will be inserted. You can retrieve the ID using the [GET /api/v2/connections](/api/management/v2#!/Connections/get_connections) endpoint. |
-| `upsert` | Boolean value; `false` by default. When set to `false`, pre-existing users that match on email address will fail. When set to `true`, pre-existing users that match on email address will be updated, but only with upsertable attributes. For a list of user profile fields that can be upserted during import, see [User Profile Attributes](/users/references/user-profile-structure#user-profile-attributes). |
+| `upsert` | Boolean value; `false` by default. When set to `false`, pre-existing users that match on email address, user id, or username will fail. When set to `true`, pre-existing users that match on any of these fields will be updated, but only with upsertable attributes. For a list of user profile fields that can be upserted during import, see [User Profile Attributes](/users/references/user-profile-structure#user-profile-attributes). |
 | `external_id` | Optional user-defined string that can be used to correlate multiple jobs. Returned as part of the job status response. |
 | `send_completion_email` | Boolean value; `true` by default. When set to `true`, sends a completion email to all tenant owners when the import job is finished. If you do *not* want emails sent, you must explicitly set this parameter to `false`. |
 

--- a/articles/users/guides/bulk-user-imports.md
+++ b/articles/users/guides/bulk-user-imports.md
@@ -47,7 +47,7 @@ Create a request that contains the following parameters:
 |-----------|-------------|
 | `users` | [File in JSON format](/users/references/bulk-import-database-schema-examples#file-example) that contains the users to import. |
 | `connection_id` | ID of the connection to which users will be inserted. You can retrieve the ID using the [GET /api/v2/connections](/api/management/v2#!/Connections/get_connections) endpoint. |
-| `upsert` | Boolean value; `false` by default. When set to `false`, pre-existing users that match on email address, user id, or username will fail. When set to `true`, pre-existing users that match on any of these fields will be updated, but only with upsertable attributes. For a list of user profile fields that can be upserted during import, see [User Profile Attributes](/users/references/user-profile-structure#user-profile-attributes). |
+| `upsert` | Boolean value; `false` by default. When set to `false`, pre-existing users that match on email address, user ID, or username will fail. When set to `true`, pre-existing users that match on any of these fields will be updated, but only with upsertable attributes. For a list of user profile fields that can be upserted during import, see [User Profile Attributes](/users/references/user-profile-structure#user-profile-attributes). |
 | `external_id` | Optional user-defined string that can be used to correlate multiple jobs. Returned as part of the job status response. |
 | `send_completion_email` | Boolean value; `true` by default. When set to `true`, sends a completion email to all tenant owners when the import job is finished. If you do *not* want emails sent, you must explicitly set this parameter to `false`. |
 

--- a/articles/users/references/bulk-import-database-schema-examples.md
+++ b/articles/users/references/bulk-import-database-schema-examples.md
@@ -31,7 +31,7 @@ The following [JSON schema](http://json-schema.org) describes valid users:
             "description": "The user's email address.",
             "format": "email"
         },
-            "email_verified": {
+        "email_verified": {
             "type": "boolean",
             "default": false,
             "description": "Indicates whether the user has verified their email address."

--- a/articles/users/references/bulk-import-database-schema-examples.md
+++ b/articles/users/references/bulk-import-database-schema-examples.md
@@ -33,6 +33,7 @@ The following [JSON schema](http://json-schema.org) describes valid users:
         },
             "email_verified": {
             "type": "boolean",
+            "default": false,
             "description": "Indicates whether the user has verified their email address."
         },
         "user_id": {
@@ -80,7 +81,7 @@ The following [JSON schema](http://json-schema.org) describes valid users:
             "description": "Data related to the user that does not affect the application's core functionality."
         }
     },
-    "required": ["email", "email_verified"],
+    "required": ["email"],
     "additionalProperties": false
 }
 ```

--- a/updates/2019-10-01.yml
+++ b/updates/2019-10-01.yml
@@ -1,0 +1,8 @@
+changed:
+  -
+    title: "Import Users Worker - Filter Duplicate Users"
+    tags:
+      - import
+      - users
+    description: |
+      User import behavior is being updated to allow for upserting users by user_id and username in addition to email.


### PR DESCRIPTION
### Description

`auth0-users-lib` is being updated to allow for finding users by `user_id` and `username` in addition to `email`. This PR updates the relevant docs to reflect that change.

### References

[auth0-users-lib PR](https://github.com/auth0/auth0-users-lib/pull/84)
