### PR TITLE
provide valid totp value

### DIFF
--- a/articles/mfa/guides/import-user-mfa.md
+++ b/articles/mfa/guides/import-user-mfa.md
@@ -101,7 +101,7 @@ When using the `upsert` option, any non-MFA related updates to existing users wi
       "mfa_factors": [
         {
           "totp": {
-            "secret": "2PRX8ZWZAYYDAWCD"
+            "secret": "2PRXZWZAYYDAWCD"
           }
         },
         {

--- a/articles/users/references/bulk-import-database-schema-examples.md
+++ b/articles/users/references/bulk-import-database-schema-examples.md
@@ -550,7 +550,7 @@ Some examples of users with MFA factors:
         "mfa_factors": [
             {
                 "totp": {
-                    "secret": "2PRX8ZWZAYYDAWCD"
+                    "secret": "2PRXZWZAYYDAWCD"
                 }
             },
             {


### PR DESCRIPTION
Current examples have invalid totp. It does not match reg ex pattern - `^[A-Z2-7]+$`