### PR TITLE
Fix rules (guides) from stray revert

### DIFF
--- a/articles/api/management/guides/rules/create-rules.md
+++ b/articles/api/management/guides/rules/create-rules.md
@@ -21,7 +21,7 @@ This guide will show you how to create [rules](/rules) using Auth0's Management 
 ```har
 {
 	"method": "POST",
-	"url": "https://${account.namespace}/api/v2/roles",
+	"url": "https://${account.namespace}/api/v2/rules",
   "headers": [
   	{ "name": "Content-Type", "value": "application/json" },
   	{ "name": "Authorization", "value": "Bearer MGMT_API_ACCESS_TOKEN" },

--- a/config/redirects.js
+++ b/config/redirects.js
@@ -2260,5 +2260,9 @@ module.exports = [
     {
       from: '/policies/requests',
       to: '/policies/unsupported-requests'
+    },
+    {
+      from: '/rules/guides/create',
+      to: '/dashboard/guides/rules/create-rules'
     }
 ];


### PR DESCRIPTION
https://docs-content-staging-pr-8312.herokuapp.com/docs/api/management/guides/rules/create-rules

Redirect:
https://docs-content-staging-pr-8312.herokuapp.com/docs/rules/guides/create
SHOULD GO TO:
https://docs-content-staging-pr-8312.herokuapp.com/docs/api/management/guides/rules/create-rules
