### PR TITLE
change AWS to Amazon 

### DIFF
--- a/articles/integrations/index.md
+++ b/articles/integrations/index.md
@@ -142,19 +142,19 @@ useCase:
     </ul>
   </li>
   <li>
-    <i></i><a href="/log-streams">Log Streaming Integrations</a>
+    <i class="icon icon-budicon-334"></i><a href="/log-streams">Log Streaming Integrations</a>
     <p>
         Learn how to set up and configure log streaming integrations with Auth0.
     </p>
     <ul>
       <li>
-        <img class="icon icon-budicon-715" /><a href="/logs/streams/aws-eventbridge">AWS Eventbridge</a>
+        <i class="icon icon-budicon-715"></i><a href="/logs/streams/amazon-eventbridge">Amazon Eventbridge</a>
       </li>
       <li>
-        <img class="icon icon-budicon-715" /><a href="/logs/streams/datadog">Datadog</a>
+        <i class="icon icon-budicon-715"></i><a href="/logs/streams/datadog">Datadog</a>
       </li>
       <li>
-        <img class="icon icon-budicon-715" /><a href="/logs/streams/azure-event-grid">Azure Event Grid</a>
+        <i class="icon icon-budicon-715"></i><a href="/logs/streams/azure-event-grid">Azure Event Grid</a>
       </li>
     </ul>
   </li>

--- a/articles/logs/streams/amazon-eventbridge.md
+++ b/articles/logs/streams/amazon-eventbridge.md
@@ -1,6 +1,6 @@
 ---
-title: Integrate AWS EventBridge with Auth0
-description: Learn how to create an event-driven workflow using AWS EventBridge to send your tenant logs to the targers of your choice such as AWS EC2 instances, Lambda functions, Kinesis streams, and ECS tasks.
+title: Integrate Amazon EventBridge with Auth0
+description: Learn how to create an event-driven workflow using Amazon EventBridge to send your tenant logs to the targers of your choice such as AWS EC2 instances, Lambda functions, Kinesis streams, and ECS tasks.
 toc: true
 topics:
  - integrations
@@ -9,17 +9,18 @@ topics:
  - event-streams
  - aws
  - eventbridge
+ - amazon
 contentType: how-to
 ---
-# Integrate AWS EventBridge with Auth0
+# Integrate Amazon EventBridge with Auth0
 
-Amazon Web Services' EventBridge is a serverless event bus that acts as an intermediary allowing you to send data from your applications to AWS services.
+Amazon EventBridge is a serverless event bus that acts as an intermediary allowing you to send data from your applications to AWS services.
 
 You can create an event-driven workflow using EventBridge to send your Auth0 tenant logs to the targets of your choice (e.g., AWS EC2 instances, Lambda functions, Kinesis streams, and ECS tasks).
 
 ## Send events from Auth0 to AWS EventBridge
 
-To send Auth0 events to AWS EventBridge, you will need:
+To send Auth0 events to Amazon EventBridge, you will need:
 
 1. A partner event source (in this case, this is Auth0)
 2. A partner event bus, which matches incoming events with the routes to which they should be targeted
@@ -46,7 +47,7 @@ Part of the integration process is to set Auth0 up for use as the event source (
 Go to AWS to complete the final steps of the integration.
 
 ## Create an event bus
-1. Go to the [AWS EventBridge partners tab](https://console.aws.amazon.com/events/home?region=us-east-1#/partners) in your AWS account and make sure you are in the **AWS Region** where the event source was created.
+1. Go to the [Amazon EventBridge partners tab](https://console.aws.amazon.com/events/home?region=us-east-1#/partners) in your AWS account and make sure you are in the **AWS Region** where the event source was created.
 
 2. Paste the **Event Source Name** in the event source search box to find the newly created AWS Event Source and click on it to associate it with an Event Bus.
 **Note**: The AWS Event Source will remain in pending state until it gets associated with an Event Bus and all the events sent to that Event Source will be dropped.
@@ -59,7 +60,7 @@ Go to AWS to complete the final steps of the integration.
 
 At this point, the events that you send will be made available on your event bus. However, before you can use the data you send to AWS services, you will need to [create rules](https://docs.aws.amazon.com/eventbridge/latest/userguide/create-event-bus.html) that map those events to specific targets.
 
-EventBridge uses rules, which are definitions specifying how you want incoming events routed to the desired targets. 
+Amazon EventBridge uses rules, which are definitions specifying how you want incoming events routed to the desired targets. 
 
 Targets are the services, such as AWS EC2 instances, Lambda functions, Kinesis streams, or ECS tasks, that processes the event-driven data that it receives. The data received by targets are JSON-formatted.
 

--- a/articles/logs/streams/amazon-eventbridge.md
+++ b/articles/logs/streams/amazon-eventbridge.md
@@ -1,5 +1,5 @@
 ---
-title: Integrate Amazon EventBridge with Auth0
+title: Amazon EventBridge Log Streams
 description: Learn how to create an event-driven workflow using Amazon EventBridge to send your tenant logs to the targers of your choice such as AWS EC2 instances, Lambda functions, Kinesis streams, and ECS tasks.
 toc: true
 topics:

--- a/articles/logs/streams/index.md
+++ b/articles/logs/streams/index.md
@@ -12,11 +12,11 @@ contentType: index
 
 # Log Streams
 
-Log Streams let you export your log events to a target of your choice given URL or via AWS EventBridge. With Log Streams you can:
+Log Streams let you export your log events to a target of your choice given URL or one of our integrations. With Log Streams you can:
 
 * export logs to a tool or service you already use
 * react to events, such as changed passwords or new registrations, with your own business logic by sending log events to custom webhooks
-* send events to AWS EventBridge for processing with lambdas or additional data pipelines
+* send events to Amazon EventBridge or Azure Event Grid
 
 ## Log Stream Health
 
@@ -46,7 +46,7 @@ To help diagnose issues with your stream, you can see the last ten errors we enc
 
 <%= include('../../_includes/_topic-links', { links: [
   'logs/streams/http-event',
-  'logs/streams/aws-eventbridge',
+  'logs/streams/amazon-eventbridge',
   'logs/streams/datadog',
   'logs/streams/azure-event-grid'
 ] }) %>

--- a/config/redirects.js
+++ b/config/redirects.js
@@ -2581,8 +2581,8 @@ module.exports = [
       to: '/hooks/view-logs'
     },
     {
-      from: '/integrations/aws-eventbridge',
-      to: '/logs/streams/aws-eventbridge'
+      from: ['/integrations/aws-eventbridge','/logs/streams/aws-eventbridge'],
+      to: '/logs/streams/amazon-eventbridge'
     },
     {
       from: '/extensions/deploy-cli/references/whats-new-v2',


### PR DESCRIPTION
The AWS team looked at our docs and pointed out that we need to refer to it as Amazon EventBridge rather than AWS EventBridge

https://docs-content-staging-pr-9103.herokuapp.com/docs/integrations - content changes aws -> amazon

https://docs-content-staging-pr-9103.herokuapp.com/docs/logs/streams/aws-eventbridge should now redirect to https://docs-content-staging-pr-9103.herokuapp.com/docs/logs/streams/amazon-eventbridge which has the same content changes

https://docs-content-staging-pr-9103.herokuapp.com/docs/logs/streams/index -> same content changes