### PR TITLE
Hosted Pages clean-up

### DIFF
--- a/articles/analytics/guides/facebook-analytics.md
+++ b/articles/analytics/guides/facebook-analytics.md
@@ -10,7 +10,7 @@ useCase:
 ---
 # Integrate Facebook Analytics with Auth0
 
-Install and configure the **Facebook Analytics for Auth0** integration on your own page that is using [Lock](/libraries/lock) or the [hosted Lock pages](/hosted-pages/login). You can configure funnels and reports inside of Facebook Analytics to get the most out of this integration.
+Install and configure the **Facebook Analytics for Auth0** integration on your own page that is using [Lock](/libraries/lock) or the [hosted Lock pages](/universal-login). You can configure funnels and reports inside of Facebook Analytics to get the most out of this integration.
 
 <%= include('../_includes/_install', { name: "Facebook Analytics" }) %>
 

--- a/articles/api-auth/intro.md
+++ b/articles/api-auth/intro.md
@@ -189,7 +189,7 @@ At the moment there is no OIDC-compliant mechanism to obtain third-party API tok
 
 Our new implementation only supports an [OIDC-conformant](/api-auth/tutorials/adoption) <dfn data-key="passwordless">passwordless</dfn> authentication mechanism when using web applications (with Lock.js or auth0.js).
 
