### PR TITLE
Fix documentation param name

### DIFF
--- a/articles/connections/passwordless/guides/embedded-login-webapps.md
+++ b/articles/connections/passwordless/guides/embedded-login-webapps.md
@@ -34,7 +34,7 @@ Below we list a few code snippets that can be used to call these API endpoints f
   }],
   "postData": {
     "mimeType": "application/json",
-    "text": "{\"client_id\": \"${account.clientId}\", \"client_client_secret\": \"YOUR_CLIENT_SECRET\", \"connection\": \"email\", \"email\": \"USER_EMAIL\",\"send\": \"code\"}"
+    "text": "{\"client_id\": \"${account.clientId}\", \"client_secret\": \"YOUR_CLIENT_SECRET\", \"connection\": \"email\", \"email\": \"USER_EMAIL\",\"send\": \"code\"}"
   }
 }
 ```
@@ -51,7 +51,7 @@ Below we list a few code snippets that can be used to call these API endpoints f
   }],
   "postData": {
     "mimeType": "application/json",
-    "text": "{\"client_id\": \"${account.clientId}\", \"client_client_secret\": \"YOUR_CLIENT_SECRET\", \"connection\": \"sms\", \"phone_number\": \"USER_PHONE_NUMBER\",\"send\": \"code\"}"
+    "text": "{\"client_id\": \"${account.clientId}\", \"client_secret\": \"YOUR_CLIENT_SECRET\", \"connection\": \"sms\", \"phone_number\": \"USER_PHONE_NUMBER\",\"send\": \"code\"}"
   }
 }
 ```
@@ -68,7 +68,7 @@ Below we list a few code snippets that can be used to call these API endpoints f
   }],
   "postData": {
     "mimeType": "application/json",
-    "text": "{\"grant_type\": \"http://auth0.com/oauth/grant-type/passwordless/otp\", \"client_id\": \"${account.clientId}\", \"client_client_secret\": \"YOUR_CLIENT_SECRET\", \"username\": \"USER_PHONE_NUMBER\", \"otp\": \"code\", \"realm\": \"sms\", \"audience\": \"your-api-audience\",\"scope\": \"opend profile email\"}"
+    "text": "{\"grant_type\": \"http://auth0.com/oauth/grant-type/passwordless/otp\", \"client_id\": \"${account.clientId}\", \"client_secret\": \"YOUR_CLIENT_SECRET\", \"username\": \"USER_PHONE_NUMBER\", \"otp\": \"code\", \"realm\": \"sms\", \"audience\": \"your-api-audience\",\"scope\": \"opend profile email\"}"
   }
 }
 ```
@@ -85,7 +85,7 @@ Below we list a few code snippets that can be used to call these API endpoints f
   }],
   "postData": {
     "mimeType": "application/json",
-    "text": "{\"grant_type\": \"http://auth0.com/oauth/grant-type/passwordless/otp\", \"client_id\": \"${account.clientId}\", \"client_client_secret\": \"YOUR_CLIENT_SECRET\", \"username\": \"USER_EMAIL\", \"otp\": \"code\", \"realm\": \"email\", \"audience\": \"your-api-audience\", \"scope\": \"opend profile email\"}"}
+    "text": "{\"grant_type\": \"http://auth0.com/oauth/grant-type/passwordless/otp\", \"client_id\": \"${account.clientId}\", \"client_secret\": \"YOUR_CLIENT_SECRET\", \"username\": \"USER_EMAIL\", \"otp\": \"code\", \"realm\": \"email\", \"audience\": \"your-api-audience\", \"scope\": \"opend profile email\"}"}
 }
 ```
 


### PR DESCRIPTION
The article was referring to a `client_client_secret` parameter