### PR TITLE
[SDK-1442] Updated SPA include to point to PKCE flow docs

### DIFF
--- a/articles/quickstart/spa/_includes/_getting_started.md
+++ b/articles/quickstart/spa/_includes/_getting_started.md
@@ -1,8 +1,9 @@
 <!-- markdownlint-disable MD041 -->
 
 ::: note
-**New to Auth?** Learn [How Auth0 works](/overview), how it [integrates with Single-Page Applications](/architecture-scenarios/application/spa-api) and which [protocol](/flows/concepts/implicit) it uses.
+**New to Auth?** Learn [How Auth0 works](/overview), how it [integrates with Single-Page Applications](/architecture-scenarios/application/spa-api) and which [protocol](/flows/concepts/auth-code-pkce) it uses.
 :::
+
 <%= include('../../../_includes/_new_app') %>
 <%= include('../../../_includes/_callback_url') %>
 


### PR DESCRIPTION
These quickstarts use Auth0 SPA SDK, which use the Auth Code + PKCE flow, and not the implicit flow.