### PR TITLE
Add a step to show that the API is unsecured.

### DIFF
--- a/articles/identity-labs/02-calling-an-api/exercise-02.md
+++ b/articles/identity-labs/02-calling-an-api/exercise-02.md
@@ -38,7 +38,7 @@ In this exercise, you will register the API with Auth0 so that tokens can be iss
 If at any point, you want to see the consent screen again when logging in, you can go to the Users screen in the Auth0 Dashboard, click on the user you'd like to modify, click the **Authorized Applications** tab, find the application you're using, and click **Revoke**. The next time you log in, the consent screen will appear again.
 :::
 
-As mentioned earlier, the expenses API is still not secure. The next steps will change the API to require a properly-scoped access token to view.
+As mentioned earlier, the expenses API is still not secure. You can see this by navigating directly to [localhost:3001](http://localhost:3001/). The expense data is available publicly, without an access token. The next steps will change the API to require a properly-scoped access token to view.
 
 4. In your terminal, stop your API with `[CTRL]` + `[c]`.
 


### PR DESCRIPTION
Suggestion - add this to show that the API is unsecured before adding the `express-oauth2-bearer` / `requiredScopes` bit.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors
- Please include a short description
- If your PR is a work in progress, title it [DO NOT MERGE]
--->
