### PR TITLE
Update express quickstart

### DIFF
--- a/articles/quickstart/webapp/express/01-login.md
+++ b/articles/quickstart/webapp/express/01-login.md
@@ -24,13 +24,13 @@ You will need to register your application with Auth0 in order to start authenti
 
 A callback URL is an application route where Auth0 redirects users after they have authenticated. This URL must be registered with Auth0 or else users will be unable to log in to the application and will get a "Callback URL mismatch" error.
 
-The callback URL for the application created in this quickstart is `https://localhost:3000/callback`. Paste that in the **Allowed Callback URLs** field for the application you just created.
+The callback URL for the application created in this quickstart is `http://localhost:3000/callback`. Paste that in the **Allowed Callback URLs** field for the application you just created.
 
 ### 2. Configure Logout URL
 
 A logout URL is an application route that Auth0 can return users to after logging out. This URL must be registered with Auth0 or else users will be unable to log out of the application and will get a "misconfiguration" error.
 
-The logout URL for the application created in this quickstart is `https://localhost:3000`. Paste that in the **Allowed Logout URLs** field for the application you just created, then scroll down and click **Save Changes**.
+The logout URL for the application created in this quickstart is `http://localhost:3000`. Paste that in the **Allowed Logout URLs** field for the application you just created, then scroll down and click **Save Changes**.
 
 ### 3. Get Your Application Keys
 
@@ -66,7 +66,7 @@ const config = {
   appSession: {
     secret: 'a long, randomly-generated string stored in env'
   },
-  baseURL: 'https://localhost:3000',
+  baseURL: 'http://localhost:3000',
   clientID: '${account.clientId}',
   issuerBaseURL: 'https://${account.namespace}',
 };
@@ -87,7 +87,7 @@ You can generate a suitable string for `appSessionSecret` using `openssl rand -h
 :::
 
 ## Login
-A user can now log into your application by visiting the `/login` route provided by the library. If you are running your project on `localhost:3000` that link would be [`https://localhost:3000/login`](https://localhost:3000/login).
+A user can now log into your application by visiting the `/login` route provided by the library. If you are running your project on `localhost:3000` that link would be [`http://localhost:3000/login`](http://localhost:3000/login).
 
 ## Display User Profile
 To display the user's profile, your application should provide a protected route.
@@ -103,7 +103,7 @@ app.get('/profile', requiresAuth(), (req, res) => {
 ```
 
 ## Logout
-A user can log out of your application by visiting the `/logout` route provided by the library. If you are running your project on `localhost:3000` that link would be [`https://localhost:3000/logout`](https://localhost:3000/logout).
+A user can log out of your application by visiting the `/logout` route provided by the library. If you are running your project on `localhost:3000` that link would be [`http://localhost:3000/logout`](http://localhost:3000/logout).
 
 ## What's next?
 We put together a few examples of how to use [Express OpenID Connect](https://github.com/auth0/express-openid-connect) in more advanced use cases:

--- a/articles/quickstart/webapp/express/01-login.md
+++ b/articles/quickstart/webapp/express/01-login.md
@@ -39,50 +39,15 @@ Finally, copy the following fields for your application for use in step 7:
 * **Domain**
 * **Client ID**
 
-## Secure Local Server
-
-Applications that handle sensitive data must be served over secure channels. This includes local applications as they may handle the same sensitive data and should be built as close to production-ready as possible.
-
-Complete instructions are below or see our [Secure Local Development guide](/libraries/secure-local-development) for additional explanation.
-
-### 4. Generate an SSL Certificate
-
-If you do not already have a method of generating local certificates, [install `mkcert`](https://github.com/FiloSottile/mkcert#installation) and run the following commands in your terminal to generate a certificate and key for this application:
-
-```bash
-#!/bin/sh
-❯ cd /path/to/application/root
-❯ mkcert -install
-❯ mkcert localhost
-```
-
-### 5. Serve the SSL certificate
-The commands above will create `localhost-key.pem` and `localhost.pem` files, which need to be read from the file system:
-
-```js
-const express = require('express');
-const https = require('https');
-const fs = require('fs');
-
-const key = fs.readFileSync('./localhost-key.pem');
-const cert = fs.readFileSync('./localhost.pem');
-
-const app = express();
-
-https.createServer({key, cert}, app).listen('3000', () => {
-  console.log('Listening on https://localhost:3000');
-});
-```
-
 ## Integrate Auth0
-### 6. Install Dependencies
+### 4. Install Dependencies
 Your application will need the [`express-openid-connect`](https://github.com/auth0/express-openid-connect) package which is an Auth0-maintained OIDC-compliant library for Express.
 
 ```sh
-npm install express express-openid-connect@0.6.0 --save
+npm install express express-openid-connect --save
 ```
 
-### 7. Configure Router
+### 5. Configure Router
 The Express OpenID Connect library provides the `auth` router in order to attach authentication routes to your application. You will need to configure the router with the following configuration keys:
 
 - `baseURL` - The URL where the application is served
@@ -98,10 +63,12 @@ const { auth } = require('express-openid-connect');
 const config = {
   required: false,
   auth0Logout: true,
+  appSession: {
+    secret: 'a long, randomly-generated string stored in env'
+  },
   baseURL: 'https://localhost:3000',
-  issuerBaseURL: 'https://${account.namespace}',
   clientID: '${account.clientId}',
-  appSessionSecret: 'a long, randomly-generated string stored in env'
+  issuerBaseURL: 'https://${account.namespace}',
 };
 
 // auth router attaches /login, /logout, and /callback routes to the baseURL


### PR DESCRIPTION
We are removing the secure localhost setup.  There were concerns with generating a root local authority and the complexity this adds to the quickstart.

The reason why we have the secure local guidance there is because of same site flags coming from Chrome for localhost.  However, they have announced that they will delay the roll out of same site here https://www.chromium.org/updates/same-site

With the delay in rollout, this gives us time to improve the secure localhost guidance, or change the quickstart to use authcode+pkce to avoid having to use secure localhost for a quickstart.