### PR TITLE
Fixed Swift Quickstart issues

### DIFF
--- a/articles/quickstart/native/_includes/_ios_dependency_centralized.md
+++ b/articles/quickstart/native/_includes/_ios_dependency_centralized.md
@@ -7,7 +7,7 @@
 If you are using Carthage, add the following to your `Cartfile`:
 
 ```ruby
-github "auth0/Auth0.swift" ~> 1.18
+github "auth0/Auth0.swift" ~> 1.19
 ```
 
 Then, run `carthage bootstrap`.
@@ -22,7 +22,7 @@ If you are using [Cocoapods](https://cocoapods.org/), add the following to your 
 
 ```ruby
 use_frameworks!
-pod 'Auth0', '~> 1.18'
+pod 'Auth0', '~> 1.19'
 ```
 
 Then, run `pod install`.

--- a/articles/quickstart/native/ios-swift/03-user-sessions.md
+++ b/articles/quickstart/native/ios-swift/03-user-sessions.md
@@ -165,7 +165,7 @@ You will need to update the original login scopes to include `read:current_user`
 
 ### Audience
 
-You will also need to change your audience to the [API Audience identifier](https://manage.auth0.com/#/apis) for the Management API.
+You will also need to change your audience to the [API Identifier](https://manage.auth0.com/#/apis) for the Management API.
 The default identifier is `https://${account.namespace}/api/v2/`
 
 ### Login

--- a/articles/quickstart/native/ios-swift/03-user-sessions.md
+++ b/articles/quickstart/native/ios-swift/03-user-sessions.md
@@ -199,7 +199,7 @@ You can add custom user information in the user metadata section by performing a
 ```swift
 // ProfileViewController.swift
 
-let accessToken = ... // You will need the accessToken from your credentials instance 'credentials.accessToken'
+let accessToken = ... // the user-scoped accessToken from your credentials instance 'credentials.accessToken'
 let profile = ... // the Profile instance you obtained accessing the `/userinfo` endpoint.
 
 Auth0
@@ -226,7 +226,7 @@ Retrieving the `user_metadata` dictionary:
 ```swift
 // ProfileViewController.swift
 
-let accessToken = ... // You will need the accessToken from your credentials instance 'credentials.accessToken'
+let accessToken = ... // the user-scoped accessToken from your credentials instance 'credentials.accessToken'
 let profile = ... // the Profile instance you obtained accessing the `/userinfo` endpoint.
 
 Auth0

--- a/articles/quickstart/native/ios-swift/03-user-sessions.md
+++ b/articles/quickstart/native/ios-swift/03-user-sessions.md
@@ -3,10 +3,10 @@ title: User Sessions
 description: This tutorial will show you how to handle user sessions and retrieve the user's profile.
 budicon: 280
 topics:
-  - quickstarts
-  - native
-  - ios
-  - swift
+    - quickstarts
+    - native
+    - ios
+    - swift
 github:
     path: 03-User-Sessions
 contentType: tutorial
@@ -15,19 +15,19 @@ useCase: quickstart
 
 ## Credentials Manager
 
-This guide shows you how to use the credentials manager to store and Refresh Tokens. 
+This guide shows you how to use the credentials manager to store and Refresh Tokens.
 
-[Auth0.swift](https://github.com/auth0/Auth0.swift) provides a utility class to streamline the process of storing and renewing credentials. You can access the `accessToken` or `idToken` properties from the [Credentials](https://github.com/auth0/Auth0.swift/blob/master/Auth0/Credentials.swift) instance. 
+[Auth0.swift](https://github.com/auth0/Auth0.swift) provides a utility class to streamline the process of storing and renewing credentials. You can access the `accessToken` or `idToken` properties from the [Credentials](https://github.com/auth0/Auth0.swift/blob/master/Auth0/Credentials.swift) instance.
 
 ::: note
-You can also use `SimpleKeychain` directly, without the added benefits and convenience of the credentials manager. To learn more, read about [Saving and Refreshing Tokens](/libraries/auth0-swift/save-and-refresh-jwt-tokens#simplekeychain). 
+You can also use `SimpleKeychain` directly, without the added benefits and convenience of the credentials manager. To learn more, read about [Saving and Refreshing Tokens](/libraries/auth0-swift/save-and-refresh-jwt-tokens#simplekeychain).
 :::
 
 ## Save the User's Credentials When They Log in
 
 When your users log in successfully, save their credentials. You can then log them in automatically when they open your application again.
 
-To get a [Refresh Token](/refresh-token) during authentication, use the `offline_access` scope. You can use the Refresh Token to request a new Access Token when the previous one expires. 
+To get a [Refresh Token](/refresh-token) during authentication, use the `offline_access` scope. You can use the Refresh Token to request a new Access Token when the previous one expires.
 
 First, import the `Auth0` module to the file that will present the login page:
 
@@ -37,7 +37,7 @@ Next, present the login page:
 
 ```swift
 // HomeViewController.swift
-Credentials manager
+
 // Create an instance of the credentials manager for storing credentials
 let credentialsManager = CredentialsManager(authentication: Auth0.authentication())
 
@@ -53,7 +53,7 @@ Auth0
         case .success(let credentials):
             // Auth0 will automatically dismiss the login page
             // Store the credentials
-            credentialsManager.store(credentials: credentials)
+            self.credentialsManager.store(credentials: credentials)
         }
 }
 ```
@@ -88,19 +88,26 @@ credentialsManager.credentials { error, credentials in
     }
     // You now have a valid credentials object, you might want to store this locally for easy access.
     // You will use this later to retrieve the user's profile
-} 
+}
 ```
 
 If the credentials have expired, the credentials manager will automatically renew them for you with the Refresh Token.
 
-### Clear the Keychain When the User Logs Out
+### Clear the Keychain and Revoke the Refresh Token When the User Logs Out
 
-When you need to log the user out, remove their credentials from the keychain:
+When you need to log the user out, remove their credentials from the keychain and revoke the refresh token:
 
 ```swift
 // SessionManager.swift
 
-credentialsManager.clear()
+credentialsManager.revoke { error in
+    guard error == nil else {
+        // Handle error
+        print("Error: \(error)")
+    }
+
+    // The user is now logged out
+}
 ```
 
 ## Retrieve the User Profile
@@ -112,8 +119,11 @@ To get the user's profile, you need a valid Access Token. You can find the token
 
 // credentials = A returned credentials object from the credentials manager in the previous step.
 
-guard let accessToken = credentials?.accessToken
-    else { // Handle Error }
+guard let accessToken = credentials?.accessToken else {
+    // Handle Error
+    return
+}
+
 Auth0
     .authentication()
     .userInfo(withAccessToken: accessToken)
@@ -155,7 +165,7 @@ You will need to update the original login scopes to include `read:current_user`
 
 ### Audience
 
-You will also need to change your audience to the [API Audience identifier](https://manage.auth0.com/#/apis) for the Management API. 
+You will also need to change your audience to the [API Audience identifier](https://manage.auth0.com/#/apis) for the Management API.
 The default identifier is `https://${account.namespace}/api/v2/`
 
 ### Login
@@ -177,7 +187,7 @@ Auth0
         case .success(let credentials):
             // Auth0 will automatically dismiss the login page
             // Store the credentials
-            credentialsManager.store(credentials: credentials)
+            self.credentialsManager.store(credentials: credentials)
         }
 }
 ```
@@ -187,10 +197,13 @@ Auth0
 You can add custom user information in the user metadata section by performing a `patch`:
 
 ```swift
+// ProfileViewController.swift
+
 let accessToken = ... // You will need the accessToken from your credentials instance 'credentials.accessToken'
 let profile = ... // the Profile instance you obtained accessing the `/userinfo` endpoint.
+
 Auth0
-    .users(token: "user-scoped access token")
+    .users(token: accessToken)
     .patch(profile.sub, userMetadata: ["country": "United Kingdom"])
     .start { result in
         switch result {
@@ -206,15 +219,18 @@ Auth0
 ## Retrieve User Metadata
 
 The `user_metadata` dictionary contains fields related to the user profile.
-You can specify the fields you want to retrieve, or use an empty array `[]` to pull back the full user profile. 
+You can specify the fields you want to retrieve, or use an empty array `[]` to pull back the full user profile.
 
 Retrieving the `user_metadata` dictionary:
 
 ```swift
+// ProfileViewController.swift
+
 let accessToken = ... // You will need the accessToken from your credentials instance 'credentials.accessToken'
 let profile = ... // the Profile instance you obtained accessing the `/userinfo` endpoint.
+
 Auth0
-    .users(token: "user-scoped access token")
+    .users(token: accessToken)
     .get(profile.sub, fields: ["user_metadata"], include: true)
     .start { result in
         switch result {

--- a/articles/quickstart/native/ios-swift/04-calling-apis.md
+++ b/articles/quickstart/native/ios-swift/04-calling-apis.md
@@ -13,7 +13,7 @@ contentType: tutorial
 useCase: quickstart
 ---
 
-Auth0 provides a set of tools for protecting your resources with end-to-end authentication in your application. 
+Auth0 provides a set of tools for protecting your resources with end-to-end authentication in your application.
 
 In this tutorial, you'll learn how to get a token, attach it to a request (using the authorization header), and call any API you need to authenticate with.
 
@@ -37,6 +37,7 @@ Depending on the standards in your API, you configure the authorization header d
 
 ```swift
 // HomeViewController.swift
+
 let APIIdentifier = "API_IDENTIFIER" // Replace with the API Identifier value you created
 
 Auth0
@@ -68,6 +69,7 @@ let url = URL(string: "your api url")! // Set to your Protected API URL
 var request = URLRequest(url: url)
 
 request.addValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+
 let task = URLSession.shared.dataTask(with: request) { data, response, error in
     // Parse the response
 }

--- a/articles/quickstart/native/ios-swift/05-authorization.md
+++ b/articles/quickstart/native/ios-swift/05-authorization.md
@@ -3,17 +3,17 @@ title: Authorization
 description: This tutorial will show you how assign roles to your users, and use those claims to authorize or deny a user to perform certain actions in the app.
 budicon: 500
 topics:
-  - quickstarts
-  - native
-  - ios
-  - swift
+    - quickstarts
+    - native
+    - ios
+    - swift
 github:
-  path: 05-Authorization
+    path: 05-Authorization
 contentType: tutorial
 useCase: quickstart
 ---
 
-Many identity providers supply access claims which contain, for example, user roles or groups. You can request the access claims in your token with `scope: openid roles` or `scope: openid groups`.
+Many identity providers supply access claims which contain, for example, user roles or groups. You can request the access claims in your token with `.scope("openid roles")` or `.scope("openid groups")`.
 
 If an identity provider does not supply this information, you can create a rule for assigning roles to users.
 
@@ -29,13 +29,13 @@ Edit the following line from the default script to match the conditions that fit
 
 ```js
 function (user, context, callback) {
-
   // Roles should only be set to verified users.
   if (!user.email || !user.email_verified) {
     return callback(null, user, context);
   }
 
   user.app_metadata = user.app_metadata || {};
+
   // You can add a Role based on what you want
   // In this case I check domain
   const addRolesToUser = function(user) {
@@ -48,8 +48,8 @@ function (user, context, callback) {
   };
 
   const roles = addRolesToUser(user);
-
   user.app_metadata.roles = roles;
+
   auth0.users.updateAppMetadata(user.user_id, user.app_metadata)
     .then(function() {
       context.idToken['https://example.com/roles'] = user.app_metadata.roles;
@@ -66,7 +66,7 @@ The rule is checked every time a user attempts to authenticate.
 * If the user has a valid email and the domain is `example.com`, the user gets the admin and user roles.
 * If the email contains anything else, the user gets the regular user role.
 
-The claim is saved in the ID Token under the name `https://access.control/roles`.
+The claim is saved in the ID Token under the name `https://example.com/roles`.
 
 ::: note
 Depending on your needs, you can define roles other than admin and user. Read about the names you give your claims in the [Rules documentation](/rules#hello-world).
@@ -81,11 +81,12 @@ import JWTDecode
 ```
 
 ```swift
-guard
-    let idToken = self.keychain.string(forKey: "id_token"),
+guard let idToken = self.keychain.string(forKey: "id_token"),
     let jwt = try? decode(jwt: idToken),
-    let roles = jwt.claim(name: "https://example.com/roles").array
-    else { // Couldn't retrieve claim }
+    let roles = jwt.claim(name: "https://example.com/roles").array else {
+    // Couldn't retrieve claim
+    return
+}
 
 if roles.contains("admin") {
     // Access Granted

--- a/articles/quickstart/native/ios-swift/07-linking-accounts.md
+++ b/articles/quickstart/native/ios-swift/07-linking-accounts.md
@@ -3,10 +3,10 @@ title: Linking Accounts
 description: This tutorial will show you how to link multiple accounts within the same user.
 budicon: 345
 topics:
-  - quickstarts
-  - native
-  - ios
-  - swift
+    - quickstarts
+    - native
+    - ios
+    - swift
 github:
     path: 07-Linking-Accounts
 contentType: tutorial
@@ -16,14 +16,14 @@ useCase: quickstart
 ## Before You Start
 
 Before you continue with this tutorial, make sure that you have completed the previous tutorials. This tutorial assumes that:
-* You have integrated [Auth0.swift](https://github.com/auth0/Auth0.swift/) as a dependency in your project. 
+* You have integrated [Auth0.swift](https://github.com/auth0/Auth0.swift/) as a dependency in your project.
 * You are familiar with presenting the login screen. To learn more, see the [Login](/quickstart/native/ios-swift/00-login) and the [User Sessions](/quickstart/native/ios-swift/03-user-sessions) tutorials.
 
 We recommend that you read the [Linking Accounts](/link-accounts) documentation to understand the process of linking accounts.
 
 ## Enter Account Credentials
 
-Your users may want to link their other accounts to the account they are logged in to. 
+Your users may want to link their other accounts to the account they are logged in to.
 
 To achieve this, present an additional login dialog where your users can enter the credentials for any additional account. You can present this dialog in the way described in the [Login](/quickstart/native/ios-swift/00-login#enter-account-credentials) tutorial.
 
@@ -37,6 +37,10 @@ import Auth0
 
 ```swift
 // UserIdentitiesViewController.swift
+
+let id = ... // the user id. (See profile.sub)
+let accessToken = ... // the user accessToken
+let otherUserToken = ... // the idToken from the secondary account
 
 Auth0
     .users(token: accessToken)
@@ -58,14 +62,17 @@ Once you have the `sub` value from the profile, you can retrieve user identities
 ```swift
 // SessionManager.swift
 
+let id = ... // the user id. (See profile.sub)
+let accessToken = ... // the user accessToken
+
 Auth0
-    .users(token: idToken)
-    .get(profile.sub, fields: ["identities"], include: true)
+    .users(token: accessToken)
+    .get(id, fields: ["identities"], include: true)
     .start { result in
         switch result {
         case .success(let user):
             let identityValues = user["identities"] as? [[String: Any]] ?? []
-            let identities = identityValues.flatMap { Identity(json: $0) }
+            let identities = identityValues.compactMap { Identity(json: $0) }
         case .failure(let error):
             // Handle error
         }
@@ -86,6 +93,7 @@ Unlink the accounts:
 let id = ... // the user id. (See profile.sub)
 let accessToken = ... // the user accessToken
 let identity: Identity = ... // the identity (account) you want to unlink from the user
+
 Auth0
     .users(token: accessToken)
     .unlink(identityId: identity.identifier, provider: identity.provider, fromUserId: id)

--- a/articles/quickstart/native/ios-swift/08-touch-id-authentication.md
+++ b/articles/quickstart/native/ios-swift/08-touch-id-authentication.md
@@ -3,13 +3,13 @@ title: Touch ID Authentication
 description: This tutorial will show you how to use Touch ID and the Credentials Manager.
 budicon: 345
 topics:
-  - quickstarts
-  - native
-  - ios
-  - swift
-  - touch-id
+    - quickstarts
+    - native
+    - ios
+    - swift
+    - touch-id
 github:
-  path: 08-Credentials-TouchID
+    path: 08-Credentials-TouchID
 contentType: tutorial
 useCase: quickstart
 ---
@@ -17,13 +17,13 @@ useCase: quickstart
 ## Before You Start
 
 Before you continue with this tutorial, make sure that you have completed the previous tutorials. This tutorial assumes that:
-* You have integrated [Auth0.swift](https://github.com/auth0/Auth0.swift/) as a dependency in your project. 
+* You have integrated [Auth0.swift](https://github.com/auth0/Auth0.swift/) as a dependency in your project.
 * You are familiar with presenting the login screen. To learn more, see the [Login](/quickstart/native/ios-swift/00-login) tutorial.
 * You know how to renew a user's credentials with a Refresh Token. To learn more, see the [User Sessions](/quickstart/native/ios-swift/03-user-sessions) tutorial.
 
 ## Apply Touch ID Authentication
 
-This tutorial shows you how to renew the user's credentials without presenting the user with the login page. Additionally, the guide shows you how to use Touch ID to validate the renewal. 
+This tutorial shows you how to renew the user's credentials without presenting the user with the login page. Additionally, the guide shows you how to use Touch ID to validate the renewal.
 
 This tutorial covers how to use the [credentials manager](https://github.com/auth0/Auth0.swift/blob/master/Auth0/CredentialsManager.swift) utility in [Auth0.swift](https://github.com/auth0/Auth0.swift/) to streamline the management of user credentials and Touch ID.
 
@@ -76,7 +76,7 @@ When the user logs in, the credentials object is encrypted and stored securely i
 
 ## Renew the User's Credentials
 
-To automatically renew the user's credentials, use the [credentials](https://github.com/auth0/Auth0.swift/blob/master/Auth0/CredentialsManager.swift#L98) method in the credentials manager. 
+To automatically renew the user's credentials, use the [credentials](https://github.com/auth0/Auth0.swift/blob/master/Auth0/CredentialsManager.swift#L98) method in the credentials manager.
 
 The credentials manager retrieves stored credentials from the keychain and checks if the Access Token is still valid:
 * If the current credentials are still valid, the credentials manager returns them
@@ -100,14 +100,14 @@ self.credentialsManager.credentials { error, credentials in
 After the line that initialized the credentials manager, add a line that enables Touch ID:
 
 ```swift
-self.credentialsManager.enableTouchAuth(withTitle: "Touch to Authenticate")
+self.credentialsManager.enableBiometrics(withTitle: "Touch to Authenticate")
 ```
 
 Next time you call the `credentials` method, the user will be prompted for their Touch ID with a "Touch to Authenticate" message.
 
 ## Improve the User Experience
 
-If the user has logged out and you have cleared the credentials from the credentials manager, for example, with the following: 
+If the user has logged out and you have cleared the credentials from the credentials manager, for example, with the following:
 
 ```swift
 self.credentialsManager.clear()

--- a/articles/quickstart/native/ios-swift/_includes/_login_centralized.md
+++ b/articles/quickstart/native/ios-swift/_includes/_login_centralized.md
@@ -66,7 +66,7 @@ com.company.myapp://company.auth0.com/ios/com.company.myapp/callback
 [Universal Login](/hosted-pages/login) is the easiest way to set up authentication in your application. We recommend using it for the best experience, best security and the fullest array of features.
 
 ::: note
-You can also embed the login dialog directly in your application using the [Lock widget](/lock). If you use this method, some features, such as single sign-on, will not be accessible. 
+You can also embed the login dialog directly in your application using the [Lock widget](/lock). If you use this method, some features, such as single sign-on, will not be accessible.
 To learn how to embed the Lock widget in your application, follow the [Embedded Login sample](https://github.com/auth0-samples/auth0-ios-swift-sample/tree/embedded-login/01-Embedded-Login). Make sure you read the [Browser-Based vs. Native Login Flows on Mobile Devices](/tutorials/browser-based-vs-native-experience-on-mobile) article to learn how to choose between the two types of login flows.
 :::
 
@@ -76,7 +76,7 @@ To learn how to embed the Lock widget in your application, follow the [Embedded 
 
 ## Add the Callback
 
-For Auth0 to handle the authentication callback, update your `AppDelegate` file. 
+For Auth0 to handle the authentication callback, update your `AppDelegate` file.
 
 First, import the `Auth0` module:
 
@@ -112,16 +112,17 @@ To learn more about the `credentials` object, read the [Credentials](https://git
 
 <%= include('../../../../_includes/_logout_url') %>
 
-## Implement logout
+## Implement Logout
+
 To clear the session on the server side you need to invoke the `clearSession` method. Add the following snippet:
 
 ```swift
 // HomeViewController.swift
-@swift
+
 Auth0
     .webAuth()
-    .clearSession(federated:false){
-        switch $0{
+    .clearSession(federated:false) {
+        switch $0 {
             case true:
                 ...
             case false:
@@ -139,5 +140,5 @@ Go to your [Dashboard Settings](${manage_url}/#/applications/${account.clientId}
 After the call, the callback will receive a BOOL with the logout status.
 
 ::: note
-Replace `{PRODUCT_BUNDLE_IDENTIFIER}` with your application's Bundle Identifier , available as the `Bundle Identifier` attribute inside the `identity`, on your `app project` properties.
+Replace `{PRODUCT_BUNDLE_IDENTIFIER}` with your application's Bundle Identifier, available as the `Bundle Identifier` attribute inside the `Identity` section, on your app project properties.
 :::

--- a/articles/quickstart/native/ios-swift/_includes/_product_bundle_note.md
+++ b/articles/quickstart/native/ios-swift/_includes/_product_bundle_note.md
@@ -1,3 +1,3 @@
 ::: note
-Replace `{PRODUCT_BUNDLE_IDENTIFIER}` with your application's Bundle Identifier , available as the `Bundle Identifier` attribute inside the `identity`, on your `app project` properties.
+Replace `{PRODUCT_BUNDLE_IDENTIFIER}` with your application's Bundle Identifier, available as the `Bundle Identifier` attribute inside the `Identity` section, on your app project properties.
 :::


### PR DESCRIPTION
This PR fixes a series of issues in the Swift Quickstart, from deprecated method calls to formatting mishaps and typos.

See the list of issues addressed in [this spreadsheet](https://docs.google.com/spreadsheets/d/1bWrIhLP29DXz_l5aps8icdILXYxw4EOQooYoWRxXZ5k/edit?usp=sharing).
