### PR TITLE
Fix session lifetime definitions.

### DIFF
--- a/articles/api/management/guides/tenants/configure-session-lifetime-settings.md
+++ b/articles/api/management/guides/tenants/configure-session-lifetime-settings.md
@@ -38,5 +38,5 @@ This guide will show you how to configure session settings for your tenant using
 | **Value** | **Description** |
 | - | - |
 | `MGMT_API_ACCESS_TOKEN`  | [Access Token for the Management API](/api/management/v2/tokens) with the <dfn data-key="scope">scope</dfn> `update:tenant_settings`. |
-| `SESSION_LIFETIME_VALUE` | Timeframe (in hours) after which a user's session will expire if they haven’t interacted with the Authorization Server. Will be superseded by system limits if over 72 hours (3 days) for self-service plans or 2,400 hours (100 days) for enterprise plans. |
-| `IDLE_SESSION_LIFETIME_VALUE` | Timeframe (in hours) after which a user will be required to log in again, regardless of their activity. Will be superseded by system limits if over 720 hours (30 days) for self-service plans or 8,760 hours (365 days) for enterprise plans. |
+| `IDLE_SESSION_LIFETIME_VALUE` | Timeframe (in hours) after which a user's session will expire if they haven’t interacted with the Authorization Server. Will be superseded by system limits if over 72 hours (3 days) for self-service plans or 2,400 hours (100 days) for enterprise plans. |
+| `SESSION_LIFETIME_VALUE` | Timeframe (in hours) after which a user will be required to log in again, regardless of their activity. Will be superseded by system limits if over 720 hours (30 days) for self-service plans or 8,760 hours (365 days) for enterprise plans. |


### PR DESCRIPTION
The existing definitions for `session_lifetime` and `idle_session_lifetime` should be swapped.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors
- Please include a short description
- If your PR is a work in progress, title it [DO NOT MERGE]
--->
