### PR TITLE
Model class requires a public constructor

### DIFF
--- a/articles/quickstart/backend/java-spring-security5/01-authorization.md
+++ b/articles/quickstart/backend/java-spring-security5/01-authorization.md
@@ -215,7 +215,7 @@ Create a new class named `Message`, which is the domain object the API will retu
 public class Message {
     private final String message;
 
-    Message(String message) {
+    public Message(String message) {
         this.message = message;
     }
 


### PR DESCRIPTION
The `Message` model class requires the constructor to be public, as it is called from outside its package.