### PR TITLE
Clarify mapping

### DIFF
--- a/articles/protocols/saml/saml-configuration/saml-assertions.md
+++ b/articles/protocols/saml/saml-configuration/saml-assertions.md
@@ -33,6 +33,10 @@ You can use rules to add more extensive or dynamic customizations to the SAML re
 
 Customizations done in Rules override customizations done using the Application Addons tab.
 
+::: note
+The `context.samlConfiguration.mappings` object is used to override default SAML attributes or add new attributes. The object keys are the name of the SAML attribute to override or add and the values are a string of the `user` object property to use as the attribute value.
+:::
+
 #### Example: Changing the SAML Token Lifetime and Using UPN as NameID
 
 ```js
@@ -43,7 +47,7 @@ function (user, context, callback) {
   // if available, use upn as NameID
   if (user.upn) {
     context.samlConfiguration.mappings = {
-      "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier": "upn"
+      "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier": "upn" // use user.upn as the value
     }
   }
 
@@ -58,11 +62,7 @@ function (user, context, callback) {
   user.user_metadata = user.user_metadata || {};
   user.user_metadata.color = "purple";
   context.samlConfiguration.mappings = {
-    //Attribute already in user_metadata
-    "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/color": "user_metadata.color",
-
-    //Attribute dynamically added to user_metadata above
-    "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/color": "user_metadata.color",
+    "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/color": "user_metadata.color", // use user.user_metadata.color as the value
   };
   callback(null, user, context);
 }


### PR DESCRIPTION
Add note to rule mappings to clarify what the object key/value pairs represent. Remove confusing, duplicated part of second rule example.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors
- Please include a short description
- If your PR is a work in progress, title it [DO NOT MERGE]
--->
