### PR TITLE
Deploy connections

### DIFF
--- a/articles/extensions/bitbucket-deploy.md
+++ b/articles/extensions/bitbucket-deploy.md
@@ -115,6 +115,10 @@ __facebook.json__
 }
 ```
 
+::: note
+The `enabled_clients` array, when used directly with the Management API v2, is a list of client IDs for which the connection is enabled. As an added convenience, the deployment extension will attempt to match entries in the `enabled_clients` array by client name and replace them with the appropriate client ID when a match is found, allowing you to specify `"my-client-name"` instead of `"my-client-id"` to refer to each application.
+:::
+
 _This will work only for non-Auth0 connections (`strategy !== auth0`); for Auth0 connections, use `database-connections`._
 
 For more info on the allowed attributes for connections, see the [Post Connections endpoint] (/api/management/v2#!/Connections/post_connections).

--- a/articles/extensions/bitbucket-deploy.md
+++ b/articles/extensions/bitbucket-deploy.md
@@ -226,6 +226,10 @@ __my-client-api.json__
 }
 ```
 
+::: note
+The deployment extension accepts an application name instead of the client ID in the `client_id` property. It will try to match the name to an existing application before creating the Client Grant.
+:::
+
 ### Deploy Resource Servers
 
 To deploy a resource server, you must create a JSON file under the `resource-servers` directory of your Bitbucket repository. Example:

--- a/articles/extensions/github-deploy.md
+++ b/articles/extensions/github-deploy.md
@@ -236,6 +236,10 @@ __my-client-api.json__
 }
 ```
 
+::: note
+The deployment extension accepts an application name instead of the client ID in the `client_id` property. It will try to match the name to an existing application before creating the Client Grant.
+:::
+
 ### Deploy Resource Servers
 
 To deploy a resource server, you must create a JSON file under the `resource-servers` directory of your GitHub repository. Example:

--- a/articles/extensions/github-deploy.md
+++ b/articles/extensions/github-deploy.md
@@ -125,6 +125,10 @@ __facebook.json__
 }
 ```
 
+::: note
+The `enabled_clients` array, when used directly with the Management API v2, is a list of client IDs for which the connection is enabled. As an added convenience, the deployment extension will attempt to match entries in the `enabled_clients` array by client name and replace them with the appropriate client ID when a match is found, allowing you to specify `"my-client-name"` instead of `"my-client-id"` to refer to each application.
+:::
+
 _This will work only for non-Auth0 connections (`strategy !== auth0`); for Auth0 connections, use `database-connections`._
 
 See [Management API v2 Docs](https://auth0.com/docs/api/management/v2#!/Connections/post_connections) for more info on allowed attributes for Connections.

--- a/articles/extensions/gitlab-deploy.md
+++ b/articles/extensions/gitlab-deploy.md
@@ -268,6 +268,10 @@ __my-client-api.json__
 }
 ```
 
+::: note
+The deployment extension accepts an application name instead of the client ID in the `client_id` property. It will try to match the name to an existing application before creating the Client Grant.
+:::
+
 ### Deploy Resource Servers
 
 To deploy a resource server, you must create a JSON file under the `resource-servers` directory of your GitLab repository. Example:

--- a/articles/extensions/gitlab-deploy.md
+++ b/articles/extensions/gitlab-deploy.md
@@ -148,6 +148,10 @@ __facebook.json__
 }
 ```
 
+::: note
+The `enabled_clients` array, when used directly with the Management API v2, is a list of client IDs for which the connection is enabled. As an added convenience, the deployment extension will attempt to match entries in the `enabled_clients` array by client name and replace them with the appropriate client ID when a match is found, allowing you to specify `"my-client-name"` instead of `"my-client-id"` to refer to each application.
+:::
+
 _This will work only for non-Auth0 connections (`strategy !== auth0`); for Auth0 connections, use `database-connections`._
 
 See [Management API v2 Docs](https://auth0.com/docs/api/management/v2#!/Connections/post_connections) for more info on allowed attributes for Connections.

--- a/articles/extensions/visual-studio-team-services-deploy.md
+++ b/articles/extensions/visual-studio-team-services-deploy.md
@@ -153,6 +153,10 @@ __facebook.json__
 }
 ```
 
+::: note
+The `enabled_clients` array, when used directly with the Management API v2, is a list of client IDs for which the connection is enabled. As an added convenience, the deployment extension will attempt to match entries in the `enabled_clients` array by client name and replace them with the appropriate client ID when a match is found, allowing you to specify `"my-client-name"` instead of `"my-client-id"` to refer to each application.
+:::
+
 _This will work only for non-Auth0 connections (`strategy !== auth0`), for Auth0 connections, use `database-connections`._
 
 See [Management API v2 Docs](https://auth0.com/docs/api/management/v2#!/Connections/post_connections) for more info on allowed attributes for Connections.

--- a/articles/extensions/visual-studio-team-services-deploy.md
+++ b/articles/extensions/visual-studio-team-services-deploy.md
@@ -272,6 +272,10 @@ __my-client-api.json__
 }
 ```
 
+::: note
+The deployment extension accepts an application name instead of the client ID in the `client_id` property. It will try to match the name to an existing application before creating the Client Grant.
+:::
+
 ### Deploy Resource Servers
 
 To deploy a resource server, you must create a JSON file under the `resource-servers` directory of your Visual Studio Team Services project. Example:


### PR DESCRIPTION
Clarifies where the deployment extensions accept a client name instead of a client ID.