### PR TITLE
Update Java Regular Webapp Quickstarts 

### DIFF
--- a/articles/quickstart/webapp/java-ee/_includes/_login.md
+++ b/articles/quickstart/webapp/java-ee/_includes/_login.md
@@ -171,7 +171,7 @@ public class Auth0AuthenticationMechanism implements HttpAuthenticationMechanism
         // Exchange the code for the ID token, and notify container of result.
         if (isCallbackRequest(httpServletRequest)) {
             try {
-                Tokens tokens = authenticationController.handle(httpServletRequest);
+                Tokens tokens = authenticationController.handle(httpServletRequest, httpServletResponse);
                 Auth0JwtCredential auth0JwtCredential = new Auth0JwtCredential(tokens.getIdToken());
                 CredentialValidationResult result = identityStoreHandler.validate(auth0JwtCredential);
                 return httpMessageContext.notifyContainerAboutLogin(result);
@@ -230,7 +230,7 @@ public class LoginServlet extends HttpServlet {
         );
 
         // Create the authorization URL to redirect the user to, to begin the authentication flow.
-        String authURL = authenticationController.buildAuthorizeUrl(request, callbackUrl)
+        String authURL = authenticationController.buildAuthorizeUrl(request, response, callbackUrl)
                 .withScope(config.getScope())
                 .build();
 

--- a/articles/quickstart/webapp/java-ee/_includes/_setup.md
+++ b/articles/quickstart/webapp/java-ee/_includes/_setup.md
@@ -16,7 +16,7 @@ If you are using Maven, add these dependencies to your `pom.xml`:
 <dependency>
     <groupId>com.auth0</groupId>
     <artifactId>mvc-auth-commons</artifactId>
-    <version>(1.0,2.0)</version>
+    <version>[1.0, 2.0)</version>
 </dependency>
 <dependency>
     <groupId>javax</groupId>

--- a/articles/quickstart/webapp/java-spring-mvc/_includes/_login.md
+++ b/articles/quickstart/webapp/java-spring-mvc/_includes/_login.md
@@ -87,26 +87,26 @@ public class AuthController {
                 .build();
     }
 
-    public Tokens handle(HttpServletRequest request) throws IdentityVerificationException {
-        return controller.handle(request);
+    public Tokens handle(HttpServletRequest request, HttpServletResponse response) throws IdentityVerificationException {
+        return controller.handle(request, response);
     }
 
-    public String buildAuthorizeUrl(HttpServletRequest request, String redirectUri) {
-        return controller.buildAuthorizeUrl(request, redirectUri)
+    public String buildAuthorizeUrl(HttpServletRequest request, HttpServletResponse response, String redirectUri) {
+        return controller.buildAuthorizeUrl(request, response, redirectUri)
                 .build();
     }
 }
 ```
 
-To enable users to login, your application will redirect them to the [Universal Login](https://auth0.com/docs/universal-login) page. Using the `AuthenticationController` instance, you can generate the redirect URL by calling the `buildAuthorizeUrl(HttpServletRequest request, String redirectUrl)` method. The redirect URL must be the URL that was added to the **Allowed Callback URLs** of your Auth0 Application.
+To enable users to login, your application will redirect them to the [Universal Login](https://auth0.com/docs/universal-login) page. Using the `AuthenticationController` instance, you can generate the redirect URL by calling the `buildAuthorizeUrl(HttpServletRequest request, HttpServletResponse response, String redirectUrl)` method. The redirect URL must be the URL that was added to the **Allowed Callback URLs** of your Auth0 Application.
 
 ```java
 // src/main/java/com/auth0/example/LoginController.java
 
 @RequestMapping(value = "/login", method = RequestMethod.GET)
-protected String login(final HttpServletRequest req) {
+protected String login(final HttpServletRequest req, final HttpServletResponse res) {
     String redirectUrl = req.getScheme() + "://" + req.getServerName() + ":" + req.getServerPort() + "/callback";
-    String authorizeUrl = controller.buildAuthorizeUrl(req, redirectUrl);
+    String authorizeUrl = controller.buildAuthorizeUrl(req, res, redirectUrl);
     return "redirect:" + authorizeUrl;
 }
 ```
@@ -121,7 +121,7 @@ The request holds the call context that the library previously set by generating
 @RequestMapping(value = "/callback", method = RequestMethod.GET)
 protected void getCallback(final HttpServletRequest req, final HttpServletResponse res) throws ServletException, IOException {
   try {
-      Tokens tokens = controller.handle(req);
+      Tokens tokens = controller.handle(req, res);
       SessionUtils.set(req, "accessToken", tokens.getAccessToken());
       SessionUtils.set(req, "idToken", tokens.getIdToken());
       res.sendRedirect("/portal/home");
@@ -132,7 +132,7 @@ protected void getCallback(final HttpServletRequest req, final HttpServletRespon
 ```
 
 ::: note
-It it's recommended to store the time in which we requested the tokens and the received `expiresIn` value, so that the next time when we are going to use the token we can check if it has already expired or if it's still valid. For the sake of this sample, we will skip that validation.
+It's recommended to store the time in which we requested the tokens and the received `expiresIn` value, so that the next time when we are going to use the token we can check if it has already expired or if it's still valid. For the sake of this sample, we will skip that validation.
 :::
 
 ## Display the Home Page

--- a/articles/quickstart/webapp/java-spring-mvc/_includes/_login.md
+++ b/articles/quickstart/webapp/java-spring-mvc/_includes/_login.md
@@ -132,7 +132,7 @@ protected void getCallback(final HttpServletRequest req, final HttpServletRespon
 ```
 
 ::: note
-It's recommended to store the time in which we requested the tokens and the received `expiresIn` value, so that the next time when we are going to use the token we can check if it has already expired or if it's still valid. For the sake of this sample, we will skip that validation.
+It is recommended to store the time in which we requested the tokens and the received `expiresIn` value, so that the next time when we are going to use the token we can check if it has already expired or if it's still valid. For the sake of this sample, we will skip that validation.
 :::
 
 ## Display the Home Page

--- a/articles/quickstart/webapp/java-spring-security-mvc/_includes/_setup.md
+++ b/articles/quickstart/webapp/java-spring-security-mvc/_includes/_setup.md
@@ -23,7 +23,7 @@ If you are using Maven, add it to your `pom.xml`:
 <dependency>
   <groupId>com.auth0</groupId>
   <artifactId>mvc-auth-commons</artifactId>
-  <version>(1.0,2.0)</version>
+  <version>[1.0, 2.0)</version>
 </dependency>
 ```
 

--- a/articles/quickstart/webapp/java/_includes/_login.md
+++ b/articles/quickstart/webapp/java/_includes/_login.md
@@ -52,7 +52,7 @@ AuthenticationController controller = AuthenticationController.newBuilder(domain
                 .build();
 ```
 
-To enable users to login, your application will redirect them to the [Universal Login](https://auth0.com/docs/universal-login) page. Using the `AuthenticationController` instance, you can generate the redirect URL by calling the `buildAuthorizeUrl(HttpServletRequest request, String redirectUrl)` method. The redirect URL must be the URL that was added to the **Allowed Callback URLs** of your Auth0 Application.
+To enable users to login, your application will redirect them to the [Universal Login](https://auth0.com/docs/universal-login) page. Using the `AuthenticationController` instance, you can generate the redirect URL by calling the `buildAuthorizeUrl(HttpServletRequest request, HttpServletResponse response, String redirectUrl)` method. The redirect URL must be the URL that was added to the **Allowed Callback URLs** of your Auth0 Application.
 
 ```java
 // src/main/java/com/auth0/example/LoginServlet.java
@@ -65,7 +65,7 @@ protected void doGet(final HttpServletRequest req, final HttpServletResponse res
     }
     redirectUri += "/callback";
 
-    String authorizeUrl = authenticationController.buildAuthorizeUrl(req, redirectUri)
+    String authorizeUrl = authenticationController.buildAuthorizeUrl(req, res, redirectUri)
             .build();
     res.sendRedirect(authorizeUrl);
 }
@@ -91,7 +91,7 @@ public void doPost(HttpServletRequest req, HttpServletResponse res) throws IOExc
 private void handle(HttpServletRequest req, HttpServletResponse res) throws IOException {
     try {
         // Parse the request
-        Tokens tokens = authenticationController.handle(req);
+        Tokens tokens = authenticationController.handle(req, res);
         SessionUtils.set(req, "accessToken", tokens.getAccessToken());
         SessionUtils.set(req, "idToken", tokens.getIdToken());
         res.sendRedirect(redirectOnSuccess);

--- a/articles/quickstart/webapp/java/_includes/_setup.md
+++ b/articles/quickstart/webapp/java/_includes/_setup.md
@@ -24,7 +24,7 @@ If you are using Maven, add them to your `pom.xml`:
 <dependency>
   <groupId>com.auth0</groupId>
   <artifactId>mvc-auth-commons</artifactId>
-  <version>1.+</version>
+  <version>(1.0,2.0)</version>
 </dependency>
 <dependency>
   <groupId>javax.servlet</groupId>

--- a/articles/quickstart/webapp/java/_includes/_setup.md
+++ b/articles/quickstart/webapp/java/_includes/_setup.md
@@ -24,7 +24,7 @@ If you are using Maven, add them to your `pom.xml`:
 <dependency>
   <groupId>com.auth0</groupId>
   <artifactId>mvc-auth-commons</artifactId>
-  <version>(1.0,2.0)</version>
+  <version>[1.0, 2.0)</version>
 </dependency>
 <dependency>
   <groupId>javax.servlet</groupId>


### PR DESCRIPTION
Update the Java regular webapp Quickstarts to use the new APIs from auth0-java-mvc-commons:

* `AuthenticationController.buildAuthorizeUrl(request, response, redirectUri)`
* `AuthenticationController.handle(request, response)`

Related changes to the sample applications can be found here:
* https://github.com/auth0-samples/auth0-servlet-sample/pull/37
* https://github.com/auth0-samples/auth0-spring-mvc-sample/pull/36
* https://github.com/auth0-samples/auth0-spring-security-mvc-sample/pull/42
* https://github.com/auth0-samples/auth0-java-ee-sample/pull/2