### PR TITLE
Retired obj-c quickstart

### DIFF
--- a/config/redirects.js
+++ b/config/redirects.js
@@ -89,8 +89,8 @@ module.exports = [
     to: '/quickstart/native/ionic'
   },
   {
-    from: ['/ios-tutorial', '/native-platforms/ios-objc'],
-    to: '/quickstart/native/ios-objc'
+    from: ['/ios-tutorial', '/native-platforms/ios-objc', '/quickstart/native/ios-objc'],
+    to: '/quickstart/native/ios-swift'
   },
   {
     from: '/java-tutorial',


### PR DESCRIPTION
This creates a redirect for ios-objc to swift