### PR TITLE
[QS-442] Remove proxy from react quickstart

### DIFF
--- a/articles/quickstart/spa/_includes/_calling_api_create_backend_no_proxy.md
+++ b/articles/quickstart/spa/_includes/_calling_api_create_backend_no_proxy.md
@@ -1,0 +1,60 @@
+<!-- markdownlint-disable MD002 MD041 -->
+
+## Create the Backend API
+
+For this example, you'll create an [Express](https://expressjs.com/) server that acts as the backend API. This API will expose an endpoint to validate incoming [JWT-formatted access tokens](https://auth0.com/docs/tokens/concepts/jwts) before returning a response.
+
+Start by installing the following packages:
+
+```bash
+npm install express express-jwt jwks-rsa npm-run-all
+```
+
+* [`express`](https://github.com/expressjs/express) - a lightweight web server for Node
+* [`express-jwt`](https://www.npmjs.com/package/express-jwt) - middleware to validate JsonWebTokens
+* [`jwks-rsa`](https://www.npmjs.com/package/jwks-rsa) - retrieves RSA signing keys from a JWKS endpoint
+* [`npm-run-all`](https://www.npmjs.com/package/npm-run-all) - a helper to run the SPA and backend API concurrently
+
+Next, create a new file `server.js` with the following code:
+
+```js
+const express = require("express");
+const jwt = require("express-jwt");
+const jwksRsa = require("jwks-rsa");
+
+// Create a new Express app
+const app = express();
+
+// Set up Auth0 configuration
+const authConfig = {
+  domain: "${account.namespace}",
+  audience: "${apiIdentifier}"
+};
+
+// Define middleware that validates incoming bearer tokens
+// using JWKS from ${account.namespace}
+const checkJwt = jwt({
+  secret: jwksRsa.expressJwtSecret({
+    cache: true,
+    rateLimit: true,
+    jwksRequestsPerMinute: 5,
+    jwksUri: `https://<%= "${authConfig.domain}" %>/.well-known/jwks.json`
+  }),
+
+  audience: authConfig.audience,
+  issuer: `https://<%= "${authConfig.domain}" %>/`,
+  algorithm: ["RS256"]
+});
+
+// Define an endpoint that must be called with an access token
+app.get("/api/external", checkJwt, (req, res) => {
+  res.send({
+    msg: "Your Access Token was successfully validated!"
+  });
+});
+
+// Start the app
+app.listen(3001, () => console.log('API listening on 3001'));
+```
+
+The above API has one available endpoint, `/api/external`, that returns a JSON response to the caller. This endpoint uses the `checkJwt` middleware to validate the supplied bearer token using your tenant's [JSON Web Key Set](https://auth0.com/docs/jwks). If the token is valid, the request is allowed to continue. Otherwise, the server returns a 401 Unauthorized response.

--- a/articles/quickstart/spa/_includes/_calling_api_create_backend_no_proxy.md
+++ b/articles/quickstart/spa/_includes/_calling_api_create_backend_no_proxy.md
@@ -7,11 +7,12 @@ For this example, you'll create an [Express](https://expressjs.com/) server that
 Start by installing the following packages:
 
 ```bash
-npm install express express-jwt jwks-rsa npm-run-all
+npm install cors express express-jwt jwks-rsa npm-run-all
 ```
 
 * [`express`](https://github.com/expressjs/express) - a lightweight web server for Node
 * [`express-jwt`](https://www.npmjs.com/package/express-jwt) - middleware to validate JsonWebTokens
+* [`cors`](https://github.com/expressjs/cors) - middleware to enable CORS
 * [`jwks-rsa`](https://www.npmjs.com/package/jwks-rsa) - retrieves RSA signing keys from a JWKS endpoint
 * [`npm-run-all`](https://www.npmjs.com/package/npm-run-all) - a helper to run the SPA and backend API concurrently
 
@@ -19,11 +20,15 @@ Next, create a new file `server.js` with the following code:
 
 ```js
 const express = require("express");
+const cors = require("cors");
 const jwt = require("express-jwt");
 const jwksRsa = require("jwks-rsa");
 
 // Create a new Express app
 const app = express();
+
+// Accept cross-origin requests from the frontend app
+app.use(cors({ origin: 'http://localhost:3000' }));
 
 // Set up Auth0 configuration
 const authConfig = {

--- a/articles/quickstart/spa/react/02-calling-an-api.md
+++ b/articles/quickstart/spa/react/02-calling-an-api.md
@@ -24,7 +24,7 @@ This tutorial shows you how to create a simple API using [Express](https://expre
 
 <%= include('../_includes/_calling_api_create_api') %>
 
-<%= include('../_includes/_calling_api_create_backend.md') %>
+<%= include('../_includes/_calling_api_create_backend_no_proxy') %>
 
 Finally, modify `package.json` to add two new scripts `dev` and `server` that can be used to start the frontend and the backend API together:
 
@@ -37,28 +37,6 @@ scripts": {
   "dev": "npm-run-all --parallel start server",
   "server": "node server.js"
 },
-```
-
-## Proxy to the Backend API
-
-In this example, the backend and the frontend apps run on two different ports. In order to call the API from the frontend application, the development server must be configured to proxy requests through to the backend API. This is so that the frontend application can make a request to `/api/external` and it will be correctly proxied through to the backend API at `http://localhost:3001/api/external`.
-
-To do this, open the `package.json` file in the root of the project and add a new key `proxy` with a value of `http://localhost:3001`.
-
-Your `package.json` file should look something like the following with these changes in place (some values have been omitted for brevity):
-
-```json
-{
-  "name": "auth0-react-03-calling-an-api",
-  "version": "0.1.0",
-  "private": true,
-  "scripts": {...},
-  "dependencies": { ... },
-  "devDependencies": { ... },
-  "eslintConfig": { ... },
-  "browserslist": { ... },
-  "proxy": "http://localhost:3001"
-}
 ```
 
 ## Specify the API Audience
@@ -113,7 +91,7 @@ const ExternalApi = () => {
     try {
       const token = await getTokenSilently();
 
-      const response = await fetch("/api/external", {
+      const response = await fetch("http://localhost:3001/api/external", {
         headers: {
           Authorization: `Bearer <%= "${token}" %>`
         }


### PR DESCRIPTION
Remove backend proxy from the React QS, replace with CORS (follows auth0-samples/auth0-react-samples/pull/186)
