### PR TITLE
Correcting PBKDF2 value requirement

### DIFF
--- a/articles/users/references/bulk-import-database-schema-examples.md
+++ b/articles/users/references/bulk-import-database-schema-examples.md
@@ -309,7 +309,7 @@ When the `algorithm` is set to `pbkdf2`:
 - `hash.encoding` must be `utf8`.
 - `hash.salt` is not allowed.
 - `hash.value` should be in [PHC string format](https://github.com/P-H-C/phc-string-format/blob/master/phc-sf-spec.md).
-- `hash.value` must include the base64 encoded salt (as specified in the `PHC` documentation).
+- `hash.value` must include the B64 encoded salt (base64 omitting padding characters `=`, as specified in the `PHC` documentation).
 - `hash.value` should include `i` (iterations) and `l` (keylen) parameters. If these parameters are omitted, they will default to `i=100000` and `l=64`.
 - The `id` should be in a `pbkdf2-<digest>` format (`pbkdf2-sha512`, `pbkdf2-md5`, etc). The supported digests are:
     - `RSA-MD4`


### PR DESCRIPTION
B64 hash.value is expected, not base64 (https://github.com/P-H-C/phc-string-format/blob/master/phc-sf-spec.md#b64)

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors
- Please include a short description
- If your PR is a work in progress, title it [DO NOT MERGE]
--->
