### PR TITLE
Update application delegate methods for Lock.swift [SDK-1306]

### DIFF
--- a/articles/connections/passwordless/_old/ios-magic-link.md
+++ b/articles/connections/passwordless/_old/ios-magic-link.md
@@ -48,17 +48,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
-    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
         A0Lock.sharedLock().applicationLaunchedWithOptions(launchOptions)
         return true
     }
 
-    func application(application: UIApplication, openURL url: NSURL, sourceApplication: String?, annotation: AnyObject) -> Bool {
-        return A0Lock.sharedLock().handleURL(url, sourceApplication: sourceApplication)
+    func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
+        return A0Lock.sharedLock().handleURL(url, sourceApplication: app)
     }
 
-    func application(application: UIApplication, continueUserActivity userActivity: NSUserActivity, restorationHandler: ([AnyObject]?) -> Void) -> Bool {
-        return A0Lock.sharedLock().continueUserActivity(userActivity, restorationHandler:restorationHandler)
+    func application(_ application: NSApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([NSUserActivityRestoring]) -> Void) -> Bool {
+        return A0Lock.sharedLock().continueUserActivity(userActivity, restorationHandler: restorationHandler)
     }
 }
 

--- a/articles/connections/passwordless/_old/ios-magic-link.md
+++ b/articles/connections/passwordless/_old/ios-magic-link.md
@@ -57,7 +57,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return A0Lock.sharedLock().handleURL(url, sourceApplication: app)
     }
 
-    func application(_ application: NSApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([NSUserActivityRestoring]) -> Void) -> Bool {
+    func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
         return A0Lock.sharedLock().continueUserActivity(userActivity, restorationHandler: restorationHandler)
     }
 }

--- a/articles/libraries/lock-ios/v1/index.md
+++ b/articles/libraries/lock-ios/v1/index.md
@@ -119,21 +119,22 @@ Then call this method:
 lock.applicationLaunched(options: launchOptions)
 ```
 
-Lastly, you will need to handle the already registered custom scheme in your `AppDelegate`. To do so, override the `-application:openURL:sourceApplication:annotation:` method and add the following line:
+Lastly, you will need to handle the already registered custom scheme in your `AppDelegate`. To do so, override the `-application:openURL:options:` method and add the following line:
 
 **Objective C**:
 
 ```objc
-- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url sourceApplication:(NSString *)sourceApplication annotation:(id)annotation {
-    return [self.lock handleURL:url sourceApplication:sourceApplication];
+- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url
+            options:(NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options {
+    return [self.lock handleURL:url sourceApplication:app];
 }
 ```
 
 **Swift**:
 
 ```swift
-func application(_ application: UIApplication, open url: URL, sourceApplication: String?, annotation: Any) -> Bool {
-    return self.lock.handle(url, sourceApplication: sourceApplication)
+func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
+    return self.lock.handle(url, sourceApplication: app)
 }
 ```
 

--- a/articles/libraries/lock-ios/v1/use-your-own-ui.md
+++ b/articles/libraries/lock-ios/v1/use-your-own-ui.md
@@ -96,15 +96,15 @@ After that, you may want to save the user's token to be able to use them later, 
 
 2. Also add the following lines to your `AppDelegate` too
   ```objc
-  - (BOOL)application:(UIApplication *)application openURL:(NSURL *)url sourceApplication:(NSString *)sourceApplication annotation:(id)annotation {
-    A0Lock *lock = ... //Get your Lock instance
-    return [lock handleURL:url sourceApplication:sourceApplication];
+- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options {
+    A0Lock *lock = ... // Get your Lock instance
+    return [lock handleURL:url sourceApplication:app];
   }
   ```
   ```swift
-  func application(_ application: UIApplication, open url: URL, sourceApplication: String?, annotation: Any) -> Bool {
+  func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
     let lock = ... // Get your Lock instance
-    return lock.handle(url, sourceApplication: sourceApplication)
+    return lock.handle(url, sourceApplication: app)
   }
   ```
 

--- a/articles/libraries/lock-ios/v2/migration.md
+++ b/articles/libraries/lock-ios/v2/migration.md
@@ -70,15 +70,15 @@ In Lock v2, this is no longer required.
 In Lock v1 you'd add the following:
 
 ```swift
-func application(application: UIApplication, openURL url: NSURL, sourceApplication: String?, annotation: AnyObject?) -> Bool {
-  return A0Lock.shared().handle(url, sourceApplication: sourceApplication)
+func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
+  return A0Lock.shared().handle(url, sourceApplication: app)
 }
 ```
 
 In Lock v2 you need to instead use the following:
 
 ```swift
-func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any]) -> Bool {
+func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
   return Lock.resumeAuth(url, options: options)
 }
 ```

--- a/articles/quickstart/native/react-native/00-login.md
+++ b/articles/quickstart/native/react-native/00-login.md
@@ -107,11 +107,10 @@ In the file `ios/<YOUR PROJECT>/AppDelegate.m` add the following:
 ```objc
 #import <React/RCTLinkingManager.h>
 
-- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url
-  sourceApplication:(NSString *)sourceApplication annotation:(id)annotation
+- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url
+            options:(NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options
 {
-  return [RCTLinkingManager application:application openURL:url
-                      sourceApplication:sourceApplication annotation:annotation];
+  return [RCTLinkingManager application:app openURL:url options:options];
 }
 ```
 


### PR DESCRIPTION
## Changes

The `UIApplicationDelegate` method signatures have been updated to reflect the ones in Apple's documentation. Also the deprecated method calls have been replaced with the current ones.

## References

- [application(_:didFinishLaunchingWithOptions:)](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1622921-application)
- [application(_:continue:restorationHandler:)](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623072-application)
- [application(_:open:options:)](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623112-application)
- Closes https://github.com/auth0/react-native-auth0/issues/219