### PR TITLE
Fix PHP WebApp Quickstart callback URL

### DIFF
--- a/articles/quickstart/webapp/php/01-login.md
+++ b/articles/quickstart/webapp/php/01-login.md
@@ -45,7 +45,7 @@ $auth0 = new Auth0([
   'domain' => '${account.namespace}',
   'client_id' => '${account.clientId}',
   'client_secret' => 'YOUR_CLIENT_SECRET',
-  'redirect_uri' => '${account.callback}',
+  'redirect_uri' => 'http://localhost:3000/',
   'scope' => 'openid profile email',
 ]);
 ```

--- a/articles/quickstart/webapp/php/download.md
+++ b/articles/quickstart/webapp/php/download.md
@@ -3,7 +3,7 @@ To run the sample follow these steps:
 1) Set the **Allowed Callback URLs** in the [Application Settings](${manage_url}/#/applications/${account.clientId}/settings) to:
 
 ```text
-${account.callback}
+http://localhost:3000/
 ```
 
 2) Set the **Allowed Logout URLs** in the [Application Settings](${manage_url}/#/applications/${account.clientId}/settings) to:


### PR DESCRIPTION
When viewing the Quickstart in the management dashboard after creating a new application, using `${account.callback}` will not resolve correctly as the (new) application does not yet have a callback URL. 

This change simply uses the `http://localhost:3000/` value directly to fix this issue, and is consistent with other Quickstart articles.