### PR TITLE
Fix broken link in mitigate-csrf-attacks.md

### DIFF
--- a/articles/protocols/oauth2/mitigate-csrf-attacks.md
+++ b/articles/protocols/oauth2/mitigate-csrf-attacks.md
@@ -69,6 +69,6 @@ The allowed length for state is not unlimited. If you get the error `414 Request
 
 ## Keep reading
 
-* [State Parameter Overview](/protocols/oauth2/oauth0-state)
+* [State Parameter Overview](/protocols/oauth2/oauth-state)
 * [OAuth 2.0 Framework](/protocols/oauth2)
 * [Protecting against other common threats](/security/common-threats)


### PR DESCRIPTION
Fix broken "State Parameter Overview" link. Typo, change `oauth0-state` to `oauth-state`.
