### PR TITLE
deprecate api/users/:user_id/devices

### DIFF
--- a/articles/api/management/v1/index.md
+++ b/articles/api/management/v1/index.md
@@ -62,7 +62,7 @@ Authorization: Bearer {token}
   <div class="span4 col-sm-4 api-description" style="text-align:right">Gets an user by id</div>
 </div>
 
-Gets an user who have logged in through any of your connections that has a given id.
+Gets a user who has logged in through any of your connections that has a given id.
 
 ```text
 GET /api/users/{user_id}

--- a/articles/api/management/v1/index.md
+++ b/articles/api/management/v1/index.md
@@ -70,18 +70,6 @@ Authorization: Bearer {token}
 ```
 
 <div class="row api-explorer-row api-get">
-  <div class="span8 col-sm-8 api-method"><span class="verb get">GET</span> /api/users/{user_id}/devices</div>
-  <div class="span4 col-sm-4 api-description" style="text-align:right">Gets all user's devices</div>
-</div>
-
-Gets all devices/<dfn data-key="refresh-token">Refresh Tokens</dfn> being used by the user.
-
-```text
-GET /api/users/{user_id}/devices
-Authorization: Bearer {token}
-```
-
-<div class="row api-explorer-row api-get">
   <div class="span8 col-sm-8 api-method"><span class="verb get">GET</span> /api/connections/{connection}/users</div>
   <div class="span4 col-sm-4 api-description" style="text-align:right">Gets all users from an enterprise directory</div>
 </div>


### PR DESCRIPTION
👋 

We (the iam-authorization team) are deprecating this endpoint (`/api/users/:user_id/devices`) . On checking logs, we've observed no usage of it across all environments. Deprecation of this endpoint would reduce the complexity of a feature that we are delivering.

 