### PR TITLE
Fix a typo in bulletin URL

### DIFF
--- a/articles/security/bulletins/index.md
+++ b/articles/security/bulletins/index.md
@@ -27,7 +27,7 @@ Each bulletin contains a description of the vulnerability, how to identify if yo
 
 | **Date** | **Bulletin number** | **Title** | **Affected software** |
 |-|-|-|-|
-| October 04, 2019 | [CVE 2019-16929](/security/bulletins/cve-2019-16929.md) | Auth0 Security Bulletin for auth0.net between versions 5.8.0 and 6.5.3 inclusive | [auth0.net](https://www.nuget.org/packages/Auth0.AuthenticationApi/) |
+| October 04, 2019 | [CVE 2019-16929](/security/bulletins/cve-2019-16929) | Auth0 Security Bulletin for auth0.net between versions 5.8.0 and 6.5.3 inclusive | [auth0.net](https://www.nuget.org/packages/Auth0.AuthenticationApi/) |
 | September 05, 2019 | [Auth0 bulletin](/security/bulletins/2019-09-05_scopes) | Auth0 Security Bulletin for assigning scopes based on email address | Custom code within Auth0 rules |
 | July 23, 2019 | [CVE 2019-13483](/security/bulletins/cve-2019-13483) | Security Bulletin for Passport-SharePoint < 0.4.0 | [Passport-SharePoint](https://github.com/auth0/passport-sharepoint) |
 | February 15, 2019 | [CVE 2019-7644](/security/bulletins/cve-2019-7644) | Security Bulletin for Auth0-WCF-Service-JWT < 1.0.4 | [Auth0-WCF-Service-JWT](https://www.nuget.org/packages/Auth0-WCF-Service-JWT/) |


### PR DESCRIPTION
The link to the security bulletin included a typo, which led to broken link.