### PR TITLE
Adding a note about one time password limitations

### DIFF
--- a/articles/connections/_otp-limitations.md
+++ b/articles/connections/_otp-limitations.md
@@ -1,0 +1,3 @@
+* Only the last one-time password issued will be accepted. Once the latest one is issued, any others are invalidated.
+* Only three failed attempts to input the one-time password are allowed. After this, a new code will need to be requested.
+* The one-time password issued will be valid (by default) for three minutes before it expires. This time can be altered in the connection settings in the [Dashboard](${manage_url}).

--- a/articles/connections/_otp-limitations.md
+++ b/articles/connections/_otp-limitations.md
@@ -1,3 +1,3 @@
-* Only the last one-time password issued will be accepted. Once the latest one is issued, any others are invalidated.
+* Only the last one-time password (or link) issued will be accepted. Once the latest one is issued, any others are invalidated. Once used, the latest one is also invalidated.
 * Only three failed attempts to input the one-time password are allowed. After this, a new code will need to be requested.
 * The one-time password issued will be valid (by default) for three minutes before it expires. This time can be altered in the connection settings in the [Dashboard](${manage_url}).

--- a/articles/connections/passwordless/index.md
+++ b/articles/connections/passwordless/index.md
@@ -166,6 +166,10 @@ Passwordless connections have several limitations:
     - support TLS 1.0 or higher
     - use a certificate signed by a public certificate authority (CA)
 
+### Limitations of One-Time Passwords
+
+<%= include('../_otp-limitations') %>
+
 ## Best practices
 
 * Use the [Universal Login](/universal-login) [Classic Experience](/universal-login/classic) with the Lock (passwordless) template for your login page.

--- a/articles/connections/passwordless/reference/troubleshoot.md
+++ b/articles/connections/passwordless/reference/troubleshoot.md
@@ -16,10 +16,6 @@ useCase:
 
 In this guide, you'll find some information for troubleshooting passwordless authentication. If these tips don't outright solve your issue, they can at least narrow down a possible cause and help Auth0 support resolve your issue faster.
 
-## How long is the one-time use code/link valid?
-
-One-time use authentication codes or magic links are valid for an amount of time set in your app's [Passwordless Connection Settings](${manage_url}/connections/passwordless).
-
 ## Can users share passwords with others?
 
 No, because Passwordless authentication removes the need for and use of passwords.
@@ -42,3 +38,7 @@ If a user does not receive the requested email or SMS message, here are some thi
 ## What if a user receives multiple authentication emails/SMS messages?
 
 If a user accidentally requests more than one email or SMS message containing magic links or authentication codes, the last **five** codes will be valid. After successful log in using any of the codes/links, **all** of the existing codes/links will be invalidated.
+
+## One-Time Password Limitations
+
+<%= include('../../_otp-limitations') %>

--- a/articles/connections/passwordless/reference/troubleshoot.md
+++ b/articles/connections/passwordless/reference/troubleshoot.md
@@ -37,7 +37,7 @@ If a user does not receive the requested email or SMS message, here are some thi
 
 ## What if a user receives multiple authentication emails/SMS messages?
 
-If a user accidentally requests more than one email or SMS message containing magic links or authentication codes, the last **five** codes will be valid. After successful log in using any of the codes/links, **all** of the existing codes/links will be invalidated.
+If a user accidentally requests more than one email or SMS message containing magic links or authentication codes, only the most recent code/link will be valid. After successful log in using any of the codes/links, **all** of the existing codes/links will be invalidated.
 
 ## One-Time Password Limitations
 

--- a/articles/connections/passwordless/reference/troubleshoot.md
+++ b/articles/connections/passwordless/reference/troubleshoot.md
@@ -35,10 +35,6 @@ If a user does not receive the requested email or SMS message, here are some thi
 * Did the email get filed into a junk or spam folder?
 * Has there been some type of server delay, latency, or connectivity issue preventing the user from email or SMS messages?
 
