### PR TITLE
[SDK-735] Reworded include to remove reference to access tokens in cookies

### DIFF
--- a/articles/quickstart/spa/_includes/_calling_api_access_token.md
+++ b/articles/quickstart/spa/_includes/_calling_api_access_token.md
@@ -1,8 +1,3 @@
-To give the authenticated user access to secured resources in your API, include the user's Access Token in the requests you send to your API. 
-There are two common ways to do this. 
-* Store the Access Token in a cookie. The Access Token is then included in all requests. 
-* Send `access_token` in the `Authorization` header using the `Bearer` scheme. 
+<!-- markdownlint-disable MD041 -->
 
-::: note
-The examples below use the `Bearer` scheme.
-:::
+To give the authenticated user access to secured resources in your API, include the user's Access Token in the requests you send to your API. One common way to do this is to send `access_token` in the `Authorization` header using the `Bearer` scheme. This is the method used in the examples below.


### PR DESCRIPTION
Reworded include to remove reference to access tokens in cookies. There are many reasons for not recommending that the tokens are transmitted using cookies and there are a number of security reasons to recommend sending the token in the `Authorization` header instead.

This PR tidies up that recommendation, which makes sense when you also consider that the only quickstart that uses this include (AngularJS) demonstrates the header method anyway.