### PR TITLE
Fixed callback URLs in download for Angular2, Vue

### DIFF
--- a/articles/quickstart/spa/angular2/download.md
+++ b/articles/quickstart/spa/angular2/download.md
@@ -4,7 +4,7 @@ To run the sample follow these steps:
 
 1) Set the **Allowed Callback URLs** in the [Application Settings](${manage_url}/#/applications/${account.clientId}/settings) to
 ```text
-http://localhost:3000/callback
+http://localhost:3000
 ```
 2) Set **Allowed Web Origins** in the [Application Settings](${manage_url}/#/applications/${account.clientId}/settings) to
 ```text

--- a/articles/quickstart/spa/vuejs/download.md
+++ b/articles/quickstart/spa/vuejs/download.md
@@ -1,8 +1,10 @@
+<!-- markdownlint-disable MD031 MD041 -->
+
 To run the sample follow these steps:
 
 1) Set the **Callback URL** in the [Application Settings](${manage_url}/#/applications/${account.clientId}/settings) to
 ```text
-http://localhost:3000/callback
+http://localhost:3000
 ```
 2) Set **Allowed Web Origins** in the [Application Settings](${manage_url}/#/applications/${account.clientId}/settings) to
 ```text


### PR DESCRIPTION
The callback URLs that were specified in the "download sample" dialog for Angular 2 and Vue were inconsistent with the guidance in the doc itself. This PR fixes that inconsistency.