### PR TITLE
Add clarity on when to contact Support

### DIFF
--- a/articles/support/reset-account-password.md
+++ b/articles/support/reset-account-password.md
@@ -23,7 +23,7 @@ If you need to change your password or you have forgotten the password to your A
 
 ## Special password reset circumstances
 
-- If you've enabled <dfn data-key="multifactor-authentication">multi-factor authentication (MFA)</dfn> and you need your password reset, you need to contact [Auth0 Support](${env.DOMAIN_URL_SUPPORT}).
+- If you've enabled <dfn data-key="multifactor-authentication">multi-factor authentication (MFA)</dfn> and your MFA device reset, you need to contact [Auth0 Support](${env.DOMAIN_URL_SUPPORT}).
 - If you're using a social or enterprise account to log in to Auth0, you will need to reset your password with the appropriate identity provider.
 - If you are an administrator trying to reset a *user's* password, see [Change Users' Passwords](/connections/database/password-change).
 

--- a/articles/support/reset-account-password.md
+++ b/articles/support/reset-account-password.md
@@ -23,7 +23,7 @@ If you need to change your password or you have forgotten the password to your A
 
 ## Special password reset circumstances
 
-- If you've enabled <dfn data-key="multifactor-authentication">multi-factor authentication (MFA)</dfn> and your MFA device reset, you need to contact [Auth0 Support](${env.DOMAIN_URL_SUPPORT}).
+- If you've enabled <dfn data-key="multifactor-authentication">multi-factor authentication (MFA)</dfn> and need an MFA reset for your admin account, you will need to contact [Auth0 Support](https://auth0.com/docs/support).
 - If you're using a social or enterprise account to log in to Auth0, you will need to reset your password with the appropriate identity provider.
 - If you are an administrator trying to reset a *user's* password, see [Change Users' Passwords](/connections/database/password-change).
 


### PR DESCRIPTION
The line I edited implied that if you wanted to have your password changed and you had MFA on, you had to contact Support, which is not the case. Support can only assist with MFA resets, but not password resets. I've edited this for clarity.