### PR TITLE
Fix link to connection status doc

### DIFF
--- a/articles/api/management/v2/changes.md
+++ b/articles/api/management/v2/changes.md
@@ -73,7 +73,7 @@ This document describes the major differences between Auth0's Management API v1 
 | [PUT /api/connections/{connection-name}](/api/v1#!#put--api-connections--connection-name-) | Not available. Changed `connection-name` to `id`. | [PATCH /api/v2/connections/{id}](/api/v2#!/Connections/patch_connections_by_id) |
 | [DELETE /api/connections/{connection-name}](/api/v1#!#delete--api-connections--connection-name-) | Changed `connection-name` to `id`. | [DELETE /api/v2/clients/{id}](/api/v2#!/Connections/delete_connections_by_id) |
 | [GET /api/connections/{connection}/users](/api/v1) | None. | [GET /api/v2/users](/api/v2#!/Users/get_users) (see note) |
-| [GET /api/connections/{connection}/socket](/api/v1) | None. | [GET /api/v2/connections/{id}/status](/api/v2#!/Connections/get_connection_status_by_id) |
+| [GET /api/connections/{connection}/socket](/api/v1) | None. | [GET /api/v2/connections/{id}/status](/api/v2#!/Connections/get_status) |
 
 ::: note
 For Private Cloud (search_engine:v2), use `q=identities.connection:"connection_name"`


### PR DESCRIPTION
The link to the `GET /api/v2/connections/{id}/status` endpoint points to 
https://auth0.com/docs/api/management/v2#!/Connections/get_connection_status_by_id that does not exist. 

Instead, it should point to https://auth0.com/docs/api/management/v2#!/Connections/get_status