### PR TITLE
[QS-441] Fix typo in Angular QS code

### DIFF
--- a/articles/quickstart/spa/angular2/_includes/_centralized_login.md
+++ b/articles/quickstart/spa/angular2/_includes/_centralized_login.md
@@ -245,7 +245,7 @@ import { AuthService } from '../auth.service';
   templateUrl: './nav-bar.component.html',
   styleUrls: ['./nav-bar.component.css']
 })
-export class NavbarComponent implements OnInit {
+export class NavBarComponent implements OnInit {
 
   constructor(public auth: AuthService) { }
 


### PR DESCRIPTION
The named export from `nav-bar.component.ts` should be `NavBarComponent` not `NavbarComponent`, otherwise the application will not compile
