### PR TITLE
Rename 'Verify Passwordless' to 'Passwordless Login'

### DIFF
--- a/articles/libraries/auth0js/v9/index.md
+++ b/articles/libraries/auth0js/v9/index.md
@@ -271,7 +271,7 @@ webAuth.passwordlessStart({
 );
 ```
 
-### Verify passwordless
+### Passwordless Login
 
 If sending a code, you will then need to prompt the user to enter that code. You will process the code, and authenticate the user, with the `passwordlessLogin` method, which has several parameters which can be sent in its `options` object:
 


### PR DESCRIPTION
In the past the method to login with passwordless was called 'passwordlessVerify', so it could have made sense that section was called "Verify Passwordless" . Now the method is called "passwordlessLogin", so I think it's better to use "Passwordless Login" as the title.
