### PR TITLE
Fix broken passwordless and anomaly detection links

### DIFF
--- a/articles/anomaly-detection/references/breached-password-detection-triggers-actions.md
+++ b/articles/anomaly-detection/references/breached-password-detection-triggers-actions.md
@@ -21,7 +21,7 @@ Watch our [Breached Password Detection 101 video tutorial](https://auth0.com/res
 
 ## Actions
 
-* Send an email to the affected user.
+* Send an email to the affected user. (You can [customize the email](/anomaly-detection/guides/customize-blocked-account-emails).)
 * Send an email to dashboard owners immediately, and/or have a daily/weekly/monthly summary.
 * Block login attempts for suspected user accounts using that username and password combination.
 

--- a/articles/anomaly-detection/references/breached-password-detection-triggers-actions.md
+++ b/articles/anomaly-detection/references/breached-password-detection-triggers-actions.md
@@ -21,7 +21,7 @@ Watch our [Breached Password Detection 101 video tutorial](https://auth0.com/res
 
 ## Actions
 
-* Send an email to the affected user. (You can [customize the email](/anomaly-detection/guides/customize-blocked-account-emails).)
+* Send an email to the affected user.
 * Send an email to dashboard owners immediately, and/or have a daily/weekly/monthly summary.
 * Block login attempts for suspected user accounts using that username and password combination.
 

--- a/articles/anomaly-detection/references/brute-force-protection-triggers-actions.md
+++ b/articles/anomaly-detection/references/brute-force-protection-triggers-actions.md
@@ -23,7 +23,7 @@ The default trigger amount of 10 cannot be changed.
 
 ### Actions
 
-* Send an email to the affected user. (You can [customize](#customize-the-blocked-account-email) the email.)
+* Send an email to the affected user.  (You can [customize the email](/anomaly-detection/guides/customize-blocked-account-emails).)
 * Block the suspicious IP address for that user.
 
 ### Remove block

--- a/articles/api/authentication/_passwordless.md
+++ b/articles/api/authentication/_passwordless.md
@@ -112,9 +112,8 @@ For the complete error code reference for this endpoint refer to [Errors > POST 
 ### More Information
 
 - [Passwordless Authentication](/connections/passwordless)
-- [Authenticate users with using Passwordless Authentication via Email](/connections/passwordless/email)
-- [Authenticate users with a one-time code via SMS](/connections/passwordless/sms)
-- [Passwordless FAQ](/connections/passwordless/faq)
+- [Authenticate Users with Passwordless Authentication](/connections/passwordless/guides/implement-passwordless)
+- [Passwordless Troubleshooting](/connections/passwordless/reference/troubleshoot)
 
 ## Authenticate User
 
@@ -231,7 +230,5 @@ For the complete error code reference for this endpoint refer to [Errors > POST 
 ### More Information
 
 - [Passwordless Authentication](/connections/passwordless)
-- [Authenticate users with using Passwordless Authentication via Email](/connections/passwordless/email)
-- [Authenticate users with a one-time code via SMS](/connections/passwordless/sms)
-- [Authenticate users with Touch ID](/connections/passwordless/ios-touch-id-swift)
-- [Passwordless FAQ](/connections/passwordless/faq)
+- [Authenticate Users with Passwordless Authentication](/connections/passwordless/guides/implement-passwordless)
+- [Passwordless Troubleshooting](/connections/passwordless/reference/troubleshoot)

--- a/articles/api/authentication/legacy/_login.md
+++ b/articles/api/authentication/legacy/_login.md
@@ -180,7 +180,7 @@ Use this endpoint for API-based (active) authentication. Given the user credenti
 | `password` <br/><span class="label label-danger">Required</span> | Password of the user to login |
 | `connection` <br/><span class="label label-danger">Required</span> | The name of the connection to use for login |
 | <dfn data-key="scope">`scope`</dfn> | Set to `openid` to retrieve also an ID Token, leave null to get only an Access Token |
-| `grant_type` <br/><span class="label label-danger">Required</span> | Set to `password` to authenticate using username/password or `urn:ietf:params:oauth:grant-type:jwt-bearer` to authenticate using an ID Token (used to [Authenticate users with Touch ID](/connections/passwordless/ios-touch-id-swift)) |
+| `grant_type` <br/><span class="label label-danger">Required</span> | Set to `password` to authenticate using username/password or `urn:ietf:params:oauth:grant-type:jwt-bearer` to authenticate using an ID Token instead of username/password, in [Touch ID](/libraries/lock-ios/touchid-authentication) scenarios. |
 | `device` | String value. Required when `grant_type` is `urn:ietf:params:oauth:grant-type:jwt-bearer` |
 | `id_token` | Used to authenticate using a token instead of username/password, in [Touch ID](/libraries/lock-ios/touchid-authentication) scenarios. Required when `grant_type` is `urn:ietf:params:oauth:grant-type:jwt-bearer` |
 
@@ -219,5 +219,3 @@ For the complete error code reference for this endpoint, refer to [Errors > POST
 - [Rate Limits on User/Password Authentication](/connections/database/rate-limits)
 
 - [Active Directory/LDAP Connector](/connector)
-
-- [Authenticate users with Touch ID](/connections/passwordless/ios-touch-id-swift)

--- a/articles/link-accounts/user-initiated-linking.md
+++ b/articles/link-accounts/user-initiated-linking.md
@@ -61,7 +61,7 @@ The following is a sample login using Lock:
 <button onclick="javascript:login()">Login</button>
 ```
 
-In the typical SPA login, the callback is handled client-side by the same page and a JWT is received after successful authentication. You can refer to the [Single-Page Apps Quickstarts](/quickstart/spa) for more details. You can also see the [Passwordless for Single-Page Apps](/connections/passwordless/spa) tutorials for examples of <dfn data-key="passwordless">passwordless</dfn> login.
+In the typical SPA login, the callback is handled client-side by the same page and a JWT is received after successful authentication. You can refer to the [Single-Page Apps Quickstarts](/quickstart/spa) for more details. You can also see the [Implement Passwordless](/connections/passwordless/guides/implement-passwordless) tutorial for examples of <dfn data-key="passwordless">passwordless</dfn> login.
 
 ## 2. User initiates account linking
 

--- a/config/redirects.js
+++ b/config/redirects.js
@@ -2272,5 +2272,25 @@ module.exports = [
     {
       from: '/connections/apple-setup',
       to: '/connections/apple-siwa/set-up-apple'
+    },
+    {
+      from: '/connections/passwordless/email',
+      to: '/connections/passwordless/guides/implement-passwordless'
+    },
+    {
+      from: '/connections/passwordless/sms',
+      to: '/connections/passwordless/guides/implement-passwordless'
+    },
+    {
+      from: '/connections/passwordless/spa',
+      to: '/connections/passwordless/guides/implement-passwordless'
+    },
+    {
+      from: '/connections/passwordless/regular-web-app',
+      to: '/connections/passwordless/guides/implement-passwordless'
+    },
+    {
+      from: '/connections/passwordless/faq',
+      to: '/connections/passwordless/reference/troubleshoot'
     }
 ];


### PR DESCRIPTION
Fix broken links and add redirects for Passwordless section.

- https://docs-content-staging-pr-8401.herokuapp.com/docs/anomaly-detection/references/brute-force-protection-triggers-actions
- https://docs-content-staging-pr-8401.herokuapp.com/docs/api/authentication#get-code-or-link
- https://docs-content-staging-pr-8401.herokuapp.com/docs/api/authentication#authenticate-user
- https://docs-content-staging-pr-8401.herokuapp.com/docs/api/authentication#database-ad-ldap-active-

Also, the following is changed, but can't figure out how to view it in Heroku because seems file structure is overriding it with /link-accounts/user-initiated-linking/index:

- https://docs-content-staging-pr-8401.herokuapp.com/docs/link-accounts/user-initiated-linking

Redirects:

- https://docs-content-staging-pr-8401.herokuapp.com/docs/connections/passwordless/email
- https://docs-content-staging-pr-8401.herokuapp.com/docs/connections/passwordless/sms
- https://docs-content-staging-pr-8401.herokuapp.com/docs/connections/passwordless/spa
- https://docs-content-staging-pr-8401.herokuapp.com/docs/connections/passwordless/regular-web-app
- https://docs-content-staging-pr-8401.herokuapp.com/docs/connections/passwordless/faq