### PR TITLE
Update Enum property list on pass-parameters-to-idps.md

### DIFF
--- a/articles/connections/pass-parameters-to-idps.md
+++ b/articles/connections/pass-parameters-to-idps.md
@@ -98,7 +98,6 @@ Here are fields available for the `enum` parameter:
 * `id_token_hint`
 * `login_hint`
 * `max_age`
-* `max_age`
 * `prompt`
 * `resource`
 * `response_mode`


### PR DESCRIPTION
Removed the duplicate "max_age" Enum in the options list for allowed parameters.
