### PR TITLE
Change backticks to single quotes

### DIFF
--- a/articles/quickstart/backend/rails/01-authorization.md
+++ b/articles/quickstart/backend/rails/01-authorization.md
@@ -26,7 +26,7 @@ This tutorial performs Access Token validation using the  **jwt** Gem within a c
 Install the **jwt** Gem.
 
 ```bash
-gem `jwt`
+gem 'jwt'
 bundle install
 ```
 


### PR DESCRIPTION
In ruby, backticks shell out, instead of denoting strings

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors
- Please include a short description
- If your PR is a work in progress, title it [DO NOT MERGE]
--->
