### PR TITLE
Use npm instead of yarn

### DIFF
--- a/articles/quickstart/spa/react/_includes/_centralized_login.md
+++ b/articles/quickstart/spa/react/_includes/_centralized_login.md
@@ -266,7 +266,7 @@ export default App;
 This replaces the default content created by `create-react-app` and simply shows the `NavBar` component you created earlier.
 
 :::panel Checkpoint
-At this point, you should be able to go through the complete authentication flow: logging in and logging out. Start the application from the terminal using `yarn start` and browse to [localhost:3000](http://localhost:3000) (if the application does not open automatically). From there, clicking the **Log in** button should redirect you to the Auth0 login page where you will be given the opportunity to log in.
+At this point, you should be able to go through the complete authentication flow: logging in and logging out. Start the application from the terminal using `npm start` and browse to [localhost:3000](http://localhost:3000) (if the application does not open automatically). From there, clicking the **Log in** button should redirect you to the Auth0 login page where you will be given the opportunity to log in.
 
 Once you are logged in, control returns to your application and you should see that the **Log out** button is now visible. Clicking this should log you out of the application and return you to an unauthenticated state.
 :::


### PR DESCRIPTION
The rest of the tutorial uses `npm`. Also, we haven't given any specific instructions to install `yarn`. Using `npm start` is a good default.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors
- Please include a short description
- If your PR is a work in progress, title it [DO NOT MERGE]
--->
