### PR TITLE
Update Identity Labs to Include Videos PET-475

### DIFF
--- a/articles/identity-labs/01-web-sign-in/exercise-01.md
+++ b/articles/identity-labs/01-web-sign-in/exercise-01.md
@@ -196,7 +196,7 @@ listening on http://localhost:3000
 
 listening on http://localhost:3000
 ```
-    </div>
+</div>
   </div>
 </div>
 

--- a/articles/identity-labs/01-web-sign-in/exercise-01.md
+++ b/articles/identity-labs/01-web-sign-in/exercise-01.md
@@ -22,6 +22,28 @@ In this exercise, you will learn how to add sign-in to an app using:
 - An Express middleware to handle checking authentication and redirecting to login
 - Auth0 as an Authorization Server
 
+<div>
+  <div>
+    <ul class="nav nav-tabs">
+      <li class="active">
+        <a href="#video-tutorial" data-toggle="tab">
+          Video Turorial
+        </a>
+      </li>
+      <li>
+        <a href="#text-tutorial" data-toggle="tab">
+          Text Tutorial
+        </a>
+      </li>
+    </ul>
+  </div>
+  <div class="tab-content">
+    <div id="video-tutorial" class="tab-pane active">
+      <div class="video-wrapper" data-video="0divx974tx"></div>
+      <hr>
+    </div>
+    <div id="text-tutorial" class="tab-pane">
+
 A simple Node.js Express application has been created to get you started. This is a web application with two pages. The first page, served under the root path `/`, shows “Hello World” and a link (“Expenses”) to the second page. The second page, served at `/expenses`, shows a table with expenses. At this point, these expenses are hard-coded; you will learn how to consume them from an API secured with Auth0 in the next lab.
 
 1. Open your Terminal app, clone the [identity exercise repo](https://github.com/auth0/identity-102-exercises/), then go to the `/lab-01/begin` folder:
@@ -174,5 +196,8 @@ listening on http://localhost:3000
 
 listening on http://localhost:3000
 ```
+    </div>
+  </div>
+</div>
 
 <a href="/identity-labs/01-web-sign-in/exercise-02" class="btn btn-transparent">Next →</a>

--- a/articles/identity-labs/01-web-sign-in/exercise-01.md
+++ b/articles/identity-labs/01-web-sign-in/exercise-01.md
@@ -27,12 +27,12 @@ In this exercise, you will learn how to add sign-in to an app using:
     <ul class="nav nav-tabs">
       <li class="active">
         <a href="#video-tutorial" data-toggle="tab">
-          Video Turorial
+          Video Tutorial
         </a>
       </li>
       <li>
         <a href="#text-tutorial" data-toggle="tab">
-          Text Tutorial
+          Lab
         </a>
       </li>
     </ul>

