### PR TITLE
Add sample ID Token contents with custom claims

### DIFF
--- a/articles/scopes/current/sample-use-cases.md
+++ b/articles/scopes/current/sample-use-cases.md
@@ -169,20 +169,20 @@ For this profile, Auth0 would normally return the following ID Token claims to y
 
 ```json
 {
+  "email": "jane@example.com",
+  "email_verified": true,
   "iss": "https://my-domain.auth0.com/",
   "sub": "custom|123",
   "aud": "my_client_id",
-  "exp": 1311281970,
   "iat": 1311280970,
-  "email": "jane@example.com",
-  "email_verified": true
+  "exp": 1311281970
 }
 ```
 
 Notice that in this example:
 
  * the `sub` claim contains the value of the `user_id` property
- * neither the `favorite_color` or `user_metadata` properties are present because OpenID Connect (OIDC) does not define standard claims that represent `favorite_color` or `user_metadata`
+ * neither the `favorite_color` nor `user_metadata` properties are present because OpenID Connect (OIDC) does not define standard claims that represent `favorite_color` or `user_metadata`
  
 To receive the custom data, create a rule to customize the token with [namespaced](/tokens/guides/create-namespaced-custom-claims) [custom claims](/tokens/concepts/jwt-claims#custom-claims) that represent these properties from the user profile. Custom data will be available in the token after all rules have run.
 
@@ -202,6 +202,22 @@ This example shows custom claims being added to an ID Token, which uses the `con
 ::: warning
 When creating your rule, make sure to set some logic that determines when to include additional claims. Injecting custom claims into every ID Token that is issued is not ideal.
 :::
+
+With this rule enabled, Auth0 will include the `favorite_color` and `preferred_contact` custom claims in the ID Token:
+
+```json
+{
+  "https://myapp.example.com/favorite_color": "blue",
+  "https://myapp.example.com/preferred_contact": "email",
+  "email": "jane@example.com",
+  "email_verified": true,
+  "iss": "https://my-domain.auth0.com/",
+  "sub": "custom|123",
+  "aud": "my_client_id",
+  "iat": 1311280970,
+  "exp": 1311281970
+}
+```
 
 ## Keep reading
 


### PR DESCRIPTION
https://auth0team.atlassian.net/browse/DOCS-1138

- Updated order of claims returned in ID Token
- Added sample of ID Token contents after the example rule for adding custom claims has been implemented

https://docs-content-staging-pr-8976.herokuapp.com/docs/scopes/current/sample-use-cases#add-custom-claims-to-a-token