### PR TITLE
Update Servlet Quickstart for RS256

### DIFF
--- a/articles/quickstart/webapp/java/_includes/_login.md
+++ b/articles/quickstart/webapp/java/_includes/_login.md
@@ -37,7 +37,7 @@ Lastly, the project defines a helper class: the `AuthenticationControllerProvide
 
 ## Trigger Authentication
 
-Let's begin by creating the `AuthenticationController` instance. From any Servlet class we can obtain the ServletConfig instance and read the properties defined in the `web.xml` file. Let's read our application properties and create a new instance of this controller:
+To enable users to authenticate, create an instance of the `AuthenticationController` provided by the `auth0-java-mvc-commons` SDK using the `domain`, `clientId`, and `clientSecret`.  The sample below shows how to configure the component for use with tokens signed using the RS256 asymmetric signing algorithm, by specifying a `JwkProvider` to fetch the public key used to verify the token's signature. See the [jwks-rsa-java repository](https://github.com/auth0/jwks-rsa-java) to learn about additional configuration options. If you are using HS256, there is no need to configure the `jwkProvider`. 
 
 ```java
 // src/main/java/com/auth0/example/AuthenticationControllerProvider.java
@@ -46,11 +46,13 @@ String domain = getServletConfig().getServletContext().getInitParameter("com.aut
 String clientId = getServletConfig().getServletContext().getInitParameter("com.auth0.clientId");
 String clientSecret = getServletConfig().getServletContext().getInitParameter("com.auth0.clientSecret");
 
+JwkProvider jwkProvider = new JwkProviderBuilder(domain).build();
 AuthenticationController controller = AuthenticationController.newBuilder(domain, clientId, clientSecret)
+                .withJwkProvider(jwkProvider)
                 .build();
 ```
 
-To authenticate the users we will redirect them to the **Auth0 Login Page** which uses the best version available of [Lock](/lock). This page is what we call the "Authorize URL". By using this library we can generate it with a simple method call. It will require a `HttpServletRequest` to store the call context in the session and the URI to redirect the authentication result to. This URI is normally the address where our app is running plus the path where the result will be parsed, which happens to be also the "Callback URL" whitelisted before. Finally, we will request the "User Info" *audience* in order to obtain an Open ID Connect compliant response. After we create the Authorize URL, we redirect the request there so the user can enter their credentials. The following code snippet is located on the `LoginServlet` class of our sample.
+To authenticate users we will redirect them to the login page which uses [Universal Login](https://auth0.com/docs/universal-login). This page is what we call the "Authorize URL". By using this library we can generate it with a simple method call. It will require a `HttpServletRequest` to store the call context in the session and the URI to redirect the authentication result to. This URI is normally the address where our app is running plus the path where the result will be parsed, which happens to be also the "Callback URL" whitelisted before. After we create the Authorize URL, we redirect the request there so the user can enter their credentials. The following code snippet is located on the `LoginServlet` class of our sample.
 
 ```java
 // src/main/java/com/auth0/example/LoginServlet.java
@@ -64,13 +66,12 @@ protected void doGet(final HttpServletRequest req, final HttpServletResponse res
     redirectUri += "/callback";
 
     String authorizeUrl = authenticationController.buildAuthorizeUrl(req, redirectUri)
-            .withAudience(String.format("https://%s/userinfo", domain))
             .build();
     res.sendRedirect(authorizeUrl);
 }
 ```
 
-After the user logs in the result will be received in our `CallbackServlet`, either via a GET or a POST Http method. The request holds the call context that we've previously set by generating the Authorize URL with the controller. When we pass it to the controller, we get back either a valid `Tokens` instance or an Exception indicating what went wrong. In the case of a successful call, we need to save the credentials somewhere we can access them later. We will use again the `HttpSession` of the request. A helper class called `SessionUtils` is included in the library to set and read values from a request's session.
+After the user logs in, the result will be received in our `CallbackServlet` via either a GET or POST HTTP request. Because we are using the Authorization Code Flow (the default), a GET request will be sent. If you have configured the library for the Implicit Flow, a POST request will be sent instead. The request holds the call context that we've previously set by generating the Authorize URL with the controller. When we pass it to the controller, we get back either a valid `Tokens` instance or an Exception indicating what went wrong. In the case of a successful call, we need to save the credentials somewhere we can access them later. We will use again the `HttpSession` of the request. A helper class called `SessionUtils` is included in the library to set and read values from a request's session.
 
 ```java
 // src/main/java/com/auth0/example/CallbackServlet.java

--- a/articles/quickstart/webapp/java/_includes/_login.md
+++ b/articles/quickstart/webapp/java/_includes/_login.md
@@ -37,7 +37,7 @@ Lastly, the project defines a helper class: the `AuthenticationControllerProvide
 
 ## Trigger Authentication
 
-To enable users to authenticate, create an instance of the `AuthenticationController` provided by the `auth0-java-mvc-commons` SDK using the `domain`, `clientId`, and `clientSecret`.  The sample below shows how to configure the component for use with tokens signed using the RS256 asymmetric signing algorithm, by specifying a `JwkProvider` to fetch the public key used to verify the token's signature. See the [jwks-rsa-java repository](https://github.com/auth0/jwks-rsa-java) to learn about additional configuration options. If you are using HS256, there is no need to configure the `jwkProvider`. 
+To enable users to authenticate, create an instance of the `AuthenticationController` provided by the `auth0-java-mvc-commons` SDK using the `domain`, `clientId`, and `clientSecret`.  The sample below shows how to configure the component for use with tokens signed using the RS256 asymmetric signing algorithm, by specifying a `JwkProvider` to fetch the public key used to verify the token's signature. See the [jwks-rsa-java repository](https://github.com/auth0/jwks-rsa-java) to learn about additional configuration options. If you are using HS256, there is no need to configure the `JwkProvider`. 
 
 ```java
 // src/main/java/com/auth0/example/AuthenticationControllerProvider.java

--- a/articles/quickstart/webapp/java/_includes/_login.md
+++ b/articles/quickstart/webapp/java/_includes/_login.md
@@ -52,7 +52,7 @@ AuthenticationController controller = AuthenticationController.newBuilder(domain
                 .build();
 ```
 
-To authenticate users we will redirect them to the login page which uses [Universal Login](https://auth0.com/docs/universal-login). This page is what we call the "Authorize URL". By using this library we can generate it with a simple method call. It will require a `HttpServletRequest` to store the call context in the session and the URI to redirect the authentication result to. This URI is normally the address where our app is running plus the path where the result will be parsed, which happens to be also the "Callback URL" whitelisted before. After we create the Authorize URL, we redirect the request there so the user can enter their credentials. The following code snippet is located on the `LoginServlet` class of our sample.
+To enable users to login, your application will redirect them to the [Universal Login](https://auth0.com/docs/universal-login) page. Using the `AuthenticationController` instance, you can generate the redirect URL by calling the `buildAuthorizeUrl(HttpServletRequest request, String redirectUrl)` method. The redirect URL must be the URL that was added to the **Allowed Callback URLs** of your Auth0 Application.
 
 ```java
 // src/main/java/com/auth0/example/LoginServlet.java
@@ -71,7 +71,9 @@ protected void doGet(final HttpServletRequest req, final HttpServletResponse res
 }
 ```
 
-After the user logs in, the result will be received in our `CallbackServlet` via either a GET or POST HTTP request. Because we are using the Authorization Code Flow (the default), a GET request will be sent. If you have configured the library for the Implicit Flow, a POST request will be sent instead. The request holds the call context that we've previously set by generating the Authorize URL with the controller. When we pass it to the controller, we get back either a valid `Tokens` instance or an Exception indicating what went wrong. In the case of a successful call, we need to save the credentials somewhere we can access them later. We will use again the `HttpSession` of the request. A helper class called `SessionUtils` is included in the library to set and read values from a request's session.
+After the user logs in, the result will be received in our `CallbackServlet` via either a GET or POST HTTP request. Because we are using the Authorization Code Flow (the default), a GET request will be sent. If you have configured the library for the Implicit Flow, a POST request will be sent instead.
+
+The request holds the call context that the library previously set by generating the Authorize URL with the `AuthenticationController`. When passed to the controller, you get back either a valid `Tokens` instance or an Exception indicating what went wrong. In the case of a successful call, you need to save the credentials somewhere to access them later. You can use the `HttpSession` of the request by using the `SessionsUtils` class included in the library.
 
 ```java
 // src/main/java/com/auth0/example/CallbackServlet.java

--- a/articles/quickstart/webapp/java/_includes/_setup.md
+++ b/articles/quickstart/webapp/java/_includes/_setup.md
@@ -56,16 +56,9 @@ Your Java App needs some information in order to authenticate against your Auth0
 </context-param>
 ```
 
-The library we're using has this default behavior:
-- Request the scope `openid`, needed to call the `/userinfo` endpoint later to verify the User's identity.
-- Request the `code` Response Type and later perform a Code Exchange to obtain the tokens.
-- Use the `HS256` Algorithm along with the Client Secret to verify the tokens.
+By default, the **auth0-java-mvc-commons** library will execute the [Open ID Connect](https://openid.net/specs/openid-connect-core-1_0-final.html) Authorization Code Flow and verify the ID token using the **HS256 symmetric algorithm**. This article will demonstrate how to configure the library for use with the **RS256 asymmetric algorithm**, which is the recommended signing algorithm.
 
-But it also allows us to customize its behavior:
-* To use the `RS256` Algorithm along with the Public Key obtained dynamically from the Auth0 hosted JWKs file, pass a `JwkProvider` instance to the `AuthenticationController` builder.
-* To use a different Response Type, set the desired value in the `AuthenticationController` builder. Any combination of `code token id_token` is allowed.
-* To request a different `scope`, set the desired value in the `AuthorizeUrl` received after calling `AuthenticationController#buildAuthorizeUrl()`.
-* To specify the `audience`, set the desired value in the `AuthorizeUrl` received after calling `AuthenticationController#buildAuthorizeUrl()`.
+To learn more about the library, including its various configuration options, see the [README](https://github.com/auth0/auth0-java-mvc-common/blob/master/README.md) of the library.
 
 
 ::: panel Check populated attributes

--- a/articles/quickstart/webapp/java/_includes/_setup.md
+++ b/articles/quickstart/webapp/java/_includes/_setup.md
@@ -56,7 +56,7 @@ Your Java App needs some information in order to authenticate against your Auth0
 </context-param>
 ```
 
-This information will be used to configure the **auth0-java-mvc-commons** library to enable users to login to your application. To learn more about the library, including its various configuration options, see the [README](https://github.com/auth0/auth0-java-mvc-common/blob/master/README.md) of the library.
+This information will be used to configure the **auth0-java-mvc-commons** library to enable users to login to your application. To learn more about the library, including its various configuration options, see the [library's documentation](https://github.com/auth0/auth0-java-mvc-common/blob/master/README.md).
 
 
 ::: panel Check populated attributes

--- a/articles/quickstart/webapp/java/_includes/_setup.md
+++ b/articles/quickstart/webapp/java/_includes/_setup.md
@@ -56,11 +56,9 @@ Your Java App needs some information in order to authenticate against your Auth0
 </context-param>
 ```
 
-By default, the **auth0-java-mvc-commons** library will execute the [Open ID Connect](https://openid.net/specs/openid-connect-core-1_0-final.html) Authorization Code Flow and verify the ID token using the **HS256 symmetric algorithm**. This article will demonstrate how to configure the library for use with the **RS256 asymmetric algorithm**, which is the recommended signing algorithm.
-
-To learn more about the library, including its various configuration options, see the [README](https://github.com/auth0/auth0-java-mvc-common/blob/master/README.md) of the library.
+This information will be used to configure the **auth0-java-mvc-commons** library to enable users to login to your application. To learn more about the library, including its various configuration options, see the [README](https://github.com/auth0/auth0-java-mvc-common/blob/master/README.md) of the library.
 
 
 ::: panel Check populated attributes
-If you download the seed using our **Download Sample** button then the `domain`, `clientId` and `clientSecret` attributes will be populated for you, unless you are not logged in or you do not have at least one registered application. In any case, you should verify that the values are correct if you have multiple applications in your account and you might want to use another than the one we set the information for.
+If you downloaded this sample using the **Download Sample** button, the `domain`, `clientId` and `clientSecret` attributes will be populated for you. You should verify that the values are correct, especially if you have multiple Auth0 applications in your account.
 :::


### PR DESCRIPTION
Updates the Java Servlet Quickstart article to demonstrate configuring the library for RS256, and removes the userinfo audience configuration.

This change accompanies the update to the sample application, found here: https://github.com/auth0-samples/auth0-servlet-sample/pull/36