### PR TITLE
Adds link in the rules bulletin to the email verified usage document

### DIFF
--- a/articles/security/bulletins/2019-01-10_rules.md
+++ b/articles/security/bulletins/2019-01-10_rules.md
@@ -43,7 +43,7 @@ This security bulletin covers several scenarios that customers should avoid in c
 ### Silent authentication
 Within a single-page application (SPA) using the implicit flow, silent authentication enables new access tokens to be issued without user interaction as long as the current session is valid against the authorization server.
 
-Auth0 offers silent authentication through a special parameter which is added to the authorization endpoint as follows:  
+Auth0 offers silent authentication through a special parameter which is added to the authorization endpoint as follows:
 `/authorize?prompt=none`
 
 If MFA is added to the silent authentication process, however, then user interaction becomes necessary.
@@ -86,7 +86,7 @@ The examples below illustrate improper verification checks which can result in f
 function (user, context, callback) {
 
   var crypto = require('crypto');
-  
+
   var deviceFingerPrint = getDeviceFingerPrint();
   user.app_metadata = user.app_metadata || {};
 
@@ -169,7 +169,7 @@ Utilize logic such as:
   const userEmailDomain = emailSplit[emailSplit.length - 1].toLowerCase();
 ```
 
-Please refer to the following rule template for more information:  
+Please refer to the following rule template for more information:
 https://github.com/auth0/rules/blob/master/src/rules/check-domains-against-connection-aliases.js
 
 Alternatively, in the _Rules_ section of the Auth0 dashboard, view the rule template named "Check if user email domain matches configured domain".
@@ -198,10 +198,10 @@ If you have rule logic that sends the Auth0 context object to an external servic
 Only customers with rule logic as described above are affected.
 
 ### Mitigation steps
-You should modify your rule so it no longer sends the entire context object to _requestbin_, as this may expose any `id_token` or `access_token` associated with each request. Instead, you should send a subset of attributes from the context object that are less sensitive.  
+You should modify your rule so it no longer sends the entire context object to _requestbin_, as this may expose any `id_token` or `access_token` associated with each request. Instead, you should send a subset of attributes from the context object that are less sensitive.
 The variables contained in the context object are detailed here: https://auth0.com/docs/rules/current/context
 
-Please refer to the following rule template for more information:  
+Please refer to the following rule template for more information:
 https://github.com/auth0/rules/blob/master/src/rules/requestbin.js
 
 Alternatively, in the _Rules_ section of the Auth0 dashboard, view the rule template named "Dump rule variables to RequestBin".
@@ -279,6 +279,10 @@ function (user, context, callback) {
     return callback(new UnauthorizedError('Access denied.'));
   }
 ```
+
+::: warning
+Sometimes even a verified email may not be an adequate check for the authorization you want to perform. To find out more about such cases, please read about the [Email Verified Usage](/users/guides/email-verified)
+:::
 
 ### Will this update impact my users?
 This will only affect existing users if they have not verified their email addresses.


### PR DESCRIPTION
Adds a link to the email verified usage document when talking about authorization based on unverified email address