### PR TITLE
Added check for undefined app_metadata when fetching department.

### DIFF
--- a/articles/extensions/delegated-admin/v3/hooks/membership.md
+++ b/articles/extensions/delegated-admin/v3/hooks/membership.md
@@ -25,7 +25,7 @@ Users of the IT department should be able to create users in other departments. 
 
 ```js
 function(ctx, callback) {
-  var currentDepartment = ctx.payload.user.app_metadata.department;
+  var currentDepartment = ctx.payload.user.app_metadata && ctx.payload.user.app_metadata.department;
   if (!currentDepartment || !currentDepartment.length) {
     return callback(null, [ ]);
   }


### PR DESCRIPTION
The existing sample membership hook made the assumption that the user would have app_metadata.  If this is not the case an error would result when opening the User Details page for a user with no app_metadata.  Added a check to avoid this.
