### PR TITLE
Update nonce.md

### DIFF
--- a/articles/api-auth/tutorials/nonce.md
+++ b/articles/api-auth/tutorials/nonce.md
@@ -25,7 +25,7 @@ One way to generate a cryptographically random nonce is to use a tool like [Nano
 
 ```js
 function randomString(length) {
-    var charset = '0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._~'
+    var charset = '0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._'
     result = ''
 
     while (length > 0) {


### PR DESCRIPTION
~ is an unsafe url character. The nonce returned in the id token could have ~ replaced with %7E, causing auth to fail. Above change is to remove that from the charset from which nonce can be generated.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors
- Please include a short description
- If your PR is a work in progress, title it [DO NOT MERGE]
--->
