### PR TITLE
Fix batch size include + typos for extensions from stray revert

### DIFF
--- a/articles/extensions/_includes/_batch-size.md
+++ b/articles/extensions/_includes/_batch-size.md
@@ -1,0 +1,16 @@
+### Batch size
+
+When setting your **BATCH_SIZE**, please keep the following information in mind.
+
+During each time frame/window (defined by your chosen **Schedule**), outstanding logs will be batched into groups and sent. The size of each group is determined by the **BATCH_SIZE** value.
+
+In other words, during each window, `NUM_BATCHES` batches of logs will be sent based on the following logic:
+
+```
+IF (NUM_LOGS modulo 100 == 0):
+  NUM_BATCHES = (NUM_LOGS / BATCH_SIZE)
+ELSE:
+  NUM_BATCHES = (NUM_LOGS / BATCH_SIZE) + 1
+```
+
+In the `ELSE` case, the last batch will have < 100 logs.

--- a/articles/extensions/application-insight.md
+++ b/articles/extensions/application-insight.md
@@ -26,6 +26,8 @@ At this point you should set the following configuration variables:
 
  Once you have provided the appropriate values for the above fields, click __Install__ to proceed.
 
+ <%= include('./_includes/_batch-size') %>
+
 ## Retrieve the required information from Application Insights
 
 Let's see how we can retrieve the __AppInsights_Instrumentation_Key__ information.

--- a/articles/extensions/azure-blob-storage.md
+++ b/articles/extensions/azure-blob-storage.md
@@ -33,6 +33,8 @@ At this point you should set the following configuration variables:
 
 Once you have provided this information, click the *Install* button to finish installing the extension.
 
+<%= include('./_includes/_batch-size') %>
+
 ## Retrieve the required information from Azure Portal
 
 We need the following information: Account Name, Account Key, and Container Name. Let's see how we can retrieve these values from Azure Portal.

--- a/articles/extensions/cloudwatch.md
+++ b/articles/extensions/cloudwatch.md
@@ -41,6 +41,8 @@ Extension requires these AWS permissions in order to send logs to CloudWatch:
 
 Once you have provided this information, click the _Install_ button to finish installing the extension.
 
+<%= include('./_includes/_batch-size') %>
+
 ## Use the Extension
 
 You can monitor activity by logging into the extension. There you can find reports on most recent runs. Reports contains amount of logs processed and errors, if any.

--- a/articles/extensions/deploy-cli/guides/incorporate-deploy-cli-into-build-environment.md
+++ b/articles/extensions/deploy-cli/guides/incorporate-deploy-cli-into-build-environment.md
@@ -30,7 +30,7 @@ We recommend that you have a separate Auth0 tenant/account for each environment 
 
 ### Your deploy configuration repository
 
-Your configuration repository should continue a specific set of files based on how you've chosen to import/export your tenant configuration information:
+Your configuration repository should contain a specific set of files based on how you've chosen to import/export your tenant configuration information:
 
 * [Directory Structure](/extensions/deploy-cli/guides/import-export-directory-structure)
 * [YAML File](/extensions/deploy-cli/guides/import-export-yaml-file)

--- a/articles/extensions/deploy-cli/references/environment-variables-keyword-mappings.md
+++ b/articles/extensions/deploy-cli/references/environment-variables-keyword-mappings.md
@@ -14,7 +14,7 @@ The mappings allow you to do the following:
 
 * Use the same configuration file for all of your environments (e.g. dev, uat, staging, and prod).
 
-* Replace certain values in your configuration repo with environment specic values. There are two ways to use the keyword mappings: You can either wrap the key in `@@key@@` or `##key##`. 
+* Replace certain values in your configuration repo with environment-specific values. There are two ways to use the keyword mappings: You can either wrap the key in `@@key@@` or `##key##`. 
 
   - If you use the `@` symbols, it will do a `JSON.stringify` on your value before replacing it.  So if it is a string, it will add quotes. and if it is an array or object, it will add braces.  
 

--- a/articles/extensions/logentries.md
+++ b/articles/extensions/logentries.md
@@ -27,6 +27,8 @@ At this point you should set the following configuration variables:
 
 Once you have provided this information, click the *Install* button to finish installing the extension.
 
