### PR TITLE
Update refresh-tokens.md

### DIFF
--- a/articles/tokens/concepts/refresh-tokens.md
+++ b/articles/tokens/concepts/refresh-tokens.md
@@ -45,7 +45,7 @@ Providing secure authentication in SPAs has a number of challenges based on your
 
 Auth0 recommends using [Refresh Token Rotation](/tokens/concepts/refresh-token-rotation) which provides a secure method for using Refresh Tokens in SPAs while providing end-users with seamless access to resources without the disruption in UX caused by browser privacy technology like ITP.
 
-Auth0’s former guidance was to use the [Authorization Code Flow with Proof Key for Code Exchange (PKCE)](/flows/concepts/auth-code-pkce) in conjuntion with [Silent Authentication](/api-auth/tutorials/silent-authentication) in SPAs. This is more secure solution than the Implicit Flow but not as secure as Refresh Token Rotation. If you want a more detailed explanation about the challenges of using the Implicit Flow in SPAs, please read this blog article [OAuth2 Implicit Grant and SPA](https://auth0.com/blog/oauth2-implicit-grant-and-spa/).
+Auth0’s former guidance was to use the [Authorization Code Flow with Proof Key for Code Exchange (PKCE)](/flows/concepts/auth-code-pkce) in conjuntion with [Silent Authentication](/api-auth/tutorials/silent-authentication) in SPAs. This is more secure solution than the Implicit Flow but not as secure as the [Authorization Code Flow with Proof Key for Code Exchange (PKCE)](/flows/concepts/auth-code-pkce) with Refresh Token Rotation. If you want a more detailed explanation about the challenges of using the Implicit Flow in SPAs, please read this blog article [OAuth2 Implicit Grant and SPA](https://auth0.com/blog/oauth2-implicit-grant-and-spa/).
 
 ### Native/Mobile apps
 


### PR DESCRIPTION
Line 48 is a bit ambiguous. It sounds like auth code + pkce is no longer recommended and is being replaced with RTR. This is not the case, as RTR replaces silent auth, but auth code + pkce is still used.

Originally mentioned in this thread: https://community.auth0.com/t/current-recommendation-for-spa/42788

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors
- Please include a short description
- If your PR is a work in progress, title it [DO NOT MERGE]
--->
