### PR TITLE
Clarify passwordless connection vs. other connections

### DIFF
--- a/articles/connections/passwordless/index.md
+++ b/articles/connections/passwordless/index.md
@@ -20,7 +20,9 @@ When a user authenticates via Passwordless, the user is attached to the connecti
 
 A passwordless connection is another type of connection separate from any existing database, social, or Enterprise connections. Even though a user from an Auth0 user database or social provider might share the same email address, the identity associated with their passwordless connection is distinct. As with linking multiple email addresses or mobile phone numbers used for the passwordless connection, [account linking](/extensions/account-link) can also be used to associate a passwordless identity with identities from other types of connections.
 
-Also note that passwordless users cannot currently be created from the Dashboard and will need to be created from the [Management API](/api/management/v2#!/Users/post_users) if signup is disabled or users need to be created directly. The connection field should be "email" for passwordless users based on an email address and "sms" for passwordless users based on a mobile phone number.
+::: note
+You cannot create passwordless users from the Dashboard. Create then directly from the [Management API](/api/management/v2#!/Users/post_users) if signup is disabled. In the **Connection** field, use **email** for passwordless users using an email address and **sms** for passwordless users using a mobile phone number.
+:::
 
 Passwordless differs from Multi-factor Authentication (MFA) in that only one factor is used to authenticate a user&mdash;the one-time code or link received by the user. If you want to require that users log in with a one-time code or link **in addition** to another factor (e.g., username/password or a social Identity Provider, such as Google), see [Multi-factor Authentication (MFA)](/multifactor-authentication).
 

--- a/articles/connections/passwordless/index.md
+++ b/articles/connections/passwordless/index.md
@@ -18,6 +18,10 @@ useCase: customize-connections
 
 When a user authenticates via Passwordless, the user is attached to the connection using Auth0 as the Identity Provider (IdP). Since you can't force users to use the same mobile phone number or email address every time they authenticate, users may end up with multiple user profiles in the Auth0 datastore; you can link multiple user profiles through [account linking](/extensions/account-link).
 
+A passwordless connection is another type of connection separate from any existing database, social, or Enterprise connections. Even though a user from an Auth0 user database or social provider might share the same email address, the identity associated with their passwordless connection is distinct. As with linking multiple email addresses or mobile phone numbers used for the passwordless connection, [account linking](/extensions/account-link) can also be used to associate a passwordless identity with identities from other types of connections.
+
+Also note that passwordless users cannot currently be created from the Dashboard and will need to be created from the [Management API](/api/management/v2#!/Users/post_users) if signup is disabled or users need to be created directly. The connection field should be "email" for passwordless users based on an email address and "sms" for passwordless users based on a mobile phone number.
+
 Passwordless differs from Multi-factor Authentication (MFA) in that only one factor is used to authenticate a user&mdash;the one-time code or link received by the user. If you want to require that users log in with a one-time code or link **in addition** to another factor (e.g., username/password or a social Identity Provider, such as Google), see [Multi-factor Authentication (MFA)](/multifactor-authentication).
 
 ## Benefits


### PR DESCRIPTION
I found the connection (or lack thereof) between my existing user database and the passwordless connection users to be very confusing (see https://community.auth0.com/t/are-passwordless-users-distinct-from-database-users/33790). There are also several other community issues with similar questions and concerns (see https://community.auth0.com/t/passwordless-disable-signups/30981).

The proposed addition attempts to clarify the distinction between connection types and their user identities. I have two questions that need to be confirmed before this is accepted:
- Can the account linking extension actually link users between a database connection and a passwordless connection? The text I wrote above assumes that it can, but I'm not quite clear on if that's the case or if it can only link multiple passwordless users.
- Is the "sms" connection name for use in the API correct? I've been able to verify "email" since that's what I see in my Dashboard, but not the connection name for mobile phone users.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors
- Please include a short description
- If your PR is a work in progress, title it [DO NOT MERGE]
--->
