### PR TITLE
Update curl command

### DIFF
--- a/articles/quickstart/webapp/rails/01-login.md
+++ b/articles/quickstart/webapp/rails/01-login.md
@@ -331,7 +331,7 @@ Under some configurations, Ruby may not be able to find certification authority 
 Download the CA certs bundle to the project directory:
 
 ```bash
-curl -o lib/ca-bundle.crt http://curl.haxx.se/ca/ca-bundle.crt
+curl -L -o lib/ca-bundle.crt http://curl.haxx.se/ca/ca-bundle.crt
 ```
 
 Add this initializer to `config/initializers/fix_ssl.rb`:


### PR DESCRIPTION
From the QS helpful channel:

> This downloads an empty crt, it should contain -L to follow redirects to actual file, i.e. curl -L -o lib/ca-bundle.crt http://curl.haxx.se/ca/ca-bundle.crt

Both commands worked locally, nothing wrong with including the redirect follow.

