### PR TITLE
Clarifying What the User Should See When Testing

### DIFF
--- a/articles/identity-labs/04-single-page-app/exercise-01.md
+++ b/articles/identity-labs/04-single-page-app/exercise-01.md
@@ -285,7 +285,7 @@ If you log in using a social identity provider (Google, Facebook, etc.), you wil
 For more information, see [Test Social Connections with Auth0 Developer Keys](https://auth0.com/docs/connections/social/devkeys).
 :::
 
-If you want to test the `allowAccess()` function, which restricts access for particular routes depending on whether the user is authenticated, try navigating to [localhost:5000/#expenses](http://localhost:5000/#expenses). If you are logged in, the page will load successfully (the content for this page will be implemented in the next exercise). If you are not logged in, the app will redirect you to the homepage.
+If you want to test the `allowAccess()` function, which restricts access for particular routes depending on whether the user is authenticated, try navigating to [localhost:5000/#expenses](http://localhost:5000/#expenses). If you are logged in, the page will load successfully showing a "Loading..." text (the content for this page will be implemented in the next exercise). If you are not logged in, the app will redirect you to the homepage.
 
 25. Let's explore the relevant network traces of the authentication process used in this lab. First, click the **Log Out** button, then, once you return to the app with your session ended, open Chrome's **Developer Tools** and go to the **Network** tab.
 


### PR DESCRIPTION
After completing step 24, the documentation says that the "expenses" page should load successfully. It does load successfully but the pages displays the text, "loading...". This is slightly confusing since an indefinite loading text hints at something is not working. I think it is worth it to specify to the user that the page will open successfully AND they can expect to see the loading text.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors
- Please include a short description
- If your PR is a work in progress, title it [DO NOT MERGE]
--->
