### PR TITLE
SameSite breaking changes bandaid

### DIFF
--- a/articles/extensions/authorization-extension/v2/index.md
+++ b/articles/extensions/authorization-extension/v2/index.md
@@ -13,6 +13,11 @@ useCase: extensibility-extensions
 ---
 
 # Authorization Extension
+
+::: panel Breaking Changes
+No breaking changes to this extension exist for the most recent update released on January 30, 2020. For more info, see the [changelog](https://github.com/auth0/auth0-authorization-extension/blob/master/CHANGELOG.md).
+:::
+
 ::: note
 <%= include('../../../_includes/_rbac_methods') %>
 :::


### PR DESCRIPTION
Temporary band-aid. When users go to dashboard to upgrade extensions, dashboard needs to be updated to direct users to Github extension changelogs rather than to our docs for breaking changes. This is a band-aid since we just sent a mass customer email telling them to upgrade out, and we're getting feedback from worried customers who are being directed to our Authz extension docs to learn about breaking changes when no section for that content exists.

https://docs-content-staging-pr-8714.herokuapp.com/docs/extensions/authorization-extension/v2