### PR TITLE
Fix language code_verifier statement

### DIFF
--- a/articles/flows/guides/auth-code-pkce/includes/create-code-verifier.md
+++ b/articles/flows/guides/auth-code-pkce/includes/create-code-verifier.md
@@ -1,6 +1,6 @@
 ## Create a Code Verifier
 
-Create a `code_verifier`, which is a cryptographically-random key that will eventually be sent to Auth0 to request an `authorization_code`.
+Create a `code_verifier`, which is a cryptographically-random key that will eventually be sent to Auth0 to request an `access_token`.
 
 <div class="code-picker">
   

--- a/articles/flows/guides/auth-code-pkce/includes/create-code-verifier.md
+++ b/articles/flows/guides/auth-code-pkce/includes/create-code-verifier.md
@@ -1,6 +1,6 @@
 ## Create a Code Verifier
 
-Create a `code_verifier`, which is a cryptographically-random key that will eventually be sent to Auth0 to request an `access_token`.
+Create a `code_verifier`, which is a cryptographically-random key that will eventually be sent to Auth0 to request tokens.
 
 <div class="code-picker">
   


### PR DESCRIPTION
A `code_verifier` is used in the `access_token` request, not the `authorization_code` request.
