### PR TITLE
Update Lock.swift main docs page

### DIFF
--- a/articles/libraries/lock-ios/_includes/_dependencies.md
+++ b/articles/libraries/lock-ios/_includes/_dependencies.md
@@ -6,7 +6,6 @@ If you are using Carthage, add the following lines to your `Cartfile`:
 
 ```ruby
 github "auth0/Lock.swift" ~> 2.0
-github "auth0/Auth0.swift" ~> 1.0
 ```
 
 Then run `carthage bootstrap`.
@@ -22,7 +21,6 @@ If you are using [Cocoapods](https://cocoapods.org/), add these lines to your `P
 ```ruby
 use_frameworks!
 pod 'Lock', '~> 2.0'
-pod 'Auth0', '~> 1.0'
 ```
 
 Then, run `pod install`.

--- a/articles/libraries/lock-ios/v2/index.md
+++ b/articles/libraries/lock-ios/v2/index.md
@@ -18,7 +18,7 @@ useCase:
 ---
 # Lock v2 for iOS
 
-This reference guide will show you how to implement the <dfn data-key="lock">Lock</dfn> user interface, and give you the details on configuring and customizing Lock in order to use it as the UI for your authentication needs. However, if you'd like to learn how to do more with Auth0 and Swift, such as how to save, call and refresh <dfn data-key="access-token">Access Tokens</dfn>, get user profile info, and more, check out the [Auth0.Swift SDK](/libraries/auth0-swift). Or, take a look at the [Swift QuickStart](/quickstart/native/ios-swift) to walk through complete examples and see options, both for using Lock as the interface, and for using a custom interface. 
+This reference guide will show you how to implement the <dfn data-key="lock">Lock</dfn> user interface, and give you the details on configuring and customizing Lock in order to use it as the UI for your authentication needs. However, if you'd like to learn how to do more with Auth0 and Swift, such as how to save, call and refresh <dfn data-key="access-token">Access Tokens</dfn>, get user profile info, and more, check out the [Auth0.swift SDK](/libraries/auth0-swift). Or, take a look at the [Swift QuickStart](/quickstart/native/ios-swift) to walk through complete examples and see options, both for using Lock as the interface, and for using a custom interface. 
 
 ::: note
 Check out the [Lock.swift repository](https://github.com/auth0/Lock.swift) on GitHub.
@@ -26,9 +26,9 @@ Check out the [Lock.swift repository](https://github.com/auth0/Lock.swift) on Gi
 
 ## Requirements
 
-- iOS 9 or later
-- Xcode 8
-- Swift 3.0
+- iOS 9+
+- Xcode 10+
+- Swift 4+
 
 <%= include('../_includes/_dependencies') %>
 
@@ -39,7 +39,7 @@ Check out the [Lock.swift repository](https://github.com/auth0/Lock.swift) on Gi
 Lock needs to be notified when the application is asked to open a URL. You can do this in the `AppDelegate` file.
 
 ```swift
-func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any]) -> Bool {
+func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
   return Lock.resumeAuth(url, options: options)
 }
 ```


### PR DESCRIPTION
### Changes
- Requirements were brought up to date
- A code snippet was updated to reflect the latest API from Apple
- The dependencies were updated to reflect the fact you only need to install Lock.swift (Auth0.swift is a dependency, so it will be automatically installed as well)
- The Auth0.swift name was kept consistent