### PR TITLE
Case iOS/RN Quickstart titles according to Style Guide

### DIFF
--- a/articles/quickstart/native/ios-swift-siwa/00-login.md
+++ b/articles/quickstart/native/ios-swift-siwa/00-login.md
@@ -20,7 +20,7 @@ requirements:
 
 <!-- markdownlint-disable MD002 MD041 -->
 
-## Before you Start
+## Before You Start
 
 This tutorial describes how to implement the native [Sign In With Apple](https://developer.apple.com/sign-in-with-apple/) introduced in iOS 13. Alternatively check out the [iOS Swift Login tutorial](/quickstart/native/ios-swift) for Web Authentication with Auth0.
 

--- a/articles/quickstart/native/ios-swift-siwa/_includes/_login_centralized.md
+++ b/articles/quickstart/native/ios-swift-siwa/_includes/_login_centralized.md
@@ -110,7 +110,7 @@ extension ViewController: ASAuthorizationControllerDelegate {
 }
 ```
 
-### Add the Sign In With Apple capability
+### Add the Sign in with Apple capability
 
 To enable Sign In With Apple in your application, you need to enable this capability to your app, as shown:
 

--- a/articles/quickstart/native/ios-swift/02-custom-login-form.md
+++ b/articles/quickstart/native/ios-swift/02-custom-login-form.md
@@ -158,7 +158,7 @@ func application(_ app: UIApplication, open url: URL, options: [UIApplication.Op
 }
 ```
 
-### Web Authentication
+### Web authentication
 
 Finally, you can now perform webAuth authentication by specifying the social connection name, for example with Facebook.
 
@@ -180,7 +180,7 @@ Auth0
 
 Once you obtain the `credentials` object upon a successful authentication, you can deal with them as usual.
 
-#### Connection Scopes
+#### Connection scopes
 
 If you need additional provider permissions these can be specified using the `connectionScope` method and providing
 a comma separated list of provider permissions.

--- a/articles/quickstart/native/ios-swift/03-user-sessions.md
+++ b/articles/quickstart/native/ios-swift/03-user-sessions.md
@@ -23,7 +23,7 @@ This guide shows you how to use the credentials manager to store and Refresh Tok
 You can also use `SimpleKeychain` directly, without the added benefits and convenience of the credentials manager. To learn more, read about [Saving and Refreshing Tokens](/libraries/auth0-swift/save-and-refresh-jwt-tokens#simplekeychain).
 :::
 
-## Save the User's Credentials When They Log in
+## Save the User's Credentials When They Log In
 
 When your users log in successfully, save their credentials. You can then log them in automatically when they open your application again.
 
@@ -58,7 +58,7 @@ Auth0
 }
 ```
 
-### Check for Credentials When the User Opens Your Application
+### Check for credentials when the user opens your application
 
 When the user opens your application, check for valid credentials. If they exist, you can log the user in automatically and redirect them to the app's main flow without any additional login steps.
 
@@ -93,9 +93,9 @@ credentialsManager.credentials { error, credentials in
 
 If the credentials have expired, the credentials manager will automatically renew them for you with the Refresh Token.
 
-### Clear the Keychain and Revoke the Refresh Token When the User Logs Out
+### Clear the Keychain and revoke the Refresh Token when the user logs out
 
-When you need to log the user out, remove their credentials from the keychain and revoke the refresh token:
+When you need to log the user out, remove their credentials from the keychain and revoke the Refresh Token:
 
 ```swift
 // SessionManager.swift
@@ -139,7 +139,7 @@ Auth0
     }
 ```
 
-### User Profile Information
+### User profile information
 
 To show the information contained in the user profile, access its properties, for example:
 

--- a/articles/quickstart/native/ios-swift/_includes/_login_centralized.md
+++ b/articles/quickstart/native/ios-swift/_includes/_login_centralized.md
@@ -1,6 +1,6 @@
 <!-- markdownlint-disable MD002 MD041 -->
 
-## Before you Start
+## Before You Start
 
 This tutorial demonstrates how to add user login to a Swift application using Web Authentication with Auth0. Alternatively, check out the [iOS Swift - Sign In With Apple tutorial](/quickstart/native/ios-swift-siwa).
 

--- a/articles/quickstart/native/ios-swift/_includes/_login_embedded.md
+++ b/articles/quickstart/native/ios-swift/_includes/_login_embedded.md
@@ -40,7 +40,7 @@ For further reference on the `credentials` object, please see
 
 This sets you up for handling Database connections.
 
-### Log In with Enterprise & Social Connections
+### Log in with enterprise & social connections
 
 In order to use browser based Auth mechanism through social and enterprise connections, all you have to do is enable them in your account's [connections dashboard](${manage_url}/#/connections/social). Every connection you switch on there, will appear in the Login screen of your app.
 

--- a/articles/quickstart/native/react-native/00-login.md
+++ b/articles/quickstart/native/react-native/00-login.md
@@ -22,7 +22,7 @@ How to install the React Native Auth0 module.
 Please refer to the [official documentation](https://facebook.github.io/react-native/) for additional details on React Native.
 :::
 
-### yarn
+### Yarn
 
 ```bash
 yarn add react-native-auth0
