### PR TITLE
React quickstart - resolve route params lost on redirect

### DIFF
--- a/articles/quickstart/spa/react/_includes/_centralized_login.md
+++ b/articles/quickstart/spa/react/_includes/_centralized_login.md
@@ -405,7 +405,7 @@ const PrivateRoute = ({ component: Component, path, ...rest }) => {
     }
     const fn = async () => {
       await loginWithRedirect({
-        appState: { targetUrl: path }
+        appState: {targetUrl: window.location.pathname}
       });
     };
     fn();


### PR DESCRIPTION
When using the PrivateRoute component for a path with route parameters, the current sample code will redirect to the path without taking route parameters into account.

e.g.

```js
<PrivateRoute
    path="/foo/:bar"
    component={FooComponent}
/>
```
A request for /foo/baz will result in a redirect to "/foo/:bar"

When really what one would expect is to login and get returned to /foo/baz
