### PR TITLE
Add redirect for MFA troubleshooting

### DIFF
--- a/config/redirects.js
+++ b/config/redirects.js
@@ -758,8 +758,8 @@ module.exports = [
     ],
     to: '/multifactor-authentication'
   },
-    {
-    from: '/multifactor-authentication/google-auth/user-guide#troubleshooting',
+  {
+    from: '/multifactor-authentication/google-auth/user-guide',
     to: '/multifactor-authentication/troubleshooting'
   },
   {

--- a/config/redirects.js
+++ b/config/redirects.js
@@ -758,6 +758,10 @@ module.exports = [
     ],
     to: '/multifactor-authentication'
   },
+    {
+    from: '/multifactor-authentication/google-auth/user-guide#troubleshooting',
+    to: '/multifactor-authentication/troubleshooting'
+  },
   {
     from: '/multi-factor-authentication/yubikey',
     to: '/multifactor-authentication/yubikey'


### PR DESCRIPTION
Per #docs.

When you go to this URL:
https://docs-content-staging-pr-8541.herokuapp.com/docs/multifactor-authentication/google-auth/user-guide#troubleshooting

It should now take you here (rather than break):
https://docs-content-staging-pr-8541.herokuapp.com/docs/multifactor-authentication/troubleshooting#troubleshooting
