### PR TITLE
Add scope param to first config object.

### DIFF
--- a/articles/quickstart/webapp/php/01-login.md
+++ b/articles/quickstart/webapp/php/01-login.md
@@ -46,9 +46,7 @@ $auth0 = new Auth0([
   'client_id' => '${account.clientId}',
   'client_secret' => 'YOUR_CLIENT_SECRET',
   'redirect_uri' => '${account.callback}',
-  'persist_id_token' => true,
-  'persist_access_token' => true,
-  'persist_refresh_token' => true,
+  'scope' => 'openid profile email',
 ]);
 ```
 


### PR DESCRIPTION
Based on [feedback from community](https://community.auth0.com/t/php-crash-issue-when-reloading-link-the-following-day/34739).