### PR TITLE
Updated document to reflect public environment names

### DIFF
--- a/articles/policies/penetration-testing.md
+++ b/articles/policies/penetration-testing.md
@@ -35,7 +35,7 @@ Auth0 requires that:
 
 * The test be restricted to only your tenant
 * You disclose any suspected findings to the Auth0 Security team for explanation/discussion
-* You understand that your tenant will be moved between environments during testing. Auth0 will move your tenant from the stable environment to the preview environment before the testing commences. Auth0 will then return your tenant to the stable environment once the testing period ends. Note that while your tenant is on the preview environment it may receive updates more rapidly.
+* You understand that your tenant will be moved between environments during testing. Auth0 will move your tenant from the Production environment to the Preview environment before the testing commences. Auth0 will then return your tenant to the Production environment once the testing period ends. Note that while your tenant is on the Preview environment it may receive updates more rapidly.
 
 ## Private Cloud customers
 


### PR DESCRIPTION
Doc used to say "stable" and "preview" environments - these are internal names. Our public names for these environments are "Production" and "Preview", accordingly.