+<%= include('./_includes/_batch-size') %>
+
 ## Retrieve the required information from Logentries
 
 In order to acquire the *LOGENTRIES_TOKEN* information, navigate to [Logentries](https://logentries.com) and login to your account or register for a new one. From the menu on the left select *Logs > Add New Log*.

--- a/articles/extensions/loggly.md
+++ b/articles/extensions/loggly.md
@@ -35,6 +35,8 @@ You can find the __Global Client ID__ and __Global Client Secret__ information a
 
 Once you have provided this information, click the *Install* button to finish installing the extension.
 
+<%= include('./_includes/_batch-size') %>
+
 ## Retrieve the required information from Loggly
 
 Let's see how we can retrieve the __Loggly_Customer_Token__ information.

--- a/articles/extensions/logstash.md
+++ b/articles/extensions/logstash.md
@@ -37,6 +37,8 @@ At this point you should set the following configuration variables:
 
 Once you have provided this information, click the _Install_ button to finish installing the extension.
 
+<%= include('./_includes/_batch-size') %>
+
 ### Using extension with ElasticSearch
 
 The extension is sending logs to the logstash instance as they are, including `_id`, which cannot be accepted by ElasticSearch. To fix that, you need rename `_id` to something else. You can do that by adding pipeline with `filter { mutate { rename => { "_id" => "log_id" } } }`.

--- a/articles/extensions/mixpanel.md
+++ b/articles/extensions/mixpanel.md
@@ -41,6 +41,8 @@ Set the following configuration variables:
 
 Once you have provided this information, click the **Install** button to finish installing the extension.
 
+<%= include('./_includes/_batch-size') %>
+
 ## Use your extension
 
 To view all jobs, navigate to [Dashboard > Extensions](${manage_url}/#/extensions), click on the **Installed Extensions** link, and select the **Auth0 Logs to Mixpanel** line. There you can see the alls job and failed jobs. You can also view the logs of these runs.

--- a/articles/extensions/papertrail.md
+++ b/articles/extensions/papertrail.md
@@ -33,22 +33,7 @@ At this point, you should set the following configuration variables:
 
 Once you have provided this information, click the *Install* button to finish installing the extension.
 
-### Batch size
-
-When setting your **BATCH_SIZE**, please keep the following information in mind.
-
-During each time frame/window (defined by your chosen **Schedule**), outstanding logs will be batched into groups and sent to Papertrail. The size of each group is determined by the **BATCH_SIZE** value. 
-
-In other words, during each window, `NUM_BATCHES` batches of logs will be sent to Papertrail, based on the following logic:
-
-```
-IF (NUM_LOGS modulo 100 == 0):
-  NUM_BATCHES = (NUM_LOGS / BATCH_SIZE)
-ELSE:
-  NUM_BATCHES = (NUM_LOGS / BATCH_SIZE) + 1
-```
-
-In the `ELSE` case, the last batch will have < 100 logs.
+<%= include('./_includes/_batch-size') %>
 
 ## Retrieve the required information from Papertrail
 

--- a/articles/extensions/segment.md
+++ b/articles/extensions/segment.md
@@ -28,6 +28,8 @@ At this point you should set the following configuration variables:
 
 Once you have provided this information, click the _Install_ button to finish installing the extension.
 
+<%= include('./_includes/_batch-size') %>
+
 ## Use the Extension
 
 You can monitor activity by logging into the extension. There you can find reports on most recent runs. Reports contains amount of logs processed and errors, if any.

--- a/articles/extensions/splunk.md
+++ b/articles/extensions/splunk.md
@@ -32,6 +32,8 @@ At this point you should set the following configuration variables:
 
 Once you have provided this information, click the *Install* button to finish installing the extension.
 
+<%= include('./_includes/_batch-size') %>
+
 ## Retrieve the required information from Splunk
 
 The HTTP Event Collector (HEC) is an endpoint that lets you send application events into Splunk Enterprise using the HTTP or Secure HTTP (HTTPS) protocols. In order to configure a new HTTP Event Collector for Auth0 logs and acquire the URL, Token and Port information, follow the next steps:

--- a/articles/extensions/sumologic.md
+++ b/articles/extensions/sumologic.md
@@ -60,6 +60,8 @@ Once you have provided this information, click the **Install** button to finish 
 
 The integration between Auth0 and Sumo Logic is now in place!
 
+<%= include('./_includes/_batch-size') %>
+
 ## How to view the results
 
 The integration you just setup, created a scheduled job that will be responsible to export the logs.


### PR DESCRIPTION
Batch size:
https://docs-content-staging-pr-8301.herokuapp.com/docs/extensions/application-insight#batch-size
https://docs-content-staging-pr-8301.herokuapp.com/docs/extensions/azure-blob-storage#batch-size
https://docs-content-staging-pr-8301.herokuapp.com/docs/extensions/cloudwatch#batch-size
https://docs-content-staging-pr-8301.herokuapp.com/docs/extensions/logentries#batch-size
https://docs-content-staging-pr-8301.herokuapp.com/docs/extensions/loggly#batch-size
https://docs-content-staging-pr-8301.herokuapp.com/docs/extensions/logstash#batch-size
https://docs-content-staging-pr-8301.herokuapp.com/docs/extensions/mixpanel#batch-size
https://docs-content-staging-pr-8301.herokuapp.com/docs/extensions/papertrail#batch-size
https://docs-content-staging-pr-8301.herokuapp.com/docs/extensions/segment#batch-size
https://docs-content-staging-pr-8301.herokuapp.com/docs/extensions/splunk#batch-size
https://docs-content-staging-pr-8301.herokuapp.com/docs/extensions/sumologic#batch-size

Typos:
https://docs-content-staging-pr-8301.herokuapp.com/docs/extensions/deploy-cli/guides/incorporate-deploy-cli-into-build-environment#your-deploy-configuration-repository
https://docs-content-staging-pr-8301.herokuapp.com/docs/extensions/deploy-cli/references/environment-variables-keyword-mappings