### PR TITLE
Fix typo in _centralized_login.md

### DIFF
--- a/articles/quickstart/spa/react/_includes/_centralized_login.md
+++ b/articles/quickstart/spa/react/_includes/_centralized_login.md
@@ -419,7 +419,7 @@ const PrivateRoute = ({ component: Component, path, ...rest }) => {
 export default PrivateRoute;
 ```
 
-This component takes another component as one of its arguments. It makes use of the [`useEffect` hook](https://reactjs.org/docs/hooks-effect.html) to redirect to the user to the login page if they are not yet authenticated.
+This component takes another component as one of its arguments. It makes use of the [`useEffect` hook](https://reactjs.org/docs/hooks-effect.html) to redirect the user to the login page if they are not yet authenticated.
 
 If the user is authenticated, the redirect will not take place and the component that was specified as the argument will be rendered instead. In this way, components that require the user to be logged in can be protected simply by wrapping the component using `PrivateRoute`.
 


### PR DESCRIPTION
Fix typo (incorrectly placed "to") under the "Secure the Profile Page" section.
"redirect to the user to the login page" -> "redirect the user to the login page"

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors
- Please include a short description
- If your PR is a work in progress, title it [DO NOT MERGE]
--->
