### PR TITLE
Adding client_secret to the refresh token request

### DIFF
--- a/articles/flows/guides/device-auth/includes/refresh-tokens.md
+++ b/articles/flows/guides/device-auth/includes/refresh-tokens.md
@@ -30,6 +30,10 @@ To refresh your token, make a `POST` request to the `/oauth/token` endpoint in t
         "value": "${account.clientId}"
       },
       {
+        "name": "client_secret",
+        "value": "${account.clientSecret}"
+      },
+      {
         "name": "refresh_token",
         "value": "YOUR_REFRESH_TOKEN"
       }
@@ -44,6 +48,7 @@ To refresh your token, make a `POST` request to the `/oauth/token` endpoint in t
 |-----------------|-------------|
 | `grant_type`    | Set this to "refresh_token". |
 | `client_id`     | Your application's Client ID. You can find this value in your [Application Settings](${manage_url}/#/Applications/${account.clientId}/settings). |
+| `client_secret` | Your application's Client Secret. You can find this value in your [Application Settings](${manage_url}/#/Applications/${account.clientSecret}/settings). |
 | `refresh_token` | The Refresh Token to use. |
 | `scope`         | (Optional) A space-delimited list of requested scope permissions. If not sent, the original scopes will be used; otherwise you can request a reduced set of scopes. Note that this must be URL encoded. |
 


### PR DESCRIPTION
Is necessary to pass the client_secret to the refresh token request or otherwise the response will be unauthorized.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors
- Please include a short description
- If your PR is a work in progress, title it [DO NOT MERGE]
--->
