### PR TITLE
Breaking changes warning - Authz Ext

### DIFF
--- a/articles/extensions/authorization-extension/v2/index.md
+++ b/articles/extensions/authorization-extension/v2/index.md
@@ -15,9 +15,9 @@ useCase: extensibility-extensions
 # Authorization Extension
 
 ::: panel Breaking Changes
-Authorization Extension 2.6 contains breaking changes. If you are upgrading from a version <2.6, you must rotate your API Key and re-publish the rule on the Authorization Extension’s configuration page. Failing to do this will cause an “InvalidApiKey” error on rule execution. This results from the changed logic for storing and handling the API Key.
+Authorization Extension 2.6 contains breaking changes. If you are upgrading from a version before 2.6, you must rotate your API Key and re-publish the rule on the Authorization Extension’s configuration page. Failing to do this will cause an “InvalidApiKey” error on rule execution. This results from the changed logic for storing and handling the API Key.
 
-Upgrading from a version >= 2.6 doesn’t have breaking changes and requires no further action.
+Upgrades from version 2.6 or later do not have breaking changes and require no further action.
 :::
 
 ::: note

--- a/articles/extensions/authorization-extension/v2/index.md
+++ b/articles/extensions/authorization-extension/v2/index.md
@@ -15,28 +15,26 @@ useCase: extensibility-extensions
 # Authorization Extension
 
 ::: panel Breaking Changes
-Authorization Extension 2.6 contains breaking changes that result from changed logic for storing and handling the API Key. If you are upgrading from a version before 2.6, you must:
+Authorization Extension 2.6 contains breaking changes that result from changed logic for storing and handling the API Key; these require you to perform additional steps upon upgrade, as detailed below. Failing to complete these steps will result in an `InvalidApiKey` error on rule execution.
 
-**Upgrade the Authorization Extension**
+Upgrades from version 2.6 or later do not have breaking changes and require no further action. 
+
+**If you are upgrading from a version before 2.6, you must:**
+
+Upgrade the Authorization Extension
 
 1. Navigate to the [Extensions](${manage_url}/#/extensions) page in the [Auth0 Dashboard](${manage_url}), and click the **Installed Extensions** tab. 
-2. Locate **Auth0 Authorization**, click **Upgrade**, and confirm.
+2. Locate **Auth0 Authorization**, click **Upgrade**, and confirm. Wait for the upgrade to complete.
 
-    Wait for the upgrade to complete.
-
-**Rotate the extension's API Key**
+Rotate the extension's API Key
 
 1. Click on **Auth0 Authorization** to open the extension.
 2. From the dropdown menu in the top-right of the extension dashboard, select **Configuration**.
 3. Locate the **API Key** section, and click **Rotate**.
 
-**Republish the extension's Rule**
+Republish the extension's Rule
 
 1. Click **Publish Rule**.
-
-Failing to complete these steps will result in an `InvalidApiKey` error on rule execution.
-
-Upgrades from version 2.6 or later do not have breaking changes and require no further action.
 :::
 
 ::: note

--- a/articles/extensions/authorization-extension/v2/index.md
+++ b/articles/extensions/authorization-extension/v2/index.md
@@ -15,7 +15,9 @@ useCase: extensibility-extensions
 # Authorization Extension
 
 ::: panel Breaking Changes
-No breaking changes to this extension exist for the most recent update released on January 30, 2020. For more info, see the [changelog](https://github.com/auth0/auth0-authorization-extension/blob/master/CHANGELOG.md).
+Authorization Extension 2.6 contains breaking changes. If you are upgrading from a version <2.6, you must rotate your API Key and re-publish the rule on the Authorization Extension’s configuration page. Failing to do this will cause an “InvalidApiKey” error on rule execution. This results from the changed logic for storing and handling the API Key.
+
+Upgrading from a version >= 2.6 doesn’t have breaking changes and requires no further action.
 :::
 
 ::: note

--- a/articles/extensions/authorization-extension/v2/index.md
+++ b/articles/extensions/authorization-extension/v2/index.md
@@ -15,7 +15,26 @@ useCase: extensibility-extensions
 # Authorization Extension
 
 ::: panel Breaking Changes
-Authorization Extension 2.6 contains breaking changes. If you are upgrading from a version before 2.6, you must rotate your API Key and re-publish the rule on the Authorization Extension’s configuration page. Failing to do this will cause an “InvalidApiKey” error on rule execution. This results from the changed logic for storing and handling the API Key.
+Authorization Extension 2.6 contains breaking changes that result from changed logic for storing and handling the API Key. If you are upgrading from a version before 2.6, you must:
+
+**Upgrade the Authorization Extension**
+
+1. Navigate to the [Extensions](${manage_url}/#/extensions) page in the [Auth0 Dashboard](${manage_url}), and click the **Installed Extensions** tab. 
+2. Locate **Auth0 Authorization**, click **Upgrade**, and confirm.
+
+    Wait for the upgrade to complete.
+
+**Rotate the extension's API Key**
+
+1. Click on **Auth0 Authorization** to open the extension.
+2. From the dropdown menu in the top-right of the extension dashboard, select **Configuration**.
+3. Locate the **API Key** section, and click **Rotate**.
+
+**Republish the extension's Rule**
+
+1. Click **Publish Rule**.
+
+Failing to complete these steps will result in an `InvalidApiKey` error on rule execution.
 
 Upgrades from version 2.6 or later do not have breaking changes and require no further action.
 :::


### PR DESCRIPTION
Authz extension didn't go according to plan. This warning explains breaking changes for users.

https://docs-content-staging-pr-8730.herokuapp.com/docs/extensions/authorization-extension/v2