### PR TITLE
Fix Swift Quickstart issues [QS-410]

### DIFF
--- a/articles/quickstart/native/ios-swift/03-user-sessions.md
+++ b/articles/quickstart/native/ios-swift/03-user-sessions.md
@@ -112,7 +112,7 @@ credentialsManager.revoke { error in
 
 ## Retrieve the User Profile
 
-To get the user's profile, you need a valid Access Token. You can find the token in the `credentials` object returned by the credentials manager.
+To get the user's profile, you need a valid Access Token. You can find the token in the `Credentials` object returned by the credentials manager.
 
 ```swift
 // SessionManager.swift

--- a/articles/quickstart/native/ios-swift/05-authorization.md
+++ b/articles/quickstart/native/ios-swift/05-authorization.md
@@ -15,7 +15,7 @@ useCase: quickstart
 
 Many identity providers supply access claims which contain, for example, user roles or groups. You can request the access claims in your token with `.scope("openid roles")` or `.scope("openid groups")`.
 
-If an identity provider does not supply this information, you can create a rule for assigning roles to users.
+If an identity provider does not supply this information, you can [create a Rule](https://auth0.com/docs/rules) for assigning roles to users.
 
 ## Create a Rule to Assign Roles
 

--- a/articles/quickstart/native/ios-swift/05-authorization.md
+++ b/articles/quickstart/native/ios-swift/05-authorization.md
@@ -25,40 +25,17 @@ Create a rule that assigns the following access roles to your user:
 
 To assign roles, go to the [New rule](${manage_url}/#/rules/new) page. In the **Access Control** section, select the **Set roles to a user** template.
 
-Edit the following line from the default script to match the conditions that fit your needs:
+Edit the following lines from the default script to match the conditions that fit your needs:
 
 ```js
-function (user, context, callback) {
-  // Roles should only be set to verified users.
-  if (!user.email || !user.email_verified) {
-    return callback(null, user, context);
-  }
-
-  user.app_metadata = user.app_metadata || {};
-
-  // You can add a Role based on what you want
-  // In this case I check domain
-  const addRolesToUser = function(user) {
+const addRolesToUser = function (user) {
     const endsWith = '@example.com';
 
     if (user.email && (user.email.substring(user.email.length - endsWith.length, user.email.length) === endsWith)) {
       return ['admin'];
     }
     return ['user'];
-  };
-
-  const roles = addRolesToUser(user);
-  user.app_metadata.roles = roles;
-
-  auth0.users.updateAppMetadata(user.user_id, user.app_metadata)
-    .then(function() {
-      context.idToken['https://example.com/roles'] = user.app_metadata.roles;
-      callback(null, user, context);
-    })
-    .catch(function (err) {
-      callback(err);
-    });
-}
+};
 ```
 
 The rule is checked every time a user attempts to authenticate.

--- a/articles/quickstart/native/ios-swift/08-touch-id-authentication.md
+++ b/articles/quickstart/native/ios-swift/08-touch-id-authentication.md
@@ -113,7 +113,7 @@ If the user has logged out and you have cleared the credentials from the credent
 self.credentialsManager.clear()
 ```
 
-The user is still prompted for their touch ID. This returns an error in the `credentials` closure because there are no credentials to renew from.
+The user is still prompted for their Touch ID. This returns an error in the `credentials` closure because there are no credentials to renew from.
 
 The credentials manager has a `hasValid()` method that lets you know if there are valid credentials that can be returned directly or renewed and returned.
 

--- a/articles/quickstart/native/ios-swift/_includes/_login_centralized.md
+++ b/articles/quickstart/native/ios-swift/_includes/_login_centralized.md
@@ -104,10 +104,10 @@ ${snippet(meta.snippets.use)}
 
 This adds the `profile` scope to enable [retrieving the User Profile](/quickstart/native/ios-swift/03-user-sessions#fetch-the-user-profile).
 
-After the user authenticates, their information is returned in a `credentials` object.
+After the user authenticates, their information is returned in a `Credentials` object.
 
 ::: note
-To learn more about the `credentials` object, read the [Credentials](https://github.com/auth0/Auth0.swift/blob/master/Auth0/Credentials.swift) article.
+To learn more about the `Credentials` object, read the [Credentials](https://github.com/auth0/Auth0.swift/blob/master/Auth0/Credentials.swift) article.
 :::
 
 <%= include('../../../../_includes/_logout_url') %>


### PR DESCRIPTION
- Limited the JavaScript code snippet to the relevant lines that the user would have to change, instead of including the whole default script. 
- Fixed a typo.
- The `Credentials` object mentions were properly cased to match the Objective C Quickstart.