### PR TITLE
[QS-436] Update router location on Vue.JS quickstart docs

### DIFF
--- a/articles/quickstart/spa/vuejs/02-calling-an-api.md
+++ b/articles/quickstart/spa/vuejs/02-calling-an-api.md
@@ -181,14 +181,14 @@ export default {
 Modify the Vue router to include a route to this new page whenever the `/external-api` URL is accessed:
 
 ```js
-// src/router.js
+// src/router/index.js
 
 // .. other imports
 
 // NEW - import the view for calling the API
-import ExternalApiView from "./views/ExternalApi.vue";
+import ExternalApiView from "../views/ExternalApi.vue";
 
-const router = new Router({
+const router = new VueRouter({
   mode: "history",
   base: process.env.BASE_URL,
   routes: [

--- a/articles/quickstart/spa/vuejs/_includes/_centralized_login.md
+++ b/articles/quickstart/spa/vuejs/_includes/_centralized_login.md
@@ -326,13 +326,13 @@ To display the profile information, create a new file called `Profile.vue` in th
 
 You will add a route to this Profile component so that the user may access it via the UI and the navigation bar. In the next section, you will protect this route from unauthenticated users.
 
-To access the profile page, open the `router.js` file and import the `Profile` component. Then, modify the routes list so that the `Profile` component is mapped to `/profile`, as in the following example:
+To access the profile page, open the `router/index.js` file and import the `Profile` component. Then, modify the routes list so that the `Profile` component is mapped to `/profile`, as in the following example:
 
 ```js
 //.. other imports
 
 // NEW - Import the profile component
-import Profile from "./views/Profile.vue";
+import Profile from "../views/Profile.vue";
 
 const router = new VueRouter({
   mode: 'history',
@@ -416,14 +416,14 @@ Notice that in the call to `loginWithRedirect`, the URL that the user was trying
 To see how the `targetUrl` property is used to navigate the user once they have authenticated, revisit the <a href="#create-a-vue-plugin">Create a Vue Plugin</a> section again and inspect how the plugin is installed into your Vue app.
 :::
 
-Finally, open up `src/router.js` and use the guard to protect the `/profile` route, as in the following example:
+Finally, open up `src/router/index.js` and use the guard to protect the `/profile` route, as in the following example:
 
 ```js
 // .. other imports ..
 
-import { authGuard } from "./auth/authGuard";
+import { authGuard } from "../auth/authGuard";
 
-export default new Router({
+const router = new VueRouter({
   mode: "history",
   base: process.env.BASE_URL,
   routes: [

--- a/articles/quickstart/spa/vuejs/index.yml
+++ b/articles/quickstart/spa/vuejs/index.yml
@@ -35,7 +35,7 @@ github:
   repo: auth0-vue-samples
   branch: master
 requirements:
-  - Vue 2.6.10
+  - Vue 2.6.11
 next_steps:
   - path: 01-login
     list:

--- a/articles/quickstart/spa/vuejs/index.yml
+++ b/articles/quickstart/spa/vuejs/index.yml
@@ -36,6 +36,7 @@ github:
   branch: master
 requirements:
   - Vue 2.6.11
+  - Vue CLI 4.2.2
 next_steps:
   - path: 01-login
     list:


### PR DESCRIPTION
- **update for new router location**
Since `@vue/cli` 4, the location of the router has changed from `src/router.js` to `src/router/index.js`
- **standardise router assignment across examples**
`const router = new VueRouter` everywhere
- **bump Vue requirements** 
2.6.10 -> 2.6.11
