### PR TITLE
Remove misplaced webtask warning

### DIFF
--- a/articles/best-practices/custom-db-connections-scripts.md
+++ b/articles/best-practices/custom-db-connections-scripts.md
@@ -20,8 +20,6 @@ useCase:
 Only **Enterprise** subscription plans include the ability to use a custom database for authentication requests. For more information refer to [Auth0 pricing plans](https://auth0.com/pricing).
 :::
 
-<%= include('../_includes/_webtask') %>
-
 ## Custom database connection best practices
 
 * Make sure that your database has the appropriate fields to store user profiles attributes, such as **id**, **nickname**, **email**, and **password**. See [Normalized User Profile](/users/normalized) for details on Auth0's user profile schema and the expected fields. Also, see [Update User Profile Using Your Database](/users/guides/update-user-profiles-using-your-database) for more information.


### PR DESCRIPTION
This warning doesn't belong on the [Custom Database Connection and Action Script Best Practices](https://auth0.com/docs/best-practices/custom-db-connections-scripts) docs page.