### PR TITLE
Clarify rules in context of authentication transaction flow

### DIFF
--- a/articles/flows/guides/auth-code-pkce/includes/sample-use-cases-call-api.md
+++ b/articles/flows/guides/auth-code-pkce/includes/sample-use-cases-call-api.md
@@ -18,6 +18,8 @@ function(user, context, callback) {
 }
 ```
 
+Scopes will be available in the token after all rules have run.
+
 ::: panel-warning Namespacing Custom Claims 
 Auth0 returns profile information in a [structured claim format as defined by the OpenID Connect (OIDC) specification](https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims). This means that custom claims added to ID Tokens or Access Tokens must [conform to a namespaced format](/tokens/guides/create-namespaced-custom-claims) to avoid possible collisions with standard OIDC claims. 
 :::

--- a/articles/flows/guides/auth-code/includes/sample-use-cases-call-api.md
+++ b/articles/flows/guides/auth-code/includes/sample-use-cases-call-api.md
@@ -18,6 +18,8 @@ function(user, context, callback) {
 }
 ```
 
+Scopes will be available in the token after all rules have run.
+
 ::: panel-warning Namespacing Custom Claims 
 Auth0 returns profile information in a [structured claim format as defined by the OpenID Connect (OIDC) specification](https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims). This means that custom claims added to ID Tokens or Access Tokens must [conform to a namespaced format](/tokens/guides/create-namespaced-custom-claims) to avoid possible collisions with standard OIDC claims. 
 :::

