### PR TITLE
Added note about Keychain items in Auth0.swift documentation

### DIFF
--- a/articles/libraries/auth0-swift/save-and-refresh-jwt-tokens.md
+++ b/articles/libraries/auth0-swift/save-and-refresh-jwt-tokens.md
@@ -43,6 +43,10 @@ Auth0
 }
 ```
 
+::: note
+The Keychain items do not get deleted after your app is uninstalled. We recommend to always clear all of your app's Keychain items on first launch.
+:::
+
 ### Credentials Check
 
 It can be useful to perform a quick sanity check that you have valid credentials stored in the manager. If not the user can then be directed to authenticate.


### PR DESCRIPTION
## Changes
Following up on the outcome of an internal discussion, this PR adds a note to the `Auth0.swift` documentation recommending the developers to always clear their app's Keychain items on first launch.

## References
- https://forums.developer.apple.com/message/112523#281900