### PR TITLE
Added instructions for SSL Certificate field in Cloudfront setup.

### DIFF
--- a/articles/custom-domains/set-up-cloudfront.md
+++ b/articles/custom-domains/set-up-cloudfront.md
@@ -35,7 +35,7 @@ You can configure AWS CloudFront for use as the reverse proxy with custom domain
   | Origin ID | A description for the origin. This value lets you distinguish between multiple origins in the same distribution and therefore must be unique. |
   | Origin Protocol Policy | Set to `HTTPS Only` |
   | Alternate Domain Names (CNAMEs) | Set to your custom domain name (the same one your configured in the Auth0 Dashboard) |
-  | SSL Certificate | Set to the SSL Certificate for your domain stored in AWS Certificate Manager (ACM) in the US East(N. Virginia) Region or in IAM. |
+  | SSL Certificate | Set to the SSL Certificate for your custom domain stored in AWS Certificate Manager (ACM) in the US East(N. Virginia) Region or in IAM. |
 
   ![Create Distribution](/media/articles/custom-domains/aws/create-distribution.png)
 

--- a/articles/custom-domains/set-up-cloudfront.md
+++ b/articles/custom-domains/set-up-cloudfront.md
@@ -35,6 +35,7 @@ You can configure AWS CloudFront for use as the reverse proxy with custom domain
   | Origin ID | A description for the origin. This value lets you distinguish between multiple origins in the same distribution and therefore must be unique. |
   | Origin Protocol Policy | Set to `HTTPS Only` |
   | Alternate Domain Names (CNAMEs) | Set to your custom domain name (the same one your configured in the Auth0 Dashboard) |
+  | SSL Certificate | Set to the SSL Certificate for your domain stored in AWS Certificate Manager (ACM) in the US East(N. Virginia) Region or in IAM. |
 
   ![Create Distribution](/media/articles/custom-domains/aws/create-distribution.png)
 


### PR DESCRIPTION
The setting up Cloudfront as a reverse proxy instructions don't explicitly mention setting the SSL Certificate option.  This setting must you used to provide a certificate for the domain you specify in the Alternate Domain Names (CNAMEs) setting.
