### PR TITLE
Update Custom DB Create Example to Match Default

### DIFF
--- a/articles/connections/database/custom-db/templates/create.md
+++ b/articles/connections/database/custom-db/templates/create.md
@@ -109,8 +109,31 @@ Auth0 provides sample scripts for use with the following languages/technologies:
 
 ```
 function create (user, callback) {
-  var msg = "Please implement the Create script for this database connection " +
-       "at https://manage.auth0.com/#/connections/database";
+  // This script should create a user entry in your existing database. It will
+  // be executed when a user attempts to sign up, or when a user is created
+  // through the Auth0 dashboard or API.
+  // When this script has finished executing, the Login script will be
+  // executed immediately afterwards, to verify that the user was created
+  // successfully.
+  //
+  // The user object will always contain the following properties:
+  // * email: the user's email
+  // * password: the password entered by the user, in plain text
+  // * tenant: the name of this Auth0 account
+  // * client_id: the client ID of the application where the user signed up, or
+  //              API key if created through the API or Auth0 dashboard
+  // * connection: the name of this database connection
+  //
+  // There are three ways this script can finish:
+  // 1. A user was successfully created
+  //     callback(null);
+  // 2. This user already exists in your database
+  //     callback(new ValidationError("user_exists", "my error message"));
+  // 3. Something went wrong while trying to reach your database
+  //     callback(new Error("my error message"));
+
+  const msg = 'Please implement the Create script for this database connection ' +
+    'at https://manage.auth0.com/#/connections/database';
   return callback(new Error(msg));
 }
 ```


### PR DESCRIPTION
Update javascript example to match what is under the Custom DB Create tab similar to how other pages show them.
https://docs-content-staging-pr-8683.herokuapp.com/docs/connections/database/custom-db/templates/create#javascript