### PR TITLE
Fix instantiation of mysql connection

### DIFF
--- a/articles/connections/database/custom-db/templates/change-password.md
+++ b/articles/connections/database/custom-db/templates/change-password.md
@@ -325,7 +325,7 @@ function changePassword(email, newPassword, callback) {
 
 ```sql
 function changePassword (email, newPassword, callback) {
-  var connection = mysql({
+  var connection = mysql.createConnection({
     host     : 'localhost',
     user     : 'me',
     password : 'secret',

--- a/articles/connections/database/custom-db/templates/create.md
+++ b/articles/connections/database/custom-db/templates/create.md
@@ -407,7 +407,7 @@ function create (user, callback) {
 
 ```sql
 function create(user, callback) {
-  var connection = mysql({
+  var connection = mysql.createConnection({
     host: 'localhost',
     user: 'me',
     password: 'secret',

--- a/articles/connections/database/custom-db/templates/delete.md
+++ b/articles/connections/database/custom-db/templates/delete.md
@@ -186,7 +186,7 @@ function remove (id, callback) {
 ```
 function remove (id, callback) {
 
-  var connection = mysql({
+  var connection = mysql.createConnection({
     host     : 'localhost',
     user     : 'me',
     password : 'secret',

--- a/articles/connections/database/custom-db/templates/login.md
+++ b/articles/connections/database/custom-db/templates/login.md
@@ -431,7 +431,7 @@ function login(email, password, callback) {
 
 ```sql
 function login(email, password, callback) {
-  var connection = mysql({
+  var connection = mysql.createConnection({
     host: 'localhost',
     user: 'me',
     password: 'secret',

--- a/articles/connections/database/custom-db/templates/verify.md
+++ b/articles/connections/database/custom-db/templates/verify.md
@@ -265,7 +265,7 @@ function verify (email, callback) {
 
 ```
 function verify (email, callback) {
-  var connection = mysql({
+  var connection = mysql.createConnection({
     host     : 'localhost',
     user     : 'me',
     password : 'secret',


### PR DESCRIPTION
This PR goes hand in hand with https://github.com/auth0/db-connections-templates/pull/27

Our existing custom db script template for mysql is not using the `mysql.createConnection()` constructor to instantiate a mysql connection. The PR mentioned above fixes that, and this PR updates our docs accordingly.