### PR TITLE
Fix link 404 for JSON Web Token Structure

### DIFF
--- a/articles/architecture-scenarios/_includes/_api-signing-algorithms.md
+++ b/articles/architecture-scenarios/_includes/_api-signing-algorithms.md
@@ -3,7 +3,7 @@
 When you create an API you have to select the algorithm your tokens will be signed with. The signature is used to verify that the sender of the JWT is who it says it is and to ensure that the message wasn't changed along the way.
 
 ::: note
-The signature is part of a JWT. If you are not familiar with the JWT structure please refer to: [JSON Web Tokens (JWTs) in Auth0](/jwt#what-is-the-json-web-token-structure-).
+The signature is part of a JWT. If you are not familiar with the JWT structure please refer to: [JSON Web Token Structure](/tokens/references/jwt-structure).
 :::
 
 To create the signature part you have to take the encoded header, the encoded payload, a secret, the algorithm specified in the header, and sign that. That algorithm, which is part of the JWT header, is the one you select for your API: `HS256` or `RS256`.


### PR DESCRIPTION
The link in the screenshot is broken.
https://auth0.com/docs/architecture-scenarios/mobile-api/part-2#signing-algorithms
![image](https://user-images.githubusercontent.com/2281521/73394691-ebfb6100-4292-11ea-91d0-24313b46c184.png)
This PR is trying to have it fixed with the new link: https://auth0.com/docs/tokens/references/jwt-structure