### PR TITLE
Update _ropg-warning.md

### DIFF
--- a/articles/api-auth/_includes/_ropg-warning.md
+++ b/articles/api-auth/_includes/_ropg-warning.md
@@ -4,7 +4,6 @@ Since the Resource Owner Password Grant (ROPG) flow involves the client handling
 Only consider using it when there is a high degree of trust between the user and the application and when other authorization flows (such as redirect-based flows) are not available.
 
 Instead, Auth0 recommends: 
-* For confidential clients, use the [Authorization Code Flow](/flows/concepts/auth-code).
-* For public clients, use the [Authorization Code Flow with PKCE](/flows/concepts/auth-code-pkce).
-* For [Single-Page Applications](/flows/concepts/implicit) and [Native/Mobile Apps](/flows/concepts/auth-code-pkce), use web flows.
+* For confidential clients, like Regular Web Applications, use the [Authorization Code Flow](/flows/concepts/auth-code).
+* For public clients, like Native/Mobile Apps and Single-Page Applications, use the [Authorization Code Flow with PKCE](/flows/concepts/auth-code-pkce).
 :::


### PR DESCRIPTION
The third bullet, which said "For Single-Page Applications and Native/Mobile Apps, use web flows." is confusing. Single Page Apps and Native/Mobile apps are actually public clients, and the 'Authorization Code Flow' and 'Authorization Code Flow with PKCE' are web flows.