### PR TITLE
Fixed missing curly bracket

### DIFF
--- a/articles/universal-login/custom-error-pages.md
+++ b/articles/universal-login/custom-error-pages.md
@@ -96,7 +96,7 @@ To provide the appropriate HTML, pass in a string containing the appropriate Liq
     "queryString" : [],
     "postData": {
         "mimeType": "application/json",
-    "text": "{\"error_page\": {\"html\": \"<h1>{{error} {{error_description}} This error was generated {{'now' | date: '%Y %h'}}.</h1>\", \"show_log_link\": false, \"url\": \"\"}}"
+    "text": "{\"error_page\": {\"html\": \"<h1>{{error}} {{error_description}} This error was generated {{'now' | date: '%Y %h'}}.</h1>\", \"show_log_link\": false, \"url\": \"\"}}"
     },
     "headersSize" : -1,
     "bodySize" : -1,


### PR DESCRIPTION
In the example `html` in the **Render a custom error page** section, the `<h1>{{error}` is missing 1 right curly bracket.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors
- Please include a short description
- If your PR is a work in progress, title it [DO NOT MERGE]
--->