-## What if a user receives multiple authentication emails/SMS messages?
-
-If a user accidentally requests more than one email or SMS message containing magic links or authentication codes, only the most recent code/link will be valid. After successful log in using any of the codes/links, **all** of the existing codes/links will be invalidated.
-
 ## One-Time Password Limitations
 
 <%= include('../../_otp-limitations') %>

--- a/articles/multifactor-authentication/troubleshooting.md
+++ b/articles/multifactor-authentication/troubleshooting.md
@@ -57,17 +57,21 @@ When you exceed your messaging limit, you'll need to wait at least an hour after
 
 ## OTP-related issues
 
-If the 6-digit code in the Guardian or the Google Authenticator app are being rejected for sign in (often with the message `Incorrect Code`), first check that you are selecting the right application from the list in your authenticator app.
+### Rejected Codes
 
-If Guardian or Google Authenticator rejects the six-digit code that you provide and displays the `Incorrect Code` message, check that you are using the correct application from the list of options available in your authenticator app.
-
-If you've verified that you're selecting the correct application, make sure that your mobile device's clock settings are correct. One-time passwords are generated using Coordinated Universal Time (UTC), so your device's time must be correct for your code to work.
+If the 6-digit code in the Guardian or the Google Authenticator app are being rejected for sign in (often with the message `Incorrect Code`), first check that you are selecting the right application from the list in your authenticator app. If you've verified that you're selecting the correct application, make sure that your mobile device's clock settings are correct. One-time passwords are generated using Coordinated Universal Time (UTC), so your device's time must be correct for your code to work.
 
 To check your clock settings:
 
 * **Android Devices** - Go **Settings** > **Date & Time**. Make sure that the box next to **Automatic** is checked.
 
 * **iOS Devices** - Go to  **Settings** > **General** > **Date & Time**. Enable **Set Automatically**. If this setting was already enabled, you can disable it for a moment, then re-enable.
+
+### One-Time Password Limitations
+
+* Only the last one-time password issued will be accepted. Once the latest one is issued, any others are invalidated.
+* Only three failed attempts to input the one-time password are allowed.
+* The one-time password issued will be valid for three minutes before it expires.
 
 ## Duo-related issues
 

--- a/articles/multifactor-authentication/troubleshooting.md
+++ b/articles/multifactor-authentication/troubleshooting.md
@@ -55,9 +55,7 @@ If you attempt to send more than ten SMS messages to your device within one hour
 
 When you exceed your messaging limit, you'll need to wait at least an hour after your request for your first message before requesting another. You will receive an additional attempt after the passage of each additional hour.
 
-## OTP-related issues
-
-### Rejected Codes
+## Rejected Codes
 
 If the 6-digit code in the Guardian or the Google Authenticator app are being rejected for sign in (often with the message `Incorrect Code`), first check that you are selecting the right application from the list in your authenticator app. If you've verified that you're selecting the correct application, make sure that your mobile device's clock settings are correct. One-time passwords are generated using Coordinated Universal Time (UTC), so your device's time must be correct for your code to work.
 
@@ -66,12 +64,6 @@ To check your clock settings:
 * **Android Devices** - Go **Settings** > **Date & Time**. Make sure that the box next to **Automatic** is checked.
 
 * **iOS Devices** - Go to  **Settings** > **General** > **Date & Time**. Enable **Set Automatically**. If this setting was already enabled, you can disable it for a moment, then re-enable.
-
-### One-Time Password Limitations
-
-* Only the last one-time password issued will be accepted. Once the latest one is issued, any others are invalidated.
-* Only three failed attempts to input the one-time password are allowed.
-* The one-time password issued will be valid for three minutes before it expires.
 
 ## Duo-related issues
 


### PR DESCRIPTION
https://docs-content-staging-pr-8384.herokuapp.com/docs/connections/passwordless

and

https://docs-content-staging-pr-8384.herokuapp.com/docs/connections/passwordless/reference/troubleshoot

Both docs include a new section on the limitations of OTP. There's also a couple of minor adjustments to fix the MFA troubleshooting area.