### PR TITLE
use Hook Secrets in example for post change password hook

### DIFF
--- a/articles/hooks/extensibility-points/post-change-password.md
+++ b/articles/hooks/extensibility-points/post-change-password.md
@@ -88,18 +88,19 @@ When you run a Hook based on the starter code, the response object is:
 
 ## Sample script: Send a notification email upon password change
 
-In this example, we use a Hook to have SendGrid send a notification email to the user upon password change.
+In this example, we use a Hook to have SendGrid send a notification email to the user upon password change. The example requires a valid SendGrid API key to be stored in [Hook Secrets](/hooks/secrets) as `SENDGRID_API_KEY`.
 
 ```js
 module.exports = function (user, context, cb) {
 
   const request = require('request');
+  const sendgridApiKey = context.webtask.secrets.SENDGRID_API_KEY;
 
   // https://sendgrid.api-docs.io/v3.0/mail-send
   request.post({
     url: 'https://api.sendgrid.com/v3/mail/send',
     headers: {
-      'Authorization': 'Bearer YOUR_API_KEY'
+      'Authorization': 'Bearer ' + sendgridApiKey
     },
     json: {
       personalizations: [{


### PR DESCRIPTION
The example should show the best practice of storing sensitive secrets in Hook Secrets instead of inline in the hook source code.