### PR TITLE
deploy-cli: update for v5.0.0

### DIFF
--- a/articles/extensions/deploy-cli/guides/import-export-directory-structure.md
+++ b/articles/extensions/deploy-cli/guides/import-export-directory-structure.md
@@ -80,7 +80,8 @@ Here is an example of a `config.json` file:
   },
   "AUTH0_EXCLUDED_RULES": [ "auth0-account-link-extension" ],
   "AUTH0_EXCLUDED_CLIENTS": [ "auth0-account-link" ],
-  "AUTH0_EXCLUDED_RESOURCE_SERVERS": [ "SSO Dashboard API" ]
+  "AUTH0_EXCLUDED_RESOURCE_SERVERS": [ "SSO Dashboard API" ],
+  "AUTH0_EXCLUDED_DEFAULTS": ["emailProvider"]
 }
 ```
 

--- a/articles/extensions/deploy-cli/guides/import-export-yaml-file.md
+++ b/articles/extensions/deploy-cli/guides/import-export-yaml-file.md
@@ -79,7 +79,8 @@ Here is the example of a `config.json` file:
   },
   "AUTH0_EXCLUDED_RULES": [ "auth0-account-link-extension" ],
   "AUTH0_EXCLUDED_CLIENTS": [ "auth0-account-link" ],
-  "AUTH0_EXCLUDED_RESOURCE_SERVERS": [ "SSO Dashboard API" ]
+  "AUTH0_EXCLUDED_RESOURCE_SERVERS": [ "SSO Dashboard API" ],
+  "AUTH0_EXCLUDED_DEFAULTS": ["emailProvider"]
 }
 ```
 

--- a/articles/extensions/deploy-cli/index.md
+++ b/articles/extensions/deploy-cli/index.md
@@ -34,13 +34,21 @@ This tool can be destructive to your Auth0 tenant. Please ensure you have read t
 
 ## Upgrade to latest version
 
-For version 4, the `auth0-deploy-cli` tool was updated to add support for Hooks and Hook Secrets.
+For version 5, the `auth0-deploy-cli` tool was updated with support for Node.js v14 and dropped support for Node.js versions earlier than v8.
 
-<%= include('./_includes/_upgrade-v4') %>
+If you are upgrading `auth0-deploy-cli` from versions earlier than v4, please upgrade the **Auth0 Deploy CLI** extension by following the instructions for [Deploy CLI Tool v4](#deploy-cli-tool-v4) below.
 
 ## Previous versions
 
 Features released in previous versions of the Deploy CLI Tool are listed below. For a complete list of changes, see the [changelog](https://github.com/auth0/auth0-deploy-cli/blob/master/CHANGELOG.md).
+
+
+### Deploy CLI Tool v4
+
+For version 4, the `auth0-deploy-cli` tool was updated to add support for Hooks and Hook Secrets.
+
+<%= include('./_includes/_upgrade-v4') %>
+
 
 ### Deploy CLI Tool v3
 

--- a/articles/extensions/deploy-cli/index.md
+++ b/articles/extensions/deploy-cli/index.md
@@ -34,7 +34,7 @@ This tool can be destructive to your Auth0 tenant. Please ensure you have read t
 
 ## Upgrade to latest version
 
-For version 5, the `auth0-deploy-cli` tool was updated with support for Node.js v14 and dropped support for Node.js versions earlier than v8.
+For version 5, the `auth0-deploy-cli` tool was updated to add support for Node.js v14 and drop support for Node.js versions earlier than v8.
 
 If you are upgrading `auth0-deploy-cli` from versions earlier than v4, please upgrade the **Auth0 Deploy CLI** extension by following the instructions for [Deploy CLI Tool v4](#deploy-cli-tool-v4) below.
 

--- a/articles/extensions/deploy-cli/references/whats-new.md
+++ b/articles/extensions/deploy-cli/references/whats-new.md
@@ -20,10 +20,9 @@ For version 5, the `auth0-deploy-cli` tool was updated to include the following 
 
 - Updated dependencies and deprecated support for Node.js versions earlier than 8
 
-- Allow excluding default values for emailProvider with `AUTH0_EXCLUDED_DEFAULTS`
+- Allowed excluding default values for emailProvider with `AUTH0_EXCLUDED_DEFAULTS`
 
-- pages: fix error when dumping error_page without html property
-
+- For pages, fixed error when dumping error_page without html property
 
 ## Deploy CLI Tool v4
 

--- a/articles/extensions/deploy-cli/references/whats-new.md
+++ b/articles/extensions/deploy-cli/references/whats-new.md
@@ -14,6 +14,17 @@ useCase: extensibility-extensions
 
 Features released in each version of the Deploy CLI Tool are listed below. For a complete list of changes, see the [changelog](https://github.com/auth0/auth0-deploy-cli/blob/master/CHANGELOG.md).
 
+## Deploy CLI Tool v5
+
+For version 5, the `auth0-deploy-cli` tool was updated to include the following changes.
+
+- Updated dependencies and deprecated support for Node.js versions earlier than 8
+
+- Allow excluding default values for emailProvider with `AUTH0_EXCLUDED_DEFAULTS`
+
+- pages: fix error when dumping error_page without html property
+
+
 ## Deploy CLI Tool v4
 
 For version 4, the `auth0-deploy-cli` tool was updated to include the following changes.


### PR DESCRIPTION
This PR updates the docs for v5.0.0 release of `deploy-cli`.

Reference: https://github.com/auth0/auth0-deploy-cli/releases/tag/v5.0.0