### PR TITLE
updated documentation for passwordless connections in hooks

### DIFF
--- a/articles/hooks/concepts/post-user-registration-extensibility-point.md
+++ b/articles/hooks/concepts/post-user-registration-extensibility-point.md
@@ -11,7 +11,7 @@ v2: true
 ---
 # Post-User-Registration Extensibility Point
 
-For [Database Connections](/connections/database), the `post-user-registration` extensibility point allows you to implement custom actions that execute after a new user registers and is added to the database.
+For [Database Connections](/connections/database) and [Passwordless Connections](/connections/passwordless), the `post-user-registration` extensibility point allows you to implement custom actions that execute after a new user registers and is added to the database.
 
 [Hooks](/hooks#work-with-hooks) associated with the `post-user-registration` extensibility point execute asynchronously from the actions that are a part of the Auth0 authentication process.
 

--- a/articles/hooks/concepts/pre-user-registration-extensibility-point.md
+++ b/articles/hooks/concepts/pre-user-registration-extensibility-point.md
@@ -11,7 +11,7 @@ v2: true
 ---
 # Pre-User-Registration Extensibility Point
 
-For [Database Connections](/connections/database), the Pre-User-Registration extensibility point allows you to add custom data points to a newly-created user's profile.
+For [Database Connections](/connections/database) and [Passwordless Connections](/connections/passwordless), the Pre-User-Registration extensibility point allows you to add custom data points to a newly-created user's profile.
 
 This allows you to implement scenarios such as setting conditional information (in the form of [metadata](/users/concepts/overview-user-metadata)) on users that do not exist yet.
 

--- a/articles/hooks/guides/use-the-post-user-registration-extensibility-point.md
+++ b/articles/hooks/guides/use-the-post-user-registration-extensibility-point.md
@@ -10,7 +10,7 @@ useCase: extensibility-hooks
 ---
 # Implement Custom Actions Using Post-User Registration Extensibility Points
 
-For [Database Connections](/connections/database), the `post-user-registration` extensibility point allows you to implement custom actions that execute after a new user registers and is added to the database.
+For [Database Connections](/connections/database) and [Passwordless Connections](/connections/passwordless), the `post-user-registration` extensibility point allows you to implement custom actions that execute after a new user registers and is added to the database.
 
 [Hooks](/hooks) associated with the `post-user-registration` extensibility point execute asynchronously from the actions that are a part of the Auth0 authentication process.
 

--- a/articles/hooks/guides/use-the-pre-user-registration-extensibility-point.md
+++ b/articles/hooks/guides/use-the-pre-user-registration-extensibility-point.md
@@ -11,7 +11,7 @@ v2: true
 ---
 # Implement Custom Actions Using Pre-User Registration Extensibility Points
 
-For [Database Connections](/connections/database), the Pre-User Registration extensibility point allows you to add custom data points to a newly-created user's profile.
+For [Database Connections](/connections/database) and [Passwordless Connections](/connections/passwordless), the Pre-User Registration extensibility point allows you to add custom data points to a newly-created user's profile.
 
 This allows you to implement scenarios such as setting conditional information (in the form of [metadata](/users/concepts/overview-user-metadata) on users that do not exist yet.
 

--- a/articles/hooks/index.md
+++ b/articles/hooks/index.md
@@ -11,9 +11,9 @@ useCase: extensibility-hooks
 ---
 # Hooks
 
-Hooks are Webtasks associated with specific extensibility points of the Auth0 platform, which allow you to customize the behavior of Auth0 with custom code using Node.js. When using [Database Connections](/connections/database), Auth0 invokes the Hooks at runtime to execute custom logic.
+Hooks are Webtasks associated with specific extensibility points of the Auth0 platform, which allow you to customize the behavior of Auth0 with custom code using Node.js. When using [Database Connections](/connections/database) or [Passwordless Connections](/connections/passwordless), Auth0 invokes the Hooks at runtime to execute custom logic.
 
-When using [Database Connections](/connections/database), Hooks allow you to customize the behavior of Auth0 using Node.js code that executes against extensibility points (which are comparable to webhooks that come with a server). Hooks allow you modularity when configuring your Auth0 implementation, and extend the functionality of base Auth0 features.
+When using either of the two supported connection types ([Database Connections](/connections/database) and [Passwordless Connections](/connections/passwordless)), Hooks allow you to customize the behavior of Auth0 using Node.js code that executes against extensibility points (which are comparable to webhooks that come with a server). Hooks allow you modularity when configuring your Auth0 implementation, and extend the functionality of base Auth0 features.
 
 ::: warning How to Handle Rate Limits when calling Auth0 APIs
 For scripts that call Auth0 APIs, you should always handle rate limiting by checking the X-RateLimit-Remaining header and acting appropriately when the number returned nears 0. You should also add logic to handle cases in which you exceed the provided rate limits and receive the HTTP Status Code 429 (Too Many Requests); in this case, if a re-try is needed, it is best to allow for a back-off to avoid going into an infinite re-try loop. For more information about rate limits, see [Rate Limit Policy For Auth0 APIs](/policies/rate-limits).

--- a/updates/2019-10-24.yml
+++ b/updates/2019-10-24.yml
@@ -1,0 +1,8 @@
+changed:
+  -
+    title: "Passwordless connections with hooks"
+    tags:
+      - hooks
+      - passwordless
+    description: |
+      Updated documentation to reflect that passwordless connections now work with the pre-user-registration and post-user-registration hooks.


### PR DESCRIPTION
This change updates the documentation to reflect that passwordless connections are now supported in the pre-user-registration and post-user-registration hooks.