@@ -38,7 +38,7 @@ For further reference on yarn, check [their official documentation](https://yarn
 npm install react-native-auth0 --save
 ```
 
-### Additional iOS step: Install the Module Pod
+### Additional iOS step: install the module Pod
 
 CocoaPods is the package management tool for iOS that the React Native framework uses to install itself into your project. For the iOS native module to work with your iOS app you must first install the library Pod. If you're familiar with older React Native SDK versions, this is similar to what was called _linking a native module_. The process is now simplified:
 
@@ -53,7 +53,7 @@ The first step in adding authentication to your application is to provide a way 
 
 <div class="phone-mockup"><img src="/media/articles/native-platforms/ios-swift/lock_centralized_login.png" alt="Login Page"></div>
 
-## Integrate Auth0 in your Application 
+## Integrate Auth0 in Your Application
 
 ### Configure Android
 
@@ -156,7 +156,7 @@ For additional information please read [react native docs](https://facebook.gith
 
 <%= include('../../../_includes/_callback_url') %>
 
-#### iOS Callback URL
+#### iOS callback URL
 
 ```text
 {PRODUCT_BUNDLE_IDENTIFIER}://${account.namespace}/ios/{PRODUCT_BUNDLE_IDENTIFIER}/callback
@@ -165,7 +165,7 @@ For additional information please read [react native docs](https://facebook.gith
 Remember to replace `{PRODUCT_BUNDLE_IDENTIFIER}` with your actual application's bundle identifier name.
 
 
-#### Android Callback URL
+#### Android callback URL
 
 ```text
 {YOUR_APP_PACKAGE_NAME}://${account.namespace}/android/{YOUR_APP_PACKAGE_NAME}/callback
@@ -193,7 +193,7 @@ Remember to replace `{PRODUCT_BUNDLE_IDENTIFIER}` with your actual application's
 Remember to replace `{YOUR_APP_PACKAGE_NAME}` with your actual application's package name.
 
 
-### Add Authentication with Auth0
+### Add authentication with Auth0
 
 [Universal login](/hosted-pages/login) is the easiest way to set up authentication in your application. We recommend using it for the best experience, best security and the fullest array of features.
 
@@ -229,7 +229,7 @@ Upon successful authentication the user's `credentials` will be returned, contai
 For more information on the `accessToken`, refer to [Access Token](/tokens/concepts/access-tokens).
 :::
 
-### Log the User Out
+### Log the user out
 
 To log the user out, redirect them to the Auth0 log out endpoint by calling `clearSession`. This will remove their session from the authorization server. After this happens, remove the Access Token from the state. 
 


### PR DESCRIPTION
### Changes
This PR updates the capitalisation of the titles in the iOS and React Native Quickstart according to the [Auth0 Style Guide](https://github.com/auth0/docs/blob/master/STYLEGUIDE.md).

The Style Guide [specifies](https://github.com/auth0/docs/blob/master/STYLEGUIDE.md#formatting) that title cases should be used for first-level headings, and sentence case for subheads. Although it doesn't specify which kind of title case to use (APA/AP/Chicago/MLA, etc), it also refers to the [Microsoft Writing Style Guide](https://docs.microsoft.com/en-us/style-guide/welcome/) for everything that's not Auth0-specific. And that guide [refers in turn](https://docs.microsoft.com/en-us/style-guide/capitalization) to [The Chicago Manual of Style](https://www.chicagomanualofstyle.org/home.html). 
 
Therefore:
- Chicago-style title case was used for first-level headings.
- Sentence case was used for subheadings.
