### PR TITLE
Prefer double-hyphen option leader in command line examples for impor…

### DIFF
--- a/articles/extensions/deploy-cli/guides/import-export-directory-structure.md
+++ b/articles/extensions/deploy-cli/guides/import-export-directory-structure.md
@@ -52,7 +52,7 @@ You can either set the environment variables, or you can place the values in a c
 2. Deploy using the following command:
 
 ```bash
-a0deploy import -c config.json -i .
+a0deploy import --config_file config.json --input_file .
 ```
 
 ### Example: configuration file
@@ -88,7 +88,7 @@ Here is an example of a `config.json` file:
 
 To export your current tenant configuration, run a command that's similar to:
 
-`a0deploy export -c config.json -f directory -o path/to/export`
+`a0deploy export --config_file config.json --format directory --output_folder path/to/export`
 
 <%= include('../_includes/_strip-option') %>
 

--- a/articles/extensions/deploy-cli/guides/import-export-yaml-file.md
+++ b/articles/extensions/deploy-cli/guides/import-export-yaml-file.md
@@ -50,7 +50,7 @@ To import an Auth0 tenant configuration:
 2. Deploy using the following command:
 
    ```bash
-   a0deploy import -c config.json -i tenant.yaml
+   a0deploy import --config_file config.json --input_file tenant.yaml
    ```
 
 ### Example: configuration file
@@ -253,7 +253,7 @@ roles:
 
 To export your current tenant configuration, run a command that's similar to:
 
-`a0deploy export -c config.json -f yaml -o path/to/export`
+`a0deploy export --config_file config.json --format yaml --output_folder path/to/export`
 
 <%= include('../_includes/_strip-option') %>
 

--- a/articles/extensions/deploy-cli/guides/install-deploy-cli.md
+++ b/articles/extensions/deploy-cli/guides/install-deploy-cli.md
@@ -68,7 +68,7 @@ To configure the Deploy CLI tool to use the Deploy CLI application, create a **c
 To run the Deploy CLI Tool, use the command-line interface to run:
 
 ```bash
-a0deploy export -c config.json -f yaml -o <your repo directory>
+a0deploy export --config_file config.json --format yaml --output_folder <your repo directory>
 ```
 
 ## Keep reading

--- a/articles/extensions/deploy-cli/references/deploy-cli-options.md
+++ b/articles/extensions/deploy-cli/references/deploy-cli-options.md
@@ -27,10 +27,10 @@ The following options are supported by the Deploy CLI tool `a0deploy`.
 ## Examples
 
 ```
-  a0deploy export -c config.json --strip -f yaml -o path/to/export       Dump Auth0 config to folder in YAML format
-  a0deploy export -c config.json --strip -f directory -o path/to/export  Dump Auth0 config to folder in directory format
-  a0deploy import -c config.json -i tenant.yaml                          Deploy Auth0 via YAML
-  a0deploy import -c config.json -i path/to/files                        Deploy Auth0 via Path
+  a0deploy export --config_file config.json --strip --format yaml --output_folder path/to/export       Dump Auth0 config to folder in YAML format
+  a0deploy export --config_file config.json --strip --format directory --output_folder path/to/export  Dump Auth0 config to folder in directory format
+  a0deploy import --config_file config.json --input_file tenant.yaml                                   Deploy Auth0 via YAML
+  a0deploy import --config_file config.json --input_file path/to/files                                 Deploy Auth0 via Path
 ```
 
 ## Keep reading

--- a/articles/support/_reset-tenant.md
+++ b/articles/support/_reset-tenant.md
@@ -4,8 +4,8 @@ To reset your tenant to its initial state, you can use the [Deploy CLI Tool](/ex
 
 1. Install the tool `a0deploy` by running the following in your command-line interface: `npm i -g auth0-deploy-cli`
 
-2. Get a snapshot of the state you would like to preserve: `a0deploy export -c config.json -f yaml -o ./`
+2. Get a snapshot of the state you would like to preserve: `a0deploy export --config_file config.json --format yaml --output_folder ./`
 
 3. [Update the configuration file](/extensions/deploy-cli/guides/import-export-yaml-file#import-tenant-configuration) used for the import.
 
-4. Update your tenant with its stored state: `a0deploy import -c config.json -f yaml -i ./tenant.yaml`
+4. Update your tenant with its stored state: `a0deploy import --config_file config.json --format yaml --input_file ./tenant.yaml`


### PR DESCRIPTION
Using the double-hyphen option leader, e.g., `--config_file` instead of `-c` should reduce cognitive load for new users reading the documentation.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors
- Please include a short description
- If your PR is a work in progress, title it [DO NOT MERGE]
--->
