### PR TITLE
Fix Objective C Quickstart issues [QS-411]

### DIFF
--- a/articles/quickstart/native/ios-objc/04-calling-apis.md
+++ b/articles/quickstart/native/ios-objc/04-calling-apis.md
@@ -13,7 +13,7 @@ contentType: tutorial
 useCase: quickstart
 ---
 
-Auth0 provides a set of tools for protecting your resources with end-to-end authentication in your application. 
+Auth0 provides a set of tools for protecting your resources with end-to-end authentication in your application.
 
 This tutorial shows you how to get an Access Token, attach it to a request with an authorization header and call an API. We recommend you use this method for the best security and compliance with RFC standards.
 
@@ -29,21 +29,20 @@ Before you continue with this tutorial, make sure that you have completed the pr
 
 To retrieve an Access Token that is authorized to access your API, you need to specify the **API Identifier** value you created in the [Auth0 APIs Dashboard](https://manage.auth0.com/#/apis).
 
-Present the Hosted Login Page:
+Present the login page:
 
 ```objc
 // HomeViewController.m
 
 HybridAuth *auth = [[HybridAuth alloc] init];
-[auth showLoginWithScope:@"openid profile" connection:nil audience:"API_IDENTIFIER" callback:^(NSError * _Nullable error, A0Credentials * _Nullable credentials) {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        if (error) {
-            NSLog(@"Error: %@", error);
-        } else if (credentials) {
-          // Do something with credentials such as save them.
-          // Auth0 will dismiss itself automatically by default.
-        }
-    });
+
+[auth showLoginWithScope:@"openid profile" connection:nil audience:@"API_IDENTIFIER" callback:^(NSError * _Nullable error, A0Credentials * _Nullable credentials) {
+    if (error) {
+        NSLog(@"Error: %@", error);
+    } else if (credentials) {
+        // Do something with credentials such as save them.
+        // Auth0 will dismiss itself automatically by default.
+    }
 }];
 ```
 
@@ -60,12 +59,13 @@ To attach an Access Token to a request:
 ```objc
 // ProfileViewController.m
 
-NSString* token = ... // The accessToken you stored after authentication
+NSString *token = ... // The accessToken you stored after authentication
 NSString *url = @"https://localhost/api"; // Set to your Protected API URL
 NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:url]];
 // Configure your request here (method, body, and so on)
 
 [request addValue:[NSString stringWithFormat:@"Bearer %@", token] forHTTPHeaderField:@"Authorization"];
+
 [[[NSURLSession sharedSession] dataTaskWithRequest:request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
     // Parse the response
 }] resume];
@@ -73,7 +73,7 @@ NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:[NSURL U
 
 ### Sample project configuration
 
-When you are testing the sample project, configure your URL request in the `ProfileViewController.swift` file:
+When you are testing the sample project, configure your URL request in the `ProfileViewController.m` file:
 
 ```objc
 // ProfileViewController.m

--- a/articles/quickstart/native/ios-objc/05-authorization.md
+++ b/articles/quickstart/native/ios-objc/05-authorization.md
@@ -15,7 +15,7 @@ useCase: quickstart
 
 Many identity providers supply access claims which contain, for example, user roles or groups. You can request the access claims in your token with `showLoginWithScope:@"openid roles"` or `showLoginWithScope:@"openid groups"`.
 
-If an identity provider does not supply this information, you can create a rule for assigning roles to users.
+If an identity provider does not supply this information, you can [create a Rule](https://auth0.com/docs/rules)  for assigning roles to users.
 
 ## Create a Rule to Assign Roles
 

--- a/articles/quickstart/native/ios-objc/05-authorization.md
+++ b/articles/quickstart/native/ios-objc/05-authorization.md
@@ -13,29 +13,36 @@ contentType: tutorial
 useCase: quickstart
 ---
 
-Many identity providers supply access claims which contain, for example, user roles or groups. You can request the access claims in your token with `scope: openid roles` or `scope: openid groups`.
+Many identity providers supply access claims which contain, for example, user roles or groups. You can request the access claims in your token with `showLoginWithScope:@"openid roles"` or `showLoginWithScope:@"openid groups"`.
 
-If an identity provider does not supply this information, you can create a rule for assigning roles to users. 
+If an identity provider does not supply this information, you can create a rule for assigning roles to users.
 
 ## Create a Rule to Assign Roles
 
-Create a rule that assigns the following access roles to your user: 
+Create a rule that assigns the following access roles to your user:
 * An admin role
 * A regular user role
 
-To assign roles, go to the [New rule](${manage_url}/#/rules/new) page. In the **Access Control** section, select the **Set roles to a user** template. 
+To assign roles, go to the [New rule](${manage_url}/#/rules/new) page. In the **Access Control** section, select the **Set roles to a user** template.
 
-Edit the following line from the default script to match the conditions that fit your needs:
+Edit the following lines from the default script to match the conditions that fit your needs:
 
+```js
+const addRolesToUser = function (user) {
+    const endsWith = '@example.com';
+
+    if (user.email && (user.email.substring(user.email.length - endsWith.length, user.email.length) === endsWith)) {
+      return ['admin'];
+    }
+    return ['user'];
+};
 ```
-if (user.email.indexOf('@example.com') > -1)
-```
 
-The rule is checked every time a user attempts to authenticate. 
+The rule is checked every time a user attempts to authenticate.
 
 * If the user has a valid email and the domain is `@example.com`, the user gets the admin role.
 * If the email contains anything else, the user gets the regular user role.
- 
+
 ::: note
 Depending on your needs, you can define roles other than admin and user. Read about the names you give your claims in the [Rules documentation](/rules#hello-world).
 :::
@@ -47,21 +54,23 @@ ${snippet(meta.snippets.setup)}
 ```objc
 // ProfileViewController.m
 
-NSString *userId = ... // the id of the user, available in profile.sub
+NSString *accessToken = ... // the user accessToken
+NSString *userId = ... // the id of the user, available in 'profile.sub'
 HybridAuth *auth = [[HybridAuth alloc] init];
-[auth userProfileWithIdToken:idToken userId:userId callback:^(NSError * _Nullable error, NSDictionary<NSString *, id> * _Nullable user) {
-  if (error) {
-    // Handle error
-  } else {
-     NSDictionary *metaData = [user objectForKey:@"app_metadata"];
-     NSArray *roles = [metaData objectForKey:@"roles"];
-     if (![roles containsObject:@"admin"]) {
-        // Not an admin user, access denied.
-     } else {
-        // Admin user, grant access
-        [self performSegueWithIdentifier:@"AdminSegue" sender:nil];
-     }
-   }
+
+[auth userProfileWithAccessToken:accessToken userId:userId callback:^(NSError * _Nullable error, NSDictionary<NSString *, id> * _Nullable user) {
+    if (error) {
+        // Handle error
+    } else {
+        NSDictionary *metaData = [user objectForKey:@"app_metadata"];
+        NSArray *roles = [metaData objectForKey:@"roles"];
+
+        if (![roles containsObject:@"admin"]) {
+            // Not an admin user, access denied.
+        } else {
+            // Admin user, grant access
+        }
+    }
 }];
 ```
 

--- a/articles/quickstart/native/ios-objc/07-linking-accounts.md
+++ b/articles/quickstart/native/ios-objc/07-linking-accounts.md
@@ -16,14 +16,14 @@ useCase: quickstart
 ## Before You Start
 
 Before you continue with this tutorial, make sure that you have completed the previous tutorials. This tutorial assumes that:
-* You have integrated [Auth0.swift](https://github.com/auth0/Auth0.swift/) as a dependency in your project. 
+* You have integrated [Auth0.swift](https://github.com/auth0/Auth0.swift/) as a dependency in your project.
 * You are familiar with presenting the login screen. To learn more, see the [Login](/quickstart/native/ios-objc/00-login) and the [User Sessions](/quickstart/native/ios-objc/03-user-sessions) tutorials.
 
 We recommend that you read the [Linking Accounts](/link-accounts) documentation to understand the process of linking accounts.
 
 ## Enter Account Credentials
 
-Your users may want to link their other accounts to the account they are logged in to. 
+Your users may want to link their other accounts to the account they are logged in to.
 
 To achieve this, present an additional login dialog where your users can enter the credentials for any additional account. You can present this dialog as described in the [Login](/quickstart/native/ios-objc/00-login#implement-the-login) tutorial.
 
@@ -38,16 +38,17 @@ To link accounts:
 ```objc
 // ProfileViewController.m
 
-NSString *id = ... // the id of the user, available in profile.sub
 NSString *accessToken = ... // the user's accessToken
+NSString *id = ... // the id of the user, available in 'profile.sub'
 NSString *otherUserToken = ... // the idToken from the account you want to link the user with
+
 [auth linkUserAccountWithAccessToken:accessToken userId:id otherAccountToken:otherUserToken
-      callback:^(NSError * _Nullable error, NSArray<NSDictionary<NSString *,id> *> * _Nullable payload) {
-          if (error) {
-              // Handler Error
-          } else {
-              // Success account was linked
-          }
+    callback:^(NSError * _Nullable error, NSArray<NSDictionary<NSString *,id> *> * _Nullable payload) {
+    if (error) {
+        // Handle error
+    } else {
+        // Success account was linked
+    }
 }];
 ```
 
@@ -59,11 +60,13 @@ Once you have the `id` value from the `profile.sub`, you can retrieve user ident
 // HomeViewController.m
 
 HybridAuth *auth = [[HybridAuth alloc] init];
-[auth userProfileWithIdToken:idToken userId:id callback:^(NSError * _Nullable error, NSDictionary<NSString *, id> * _Nullable user) {
+
+[auth userProfileWithAccessToken:accessToken userId:id callback:^(NSError * _Nullable error, NSDictionary<NSString *, id> * _Nullable user) {
     if (error) {
         // Handle error
     } else {
         NSArray *identities = [[NSArray alloc] init];
+
         for (NSDictionary *identity in [user objectForKey:@"identities"]) {
            identities = [identities arrayByAddingObject:[[A0Identity alloc] initWithJson:identity]];
         }
@@ -81,9 +84,11 @@ Unlink the accounts:
 
 ```objc
 // ProfileViewController.m
-NSString *id = ... // the id of the user, available in profile.sub
+
 NSString *accessToken = ... // the user accessToken
+NSString *id = ... // the id of the user, available in 'profile.sub'
 A0Identity *identity = ... // the identity (account) you want to unlink from the user
+
 [auth unlinkUserAccountWithAccessToken:accessToken userId:id identity:identity callback:^(NSError * _Nullable error, NSArray<NSDictionary<NSString *,id> *> * _Nullable payload) {
     if (error) {
         // Handle Error

--- a/articles/quickstart/native/ios-objc/_includes/_login_centralized.md
+++ b/articles/quickstart/native/ios-objc/_includes/_login_centralized.md
@@ -56,7 +56,7 @@ Go to your [Dashboard Settings](${manage_url}/#/applications/${account.clientId}
 [Universal Login](/hosted-pages/login) is the easiest way to set up authentication in your application. We recommend using it for the best experience, best security and the fullest array of features.
 
 ::: note
-You can also embed the login dialog directly in your application using the [Lock widget](/lock). If you use this method, some features, such as single sign-on, will not be accessible. 
+You can also embed the login dialog directly in your application using the [Lock widget](/lock). If you use this method, some features, such as single sign-on, will not be accessible.
 To learn how to embed the Lock widget in your application, follow the [Embedded Login sample](https://github.com/auth0-samples/auth0-ios-objc-sample/tree/embedded-login/01-Embedded-Login).
 :::
 
@@ -72,13 +72,9 @@ Read the [Browser-Based vs. Native Login Flows on Mobile Devices](/tutorials/bro
 
 # Add the Callback
 
-For Auth0 to handle the authentication callback, update your `AppDelegate` file. 
+For Auth0 to handle the authentication callback, update your `AppDelegate` file. Add the following `UIApplicationDelegate` method:
 
-${snippet(meta.snippets.setup)}
-
-Then, add the following `UIApplicationDelegate` method:
-
-```swift
+```objc
 // AppDelegate.m
 
 - (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
@@ -88,44 +84,42 @@ Then, add the following `UIApplicationDelegate` method:
 
 # Implement Login
 
-${snippet(meta.snippets.setup)}
-
-Then, present the hosted login screen:
+Create a new `HybridAuth` instance. Then, present the login page:
 
 ```objc
 // HomeViewController.m
 
 HybridAuth *auth = [[HybridAuth alloc] init];
+
 [auth showLoginWithScope:@"openid" connection:nil callback:^(NSError * _Nullable error, A0Credentials * _Nullable credentials) {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        if (error) {
-            NSLog(@"Error: %@", error);
-        } else if (credentials) {
-          // Do something with credentials, such as save them.
-          // Auth0 will dismiss itself automatically by default.
-        }
-    });
+    if (error) {
+        NSLog(@"Error: %@", error);
+    } else if (credentials) {
+        // Do something with credentials, such as save them.
+        // Auth0 will dismiss itself automatically by default.
+    }
 }];
 ```
 
-After the user authenticates, their information is returned in a `credentials` object.
+After the user authenticates, their information is returned in a `Credentials` object.
 
 ::: note
-To learn more about the `credentials` object, read the [Credentials](https://github.com/auth0/Auth0.swift/blob/master/Auth0/Credentials.swift) article.
+To learn more about the `Credentials` object, read the [Credentials](https://github.com/auth0/Auth0.swift/blob/master/Auth0/Credentials.swift) article.
 :::
 
 <%= include('../../../../_includes/_logout_url') %>
 
-## Implement logout
+## Implement Logout
 To clear the session on the server side you need to invoke the `clearSession` method. Add the following snippet:
 
 ```swift
 // HybridAuth.swift
+
 @objc
-func logOutUser(callback: @escaping(Bool) -> Void){
+func logOutUser(callback: @escaping(Bool) -> Void) {
     Auth0
         .webAuth()
-        .clearSession(federated: true){
+        .clearSession(federated: true) {
             callback($0)
         }
 }


### PR DESCRIPTION
This PR fixes a series of issues in the Objective C Quickstart, from deprecated method calls to formatting mishaps and typos.

See the list of issues addressed in [this spreadsheet](https://docs.google.com/spreadsheets/d/1bWrIhLP29DXz_l5aps8icdILXYxw4EOQooYoWRxXZ5k/edit?usp=sharing).

[Accompanying samples PR.](https://github.com/auth0-samples/auth0-ios-swift-sample/pull/66)