### PR TITLE
Updated index.yml to remove explicit auth0-spa-js version

### DIFF
--- a/articles/quickstart/spa/angular2/index.yml
+++ b/articles/quickstart/spa/angular2/index.yml
@@ -16,7 +16,7 @@ contentType: tutorial
 useCase: quickstart
 show_releases: true
 sdk:
-  name: auth0-spa-js 1.0.0
+  name: auth0-spa-js
   url: https://github.com/auth0/auth0-spa-js
 snippets:
   dependencies: application-platforms/angular2/dependencies

--- a/articles/quickstart/spa/react/index.yml
+++ b/articles/quickstart/spa/react/index.yml
@@ -17,7 +17,7 @@ contentType: tutorial
 useCase: quickstart
 show_releases: true
 sdk:
-  name: auth0-spa-js 1.0.0
+  name: auth0-spa-js
   url: https://www.github.com/auth0/auth0-spa-js/
 snippets:
   dependencies: application-platforms/react/dependencies

--- a/articles/quickstart/spa/vanillajs/index.yml
+++ b/articles/quickstart/spa/vanillajs/index.yml
@@ -12,7 +12,7 @@ contentType: tutorial
 useCase: quickstart
 show_releases: true
 sdk:
-  name: auth0-spa-js 1.0.0
+  name: auth0-spa-js
   url: https://github.com/auth0/auth0-spa-js
 snippets:
   dependencies: application-platforms/vanillajs/dependencies

--- a/articles/quickstart/spa/vuejs/index.yml
+++ b/articles/quickstart/spa/vuejs/index.yml
@@ -14,7 +14,7 @@ contentType: tutorial
 useCase: quickstart
 show_releases: true
 sdk:
-  name: auth0-spa-js 1.0.0
+  name: auth0-spa-js
   url: https://www.github.com/auth0/auth0-spa-js/
 snippets:
   dependencies: application-platforms/vuejs/dependencies


### PR DESCRIPTION
Having the version instantly dates the quickstart, as the actual version of spa-js has moved along several minor versions. However, the quickstart will work with the latest and until there is a need to display the minimum version on the quickstart, we should remove it.