### PR TITLE
[IPS-867] Remove rate limits plicy for /authorize

### DIFF
--- a/articles/policies/rate-limits.md
+++ b/articles/policies/rate-limits.md
@@ -215,16 +215,6 @@ If you obtain Access Tokens for your SPAs, note that there are rate limits that 
         <td>100 requests per second</td>
     </tr>
     <tr>
-        <td rowspan="2">Authentication and authorization</td>
-        <td rowspan="2"><code>/authorize</code></td>
-        <td>IP Address</td>
-        <td>500 requests per minute</td>
-    </tr>
-    <tr>
-        <td>Sessions</td>
-        <td>10 requests per second</td>
-    </tr>
-    <tr>
         <td rowspan="2">User Profile</td>
         <td><code>/tokeninfo</code> (Legacy)</td>
         <td>IP Address</td>
@@ -262,16 +252,6 @@ If you obtain Access Tokens for your SPAs, note that there are rate limits that 
         <th>Path</th>
         <th>Limited By</th>
         <th>Rate Limit</th>
-    </tr>
-    <tr>
-        <td rowspan="2">Authentication and authorization</td>
-        <td rowspan="2"><code>/authorize</code></td>
-        <td>IP Address</td>
-        <td>300 requests per minute</td>
-    </tr>
-    <tr>
-        <td>Sessions</td>
-        <td>10 requests per minute</td>
     </tr>
     <tr>
         <td rowspan="2">User Profile</td>

--- a/updates/2020-01-20.yml
+++ b/updates/2020-01-20.yml
@@ -1,0 +1,8 @@
+changed:
+  -
+    title: "API Rate Limits"
+    tags:
+      - api
+      - ratelimits
+    description: |
+      Updated the [Rate Limit Policy](/rate-limits) to remove limits on the `/authorize` path.


### PR DESCRIPTION
Removes information about rate limits on the `/authorize` endpoint from documentation. The limits are being reviewed and they are not being applied at the moment.

### 🔗 References
https://auth0team.atlassian.net/browse/IPS-867
