### PR TITLE
Updated minimum Express version for Express webapp quickstart

### DIFF
--- a/articles/quickstart/webapp/express/index.yml
+++ b/articles/quickstart/webapp/express/index.yml
@@ -22,4 +22,4 @@ github:
   branch: master
 requirements:
   - NodeJS 10.13+
-  - Express 4.16+
+  - Express 4.17+


### PR DESCRIPTION
Relates to https://github.com/auth0/express-openid-connect/pull/63