### PR TITLE
refresh-token-rotation.md with partial attack

### DIFF
--- a/articles/tokens/concepts/refresh-token-rotation.md
+++ b/articles/tokens/concepts/refresh-token-rotation.md
@@ -44,11 +44,11 @@ Without enforcing sender-constraint, it’s impossible for the authorization ser
 
 For example, consider the following scenario: 
 1. Legitimate Client has **Refresh Token 1**, and it is leaked to or stolen by Malicious Client. 
-2. Legitimate Client uses **Refresh Token 1** to get a new Refresh Token/Access Token pair.
+2. Malicious Client uses **Refresh Token 1** to get a new Refresh Token/Access Token pair.
 3. Auth0 returns **Refresh Token 2/Access Token 2**.
-4. Malicious Client then attempts to use **Refresh Token 1** to get an Access Token. Auth0 recognizes that Refresh Token 1 is being reused, and immediately invalidates the Refresh Token family, including **Refresh Token 2**.
-5. Auth0 returns an **Access Denied** response to Malicious Client.
-6. **Access Token 2** expires and Legitimate Client attempts to use **Refresh Token 2** to request a new token pair. Auth0 returns an **Access Denied** response to Legitimate Client.
+4. Legitimate Client then attempts to use **Refresh Token 1** to get an Access Token. Auth0 recognizes that Refresh Token 1 is being reused, and immediately invalidates the Refresh Token family, including **Refresh Token 2**.
+5. Auth0 returns an **Access Denied** response to Legitimate Client.
+6. **Access Token 2** expires and Malicious Client attempts to use **Refresh Token 2** to request a new token pair. Auth0 returns an **Access Denied** response to Malicious Client.
 7. Re-authentication is required.
 
 ![Reuse Detection](/media/articles/tokens/reuse-detection.png)


### PR DESCRIPTION
Demonstrates the usefulness of 'Automatic reuse detection' by detailing how it can mitigate a partially successful attack. The current documentation for Automatic reuse detection has an example of how it completely prevents an attack, but in doing so it fails to note that there is still a window of attack.

I suspect the original example was written only with replay attacks in mind.