### PR TITLE
Update login.md

### DIFF
--- a/articles/connections/database/custom-db/templates/login.md
+++ b/articles/connections/database/custom-db/templates/login.md
@@ -381,7 +381,7 @@ function login (username, password, callback) {
   function validatePassword(password, originalHash, callback) {
     var iterations = 1000;
     var hashBytes = Buffer.from(originalHash, 'base64');
-    var salt = hashBytes.slice(1, 17).toString('binary');
+    var salt = hashBytes.slice(1, 17);
     var hash = hashBytes.slice(17, 49);
     crypto.pbkdf2(password, salt, iterations, hash.length, function(err, hashed) {
       if (err) {


### PR DESCRIPTION
Based on https://community.auth0.com/t/automatic-user-migration-script-breaks-when-switching-from-node-4-to-node-8/16588/13 the toString('binary') call in the validatePassword function is not necessary for getting the right salt due to Node 8 encoding changes.
