### PR TITLE
Added link to default login url docs

### DIFF
--- a/articles/email/templates.md
+++ b/articles/email/templates.md
@@ -143,7 +143,7 @@ The **Redirect To** URL is an optional destination to redirect the user to after
 ::: panel Redirect URLs
 With the Classic Experience, you can provide a URL to which users are redirected after they reset their password. Auth0 sends a success indicator and a message to the URL.
 
-With the New Experience, Auth0 redirects users to the default log in route when the user succeeds in resetting the password. If not, Auth0 handles the errors as part of the Universal Login flow and ignores the redirect URL provided in the email template.
+With the New Experience, Auth0 redirects users to the [default log in route](/universal-login/default-login-url) when the user succeeds in resetting the password. If not, Auth0 handles the errors as part of the Universal Login flow and ignores the redirect URL provided in the email template.
 :::
 
 **Only the following three variables** are available on the **Redirect To** URL:


### PR DESCRIPTION
User was confused because it wasn't explicitly called out what default login route is how to define it https://community.auth0.com/t/reset-password-success-screen-is-a-dead-end/35967/6?u=ashish

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors
- Please include a short description
- If your PR is a work in progress, title it [DO NOT MERGE]
--->
