### PR TITLE
[IPS-771] add user_profile definition to native social

### DIFF
--- a/articles/api/authentication/api-authz/_get-token.md
+++ b/articles/api/authentication/api-authz/_get-token.md
@@ -661,6 +661,7 @@ Artifacts returned by this flow (and the contents thereof) will be determined by
 | `client_id` <br/><span class="label label-danger">Required</span> | Your application's Client ID. |
 | `audience` | The unique identifier of the target API you want to access. |
 | `scope` | String value of the different <dfn data-key="scope">scopes</dfn> the application is requesting. Multiple scopes are separated with whitespace. |
+| `user_profile` <br/><span class="label label-info">Only For `apple-authz-code`</span>  | Optional element used for native iOS interactions for which profile updates can occur.  Expected parameter value will be JSON in the form of: `{ name: { firstName: 'John', lastName: 'Smith }}` |
 
 ### Request headers
 


### PR DESCRIPTION
We're adding another parameter to the native social exchange with iOS, reflecting that in token endpoint docs.
