### PR TITLE
Fix on Lock 11 config sample

### DIFF
--- a/articles/libraries/lock/v11/configuration.md
+++ b/articles/libraries/lock/v11/configuration.md
@@ -577,7 +577,7 @@ If you don't specify a `validator` the text field will be **required**. If you w
 ```js
 var options = {
   additionalSignUpFields: [{
-    name: "favorite color",
+    name: "favorite_color",
     placeholder: "Enter your favorite color (optional)",
     validator: function() { 
       return true;


### PR DESCRIPTION
`additionalSignUpFields` cant have names with spaces in them, this attempts to map to a db field, which doesn't allow spaces.
