### PR TITLE
[IUM-1008] Add note about default behavior about including email in redirect URL

### DIFF
--- a/articles/email/templates.md
+++ b/articles/email/templates.md
@@ -240,6 +240,7 @@ You can [configure a **Redirect To** URL](#configuring-redirect-to) to send the 
   * `Access expired.` (with `success=false`)
   * `User account does not exist or verification code is invalid.` (with `success=false`)
   * `This account is already verified.` (with `success=false`)
+* `email` if `Include Email In Redirect` is enabled in the template
 
 The target URL handler should be prepared to gracefully handle other possible messages as well. 
 
@@ -267,6 +268,7 @@ You can [configure a **Redirect To** URL](#configuring-redirect-to) to send the 
   * `This URL can be used only once` (with `success=false`)
   * `Access expired.` (with `success=false`)
   * `The operation cannot be completed. Please try again.` (with `success=false`)
+* `email` if `Include Email In Redirect` is enabled in the template
 
 The target URL handler should be prepared to gracefully handle other possible messages as well. 
 

--- a/articles/email/templates.md
+++ b/articles/email/templates.md
@@ -240,7 +240,7 @@ You can [configure a **Redirect To** URL](#configuring-redirect-to) to send the 
   * `Access expired.` (with `success=false`)
   * `User account does not exist or verification code is invalid.` (with `success=false`)
   * `This account is already verified.` (with `success=false`)
-* `email` if `Include Email In Redirect` is enabled in the template
+* `email` if `Include Email In Redirect` is enabled in the template. By default, `email` is not included
 
 The target URL handler should be prepared to gracefully handle other possible messages as well. 
 
@@ -268,7 +268,7 @@ You can [configure a **Redirect To** URL](#configuring-redirect-to) to send the 
   * `This URL can be used only once` (with `success=false`)
   * `Access expired.` (with `success=false`)
   * `The operation cannot be completed. Please try again.` (with `success=false`)
-* `email` if `Include Email In Redirect` is enabled in the template
+* `email` if `Include Email In Redirect` is enabled in the template. By default, `email` is not included
 
 The target URL handler should be prepared to gracefully handle other possible messages as well. 
 


### PR DESCRIPTION
Context:
SEC ticket : https://auth0team.atlassian.net/browse/SEC-473
Context: https://auth0team.atlassian.net/wiki/spaces/~257453535/pages/727515520/SEC-473+Impact+Analysis

Added a note about including email in redirect url for verify email and reset pwd email as per discussion here - https://auth0.slack.com/archives/C01376CB8CR/p1589399789005000

***Add note about default behavior about including email in redirect URL**