### PR TITLE
PSaaS API v1 eol dates

### DIFF
--- a/articles/migrations/guides/management-api-v1-v2.md
+++ b/articles/migrations/guides/management-api-v1-v2.md
@@ -11,7 +11,7 @@ useCase:
 ---
 # Migrate from Management API v1 to v2
 
-Auth0’s Management API v1 was deprecated in 2016 and replaced with the [Auth0 Management API v2](/api/management/v2/). Management API v1 will reach its End Of Life in the Public Cloud on **July 13th, 2020**. Requests will begin failing with a `410` HTTP status code on or after that date. Management API v1 will be included in the Private Cloud until the November 2020 monthly release, this is the first release that will not include Management API v1.
+Auth0’s Management API v1 was deprecated in 2016 and replaced with the [Auth0 Management API v2](/api/management/v2/). Management API v1 will reach its End Of Life in the Public Cloud on **July 13th, 2020**. Requests will begin failing with a `410` HTTP status code on or after that date. Management API v1 will be included in the Private Cloud until the November 2020 monthly release, which is the first release that will not include Management API v1.
 
 ## Am I affected by the migration?
 

--- a/articles/migrations/guides/management-api-v1-v2.md
+++ b/articles/migrations/guides/management-api-v1-v2.md
@@ -11,7 +11,7 @@ useCase:
 ---
 # Migrate from Management API v1 to v2
 
-Auth0’s Management API v1 was deprecated in 2016 and replaced with the [Auth0 Management API v2](/api/management/v2/). Management API v1 will reach its End Of Life in the Public Cloud on **July 13th, 2020**. Requests will begin failing with a `410` HTTP status code on or after that date. Private Cloud releases will continue to support Management API v1 until the December 2020 monthly release.
+Auth0’s Management API v1 was deprecated in 2016 and replaced with the [Auth0 Management API v2](/api/management/v2/). Management API v1 will reach its End Of Life in the Public Cloud on **July 13th, 2020**. Requests will begin failing with a `410` HTTP status code on or after that date. Management API v1 will be included in the Private Cloud until the November 2020 monthly release, this is the first release that will not include Management API v1.
 
 ## Am I affected by the migration?
 

--- a/articles/product-lifecycle/migrations.md
+++ b/articles/product-lifecycle/migrations.md
@@ -48,9 +48,9 @@ We are actively migrating customers to new behaviors for all <dfn data-key="depr
       <td>October 2016</td>
       <td>
         <strong>Public Cloud</strong>: 13 July 2020<br>
-        <strong>Private Cloud</strong>: December 2020 release<br>
+        <strong>Private Cloud</strong>: November 2020 release<br>
       </td>
-      <td>Management API v1 will reach its End of Life on July 13, 2020. You may be required to take action before that date to ensure no interruption to your service. A <a href="/migrations/guides/management-api-v1-v2">migration guide</a> is available to walk you through the steps required. Notifications have been and will continue to be sent to customers that need to complete this migration.<br>Useful Resources:<br>
+      <td>Management API v1 will reach its End of Life in the Public Cloud on July 13, 2020. Management API v1 will be included in the Private Cloud until the November 2020 monthly release, this is the first release that will not include Management API v1. You may be required to take action before that date to ensure no interruption to your service. A <a href="/migrations/guides/management-api-v1-v2">migration guide</a> is available to walk you through the steps required. Notifications have been and will continue to be sent to customers that need to complete this migration.<br>Useful Resources:<br>
         <a href="/migrations/guides/management-api-v1-v2">Management API v1 to v2 Migration Guide</a><br>
         <a href="/api/management/v2">Management API v2 documentation</a><br>
         <a href="/api/management/v1">Management API v1 documentation</a><br>

--- a/articles/product-lifecycle/migrations.md
+++ b/articles/product-lifecycle/migrations.md
@@ -50,7 +50,7 @@ We are actively migrating customers to new behaviors for all <dfn data-key="depr
         <strong>Public Cloud</strong>: 13 July 2020<br>
         <strong>Private Cloud</strong>: November 2020 release<br>
       </td>
-      <td>Management API v1 will reach its End of Life in the Public Cloud on July 13, 2020. Management API v1 will be included in the Private Cloud until the November 2020 monthly release, this is the first release that will not include Management API v1. You may be required to take action before that date to ensure no interruption to your service. A <a href="/migrations/guides/management-api-v1-v2">migration guide</a> is available to walk you through the steps required. Notifications have been and will continue to be sent to customers that need to complete this migration.<br>Useful Resources:<br>
+      <td>Management API v1 will reach its End of Life in the Public Cloud on July 13, 2020. Management API v1 will be included in the Private Cloud until the November 2020 monthly release, which is the first release that will not include Management API v1. You may be required to take action before that date to ensure no interruption to your service. A <a href="/migrations/guides/management-api-v1-v2">migration guide</a> is available to walk you through the required steps. Notifications have been and will continue to be sent to customers that need to complete this migration.<br>Useful Resources:<br>
         <a href="/migrations/guides/management-api-v1-v2">Management API v1 to v2 Migration Guide</a><br>
         <a href="/api/management/v2">Management API v2 documentation</a><br>
         <a href="/api/management/v1">Management API v1 documentation</a><br>


### PR DESCRIPTION
Updates migration pages to specify the 2011 release as the first to stop supporting API v1