--- a/articles/identity-labs/01-web-sign-in/exercise-02.md
+++ b/articles/identity-labs/01-web-sign-in/exercise-02.md
@@ -23,12 +23,12 @@ In this exercise, you will sign up for your application (which will also log you
     <ul class="nav nav-tabs">
       <li class="active">
         <a href="#video-tutorial" data-toggle="tab">
-          Video Turorial
+          Video Tutorial
         </a>
       </li>
       <li>
         <a href="#text-tutorial" data-toggle="tab">
-          Text Tutorial
+          Lab
         </a>
       </li>
     </ul>

--- a/articles/identity-labs/01-web-sign-in/exercise-02.md
+++ b/articles/identity-labs/01-web-sign-in/exercise-02.md
@@ -126,7 +126,7 @@ Note the following:
 
 🎉 **You have completed Lab 1 by building a web application with sign-on using OpenID Connect!** 🎉
 
-    </div>
+</div>
   </div>
 </div>
 

--- a/articles/identity-labs/01-web-sign-in/exercise-02.md
+++ b/articles/identity-labs/01-web-sign-in/exercise-02.md
@@ -18,6 +18,27 @@ If you came to this page directly, go to the [first page of this lab](/identity-
 
 In this exercise, you will sign up for your application (which will also log you in) while exploring some of the relevant network traces of the authentication process.
 
+<div>
+  <div>
+    <ul class="nav nav-tabs">
+      <li class="active">
+        <a href="#video-tutorial" data-toggle="tab">
+          Video Turorial
+        </a>
+      </li>
+      <li>
+        <a href="#text-tutorial" data-toggle="tab">
+          Text Tutorial
+        </a>
+      </li>
+    </ul>
+  </div>
+  <div class="tab-content">
+    <div id="video-tutorial" class="tab-pane active">
+      <div class="video-wrapper" data-video="7tqnyttxfb"></div>
+    </div>
+    <div id="text-tutorial" class="tab-pane">
+
 1. Using Chrome, open **Developer Tools**. Switch to the **Network** tab then open your local application. You should immediately be redirected to Auth0 to login.
 
 2. The first request you should see is a GET request to your application homepage:
@@ -104,5 +125,9 @@ Note the following:
 - The claim `exp` shows when the token expires (seconds since Unix epoch).
 
 🎉 **You have completed Lab 1 by building a web application with sign-on using OpenID Connect!** 🎉
+
+    </div>
+  </div>
+</div>
 
 <a href="/identity-labs/" class="btn btn-transparent">← All Identity Labs</a>

--- a/articles/identity-labs/02-calling-an-api/exercise-01.md
+++ b/articles/identity-labs/02-calling-an-api/exercise-01.md
@@ -209,7 +209,7 @@ The `API_AUDIENCE` value is the identifier for the API that will be created in t
 
 If you restart the application in your terminal, logout, and try to log back in, you will see an error because no resource server with the identifier `https://expenses-api` has been registered yet. In the next exercise, you will learn how to create and secure APIs with Auth0, and this request will begin to work.
 
-    </div>
+</div>
   </div>
 </div>
 

--- a/articles/identity-labs/02-calling-an-api/exercise-01.md
+++ b/articles/identity-labs/02-calling-an-api/exercise-01.md
@@ -18,6 +18,30 @@ If you came to this page directly, go to the [first page of this lab](/identity-
 
 After learning how to secure your web application with Auth0 in [lab 1](/identity-labs/01-web-sign-in), you will now learn how to make this application consume APIs on behalf of your users. You will start by running an unsecured API and a web application to see both working together, and then you will secure your API with Auth0.
 
+<div>
+  <div>
+    <ul class="nav nav-tabs">
+      <li class="active">
+        <a href="#video-tutorial" data-toggle="tab">
+          Video Turorial
+        </a>
+      </li>
+      <li>
+        <a href="#text-tutorial" data-toggle="tab">
+          Text Tutorial
+        </a>
+      </li>
+    </ul>
+  </div>
+  <div class="tab-content">
+    <div id="video-tutorial" class="tab-pane active">
+      <div class="video-wrapper" data-video="ucdc0nohs4"></div>
+      <hr>
+      <div class="video-wrapper" data-video="xjimnp9iqt"></div>
+      <hr>
+    </div>
+    <div id="text-tutorial" class="tab-pane">
+
 1. Open a new terminal and browse to `/lab-02/begin/api` in your locally-cloned copy of the [identity exercise repo](https://github.com/auth0/identity-102-exercises/). This is where the code for your API resides. The API is an Express backend that contains a single endpoint. This endpoint (served under the root path) returns expenses, which are data that belong to each user (though they are static and the same for all).
 
 <%= include('../_includes/_git-clone-note') %>
@@ -184,5 +208,9 @@ The `API_AUDIENCE` value is the identifier for the API that will be created in t
 **And that's it!** You have just configured your web application to consume the API on behalf of the logged in user.
 
 If you restart the application in your terminal, logout, and try to log back in, you will see an error because no resource server with the identifier `https://expenses-api` has been registered yet. In the next exercise, you will learn how to create and secure APIs with Auth0, and this request will begin to work.
+
+    </div>
+  </div>
+</div>
 
 <a href="/identity-labs/02-calling-an-api/exercise-02" class="btn btn-transparent">Next →</a>

--- a/articles/identity-labs/02-calling-an-api/exercise-01.md
+++ b/articles/identity-labs/02-calling-an-api/exercise-01.md
@@ -23,12 +23,12 @@ After learning how to secure your web application with Auth0 in [lab 1](/identit
     <ul class="nav nav-tabs">
       <li class="active">
         <a href="#video-tutorial" data-toggle="tab">
-          Video Turorial
+          Video Tutorial
         </a>
       </li>
       <li>
         <a href="#text-tutorial" data-toggle="tab">
-          Text Tutorial
+          Lab
         </a>
       </li>
     </ul>

--- a/articles/identity-labs/02-calling-an-api/exercise-02.md
+++ b/articles/identity-labs/02-calling-an-api/exercise-02.md
@@ -137,7 +137,7 @@ listening on http://localhost:3001
 
 To test your secured API, refresh the expenses page in your application - [localhost:3000/expenses](http://localhost:3000/expenses). If everything works as expected, you will still be able to access this view (which means that the web app is consuming the API on your behalf). If you browse directly to the API at [localhost:3001](http://localhost:3001), however, you will get an error saying the token is missing.
 
-    </div>
+</div>
   </div>
 </div>
 

--- a/articles/identity-labs/02-calling-an-api/exercise-02.md
+++ b/articles/identity-labs/02-calling-an-api/exercise-02.md
@@ -18,6 +18,30 @@ If you came to this page directly, go to the [first page of this lab](/identity-
 
 In this exercise, you will register the API with Auth0 so that tokens can be issued for it. You will also learn how to secure your API with Auth0. You will refactor the API that your web application is consuming by installing and configuring some libraries needed to secure it with Auth0.
 
+<div>
+  <div>
+    <ul class="nav nav-tabs">
+      <li class="active">
+        <a href="#video-tutorial" data-toggle="tab">
+          Video Turorial
+        </a>
+      </li>
+      <li>
+        <a href="#text-tutorial" data-toggle="tab">
+          Text Tutorial
+        </a>
+      </li>
+    </ul>
+  </div>
+  <div class="tab-content">
+    <div id="video-tutorial" class="tab-pane active">
+      <div class="video-wrapper" data-video="6omxlyo7w5"></div>
+      <hr>
+      <div class="video-wrapper" data-video="hkt0fbvxq3"></div>
+      <hr>
+    </div>
+    <div id="text-tutorial" class="tab-pane">
+
 1. To register the API with Auth0, open the Auth0 Dashboard and go to the [APIs screen](${manage_url}/#/apis).
 
 2. Click the **Create API** button. Add a descriptive Name, paste `https://expenses-api` into the **Identifier** field, and click **Create**.
@@ -112,5 +136,9 @@ listening on http://localhost:3001
 ```
 
 To test your secured API, refresh the expenses page in your application - [localhost:3000/expenses](http://localhost:3000/expenses). If everything works as expected, you will still be able to access this view (which means that the web app is consuming the API on your behalf). If you browse directly to the API at [localhost:3001](http://localhost:3001), however, you will get an error saying the token is missing.
+
+    </div>
+  </div>
+</div>
 
 <a href="/identity-labs/02-calling-an-api/exercise-03" class="btn btn-transparent">Next →</a>

--- a/articles/identity-labs/02-calling-an-api/exercise-02.md
+++ b/articles/identity-labs/02-calling-an-api/exercise-02.md
@@ -23,12 +23,12 @@ In this exercise, you will register the API with Auth0 so that tokens can be iss
     <ul class="nav nav-tabs">
       <li class="active">
         <a href="#video-tutorial" data-toggle="tab">
-          Video Turorial
+          Video Tutorial
         </a>
       </li>
       <li>
         <a href="#text-tutorial" data-toggle="tab">
-          Text Tutorial
+          Lab
         </a>
       </li>
     </ul>

--- a/articles/identity-labs/02-calling-an-api/exercise-03.md
+++ b/articles/identity-labs/02-calling-an-api/exercise-03.md
@@ -16,6 +16,28 @@ contentType:
 If you came to this page directly, go to the [first page of this lab](/identity-labs/02-calling-an-api) and read through the instructions before getting started.
 :::
 
+<div>
+  <div>
+    <ul class="nav nav-tabs">
+      <li class="active">
+        <a href="#video-tutorial" data-toggle="tab">
+          Video Turorial
+        </a>
+      </li>
+      <li>
+        <a href="#text-tutorial" data-toggle="tab">
+          Text Tutorial
+        </a>
+      </li>
+    </ul>
+  </div>
+  <div class="tab-content">
+    <div id="video-tutorial" class="tab-pane active">
+      <div class="video-wrapper" data-video="lqriaseaxq"></div>
+      <hr>
+    </div>
+    <div id="text-tutorial" class="tab-pane">
+
 Right now, if your users stay logged in for too long and try to refresh the `/expenses` page, they will face a problem. Access tokens were conceived to be exchanged by different services through the network (which makes them more prone to leakage), so they should expire quickly. When an access token is expired, your API won't accept it anymore, and your web application won't be able to fetch the data needed. A token expired error will be returned instead.
 
 To change this behavior, you can make your web app take advantage of yet another token: the refresh token. A refresh token is used to obtain new access tokens and/or ID tokens from the authorization server. In this exercise, we're going to modify the application to obtain a refresh token and use it to get a new access token when it expires.
@@ -110,5 +132,9 @@ If you are using PowerShell in Windows and you see blank lines instead of the ti
 :::
 
 🎉 **You have completed Lab 2 by building a web application that calls an API with refresh capability!** 🎉
+
+    </div>
+  </div>
+</div>
 
 <a href="/identity-labs/" class="btn btn-transparent">← All Identity Labs</a>

--- a/articles/identity-labs/02-calling-an-api/exercise-03.md
+++ b/articles/identity-labs/02-calling-an-api/exercise-03.md
@@ -21,12 +21,12 @@ If you came to this page directly, go to the [first page of this lab](/identity-
     <ul class="nav nav-tabs">
       <li class="active">
         <a href="#video-tutorial" data-toggle="tab">
-          Video Turorial
+          Video Tutorial
         </a>
       </li>
       <li>
         <a href="#text-tutorial" data-toggle="tab">
-          Text Tutorial
+          Lab
         </a>
       </li>
     </ul>

--- a/articles/identity-labs/02-calling-an-api/exercise-03.md
+++ b/articles/identity-labs/02-calling-an-api/exercise-03.md
@@ -133,7 +133,7 @@ If you are using PowerShell in Windows and you see blank lines instead of the ti
 
 🎉 **You have completed Lab 2 by building a web application that calls an API with refresh capability!** 🎉
 
-    </div>
+</div>
   </div>
 </div>
 

--- a/articles/identity-labs/03-mobile-native-app/exercise-01.md
+++ b/articles/identity-labs/03-mobile-native-app/exercise-01.md
@@ -23,12 +23,12 @@ In this exercise, you will add authentication to an existing iOS application. A 
     <ul class="nav nav-tabs">
       <li class="active">
         <a href="#video-tutorial" data-toggle="tab">
-          Video Turorial
+          Video Tutorial
         </a>
       </li>
       <li>
         <a href="#text-tutorial" data-toggle="tab">
-          Text Tutorial
+          Lab
         </a>
       </li>
     </ul>

--- a/articles/identity-labs/03-mobile-native-app/exercise-01.md
+++ b/articles/identity-labs/03-mobile-native-app/exercise-01.md
@@ -18,6 +18,30 @@ If you came to this page directly, go to the [first page of this lab](/identity-
 
 In this exercise, you will add authentication to an existing iOS application. A simple iOS application has been provided to get you started. This is a single-view application with a button to launch the Auth0 authentication process.
 
+<div>
+  <div>
+    <ul class="nav nav-tabs">
+      <li class="active">
+        <a href="#video-tutorial" data-toggle="tab">
+          Video Turorial
+        </a>
+      </li>
+      <li>
+        <a href="#text-tutorial" data-toggle="tab">
+          Text Tutorial
+        </a>
+      </li>
+    </ul>
+  </div>
+  <div class="tab-content">
+    <div id="video-tutorial" class="tab-pane active">
+      <div class="video-wrapper" data-video="qt3p9kdk2c"></div>
+      <hr>
+      <div class="video-wrapper" data-video="98q7d16ieg"></div>
+      <hr>
+    </div>
+    <div id="text-tutorial" class="tab-pane">
+
 1. Launch Xcode, go to **File > Open**, and open `/lab-03/exercise-01/begin/exercise-01.xcworkspace` in your locally-cloned copy of the [identity exercise repo](https://github.com/auth0/identity-102-exercises/).
 
 <%= include('../_includes/_git-clone-note') %>
@@ -242,5 +266,9 @@ Content-Type: application/json
 ```
 
 In the next exercise, you will use a token to validate and authorize the user and authorize against a protected API.
+
+    </div>
+  </div>
+</div>
 
 <a href="/identity-labs/03-mobile-native-app/exercise-02" class="btn btn-transparent">Next →</a>

--- a/articles/identity-labs/03-mobile-native-app/exercise-01.md
+++ b/articles/identity-labs/03-mobile-native-app/exercise-01.md
@@ -267,7 +267,7 @@ Content-Type: application/json
 
 In the next exercise, you will use a token to validate and authorize the user and authorize against a protected API.
 
-    </div>
+</div>
   </div>
 </div>
 

--- a/articles/identity-labs/03-mobile-native-app/exercise-02.md
+++ b/articles/identity-labs/03-mobile-native-app/exercise-02.md
@@ -17,6 +17,29 @@ If you came to this page directly, go to the [first page of this lab](/identity-
 
 In this exercise, you are going to enable the native application to authorize against the protected API backend that was built in [Lab 2, Exercise 2](/identity-labs/02-calling-an-api/exercise-02). In that lab, you set up an Auth0 API server for your Expenses API with an audience value of `https://expenses-api`.
 
+<div>
+  <div>
+    <ul class="nav nav-tabs">
+      <li class="active">
+        <a href="#video-tutorial" data-toggle="tab">
+          Video Turorial
+        </a>
+      </li>
+      <li>
+        <a href="#text-tutorial" data-toggle="tab">
+          Text Tutorial
+        </a>
+      </li>
+    </ul>
+  </div>
+  <div class="tab-content">
+    <div id="video-tutorial" class="tab-pane active">
+      <div class="video-wrapper" data-video="g1r8exsdl4"></div>
+      <hr>
+    </div>
+    <div id="text-tutorial" class="tab-pane">
+
+
 If you have already completed lab 2, you can use the same Auth0 configuration and local files to run the API needed for this lab. Just go to `/lab-02/begin/api` in your locally-cloned copy of the [identity exercise repo](https://github.com/auth0/identity-102-exercises/) and run `npm start` in your terminal before beginning this exercise. Make sure your token expiration times in Auth0 are back to normal (at least an hour for both).
 
 ::: panel If you did not complete Lab 2
@@ -309,5 +332,9 @@ The `Status Code: 200` (OK) lets us know the request was executed successfully. 
 ```
 
 You have now integrated your native application frontend with a protected API backend! In the next exercise, you will look at how the access token can be refreshed without having the user go through the web-based authentication flow each time.
+
+    </div>
+  </div>
+</div>
 
 <a href="/identity-labs/03-mobile-native-app/exercise-03" class="btn btn-transparent">Next →</a>

--- a/articles/identity-labs/03-mobile-native-app/exercise-02.md
+++ b/articles/identity-labs/03-mobile-native-app/exercise-02.md
@@ -333,7 +333,7 @@ The `Status Code: 200` (OK) lets us know the request was executed successfully. 
 
 You have now integrated your native application frontend with a protected API backend! In the next exercise, you will look at how the access token can be refreshed without having the user go through the web-based authentication flow each time.
 
-    </div>
+</div>
   </div>
 </div>
 

--- a/articles/identity-labs/03-mobile-native-app/exercise-02.md
+++ b/articles/identity-labs/03-mobile-native-app/exercise-02.md
@@ -22,12 +22,12 @@ In this exercise, you are going to enable the native application to authorize ag
     <ul class="nav nav-tabs">
       <li class="active">
         <a href="#video-tutorial" data-toggle="tab">
-          Video Turorial
+          Video Tutorial
         </a>
       </li>
       <li>
         <a href="#text-tutorial" data-toggle="tab">
-          Text Tutorial
+          Lab
         </a>
       </li>
     </ul>

--- a/articles/identity-labs/03-mobile-native-app/exercise-03.md
+++ b/articles/identity-labs/03-mobile-native-app/exercise-03.md
@@ -23,12 +23,12 @@ In this exercise, you will explore the use of refresh tokens. A refresh token is
     <ul class="nav nav-tabs">
       <li class="active">
         <a href="#video-tutorial" data-toggle="tab">
-          Video Turorial
+          Video Tutorial
         </a>
       </li>
       <li>
         <a href="#text-tutorial" data-toggle="tab">
-          Text Tutorial
+          Lab
         </a>
       </li>
     </ul>

--- a/articles/identity-labs/03-mobile-native-app/exercise-03.md
+++ b/articles/identity-labs/03-mobile-native-app/exercise-03.md
@@ -225,7 +225,7 @@ Now that you are able to obtain a fresh access token by using the refresh token,
 
 🎉 **You have completed Lab 3 by building a native mobile application calling a secure API with refresh capability!** 🎉
 
-    </div>
+</div>
   </div>
 </div>
 

--- a/articles/identity-labs/03-mobile-native-app/exercise-03.md
+++ b/articles/identity-labs/03-mobile-native-app/exercise-03.md
@@ -18,6 +18,28 @@ If you came to this page directly, go to the [first page of this lab](/identity-
 
 In this exercise, you will explore the use of refresh tokens. A refresh token is a special kind of token that can be used to obtain a renewed access token. You are able to request new access tokens until the refresh token is blacklisted. It’s important that refresh tokens are stored securely by the application because they essentially allow a user to remain authenticated forever.
 
+<div>
+  <div>
+    <ul class="nav nav-tabs">
+      <li class="active">
+        <a href="#video-tutorial" data-toggle="tab">
+          Video Turorial
+        </a>
+      </li>
+      <li>
+        <a href="#text-tutorial" data-toggle="tab">
+          Text Tutorial
+        </a>
+      </li>
+    </ul>
+  </div>
+  <div class="tab-content">
+    <div id="video-tutorial" class="tab-pane active">
+      <div class="video-wrapper" data-video="vm4lx2twdh"></div>
+      <hr>
+    </div>
+    <div id="text-tutorial" class="tab-pane">
+
 For native applications such as our iOS application, refresh tokens improve the authentication experience significantly. The user has to authenticate only once, through the web authentication process. Subsequent re-authentication can take place without user interaction, using the refresh token.
 
 1. Go to **File > Open** in Xcode and select `lab-03/exercise-03/begin/exercise-03.xcworkspace` (make sure you pick the right file extension), then open `exercise-03/ViewController.swift`. This code picks up where the previous exercise left off and adds a new button to refresh the access token.
@@ -202,5 +224,9 @@ Now that you are able to obtain a fresh access token by using the refresh token,
 16. Tap **Refresh Token** and check the debug area to see the refresh token grant happen. Then, tap **Call API**, and you should get a `Status Code: 200` along with the expenses data again.
 
 🎉 **You have completed Lab 3 by building a native mobile application calling a secure API with refresh capability!** 🎉
+
+    </div>
+  </div>
+</div>
 
 <a href="/identity-labs/" class="btn btn-transparent">← All Identity Labs</a>

--- a/articles/identity-labs/04-single-page-app/exercise-01.md
+++ b/articles/identity-labs/04-single-page-app/exercise-01.md
@@ -25,6 +25,36 @@ The SPA in question is a vanilla JavaScript application that consumes an API sim
 
 In this exercise, you will focus on integrating the SPA with Auth0 and getting the profile of the logged-in user. Exercise 2 will show how to consume the private endpoint exposed by the API.
 
+<div>
+  <div>
+    <ul class="nav nav-tabs">
+      <li class="active">
+        <a href="#video-tutorial" data-toggle="tab">
+          Video Turorial
+        </a>
+      </li>
+      <li>
+        <a href="#text-tutorial" data-toggle="tab">
+          Text Tutorial
+        </a>
+      </li>
+    </ul>
+  </div>
+  <div class="tab-content">
+    <div id="video-tutorial" class="tab-pane active">
+      <div class="video-wrapper" data-video="xozbeg92cm"></div>
+      <hr>
+      <div class="video-wrapper" data-video="i01sxuclba"></div>
+      <hr>
+      <div class="video-wrapper" data-video="la4r6zl99s"></div>
+      <hr>
+      <div class="video-wrapper" data-video="2sg5ofur0j"></div>
+      <hr>
+      <div class="video-wrapper" data-video="8erv7xmqod"></div>
+      <hr>
+    </div>
+    <div id="text-tutorial" class="tab-pane">
+
 1. First, you will run a version of the app that is not integrated with Auth0. Open a new terminal and browse to `/lab-04/exercise-01/begin/api` in your locally-cloned copy of the [identity exercise repo](https://github.com/auth0/identity-102-exercises/). This is where the code for your API resides. Install the dependencies using npm.
 
 ```bash
@@ -328,5 +358,9 @@ If you are using a content blocker or browser setting that blocks third-party co
 ![Silent authentication network request from single-page application](/media/articles/identity-labs/lab-04-silent-auth-request.png)
 
 For this to work properly, the silent authentication process requires the referrer URL to be whitelisted. This is why you added `http://localhost:5000` to the **Allowed Web Origins** field for your Auth0 Application. Otherwise, the silent authentication process would fail, and your users would need to log in again interactively.
+
+    </div>
+  </div>
+</div>
 
 <a href="/identity-labs/04-single-page-app/exercise-02" class="btn btn-transparent">Next →</a>

--- a/articles/identity-labs/04-single-page-app/exercise-01.md
+++ b/articles/identity-labs/04-single-page-app/exercise-01.md
@@ -30,12 +30,12 @@ In this exercise, you will focus on integrating the SPA with Auth0 and getting t
     <ul class="nav nav-tabs">
       <li class="active">
         <a href="#video-tutorial" data-toggle="tab">
-          Video Turorial
+          Video Tutorial
         </a>
       </li>
       <li>
         <a href="#text-tutorial" data-toggle="tab">
-          Text Tutorial
+          Lab
         </a>
       </li>
     </ul>

--- a/articles/identity-labs/04-single-page-app/exercise-01.md
+++ b/articles/identity-labs/04-single-page-app/exercise-01.md
@@ -359,7 +359,7 @@ If you are using a content blocker or browser setting that blocks third-party co
 
 For this to work properly, the silent authentication process requires the referrer URL to be whitelisted. This is why you added `http://localhost:5000` to the **Allowed Web Origins** field for your Auth0 Application. Otherwise, the silent authentication process would fail, and your users would need to log in again interactively.
 
-    </div>
+</div>
   </div>
 </div>
 

--- a/articles/identity-labs/04-single-page-app/exercise-02.md
+++ b/articles/identity-labs/04-single-page-app/exercise-02.md
@@ -23,12 +23,12 @@ In this exercise, you will learn how to make your SPA consume, on behalf of the 
     <ul class="nav nav-tabs">
       <li class="active">
         <a href="#video-tutorial" data-toggle="tab">
-          Video Turorial
+          Video Tutorial
         </a>
       </li>
       <li>
         <a href="#text-tutorial" data-toggle="tab">
-          Text Tutorial
+          Lab
         </a>
       </li>
     </ul>

--- a/articles/identity-labs/04-single-page-app/exercise-02.md
+++ b/articles/identity-labs/04-single-page-app/exercise-02.md
@@ -18,6 +18,28 @@ If you came to this page directly, go to the [first page of this lab](/identity-
 
 In this exercise, you will learn how to make your SPA consume, on behalf of the user, the private endpoint exposed by the API.
 
+<div>
+  <div>
+    <ul class="nav nav-tabs">
+      <li class="active">
+        <a href="#video-tutorial" data-toggle="tab">
+          Video Turorial
+        </a>
+      </li>
+      <li>
+        <a href="#text-tutorial" data-toggle="tab">
+          Text Tutorial
+        </a>
+      </li>
+    </ul>
+  </div>
+  <div class="tab-content">
+    <div id="video-tutorial" class="tab-pane active">
+      <div class="video-wrapper" data-video="a9o2c59weh"></div>
+      <hr>
+    </div>
+    <div id="text-tutorial" class="tab-pane">
+
 ::: note
 You can continue using the source code from the previous exercise, or if you are starting from scratch, use the code in the `exercise-02/begin` folder. Make sure you run steps 1-6 in [exercise 1](/identity-labs/04-single-page-app/exercise-01) either way.
 :::
@@ -159,5 +181,9 @@ If you want to recreate the scenario where consent is needed, go to the [Users s
 :::
 
 🎉 **You have completed Lab 4 by building a single-page application calling a secure API!** 🎉
+
+    </div>
+  </div>
+</div>
 
 <a href="/identity-labs/" class="btn btn-transparent">← All Identity Labs</a>

--- a/articles/identity-labs/04-single-page-app/exercise-02.md
+++ b/articles/identity-labs/04-single-page-app/exercise-02.md
@@ -182,7 +182,7 @@ If you want to recreate the scenario where consent is needed, go to the [Users s
 
 🎉 **You have completed Lab 4 by building a single-page application calling a secure API!** 🎉
 
-    </div>
+</div>
   </div>
 </div>
 

--- a/articles/identity-labs/index.md
+++ b/articles/identity-labs/index.md
@@ -15,7 +15,7 @@ contentType:
 
 _A few general things to keep in mind as you work through these labs:_
 
-**Plan to take around 1 hour or so (longer depending on your coding experience) for each lab.**
+**Plan to take around 1 hour or so (longer depending on your coding experience) for each lab.** Optionally, video demonstrations of the lab exercises are available.
 
 **These labs are designed to illustrate the basic concepts of digital identity, OAuth, and OpenID Connect.** The goal is to see the parameters and data that come together to create a complete authentication flow. As such, take your time and read through each section carefully. Completing the lab successfully is less important than understanding the concepts within.
 


### PR DESCRIPTION
This update will add the Identity Lab Training Videos to the individual exercise pages. Users are presented with the video version of these labs and have the option to view the text version.

## TODO
- [x] Decide if text or video version should be the default
- [x] Updates for instruction page?

## Example
![Screen Shot 2020-06-10 at 11 20 08 AM](https://user-images.githubusercontent.com/73120/84303819-6fb03e80-ab0c-11ea-8dfa-56c8cb5d978d.png)

## Review
### Lab 1
https://docs-content-staging-pr-9146.herokuapp.com/docs/identity-labs/01-web-sign-in/exercise-01
https://docs-content-staging-pr-9146.herokuapp.com/docs/identity-labs/01-web-sign-in/exercise-02

### Lab 2
https://docs-content-staging-pr-9146.herokuapp.com/docs/identity-labs/02-calling-an-api/exercise-01
https://docs-content-staging-pr-9146.herokuapp.com/docs/identity-labs/02-calling-an-api/exercise-02
https://docs-content-staging-pr-9146.herokuapp.com/docs/identity-labs/02-calling-an-api/exercise-03

### Lab 3
https://docs-content-staging-pr-9146.herokuapp.com/docs/identity-labs/03-mobile-native-app/exercise-01
https://docs-content-staging-pr-9146.herokuapp.com/docs/identity-labs/03-mobile-native-app/exercise-02
https://docs-content-staging-pr-9146.herokuapp.com/docs/identity-labs/03-mobile-native-app/exercise-03

### Lab 4
https://docs-content-staging-pr-9146.herokuapp.com/docs/identity-labs/04-single-page-app/exercise-01
https://docs-content-staging-pr-9146.herokuapp.com/docs/identity-labs/04-single-page-app/exercise-02