### PR TITLE
Make passwordless-start migration guide public

### DIFF
--- a/articles/migrations/guides/passwordless-start.md
+++ b/articles/migrations/guides/passwordless-start.md
@@ -1,6 +1,6 @@
 ---
 title: Migration Guide for the Use of /passwordless/start from Confidential Applications
-public: false
+public: true
 description: Auth0 is deprecating the usage of the /passwordless/start endpoint from confidential applications without a client secret in the request.
 topics:
   - passwordless

--- a/articles/migrations/guides/passwordless-start.md
+++ b/articles/migrations/guides/passwordless-start.md
@@ -1,6 +1,5 @@
 ---
 title: Migration Guide for the Use of /passwordless/start from Confidential Applications
-public: true
 description: Auth0 is deprecating the usage of the /passwordless/start endpoint from confidential applications without a client secret in the request.
 topics:
   - passwordless

--- a/config/redirects.js
+++ b/config/redirects.js
@@ -510,7 +510,7 @@ module.exports = [
     to: '/connections/enterprise/adfs'
   },
   {
-    from: ['/passwordless','/dashboard/guides/connections/set-up-connections-passwordless'],
+    from: ['/dashboard/guides/connections/set-up-connections-passwordless'],
     to: '/connections/passwordless'
   },
   {

--- a/config/redirects.js
+++ b/config/redirects.js
@@ -2460,10 +2460,6 @@ module.exports = [
       to: '/connections/passwordless/reference/troubleshoot'
     },
     {
-      from: '/migrations/guides/passwordless-start',
-      to: '/connections/passwordless'
-    },
-    {
       from: '/best-practices/custom-db-connections-scripts',
       to: '/best-practices/custom-db-connections'
     },

--- a/config/redirects.js
+++ b/config/redirects.js
@@ -510,7 +510,7 @@ module.exports = [
     to: '/connections/enterprise/adfs'
   },
   {
-    from: ['/passwordless','/dashboard/guides/connections/set-up-connections-passwordless'],
+    from: ['/connections/passwordless','/dashboard/guides/connections/set-up-connections-passwordless'],
     to: '/connections/passwordless'
   },
   {

--- a/config/redirects.js
+++ b/config/redirects.js
@@ -510,7 +510,7 @@ module.exports = [
     to: '/connections/enterprise/adfs'
   },
   {
-    from: ['/dashboard/guides/connections/set-up-connections-passwordless'],
+    from: ['/passwordless','/dashboard/guides/connections/set-up-connections-passwordless'],
     to: '/connections/passwordless'
   },
   {

--- a/config/redirects.js
+++ b/config/redirects.js
@@ -510,7 +510,7 @@ module.exports = [
     to: '/connections/enterprise/adfs'
   },
   {
-    from: ['/connections/passwordless','/dashboard/guides/connections/set-up-connections-passwordless'],
+    from: ['/passwordless','/dashboard/guides/connections/set-up-connections-passwordless'],
     to: '/connections/passwordless'
   },
   {


### PR DESCRIPTION
Migration is ongoing from the deprecated feature, so this guide is currently needed. URL to it is appearing in error messages in logs that customers receive.

https://docs-content-staging-pr-9138.herokuapp.com/docs/migrations/guides/passwordless-start