--- a/articles/flows/guides/implicit/includes/sample-use-cases-call-api.md
+++ b/articles/flows/guides/implicit/includes/sample-use-cases-call-api.md
@@ -18,6 +18,8 @@ function(user, context, callback) {
 }
 ```
 
+Scopes will be available in the token after all rules have run.
+
 ::: panel-warning Namespacing Custom Claims 
 Auth0 returns profile information in a [structured claim format as defined by the OpenID Connect (OIDC) specification](https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims). This means that custom claims added to ID Tokens or Access Tokens must [conform to a namespaced format](/tokens/guides/create-namespaced-custom-claims) to avoid possible collisions with standard OIDC claims. 
 :::

--- a/articles/rules/index.md
+++ b/articles/rules/index.md
@@ -17,6 +17,8 @@ Rules are JavaScript functions that execute when a user authenticates to your ap
 
 Please note that rules also run during the [token refresh](/tokens/concepts/refresh-tokens) flow.
 
+## Authentication transaction flow
+
 ![Rule Flow](/media/articles/rules/flow.png)
 
 1. An app initiates an authentication request to Auth0.
@@ -56,12 +58,6 @@ A Rule is a function with the following arguments:
 ## Execution order
 
 In general, rules execute in the order shown on the Auth0 Dashboard. If a rule depends on the execution of another rule, move the dependent rule lower in the list.
-
-When using rules, keep in mind that rules run before the Redirect and MFA features run. The order is as follows:
-
-1. Your rules (in the order shown in the Dashboard)
-2. Redirect feature
-3. MFA feature
 
 ## Available modules
 

--- a/articles/rules/index.md
+++ b/articles/rules/index.md
@@ -55,7 +55,13 @@ A Rule is a function with the following arguments:
 
 ## Execution order
 
-Rules execute in the order shown on the Auth0 Dashboard. If a rule depends on the execution of another rule, move the dependent rule lower in the list.
+In general, rules execute in the order shown on the Auth0 Dashboard. If a rule depends on the execution of another rule, move the dependent rule lower in the list.
+
+When using rules, keep in mind that rules run before the Redirect and MFA features run. The order is as follows:
+
+1. Your rules (in the order shown in the Dashboard)
+2. Redirect feature
+3. MFA feature
 
 ## Available modules
 

--- a/articles/rules/references/context-object.md
+++ b/articles/rules/references/context-object.md
@@ -12,6 +12,10 @@ useCase: extensibility-rules
 
 The `context` object stores contextual information about the current authentication transaction, such as the user's IP address, application, or location.
 
+::: note
+If you change token content using the context object within a rule, your changes will be available in tokens after all rules have finished running. If your application also requires multifactor authentication or user consent, the user will be prompted before changes in the token are available.
+:::
+
 ## Properties
 
 The following properties are available for the `context` object.
@@ -31,8 +35,8 @@ The following properties are available for the `context` object.
 | `context.protocol` | <%= include('../_includes/_context-prop-protocol.md') %> |
 | `context.stats` | An object containing specific user stats, like `stats.loginsCount`. Note that any of the counter variables returned as part of the `stats` object do not increase during [silent authentication](/api-auth/tutorials/silent-authentication) (as when `prompt=none`). There are also scenarios where the counter variables might increase yet a rule or set of rules do not execute, as in the case of a successful cross-origin authentication followed by a failed token request. |
 | `context.sso` | <%= include('../_includes/_context-prop-sso.md') %> |
-| `context.accessToken` | An object representing the options defined on the <dfn data-key="access-token">Access Token</dfn>. You can use this object to [add custom namespaced claims](/scopes/current/sample-use-cases#add-custom-claims-to-a-token) to the Access Token. `context.accessToken.scope` can be used to [change the Access Token's returned scopes](/rules/references/samples#modify-scope-of-access-token).  When provided, it is an array containing permissions in string format. |
-| `context.idToken` | An object representing the options defined on the [ID Token](/tokens/concepts/id-tokens). Used to add custom [namespaced](/tokens/guides/create-namespaced-custom-claims) claims to the ID Token. |
+| `context.accessToken` | An object representing the options defined on the <dfn data-key="access-token">Access Token</dfn>. You can use this object to [add custom namespaced claims](/scopes/current/sample-use-cases#add-custom-claims-to-a-token) to the Access Token. `context.accessToken.scope` can be used to [change the Access Token's returned scopes](/rules/references/samples#modify-scope-of-access-token).  When provided, it is an array containing permissions in string format. Custom claims will be included in the Access Token after all rules have run. |
+| `context.idToken` | An object representing the options defined on the [ID Token](/tokens/concepts/id-tokens). Used to add custom [namespaced](/tokens/guides/create-namespaced-custom-claims) claims to the ID Token. Custom claims will be included in the ID Token after all rules have run. |
 | `context.original_protocol` | After a [redirect rule](/rules/current/redirect) has executed and the authentication transaction is resumed, this property will be populated with the original protocol used to initiate the transaction. |
 | `context.multifactor` | An object representing the multifactor settings used in [implementing contextual MFA](/mfa). |
 | `context.redirect` | The object used to [implement the redirection of a user from a rule](/rules/current/redirect#how-to-implement-a-redirect). |
@@ -41,3 +45,9 @@ The following properties are available for the `context` object.
 | `context.primaryUser` | The unique user id of the primary account for the user. Used to [link user accounts](/users/concepts/overview-user-account-linking#automatic-account-linking) from various identity providers. |
 | `context.authentication` | <%= include('../_includes/_context-prop-authentication.md') %> |
 | `context.authorization` | <%= include('../_includes/_context-prop-authorization.md') %> |
+
+## Read more
+
+* [Debug Rules](/rules/guides/debug)
+* [User Object](/rules/references/user-object)
+* [Sample Use Cases - Scopes and Claims: Add custom claims to a token](/scopes/current/sample-use-cases#add-custom-claims-to-a-token)

--- a/articles/rules/references/user-object.md
+++ b/articles/rules/references/user-object.md
@@ -11,7 +11,7 @@ useCase: extensibility-rules
 
 # User Object in Rules
 
-The `user` object stores information about the logged in user, returned by the identity provider. It is generated when a user authenticates, before rules run.
+The `user` object stores information about the logged-in user, returned by the identity provider. It is generated when a user authenticates and before rules run. Because of the [order of events](/rules/index#authentication-transaction-flow) when a user authenticates, changes made to a user's profile from within a rule will only be available in the current user object if you also save the changes to the user object from within the same rule.
 
 ## Properties
 
@@ -38,3 +38,8 @@ The following properties are available for the `user` object.
 | `user.user_id` | text | (unique) The user's unique identifier. |
 | `user.user_metadata` | object | Custom fields that store info about a user that does not impact what they can or cannot access, such as work address, home address, or user preferences. For more info, see [Metadata](/metadata). |
 | `user.username` | text | (unique) The user's username. |
+
+## Read more
+
+* [Debug Rules](/rules/guides/debug)
+* [Context Object](/rules/references/context-object)

--- a/articles/rules/references/user-object.md
+++ b/articles/rules/references/user-object.md
@@ -11,7 +11,7 @@ useCase: extensibility-rules
 
 # User Object in Rules
 
-The `user` object stores information about the logged-in user, returned by the identity provider. It is generated when a user authenticates and before rules run. Because of the [order of events](/rules/index#authentication-transaction-flow) when a user authenticates, changes made to a user's profile from within a rule will only be available in the current user object if you also save the changes to the user object from within the same rule.
+The `user` object stores information about the logged-in user, returned by the identity provider. It is generated when a user authenticates and before rules run. Because of the [order of events](/rules#authentication-transaction-flow) when a user authenticates, changes made to a user's profile from within a rule will only be available in the current user object if you also save the changes to the user object from within the same rule.
 
 ## Properties
 

--- a/articles/scopes/current/sample-use-cases.md
+++ b/articles/scopes/current/sample-use-cases.md
@@ -184,7 +184,7 @@ Notice that in this example:
  * the `sub` claim contains the value of the `user_id` property
  * neither the `favorite_color` or `user_metadata` properties are present because OpenID Connect (OIDC) does not define standard claims that represent `favorite_color` or `user_metadata`
  
-To receive the custom data, create a rule to customize the token with [namespaced](/tokens/guides/create-namespaced-custom-claims) [custom claims](/tokens/concepts/jwt-claims#custom-claims) that represent these properties from the user profile:
+To receive the custom data, create a rule to customize the token with [namespaced](/tokens/guides/create-namespaced-custom-claims) [custom claims](/tokens/concepts/jwt-claims#custom-claims) that represent these properties from the user profile. Custom data will be available in the token after all rules have run.
 
 ```js
 function(user, context, callback) {
@@ -196,7 +196,7 @@ function(user, context, callback) {
 ```
 
 ::: note
-This example shows a custom claim being added to an ID Token, which uses the `context.idToken` property. To add to an Access Token, use the `context.accessToken` property instead. For more information, see [Context Object in Rules](/rules/references/context-object).
+This example shows custom claims being added to an ID Token, which uses the `context.idToken` property. To add to an Access Token, use the `context.accessToken` property instead. To learn more, see [Context Object in Rules](/rules/references/context-object).
 :::
 
 ::: warning


### PR DESCRIPTION
Per [DOCS-1183](https://auth0team.atlassian.net/browse/DOCS-1183)

- https://docs-content-staging-pr-8950.herokuapp.com/docs/rules#authentication-transaction-flow
- https://docs-content-staging-pr-8950.herokuapp.com/docs/rules/references/context-object
- https://docs-content-staging-pr-8950.herokuapp.com/docs/rules/references/user-object
- https://docs-content-staging-pr-8950.herokuapp.com/docs/scopes/current/sample-use-cases#add-custom-claims-to-a-token
- https://docs-content-staging-pr-8950.herokuapp.com/docs/flows/guides/implicit/call-api-implicit#sample-use-cases
- https://docs-content-staging-pr-8950.herokuapp.com/docs/flows/guides/auth-code/call-api-auth-code#sample-use-cases
- https://docs-content-staging-pr-8950.herokuapp.com/docs/flows/guides/auth-code-pkce/call-api-auth-code-pkce#sample-use-cases