-Native applications need to use Universal Login (with an Auth0-hosted login page). Customers can use the <dfn data-key="lock">Lock</dfn> (Passwordless) template in the [Dashboard](${manage_url}/#/login) under **Hosted Pages -> Login -> Default Templates**, or customize it to fit specific requirements.
+Native applications need to use Universal Login (with an Auth0-hosted login page). Customers can use the <dfn data-key="lock">Lock</dfn> (Passwordless) template in the [Dashboard](${manage_url}/#/login_settings) under **Universal Login -> Login -> Default Templates**, or customize it to fit specific requirements.
 
 ### Other Authentication API endpoints
 

--- a/articles/appliance/admin/index.md
+++ b/articles/appliance/admin/index.md
@@ -23,4 +23,4 @@ This document covers factors PSaaS Appliance administrators should be aware of w
 * [Monitoring & Performing Health Checks on Load Balancers](/appliance/admin/monitoring)
 * [Updating the PSaaS Appliance](/appliance/admin/updating-the-appliance)
   * [Why You Should Update the PSaaS Appliance Regularly](/appliance/admin/importance-of-updates)
-* [Configuring Custom Error Pages](/hosted-pages/custom-error-pages)
+* [Configuring Custom Error Pages](/universal-login/custom-error-pages)

--- a/articles/applications/concepts/grant-types-legacy.md
+++ b/articles/applications/concepts/grant-types-legacy.md
@@ -32,5 +32,5 @@ If you're currently using a legacy grant type, refer to the chart below to see w
 | `http://auth0.com/oauth/legacy/grant-type/access_token` | Use browser-based social authentication. |
 
 ::: note
-Those implementing <dfn data-key="passwordless">Passwordless</dfn> Authentication should use [Universal Login](/hosted-pages/login) instead of the `oauth/ro` endpoint.
+Those implementing <dfn data-key="passwordless">Passwordless</dfn> Authentication should use [Universal Login](/universal-login) instead of the `oauth/ro` endpoint.
 :::

--- a/articles/architecture-scenarios/_includes/_authentication/_universal-login.md
+++ b/articles/architecture-scenarios/_includes/_authentication/_universal-login.md
@@ -1,7 +1,7 @@
 Do you have, or will you have, more than one application in your system? If the answer to this question is yes, then you will want a centralized sign in experience. To achieve a seamless <dfn data-key="single-sign-on">Single Sign-on (SSO)</dfn> experience between multiple applications, it is critical to have a centralized location to redirect your users for authentication. This allows you a way to provide your users with a consistent experience if you add social authentication in the future, add third party applications to your system, or add multi-factor authentication as an option (or requirement) for your users - and also allow you to take advantage of new features for improving your users’ experience with little, if any, added development effort.
 
 ::: panel Best Practice
-If you have more than one application, the best practice is to redirect to a [centralized location](/hosted-pages/login) to authenticate the user. With Auth0, this means taking advantage of [Universal Login](/universal-login), which provides many security and user experience benefits out-of-the-box, including [SSO](/sso/current).
+If you have more than one application, the best practice is to redirect to a [centralized location](/universal-login) to authenticate the user. With Auth0, this means taking advantage of [Universal Login](/universal-login), which provides many security and user experience benefits out-of-the-box, including [SSO](/sso/current).
 :::
 
 Auth0 Universal Login makes authenticating users a short, easy process which can be accomplished in three easy steps (all of our Quickstarts demonstrate this and our SDKs hide the complexity for you too):

--- a/articles/architecture-scenarios/_includes/_provisioning/_introduction.md
+++ b/articles/architecture-scenarios/_includes/_provisioning/_introduction.md
@@ -1,7 +1,7 @@
 Determining how users get signed up is important to address early, and the decisions you make here will influence many of the decisions you will need to make going forward. We’ve found there are a typical set of patterns for how users will get added to your system, and things to take note of when considering workflow design too.
 
 ::: panel Best Practice
-Whilst Auth0 supports numerous workflows, web based workflows using Auth0 [Universal Login](/hosted-pages/login) for sign up are considered both industry and Auth0 best practice as they provide for optimal functionality and the best security.
+Whilst Auth0 supports numerous workflows, web based workflows using Auth0 [Universal Login](/universal-login) for sign up are considered both industry and Auth0 best practice as they provide for optimal functionality and the best security.
 :::
 
 Auth0 supports user sign up via a number of different [identity providers](/identityproviders). During sign up, Auth0 provisions the [user profile](/users/concepts/overview-user-profile) so that it contains the user’s account information. There are a number of things to consider when looking at functionality and workflow:

--- a/articles/architecture-scenarios/_includes/_provisioning/_self-signup.md
+++ b/articles/architecture-scenarios/_includes/_provisioning/_self-signup.md
@@ -1,5 +1,5 @@
 Self sign up leverages Auth0 [Database Connections](/connections/database) to store the user ID, password, and (optional) username identity information collected from new users during the sign up process. Database connection policies governing things such as minimum [username length](connections/database/require-username#username-length) or [password strength and complexity](/connections/database/password-options) can be configured via the Auth0 Dashboard. 
 
 ::: panel Best Practice
-Auth0 [Universal Login](/hosted-pages/login) as well Auth0 widgets such as [Lock](https://auth0.com/lock) integrate with Database Connections to provide comprehensive user interface functionality for sign up out-of-the-box. These UI artifacts are fully reactive, and with feature rich configuration and comprehensive customization, you can deploy functionality for user self sign up as well as login.
+Auth0 [Universal Login](/universal-login) as well Auth0 widgets such as [Lock](https://auth0.com/lock) integrate with Database Connections to provide comprehensive user interface functionality for sign up out-of-the-box. These UI artifacts are fully reactive, and with feature rich configuration and comprehensive customization, you can deploy functionality for user self sign up as well as login.
 :::

--- a/articles/architecture-scenarios/spa-api/spa-implementation-angular2.md
+++ b/articles/architecture-scenarios/spa-api/spa-implementation-angular2.md
@@ -134,7 +134,7 @@ export class AuthService {
 
 The service includes several methods for handling authentication.
 
-- __login__: calls `authorize` from auth0.js which initiates [Universal Login](/hosted-pages/login)
+- __login__: calls `authorize` from auth0.js which initiates [Universal Login](/universal-login)
 - __handleAuthentication__: looks for an authentication result in the URL hash and processes it with the `parseHash` method from auth0.js
 - __setSession__: sets the user's Access Token, ID Token, and a time at which the Access Token will expire
 - __logout__: removes the user's tokens from browser storage

--- a/articles/best-practices/connection-settings.md
+++ b/articles/best-practices/connection-settings.md
@@ -29,7 +29,7 @@ You should review the data you are requesting from each social connection. Users
 
 Configure the [password policy](/connections/database/password-strength) for your [Auth0 database connections](/connections/database) so created users have strong passwords. You can configure the password policy in the [database connection settings](${manage_url}/#/connections/database/) on the dashboard or with the [Auth0 Management API](/api/management/v2/#!/Connections/patch_connections_by_id).
 
-The password policy applies to password resets performed with the <dfn data-key="universal-login">Universal Login</dfn> [Page](/hosted-pages/login) as well as the [Auth0 Management API](/api/management/v2/).
+The password policy applies to password resets performed with the <dfn data-key="universal-login">Universal Login</dfn> [Page](/universal-login) as well as the [Auth0 Management API](/api/management/v2/).
 
 ## Disable user signup if it's not appropriate for each database connection
 

--- a/articles/best-practices/tenant-settings.md
+++ b/articles/best-practices/tenant-settings.md
@@ -30,13 +30,13 @@ Go to your [tenant's general settings](${manage_url}/#/tenant) and provide your 
 - your company's support email address
 - your company's support URL
 
-The support email address and URL is shown on the default error page, so users can contact your support if they have an issue. You can also [host your own custom error page](/hosted-pages/custom-error-pages) and configure Auth0 to use it instead. Using your own error page, you can provide more complete and customized explanations to users about what to do in the event of an error. Setting up your own custom error page is recommended, but not required.
+The support email address and URL is shown on the default error page, so users can contact your support if they have an issue. You can also [host your own custom error page](/universal-login/custom-error-pages) and configure Auth0 to use it instead. Using your own error page, you can provide more complete and customized explanations to users about what to do in the event of an error. Setting up your own custom error page is recommended, but not required.
 
 ## Set up Custom Domain
 
 You can configure [custom domains](/custom-domains) in your tenant settings.
 
-If you want to use a custom domain name for the <dfn data-key="universal-login">Universal Login</dfn> [page](/hosted-pages/login), set up the custom domain at the start to minimize changes you’ll need to make later.
+If you want to use a custom domain name for the <dfn data-key="universal-login">Universal Login</dfn> [page](/universal-login), set up the custom domain at the start to minimize changes you’ll need to make later.
 
 For <dfn data-key="security-assertion-markup-language">SAML</dfn> connections that authenticate users against remote SAML Identity Providers, you should set up the custom domain before configuring any SAML providers as changing the domain across multiple SAML providers is challenging.
 

--- a/articles/compliance/gdpr/features-aiding-compliance/user-consent/track-consent-with-custom-ui.md
+++ b/articles/compliance/gdpr/features-aiding-compliance/user-consent/track-consent-with-custom-ui.md
@@ -40,7 +40,7 @@ We will see four different implementations for this:
 
 ## Option 1: Use auth0.js
 
-In this section, we will use a simple Single-Page Application and customize the login widget to add a flag which users can use to provide consent information. Instead of building an app from scratch, we will use [Auth0's JavaScript Quickstart sample](/quickstart/spa/vanillajs). We will also use [Auth0's Universal Login Page](/hosted-pages/login) so we can implement a [Universal Login experience](/guides/login/centralized-vs-embedded), instead of embedding the login in our app.
+In this section, we will use a simple Single-Page Application and customize the login widget to add a flag which users can use to provide consent information. Instead of building an app from scratch, we will use [Auth0's JavaScript Quickstart sample](/quickstart/spa/vanillajs). We will also use [Auth0's Universal Login Page](/universal-login) so we can implement a [Universal Login experience](/guides/login/centralized-vs-embedded), instead of embedding the login in our app.
 
 This works **only** for database connections (we will use Auth0's infrastructure, instead of setting up our own database).
 
@@ -58,7 +58,7 @@ This works **only** for database connections (we will use Auth0's infrastructure
 
 1. [Set the Client ID and Domain](https://github.com/auth0-samples/auth0-javascript-samples/tree/master/01-Login#set-the-client-id-and-domain) values.
 
-1. Go to [Dashboard > Hosted Pages](${manage_url}/#/login_page). At the **Login** tab enable the toggle. 
+1. Go to [Dashboard > Universal Login](${manage_url}/#/login_settings). At the **Login** tab enable the toggle. 
 
 1. At the **Default Templates** dropdown make sure that `Custom Login Form` is picked. The code is prepopulated for you.
 

--- a/articles/compliance/gdpr/features-aiding-compliance/user-consent/track-consent-with-lock.md
+++ b/articles/compliance/gdpr/features-aiding-compliance/user-consent/track-consent-with-lock.md
@@ -18,7 +18,7 @@ In this tutorial we will see how you can use Lock to ask for consent information
 
 We will configure a simple JavaScript Single-Page Application and a database connection (we will use Auth0's infrastructure, instead of setting up our own database).
 
-Instead of building an app from scratch, we will use [Auth0's JavaScript Quickstart sample](/quickstart/spa/vanillajs). We will also use [Auth0's Universal Login Page](/hosted-pages/login) so we can implement a [Universal Login experience](/guides/login/centralized-vs-embedded), instead of embedding the login in our app.
+Instead of building an app from scratch, we will use [Auth0's JavaScript Quickstart sample](/quickstart/spa/vanillajs). We will also use [Auth0's Universal Login Page](/universal-login) so we can implement a [Universal Login experience](/guides/login/centralized-vs-embedded), instead of embedding the login in our app.
 
 We will capture consent information, under various scenarios, and save this at the user's metadata.
 

--- a/articles/connections/database/password-strength.md
+++ b/articles/connections/database/password-strength.md
@@ -57,9 +57,9 @@ If you opt for a higher-level password policy, but you do not specify a minimum 
 
 If you provide a minimum password length, this value supercedes that indicated by the password policy.
 
-### Minimum password length when using Hosted Pages
+### Minimum password length when using Universal Login Pages
 
-If you are using either the [Hosted Login Page](/hosted-pages/login) or the [Hosted Password Reset Page](/universal-login/password-reset), and you want to set the minimum password length value, you will need to complete a few additional configuration steps using the [Dashboard](${manage_url}).
+If you are using either the [Universal Login Page](/universal-login) or the [Universal Login Password Reset Page](/universal-login/password-reset), and you want to set the minimum password length value, you will need to complete a few additional configuration steps using the [Dashboard](${manage_url}).
 
 #### Set minimum password length when using Hosted Password Reset Pages
 
@@ -101,9 +101,9 @@ You'll need to add `password_complexity_options` to leverage the new parameter. 
 
 Scroll to the bottom and click **Save**.
 
-#### Set minimum password length when using Hosted Login Pages
+#### Set minimum password length when using Universal Login Pages
 
-If you're using a customized [Login Page](/hosted-pages/login) and you want to set the password length parameter, you must [update the page to use Lock version 11.9 or later](/hosted-pages/login/lock#customize-lock-in-the-login-page).
+If you're using a customized [Login Page](/universal-login) and you want to set the password length parameter, you must [update the page to use Lock version 11.9 or later](/universal-login/classic).
 
 ```text
 <script src="https://cdn.auth0.com/js/lock/11.9/lock.min.js"></script>

--- a/articles/cross-origin-authentication/index.md
+++ b/articles/cross-origin-authentication/index.md
@@ -11,7 +11,7 @@ useCase:
 ---
 # Cross-Origin Authentication
 
-Auth0 strongly recommends that authentication transactions be handled via [Universal Login](/hosted-pages/login). Doing so offers [the easiest and most secure way to authenticate users](guides/login/universal-vs-embedded). However, some situations may require that authentication forms be directly embedded in an application. Although not recommended, cross-origin authentication provides a way to do this.
+Auth0 strongly recommends that authentication transactions be handled via [Universal Login](/universal-login). Doing so offers [the easiest and most secure way to authenticate users](guides/login/universal-vs-embedded). However, some situations may require that authentication forms be directly embedded in an application. Although not recommended, cross-origin authentication provides a way to do this.
 
 ## What is cross-origin authentication?
 
@@ -32,7 +32,7 @@ There are two approaches you can follow to remediate the issue:
 - Enable a [Custom Domain](/custom-domains) on your tenant and host your web application in a domain that has the same top-level domain as your Auth0 custom domain. For example, you host an application at `https://northwind.com` and set your Auth0 custom domain as `https://login.northwind.com`. This way the cookies are no longer third-party (because both your Auth0 tenant and your application are using the same top-level domain), and thus, are not blocked by browsers.
 - Provide a [cross-origin verification page](#create-a-cross-origin-verification-page) that will make cross-origin authentication work in a **limited number of browsers** even with third-party cookies disabled (see the [browser testing information](#browser-testing-support) below).
 
-These issues are another reason why the more practical solution is to use [Universal Login](/hosted-pages/login).
+These issues are another reason why the more practical solution is to use [Universal Login](/universal-login).
 
 ## Configure your application for cross-origin authentication
 

--- a/articles/custom-domains/additional-configuration.md
+++ b/articles/custom-domains/additional-configuration.md
@@ -37,7 +37,7 @@ You should have already configured and verified your custom domain. To learn how
 
 ## Universal Login
 
-If you use [Universal Login](/hosted-pages/login) and you have customized the login page, you must update the code to use your custom domain. If you use the **default** login page without customization, you do not need to make any changes.
+If you use [Universal Login](/universal-login) and you have customized the login page, you must update the code to use your custom domain. If you use the **default** login page without customization, you do not need to make any changes.
 
 If you are using [Lock](/libraries/lock), you must set the `configurationBaseUrl` and `overrides` options as seen in the following sample script:
 

--- a/articles/custom-domains/index.md
+++ b/articles/custom-domains/index.md
@@ -17,7 +17,7 @@ useCase: customize-domains
 
 Auth0 allows you to map the domain for your tenant to **one custom domain** of your choosing. This allows you to maintain a consistent experience for your users by keeping them on your domain instead of redirecting or using Auth0's domain. You must register and own the domain name to which you are mapping your Auth0 domain. For example, if your Auth0 domain is **northwind.auth0.com**, you can have your users to see, use, and remain on **login.northwind.com**.
 
-We recommend that you use custom domains with Universal Login for the most seamless and secure experience for your users. See [Universal Login](/hosted-pages/login) to determine if your use case requires custom domains. 
+We recommend that you use custom domains with Universal Login for the most seamless and secure experience for your users. See [Universal Login](/universal-login) to determine if your use case requires custom domains. 
 
 ## Token issuance
 
@@ -94,7 +94,7 @@ With the [self-managed certificate approach](/custom-domains/self-managed-certif
 ## Keep reading
 
 * [Configure Custom Domains for Specific Features](/custom-domains/additional-configuration)
-* [Universal Login](/hosted-pages/login)
+* [Universal Login](/universal-login)
 * [Multi-factor Authentication](/mfa)
 * [Emails in Auth0](/email)
 * [Connections](/identityproviders)

--- a/articles/custom-domains/troubleshoot.md
+++ b/articles/custom-domains/troubleshoot.md
@@ -61,4 +61,4 @@ If you see any of these errors and you are using Embedded Login, you can move on
 3. Return to the **Security** tab, and make sure the proper zone has been selected.
 4. Click **Custom Level** and look for **Access data sources across domains** under the **Miscellaneous** section. Check the radio button next to **Enable.**.
 
-Alternatively, you can remove reliance on cross-origin authentication by implementing [Universal Login](/hosted-pages/login).
+Alternatively, you can remove reliance on cross-origin authentication by implementing [Universal Login](/universal-login).

--- a/articles/dashboard/manage-dashboard-admins.md
+++ b/articles/dashboard/manage-dashboard-admins.md
@@ -32,7 +32,7 @@ When the recipient opens and accepts the invitation, the current Auth0 account i
 If the invited administrator has not created an Auth0 admin user account, they will need to do so in order to be able to accept the invitation and log into the Management Dashboard. Auth0 admin users are managed separately from tenant users; accounts can be created by following the invitation URL or signing up through [auth0.com/signup](https://auth0.com/signup).
 :::
 
-Administrators are application-specific, so areas to which the admin doesn't have access rights (e.g., APIs, Rules, Hooks, Hosted Pages, and so on) will appear as blank pages. Administrators will also *not* be allowed to manage users, create rules, and perform other functions for applications to which they don't have access.
+Administrators are application-specific, so areas to which the admin doesn't have access rights (e.g., APIs, Rules, Hooks, Universal Login Pages, and so on) will appear as blank pages. Administrators will also *not* be allowed to manage users, create rules, and perform other functions for applications to which they don't have access.
 
 ::: panel Application-Specific Access
 Application-specific access includes the following:

--- a/articles/dashboard/reference/settings-tenant.md
+++ b/articles/dashboard/reference/settings-tenant.md
@@ -40,7 +40,7 @@ Setting the Default Audience is equivalent to appending this audience to every a
 
 ![Tenant Settings: Error Pages](/media/articles/tutorials/tenant-settings/error-pages.png)
 
-In the event of an authorization error, you can either display a generic error page to your users or you can redirect users to your own custom error page. To learn more, see [Custom Error Pages](/hosted-pages/custom-error-pages).
+In the event of an authorization error, you can either display a generic error page to your users or you can redirect users to your own custom error page. To learn more, see [Custom Error Pages](/universal-login/custom-error-pages).
 
 ### Languages
 

--- a/articles/errors/deprecation-errors.md
+++ b/articles/errors/deprecation-errors.md
@@ -77,7 +77,7 @@ Click on the **TRY** button. If successful, you should see a screen similar to t
 | You are using a legacy version of embedded Lock or Auth0.js SDK. | [Migrate away from the deprecated library versions](/migrations/guides/legacy-lock-api-deprecation) as soon as possible. |
 | Calling the /usernamepassword/login endpoint directly. | Use the Lock or Auth0.js libraries instead. |
 | Automatic monitoring tools making requests to login page | If you have an automatic monitoring tool making requests to the login page, the tool will likely not preserve state correctly and will cause the Legacy Lock API error to occur in your logs. Use of the tool should either be discontinued, or accounted for when considering causes of the log notices. |
-| Coding errors in a customized [Universal Login Page](/hosted-pages/login) | Make sure the `state` and `_csrf` fields are passed to Lock or Auth0.js in your customized login page. They are by default included in the `config.internalOptions` object, but if this is removed during customization, the error occurs. |
+| Coding errors in a customized [Universal Login Page](/universal-login) | Make sure the `state` and `_csrf` fields are passed to Lock or Auth0.js in your customized login page. They are by default included in the `config.internalOptions` object, but if this is removed during customization, the error occurs. |
 
 ### ssodata
 

--- a/articles/extensions/account-link.md
+++ b/articles/extensions/account-link.md
@@ -32,7 +32,7 @@ By default, Auth0's [Universal Login](/universal-login) allows a user to both lo
 
 To prevent this, we send over a query parameter to let the login page know that it should hide the **Sign Up** option. In order for this query parameter to take effect, however, we must first customize the login page.
 
-First go to your [Dashboard](${manage_url}) and click on **Hosted Pages**. It should open to the login page by default. 
+First go to your [Dashboard](${manage_url}) and click on **Universal Login**. It should open to the login page by default. 
 
 If it is not already enabled, toggle the **Customize Login Page** to enable the custom editor below. In the editor we're going to add a new line to the Lock config.
 

--- a/articles/guides/login/_includes/_customizing-login-page.md
+++ b/articles/guides/login/_includes/_customizing-login-page.md
@@ -2,7 +2,7 @@
 
 When you integrate Universal Login in your application, you redirect the user to the `/authorize` endpoint of your Auth0 tenant. If Auth0 needs to authenticate the user, it will show the default login page.
 
-You can customize the login page in your [Dashboard](${manage_url}/#/login_page) under Hosted Pages, by enabling the **Customize Login Page** toggle.
+You can customize the login page in your [Dashboard](${manage_url}/#/login_settings) under Universal Login, by enabling the **Customize Login Page** toggle.
 
 ![Login Page](/media/articles/hosted-pages/login.png)
 
@@ -10,7 +10,7 @@ You can customize the login page in your [Dashboard](${manage_url}/#/login_page)
 
 The default login page for Universal Login with your tenant is a template that will use [Lock](/libraries/lock) to provide your users with an attractive interface and smooth authentication process. You can look over that template and use it as a starting point if you choose to customize it in any way.
 
-If you want to change any of Lock's [configurable options](/libraries/lock/configuration), you can do so using the editor [Dashboard](${manage_url}/#/login_page) under Hosted Pages. These options can alter the behavior of Lock itself, or the look and feel of the widget using the theming options. See the [configuration documentation](/libraries/lock/configuration) for details on how to customize Lock.
+If you want to change any of Lock's [configurable options](/libraries/lock/configuration), you can do so using the editor [Dashboard](${manage_url}/#/login_settings) under Universal Login. These options can alter the behavior of Lock itself, or the look and feel of the widget using the theming options. See the [configuration documentation](/libraries/lock/configuration) for details on how to customize Lock.
 
 When you're done making changes to the code, click **Save** to persist the changes.
 

--- a/articles/guides/login/migration-embedded-universal.md
+++ b/articles/guides/login/migration-embedded-universal.md
@@ -16,7 +16,7 @@ useCase: migrate
 When you integrate Auth0 in our applications, you have to decide whether you will use embedded or Universal Login.
 
 - With embedded login the login dialog is hosted in your application. You can use [Lock](/libraries/lock) or create your own UI and use [auth0.js](/libraries/auth0js).
-- With Universal Login, you redirect to an Auth0-hosted [login page](/hosted-pages/login) where the authentication flow is performed.
+- With Universal Login, you redirect to an Auth0-hosted [login page](/universal-login) where the authentication flow is performed.
 
 Universal Login has several advantages over embedded login. For a detailed analysis refer to [Centralized vs Embedded Login](/guides/login/universal-vs-embedded).
 

--- a/articles/guides/login/migration-sso.md
+++ b/articles/guides/login/migration-sso.md
@@ -14,7 +14,7 @@ useCase: migrate
 
 # Migration in Embedded Login Scenarios with Single Sign-On
 
-Migration from legacy versions of Lock and Auth0.js is required. For <dfn data-key="single-sign-on">Single Sign-on (SSO)</dfn> scenarios, it will imply moving to [Universal Login](/hosted-pages/login) in most cases. 
+Migration from legacy versions of Lock and Auth0.js is required. For <dfn data-key="single-sign-on">Single Sign-on (SSO)</dfn> scenarios, it will imply moving to [Universal Login](/universal-login) in most cases. 
 
 ## Single-Page Apps
 

--- a/articles/guides/login/universal-vs-embedded.md
+++ b/articles/guides/login/universal-vs-embedded.md
@@ -42,7 +42,7 @@ In this article, we will evaluate the pros and cons of these two options and see
 
 ## Universal Login with Auth0
 
-For most situations, we recommend using a Universal Login strategy, where Auth0 will show a [login page](/hosted-pages/login) if authentication is required. You can customize your login page using the [Dashboard](${manage_url}/#/login_page).
+For most situations, we recommend using a Universal Login strategy, where Auth0 will show a [login page](/universal-login) if authentication is required. You can customize your login page using the [Dashboard](${manage_url}/#/login_page).
 
 You can use **Auth0's Custom Domains** in order to persist the same domain across the login page and the app. This way the redirect to the login page will be transparent to your users since the domain will not change. For more details, see [Custom Domains](/custom-domains).
 

--- a/articles/hosted-pages/login/index.md
+++ b/articles/hosted-pages/login/index.md
@@ -14,7 +14,7 @@ If you cannot use universal login, you can embed the Lock widget or a custom log
 
 ![Login Page](/media/articles/hosted-pages/hlp-lock.png)
 
-To find the default page name for the login page, see [How to Use Version Control to Manage Your Hosted Pages](/hosted-pages/version-control).
+To find the default page name for the login page, see [How to Use Version Control to Manage Your Universal Login Pages](/universal-login/version-control).
 
 ### How Does Universal Login Work
 
@@ -59,7 +59,7 @@ Currently, universal login is the **only** way to use [Passwordless](/connection
 
 ### 1. Enable Customization on the Login Page
 
-In the [Dashboard](${manage_url}), you can enable a custom login page by navigating to [Hosted Pages](${manage_url}/#/login_page) and enabling the **Customize Login Page** toggle.
+In the [Dashboard](${manage_url}), you can enable a custom login page by navigating to [Universal Login](${manage_url}/#/login_settings) and enabling the **Customize Login Page** toggle.
 
 ![Login Page](/media/articles/hosted-pages/login.png)
 
@@ -105,19 +105,19 @@ webAuth.authorize({
 
 ## Configure Multiple Pages by Using Separate Tenants
 
-In some cases, you might have multiple apps and want to configure separate login pages for each. Since the hosted pages are configured in the [Dashboard](${manage_url}) at the tenant level (every app you have set up on a single tenant would use the same login page), you would have to create a new tenant for each application that requires a different hosted page.
+In some cases, you might have multiple apps and want to configure separate login pages for each. Since the Universal Login pages are configured in the [Dashboard](${manage_url}) at the tenant level (every app you have set up on a single tenant would use the same login page), you would have to create a new tenant for each application that requires a different login page.
 
 In most cases, it would be preferable to use a single login page, which unifies your brand and the authentication experience for your users across the various areas in which they might encounter it. Additionally, using the same pages, and the same tenant, will allow you to share the resources that would otherwise need to be separated across multiple tenants.
 
-Creating a separate tenant is only really a viable option for an organization that needs two or more separate sets of custom pages, such as for branding reasons. If an example corporation has multiple branded subsidiaries or products, and separate APIs for all of them, it might make sense for them to create several separate Auth0 tenants, each with their own hosted pages set up for that brand or product's specific needs.
+Creating a separate tenant is only really a viable option for an organization that needs two or more separate sets of custom pages, such as for branding reasons. If an example corporation has multiple branded subsidiaries or products, and separate APIs for all of them, it might make sense for them to create several separate Auth0 tenants, each with their own Universal Login pages set up for that brand or product's specific needs.
 
-Bear in mind that separating tenants with the goal of having separate hosted pages will also mean that those separate tenants will have two distinct sets of applications, users, settings, and so on as these things are not shared between tenants.
+Bear in mind that separating tenants with the goal of having separate Universal Login pages will also mean that those separate tenants will have two distinct sets of applications, users, settings, and so on as these things are not shared between tenants.
 
 ### Creating New Tenants
 
 If your use case requires separate sets of custom pages, let's see how you would go about creating them.
 
-If you have five different applications, with three of them (`app1`, `app2`, `app3`) using the same set of hosted pages and the other two (`app4`, `app5`) using different ones, you would do the following:
+If you have five different applications, with three of them (`app1`, `app2`, `app3`) using the same set of Universal Login pages and the other two (`app4`, `app5`) using different ones, you would do the following:
 
 - If you already have an account, you have a tenant configured. Configure three applications under this tenant, one to represent each app (`app1`, `app2`, `app3`), and one login page  which these applications will all share.
 - Create a second tenant, configure a new application for `app4`, and configure the login page for this application.

--- a/articles/libraries/auth0-android/index.md
+++ b/articles/libraries/auth0-android/index.md
@@ -143,7 +143,7 @@ Finally, don't forget to add the internet permission:
 In versions 1.8.0 or lower of Auth0.Android you had to define the **intent-filter** inside your activity to capture the authentication result in the `onNewIntent` method and then call `WebAuthProvider.resume()` with the received data. The intent-filter declaration and resume call are no longer required for versions greater than 1.8.0, as it's now done internally by the library for you.
 :::
 
-Now, let's authenticate a user by presenting the universal [login page](hosted-pages/login):
+Now, let's authenticate a user by presenting the universal [login page](/universal-login):
 
 ```java
 WebAuthProvider.login(account)

--- a/articles/libraries/auth0js/v9/migration-guide.md
+++ b/articles/libraries/auth0js/v9/migration-guide.md
@@ -49,6 +49,6 @@ You have already migrated to Auth0.js 9 but you still see this error in your log
 Legacy Lock API: This feature is being deprecated. Please refer to our documentation to learn how to migrate your application.
 ```
 
-These deprecation notices most likely originate from a user visiting the <dfn data-key="universal-login">Universal Login</dfn> [page](/hosted-pages/login) directly without initiating the authentication flow from your app. This can happen if a user bookmarks the login page directly. After August 6, 2018, these users will not be able to log in. 
+These deprecation notices most likely originate from a user visiting the <dfn data-key="universal-login">Universal Login</dfn> [page](/universal-login) directly without initiating the authentication flow from your app. This can happen if a user bookmarks the login page directly. After August 6, 2018, these users will not be able to log in. 
 
 See [Check Deprecation Errors](/troubleshoot/guides/check-deprecation-errors) for more information on deprecation-related errors.

--- a/articles/libraries/lock/v11/configuration.md
+++ b/articles/libraries/lock/v11/configuration.md
@@ -314,7 +314,7 @@ New tenants [automatically have Seamless SSO enabled](https://auth0.com/docs/das
 ::: note
 The **Last time you signed in with [...]** message will not be available under the following circumstances:
 
-- You used Lock in a [Hosted Login Page](/hosted-pages/login) with the session established using <dfn data-key="passwordless">[Passwordless authentication](/connections/passwordless)</dfn>.
+- You used Lock in a [Hosted Login Page](/universal-login) with the session established using <dfn data-key="passwordless">[Passwordless authentication](/connections/passwordless)</dfn>.
 - You used Lock in an [embedded login scenario](/guides/login/universal-vs-embedded#embedded-login-with-auth0) where `responseType: code` (indicating the [Authorization Code Flow](/flows/concepts/auth-code), which is used for Regular Web Apps).
 :::
 

--- a/articles/libraries/lock/v11/migration-guide.md
+++ b/articles/libraries/lock/v11/migration-guide.md
@@ -62,6 +62,6 @@ You have already migrated to Lock 11 but you still see this error in your logs:
 Legacy Lock API: This feature is being deprecated. Please refer to our documentation to learn how to migrate your application.
 ```
 
-These deprecation notices most likely originate from a user visiting the <dfn data-key="universal-login">Universal Login</dfn> [page](/hosted-pages/login) directly without initiating the authentication flow from your app. This can happen if a user bookmarks the login page directly. After August 6, 2018, these users will not be able to log in.
+These deprecation notices most likely originate from a user visiting the <dfn data-key="universal-login">Universal Login</dfn> [page](/universal-login) directly without initiating the authentication flow from your app. This can happen if a user bookmarks the login page directly. After August 6, 2018, these users will not be able to log in.
 
 See [Check Deprecation Errors](/troubleshoot/guides/check-deprecation-errors) for more information on deprecation-related errors.

--- a/articles/login/index.md
+++ b/articles/login/index.md
@@ -30,8 +30,8 @@ Universal Login functionality and features are driven from web pages served by A
 
 There are two versions of Universal Login:
 
-* Classic Universal Login: Auth0 hosted pages built with [Lock.js](/libraries/lock) and other Javascript widgets, or with a library like [Auth0.js](/libraries/auth0js). HTML and CSS can also be customized.
-* New Universal Login: Auth0 hosted pages, rendered server-side, that do not use [Lock.js](/libraries/lock) or other Javascript widgets and libraries. Can only be customized based on the configuration available. HTML, CSS, and JS cannot be customized.
+* Classic Universal Login: Auth0-hosted pages built with [Lock.js](/libraries/lock) and other Javascript widgets, or with a library like [Auth0.js](/libraries/auth0js). HTML and CSS can also be customized.
+* New Universal Login: Auth0-hosted pages, rendered server-side, that do not use [Lock.js](/libraries/lock) or other Javascript widgets and libraries. Can only be customized based on the configuration available. HTML, CSS, and JS cannot be customized.
 
 In the [Dashboard](${manage_url}), the dialog shown below lets you select which Experience will be used for default, non-customized pages:
 

--- a/articles/microsites/add-login/add-login-native-mobile-app.md
+++ b/articles/microsites/add-login/add-login-native-mobile-app.md
@@ -54,7 +54,7 @@ While we strongly recommend that you use our hosted universal login page, if you
 ::: guides
   * [Auth0 Mobile/Native App Quickstarts](/quickstart/native)
   * [Add login using the Authorization Code Flow with PKCE](/flows/guides/auth-code-pkce/add-login-auth-code-pkce)
-  * [Customize the hosted login page](/hosted-pages/login#how-to-customize-your-login-page)
+  * [Customize the universal login page](/universal-login)
   * [Token Storage](/tokens/concepts/token-storage)
 :::
 

--- a/articles/microsites/add-login/add-login-regular-web-app.md
+++ b/articles/microsites/add-login/add-login-regular-web-app.md
@@ -45,7 +45,7 @@ For security in server-side web apps, Auth0 uses the [Authorization Code Flow](/
 ::: guides
   * [Auth0 Regular Web App Quickstarts](/quickstart/webapp)
   * [Add login using the Authorization Code Flow](/flows/guides/auth-code/add-login-auth-code)
-  * [Customize the hosted login page](/hosted-pages/login#how-to-customize-your-login-page)
+  * [Customize the universal login page](/universal-login)
   * [Token Storage](/tokens/concepts/token-storage)
 :::
 

--- a/articles/microsites/add-login/add-login-single-page-app.md
+++ b/articles/microsites/add-login/add-login-single-page-app.md
@@ -46,7 +46,7 @@ For security in SPAs, Auth0 uses the [Authorization Code Flow with PKCE](/flows/
   * [Auth0 Single-Page App Quickstarts](/quickstart/spa)
   * [Add login using the Authorization Code Flow with PKCE](/flows/guides/auth-code-pkce/add-login-auth-code-pkce)
   * [Add login using the Implicit Flow](/flows/guides/implicit/add-login-implicit)
-  * [Customize the hosted login page](/hosted-pages/login#how-to-customize-your-login-page)
+  * [Customize the universal login page](/universal-login)
   * [Token Storage](/tokens/concepts/token-storage)
 :::
 

--- a/articles/migrations/guides/legacy-lock-api-deprecation.md
+++ b/articles/migrations/guides/legacy-lock-api-deprecation.md
@@ -27,7 +27,7 @@ If you do not use the above libraries and do not specifically call the above end
 
 ### If you already use Universal Login / Hosted Login Page
 
-Applications which log users in via <dfn data-key="universal-login">Universal Login</dfn> through an Auth0 hosted page are not _required_ to update the version of Lock or Auth0.js that they use _inside_ that login page (if you have customized your login page in the [Dashboard](${manage_url}/#/login_page). However, the use of the newest library versions is strongly recommended, even in the Universal Login Page. For those who have not customized their login page, the Lock v11 widget is already in use and no further action is required.
+Applications which log users in via <dfn data-key="universal-login">Universal Login</dfn> through an Auth0-hosted page are not _required_ to update the version of Lock or Auth0.js that they use _inside_ that login page (if you have customized your login page in the [Dashboard](${manage_url}/#/login_page). However, the use of the newest library versions is strongly recommended, even in the Universal Login Page. For those who have not customized their login page, the Lock v11 widget is already in use and no further action is required.
 
 ### If you use embedded login
 

--- a/articles/migrations/past-migrations.md
+++ b/articles/migrations/past-migrations.md
@@ -28,7 +28,7 @@ If your Legacy Lock API migration has not yet been completed, your users may exp
 
 If you are currently implementing login in your application with Lock v8, v9, or v10, or Auth0.js v6, v7, or v8, you are affected by these changes. Additionally, you are affected if your application calls the /usernamepassword/login or /ssodata endpoints directly via the API.
 
-We **recommend** that applications using [Universal Login](/hosted-pages/login) update the library versions they use inside of the login page.
+We **recommend** that applications using [Universal Login](/universal-login) update the library versions they use inside of the login page.
 
 However, those who are using Lock or Auth0.js embedded within their applications, or are calling the affected API endpoints directly, are **required** to update, and applications which still use deprecated endpoints will cease to function properly after the removal of service date.
 

--- a/articles/pre-deployment/tests/recommended.md
+++ b/articles/pre-deployment/tests/recommended.md
@@ -24,10 +24,10 @@ See [How to Read Your Results Set](/pre-deployment/how-to-run-test#how-to-read-y
 | ---- | ----------- |
 | [Authorization Extension](/extensions/authorization-extension/v2) | Evaluate the [Authorization Extension if you have authorization requirements](${manage_url}/#/extensions). |
 | [Custom Domain](/custom-domains) is configured | Use [custom domains with Universal Login](${manage_url}/#/tenant/custom_domains) for the most seamless and secure experience for your end users. |
-| [Custom Error Page](/hosted-pages/custom-error-pages) is configured | [Configure a Custom Error Page](${manage_url}/#/account) with your application-specific details and corporate branding. |
+| [Custom Error Page](/universal-login/custom-error-pages) is configured | [Configure a Custom Error Page](${manage_url}/#/account) with your application-specific details and corporate branding. |
 | [Email Templates](/email/custom) are configured | [Configure custom email templates](${manage_url}/#/emails) with your application specific details and corporate branding. |
 | [Guardian Multi-factor](/mfa) or other Multi-factor Authentication Providers | Consider [multi-factor authentication](${manage_url}/#/guardian) as part of the authentication strategy. |
 | [MFA for Tenant Administrators](/tutorials/manage-dashboard-admins) is enabled | [Enable multi-factor authentication](${manage_url}/#/account/admins) for tenant administrators. |
-| [Hosted Password Reset Page](/universal-login/password-reset) is customized | [Configure a Custom Hosted Page for Password Reset](${manage_url}/#/password_reset) with your application details and corporate branding. |
+| [Universal Login Password Reset Page](/universal-login/password-reset) is customized | [Configure a Custom Universal Login Page for Password Reset](${manage_url}/#/password_reset) with your application details and corporate branding. |
 | [Redirect Logout URL](/logout#set-the-allowed-logout-urls-at-the-account-level) | Review the [Allowed Redirect Logout URLs](${manage_url}/#/account/advanced) for your Application. |
 | Use RS256 Instead of HS256 | Set the JSONWebToken [Signature Algorithm](/apis#signing-algorithms) to RS256 instead of HS256. |

--- a/articles/sso/current/sso-auth0.md
+++ b/articles/sso/current/sso-auth0.md
@@ -11,7 +11,7 @@ useCase:
 ---
 # Single Sign-On with Auth0
 
-The easiest and most secure way to implement <dfn data-key="single-sign-on">Single Sign-on (SSO)</dfn> with Auth0 is by using [Universal Login](/hosted-pages/login) for authentication. In fact, currently SSO is only possible with native platforms (like iOS or Android) if the application uses Universal Login. The [Swift](/quickstart/native/ios-swift/00-login) and [Android](/quickstart/native/android/00-login) quickstarts provide some examples of using Universal Login.
+The easiest and most secure way to implement <dfn data-key="single-sign-on">Single Sign-on (SSO)</dfn> with Auth0 is by using [Universal Login](/universal-login) for authentication. In fact, currently SSO is only possible with native platforms (like iOS or Android) if the application uses Universal Login. The [Swift](/quickstart/native/ios-swift/00-login) and [Android](/quickstart/native/android/00-login) quickstarts provide some examples of using Universal Login.
 
 If you cannot use Universal Login with your application, review the following for additional info on embedded authentication:
 

--- a/articles/troubleshoot/guides/check-deprecation-errors.md
+++ b/articles/troubleshoot/guides/check-deprecation-errors.md
@@ -61,7 +61,7 @@ Use the Management API to search through logs for deprecation messages by lookin
 | You are using a legacy version of embedded Lock or Auth0.js SDK. | [Migrate away from the deprecated library versions](/migrations/guides/legacy-lock-api-deprecation) as soon as possible. |
 | Calling the /usernamepassword/login endpoint directly. | Use the Lock or Auth0.js libraries instead. |
 | Automatic monitoring tools making requests to login page | If you have an automatic monitoring tool making requests to the login page, the tool will likely not preserve state correctly and will cause the Legacy Lock API error to occur in your logs. Use of the tool should either be discontinued, or accounted for when considering causes of the log notices. |
-| Coding errors in a customized [Universal Login Page](/hosted-pages/login) | Make sure the `state` and `_csrf` fields are passed to Lock or Auth0.js in your customized login page. They are by default included in the `config.internalOptions` object, but if this is removed during customization, the error occurs. |
+| Coding errors in a customized [Universal Login Page](/universal-login) | Make sure the `state` and `_csrf` fields are passed to Lock or Auth0.js in your customized login page. They are by default included in the `config.internalOptions` object, but if this is removed during customization, the error occurs. |
 
 Tenant log entries regarding the Legacy Lock API may include the referrer and information about the SDK used. This information can be used to see if any of your applications use outdated libraries.
 

--- a/articles/troubleshoot/guides/check-login-logout-issues.md
+++ b/articles/troubleshoot/guides/check-login-logout-issues.md
@@ -18,7 +18,7 @@ Here are things to check to help you narrow down when issues occur during login 
 * Does the HAR file show a call to the authorization server (`/authorize` endpoint)?
 * Is the connection enabled for the application?
 * Is the remote authorization service available? 
-* If using the [Auth0 Universal Login Page](/hosted-pages/login), try turning off customization and see if authentication works. If login works without your customizations, review your Universal Login Page customization code.
+* If using the [Auth0 Universal Login Page](/universal-login), try turning off customization and see if authentication works. If login works without your customizations, review your Universal Login Page customization code.
 
 ### Is an error message shown after entering credentials?
 

--- a/articles/universal-login/custom-error-pages.md
+++ b/articles/universal-login/custom-error-pages.md
@@ -12,9 +12,9 @@ useCase: customize-hosted-pages
 ---
 # Custom Error Pages
 
-In the event of an authorization error, you may choose to display to your users either [the default Auth0 error page](/hosted-pages/error-pages) or a customized error page.
+In the event of an authorization error, you may choose to display to your users either [the default Auth0 error page](/universal-login/error-pages) or a customized error page.
 
-This article will show you how to use a customized error page. For details on the default Auth0 error page see [Error Pages](/hosted-pages/error-pages).
+This article will show you how to use a customized error page. For details on the default Auth0 error page see [Error Pages](/universal-login/error-pages).
 
 ## How to customize the error page
 

--- a/articles/universal-login/error-pages.md
+++ b/articles/universal-login/error-pages.md
@@ -16,7 +16,7 @@ Throughout the authentication process, your users may encounter errors. Auth0 pr
 
 ![Hosted Error Page](/media/articles/hosted-pages/error-pages.png)
 
-To find the default page name for the Generic Error Page, see [How to Use Version Control to Manage Your Hosted Pages](/hosted-pages/version-control).
+To find the default page name for the Generic Error Page, see [How to Use Version Control to Manage Your Universal Login Pages](/universal-login/version-control).
 
 By going into the [Tenant Settings](${manage_url}/#/tenant/) page of the Management Dashboard, you may customize your Auth0 error page with the following fields:
 
@@ -42,4 +42,4 @@ Auth0 will display the **Tenant** information exactly as entered on the Settings
 
 In the event of an authorization error, you may choose to display to your users either the default Auth0 error page or a customized error page.
 
-The [custom error pages](/hosted-pages/custom-error-pages) page details how you can configure your own custom error page for use with Auth0.
+The [custom error pages](/universal-login/custom-error-pages) page details how you can configure your own custom error page for use with Auth0.

--- a/articles/universal-login/version-control.md
+++ b/articles/universal-login/version-control.md
@@ -1,5 +1,5 @@
 ---
-description: How to back up your Universal Login pages using the Auth0 version control extensions
+description: Learn how to back up your Universal Login pages using the Auth0 version control extensions
 topics:
   - version-control
   - hosted-pages

--- a/articles/users/guides/azure-access-control.md
+++ b/articles/users/guides/azure-access-control.md
@@ -73,6 +73,6 @@ Depending on your application and use case, you'll have to update your applicati
 
 ::: next-steps
 * [Add Rules to customize user authentication](/rules/current)
-* [Set up the Hosted Login Page](/hosted-pages/login)
+* [Set up the Universal Login Page](/universal-login)
 * [Manage user access with groups, roles, and permissions](/extensions/authorization-extension)
 :::

--- a/articles/users/references/link-accounts-client-side-scenario.md
+++ b/articles/users/references/link-accounts-client-side-scenario.md
@@ -20,7 +20,7 @@ The following steps implement this scenario for a Single-Page Application (SPA).
 
 1. Log in the user to your application. 
 
-    - Auth0 recommends using [Universal Login](/hosted-pages/login). 
+    - Auth0 recommends using [Universal Login](/universal-login). 
     - If you choose to embed the [Lock](/libraries/lock/v11) widget or the [auth0.js library](/libraries/auth0js/v9) in your app, see [Auth0 jQuery Single-Page App Account Linking Sample](https://github.com/auth0-samples/auth0-link-accounts-sample/tree/master/SPA) for sample code.
     - If you call the Authentication API directly, see [Call API Using the Implicit Flow](/flows/guides/implicit/call-api-implicit).
 

--- a/articles/users/references/link-accounts-server-side-scenario.md
+++ b/articles/users/references/link-accounts-server-side-scenario.md
@@ -18,7 +18,7 @@ See [Auth0 Node.js Regular Web App Account Linking](https://github.com/auth0/aut
 
 1. Log in the user to your application.
 
-    - Auth0 recommends using [Universal Login](/hosted-pages/login). 
+    - Auth0 recommends using [Universal Login](/universal-login). 
     - If you choose to embed the [Lock](/libraries/lock/v11) widget in your app, see [Auth0 Node.js Regular Web App Account Linking](https://github.com/auth0/auth0-link-accounts-sample/tree/master/RegularWebApp) for sample code.
     - If you call the Authentication API directly, see [Call API Using the Authorization Code Flow](/flows/guides/auth-code/call-api-auth-code).
 

--- a/config/redirects.js
+++ b/config/redirects.js
@@ -1594,6 +1594,10 @@ module.exports = [
     to: '/universal-login/default-login-url'
   },
   {
+    from: '/hosted-pages/version-control',
+    to: '/universal-login/version-control'
+  },
+  {
     from: '/hosted-pages/guardian',
     to: '/universal-login/multifactor-authentication'
   },


### PR DESCRIPTION
Fix broken link, add redirect, correct all redirected links throughout docs, replace "hosted page" references with "universal login page" where appropriate.

Original broken link per [Slack #docs thread](https://auth0.slack.com/archives/C02FE2CTZ/p1587415560075800).

- https://docs-content-staging-pr-8940.herokuapp.com/docs/universal-login/error-pages

Redirect:
https://docs-content-staging-pr-8940.herokuapp.com/docs/hosted-pages/error-pages
should redirect to:
https://docs-content-staging-pr-8940.herokuapp.com/docs/universal-login/error-pages