### PR TITLE
Remove root profile attributes sentence as is no longer relevant

### DIFF
--- a/articles/api/management/guides/users/set-root-attributes-user-signup.md
+++ b/articles/api/management/guides/users/set-root-attributes-user-signup.md
@@ -49,5 +49,5 @@ This guide will show you how to set root attributes for a user during sign-up us
 | `PICTURE_VALUE` | URL of the picture for the user to be created. |
 
 ::: note
-If you are using Lock or the [public signup endpoint](/api/authentication#signup) for user sign-up, you can set root attributes using the same method. However, be aware that Lock itself does not support the given name, family name, name, nickname, and picture fields; only the endpoint supports it.
+If you are using Lock or the [public signup endpoint](/api/authentication#signup) for user sign-up, you can set root attributes using the same method.
 :::


### PR DESCRIPTION
This is no longer relevant. Lock supports this [since v11.17.0](https://github.com/auth0/lock/blob/master/CHANGELOG.md#v11170-2019-07-15)

