### PR TITLE
Update Spring 5 API Quickstart to Spring Boot 2.2.6

### DIFF
--- a/articles/quickstart/backend/java-spring-security5/01-authorization.md
+++ b/articles/quickstart/backend/java-spring-security5/01-authorization.md
@@ -55,7 +55,7 @@ If you are using Gradle, you can add the required dependencies using the [Spring
 // build.gradle
 
 plugins {
-    id 'org.springframework.boot' version '2.2.4.RELEASE'
+    id 'org.springframework.boot' version '2.2.6.RELEASE'
     id 'io.spring.dependency-management' version '1.0.9.RELEASE'
 }
 
@@ -76,7 +76,7 @@ If you are using Maven, add the Spring dependencies to your `pom.xml` file:
 <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.2.4.RELEASE</version>
+    <version>2.2.6.RELEASE</version>
     <relativePath/>
 </parent>
 


### PR DESCRIPTION
Related to the change to the sample to use Spring Boot 2.2.6: https://github.com/auth0-samples/auth0-spring-security5-api-sample/pull/6