### PR TITLE
Fixed Lock.swift custom fields docs

### DIFF
--- a/articles/libraries/lock-ios/v2/custom-fields.md
+++ b/articles/libraries/lock-ios/v2/custom-fields.md
@@ -16,7 +16,7 @@ useCase:
 
 # Lock v2 for iOS - Custom Fields at Signup
 
-**Lock v2 for iOS** allows you to specify additional fields that the user must complete before creating a new account. The extra fields will be shown on a second screen after the user completes the basic fields (email, username, password).
+**Lock v2 for iOS** allows you to specify additional fields that the user must complete before creating a new account. The extra fields will be shown after the basic fields (email, username, password).
 
 ## Adding custom fields
 


### PR DESCRIPTION
### Changes
- The docs for Lock.swift v2 stated that the custom fields would be rendered in a new screen. Actually, they're rendered below the basic fields. This PR updates the docs to reflect that.