### PR TITLE
Add redirect for broken link

### DIFF
--- a/config/redirects.js
+++ b/config/redirects.js
@@ -2320,5 +2320,9 @@ module.exports = [
     {
       from: '/connections/passwordless/faq',
       to: '/connections/passwordless/reference/troubleshoot'
+    },
+    {
+    from: '/best-practices/custom-db-connections-scripts',
+    to: '/best-practices/custom-db-connections'
     }
 ];


### PR DESCRIPTION
This:
https://docs-content-staging-pr-8548.herokuapp.com/docs/best-practices/custom-db-connections-scripts

Should redirects here:
https://docs-content-staging-pr-8548.herokuapp.com/docs/best-practices/custom-db-connections
