### PR TITLE
Update Xamarin quickstart to use latest major

### DIFF
--- a/articles/quickstart/native/xamarin/index.yml
+++ b/articles/quickstart/native/xamarin/index.yml
@@ -27,8 +27,8 @@ github:
 requirements:
   - Visual Studio 2017 or Visual Studio for Mac
   - Xamarin for Visual Studio 4.5
-  - Auth0.OidcClient.Android 2.4.0
-  - Auth0.OidcClient.iOS 2.4.0
+  - Auth0.OidcClient.Android 3.1.3
+  - Auth0.OidcClient.iOS 3.1.3
 next_steps:
   - path: 01-login
     list:

--- a/snippets/native-platforms/xamarin/setup.md
+++ b/snippets/native-platforms/xamarin/setup.md
@@ -5,5 +5,5 @@ var client = new Auth0Client(new Auth0ClientOptions
 {
     Domain = "${account.namespace}",
     ClientId = "${account.clientId}"
-});
+}, this);
 ```


### PR DESCRIPTION
Following up https://github.com/auth0-samples/auth0-xamarin-oidc-samples/pull/36 and https://github.com/auth0-samples/auth0-xamarin-oidc-samples/pull/35, this quickstart should be updated to show the same code. 

**I haven't tested the changes** cc @stevehobbsdev 