### PR TITLE
Fixing broken link

### DIFF
--- a/articles/api/management/guides/connections/configure-connection-sync.md
+++ b/articles/api/management/guides/connections/configure-connection-sync.md
@@ -18,7 +18,7 @@ useCase:
 This guide will show you how to update connection preferences for an upstream [Identity Provider](/connections) to control when updates to user profile root attributes will be allowed using Auth0's Management API. This task can also be performed [using the Dashboard](/dashboard/guides/connections/configure-connection-sync).
 
 ::: warning
-Before completing this step, you should first [retrieve the existing values of the connection's `options` object](/api/management/guides/retrieve-connection-options) to avoid overriding the current values. If you do not, any missing parameters from the original object will be lost after you update.
+Before completing this step, you should first [retrieve the existing values of the connection's `options` object](/api/management/guides/connections/retrieve-connection-options) to avoid overriding the current values. If you do not, any missing parameters from the original object will be lost after you update.
 :::
 
 1. Make a `PATCH` call to the [Update a Connection endpoint](/api/management/v2#!/Connections/patch_connections_by_id). Make sure you include the original options values in the call to avoid overriding the current values. Also, be sure to replace `CONNECTION_ID`, `MGMT_API_ACCESS_TOKEN`, and `ATTRIBUTE_UPDATE_VALUE` placeholder values with your connection ID, Management API Access Token, and attribute update value, respectively.

--- a/config/redirects.js
+++ b/config/redirects.js
@@ -2460,5 +2460,9 @@ module.exports = [
     {
       from: '/extensions/deploy-cli/references/whats-new-v2',
       to: 'articles/extensions/deploy-cli/references/whats-new'
+    },
+    {
+      from: '/api/management/guides/retrieve-connection-options',
+      to: '/api/management/guides/connections/retrieve-connection-options'
     }
 ];


### PR DESCRIPTION
https://docs-content-staging-pr-8878.herokuapp.com/docs/api/management/guides/retrieve-connection-options 

should now redirect to 

https://docs-content-staging-pr-8878.herokuapp.com/docs/api/management/guides/connections/retrieve-connection-options 

Also, https://docs-content-staging-pr-8878.herokuapp.com/docs/api/management/guides/connections/configure_connection_sync has a link to it which is also now fixed - seems to be the only internal one.