### PR TITLE
Update .NET Core 3.0 to .NET Core 3.1

### DIFF
--- a/articles/quickstart/webapp/aspnet-core-3/index.yml
+++ b/articles/quickstart/webapp/aspnet-core-3/index.yml
@@ -1,4 +1,4 @@
-title: ASP.NET Core v3.0
+title: ASP.NET Core v3.1
 image: /media/platforms/asp.png
 author:
   name: Damien Guard
@@ -12,7 +12,7 @@ snippets:
   dependencies: server-platforms/aspnet-core/dependencies
 alias:
   - aspnetcore
-  - aspnetcore-3.0
+  - aspnetcore-3.1
 seo_alias: aspnet-core
 default_article: 01-login
 articles:
@@ -25,10 +25,10 @@ github:
   repo: auth0-aspnetcore-mvc-samples
   branch: master
 requirements:
-  - .NET Core SDK 3.0.101
-  - .NET Core 3.0.1
-  - ASP.NET Core 3.0.1
-  - Visual Studio 2019 16.3 or Visual Studio Code (Optional)
+  - .NET Core SDK 3.1.101
+  - .NET Core 3.1.1
+  - ASP.NET Core 3.1.1
+  - Visual Studio 2019 16.4, Visual Studio for Mac 8.4, or Visual Studio Code + C# for Visual Studio Code 1.21.10
 sample_download_required_data:
   - client
 next_steps:


### PR DESCRIPTION
.NET Core 3.0 is EOL'ing next month and 3.1 is not a breaking change so switching the quickstart over to 3.1