### PR TITLE
Fix Rails WebApp QS logout by adding reset_session

### DIFF
--- a/articles/quickstart/webapp/rails/01-login.md
+++ b/articles/quickstart/webapp/rails/01-login.md
@@ -232,7 +232,7 @@ Use the following command to create the controller that will handle user logout:
 rails generate controller logout
 ```
 
-To clear out all the objects stored within the session, call the `reset_session` method within the `logout_controller/logout` method. Learn more about reset_session [here](http://api.rubyonrails.org/classes/ActionController/Base.html#M000668).
+To clear out all the objects stored within the session, call the `reset_session` method within the `logout_controller/logout` method. [Learn more about reset_session here](http://api.rubyonrails.org/classes/ActionController/Base.html#M000668).
 
 ```ruby
 # app/controllers/logout_controller.rb

--- a/articles/quickstart/webapp/rails/01-login.md
+++ b/articles/quickstart/webapp/rails/01-login.md
@@ -232,12 +232,15 @@ Use the following command to create the controller that will handle user logout:
 rails generate controller logout
 ```
 
+To clear out all the objects stored within the session, call the `reset_session` method within the `logout_controller/logout` method. Learn more about reset_session [here](http://api.rubyonrails.org/classes/ActionController/Base.html#M000668).
+
 ```ruby
 # app/controllers/logout_controller.rb
 
 class LogoutController < ApplicationController
   include LogoutHelper
   def logout
+    reset_session
     redirect_to logout_url.to_s
   end
 end


### PR DESCRIPTION
This came in as feedback. Adding `reset_session` is required prior to the redirect for the logout to work. I have not tested this but the second step of the rails webapp quickstart is doing it already. ref: https://auth0.com/docs/quickstart/webapp/rails/02-session-handling#clear-session-on-logout