### PR TITLE
Add custom scope key to Node (Express) API: Authorization

### DIFF
--- a/articles/quickstart/backend/nodejs/01-authorization.md
+++ b/articles/quickstart/backend/nodejs/01-authorization.md
@@ -97,7 +97,7 @@ Pass the `checkJwt` and `checkScopes` middlewares to the route you want to prote
 ```js
 // server.js
 
-const checkScopes = jwtAuthz([ 'read:messages' ]);
+const checkScopes = jwtAuthz([ 'read:messages' ], { customScopeKey: 'permissions' });
 
 app.get('/api/private-scoped', checkJwt, checkScopes, function(req, res) {
   res.json({


### PR DESCRIPTION
In Auth0, the "scope" are actually permissions. The library express-jwt-authz, uses the actual "scope" key from the token by default and to avoid confusion, should include the custom scope key by default.

[This](https://auth0.com/docs/quickstart/backend/nodejs/01-authorization#protect-api-endpoints) is the url to the section of the requested change. 
