### PR TITLE
Security bulletin for CVE 2020-5263

### DIFF
--- a/articles/security/bulletins/cve-2020-5263.md
+++ b/articles/security/bulletins/cve-2020-5263.md
@@ -1,0 +1,38 @@
+---
+title: Auth0 Security Bulletin CVE 2020-5263
+description: Security Update for auth0.js library (CVE 2020-5263)
+toc: true
+topics:
+  - security
+  - security-bulletins
+  - auth0js
+contentType:
+  - reference
+useCase:
+  - development
+---
+# Security Update for auth0.js Library
+
+**Published**: April 09, 2020
+
+**CVE number**: CVE-2020-5263
+
+**Credit**: Bogdan Vitoc (Spatial Systems Inc)
+
+## Overview
+Between versions 8.0.0 and  9.13.1 (inclusive), in the case of an (authentication) error, the error object returned by the library contains the original request of the user, which may include the plaintext password the user entered. 
+
+If the error object is exposed or logged without modification, the application risks password exposure.
+
+## Am I affected?
+You are affected by this vulnerability if all of the following conditions apply:
+
+- You are using Auth0.js version between 8.0.0 and 9.13.1 (inclusive).
+- You store or display error objects without filtering. 
+
+## How to fix that?
+Developers should upgrade auth0.js to version 9.13.2 or later where user inputted passwords are masked in errors. If upgrading is not possible, a temporary fix may include not storing the error object or displaying it publicly without modification.
+
+## Will this update impact my users?
+
+This fix patches the Auth0.js and may require changes in application code due to password no longer available in error object, but it will not impact your users, their current state, or any existing sessions.

--- a/articles/security/bulletins/index.md
+++ b/articles/security/bulletins/index.md
@@ -27,6 +27,7 @@ Each bulletin contains a description of the vulnerability, how to identify if yo
 
 | **Date** | **Bulletin number** | **Title** | **Affected software** |
 |-|-|-|-|
+| April 09, 2020 | [CVE 2020-5263](/security/bulletins/cve-2020-5263) | Auth0 Security Bulletin for auth0.js versions <= 9.13.1 | [Auth0.js](/libraries/auth0js) |
 | March 31, 2020 | [Auth0 Bulletin](/security/bulletins/2020-03-31_wpauth0) | Auth0 Security Bulletin for WordPress Plugin for Auth0 versions < 4.0.0 | [WordPress Plugin for Auth0](https://github.com/auth0/wp-auth0) |
 | January 31, 2020 | [CVE 2019-20173](/security/bulletins/cve-2019-20173) | Auth0 Security Bulletin for WordPress Plugin for Auth0 versions 3.11.0, 3.11.1 and 3.11.2 | [WordPress Plugin for Auth0](https://github.com/auth0/wp-auth0) |
 | January 30, 2020 | [CVE 2019-20174](/security/bulletins/cve-2019-20174) | Auth0 Security Bulletin for Auth0 Lock < 11.21.0 | [Auth0 Lock](https://github.com/auth0/lock) |


### PR DESCRIPTION
This PR adds a security bulletin for CVE 2020-5263.