### PR TITLE
fix: broken links to Email MFA guide

### DIFF
--- a/articles/mfa/concepts/mfa-factors.md
+++ b/articles/mfa/concepts/mfa-factors.md
@@ -34,7 +34,7 @@ Send users push notifications to a their pre-registered devices - typically a mo
 
 ## Email notifications
 
-You can [use email](/mfa/guides/configure-email-universal-login) when you want to provide users a way to perform MFA when they don't have their phone to receive an SMS or push notification.
+You can [use email](/mfa/guides/configure-email) when you want to provide users a way to perform MFA when they don't have their phone to receive an SMS or push notification.
 
 ## Duo Security
 

--- a/articles/mfa/guides/enable-mfa.md
+++ b/articles/mfa/guides/enable-mfa.md
@@ -34,7 +34,7 @@ Duo will only be available to end-users as a factor if it is the only factor tha
 * [Configure Push Notifications for MFA](/mfa/guides/configure-push)
 * [Configure One Time Passwords for MFA](/mfa/guides/configure-otp)
 * [Configure SMS Notifications for MFA](/mfa/guides/configure-sms)
-* [Configure Email Notifications for MFA](/mfa/guides/configure-email-universal-login)
+* [Configure Email Notifications for MFA](/mfa/guides/configure-email)
 * [Configure Cisco Duo](/mfa/guides/configure-cisco-duo)
 * [Customize SMS Messages](/mfa/guides/guardian/customize-sms-messages)
 * [Customize Multi-factor Authentication](/mfa/guides/customize-mfa-universal-login)

--- a/articles/mfa/guides/mfa-api/email.md
+++ b/articles/mfa/guides/mfa-api/email.md
@@ -16,7 +16,7 @@ useCase:
 
 Auth0 provides a built-in MFA enrollment and authentication flow using [Universal Login](/universal-login). However, if you want to create your own user interface, you can use the MFA API to accomplish it. 
 
-This guide will explain how to enroll and challenge users with Email using the MFA API. Make sure that Email is [enabled as factor](/mfa/guides/configure-email-universal-login) in the Dashboard or using the [Management API](/api/management/v2#!/Guardian/put_factors_by_name).
+This guide will explain how to enroll and challenge users with Email using the MFA API. Make sure that Email is [enabled as factor](/mfa/guides/configure-email) in the Dashboard or using the [Management API](/api/management/v2#!/Guardian/put_factors_by_name).
 
 
 ::: note

--- a/config/redirects.js
+++ b/config/redirects.js
@@ -838,7 +838,11 @@ module.exports = [
   },
   {
     from: '/multifactor-authentication/factors/email',
-    to: '/mfa/guides/configure-email-universal-login'
+    to: '/mfa/guides/configure-email'
+  },
+  {
+    from: '/mfa/guides/configure-email-universal-login',
+    to: '/mfa/guides/configure-email'
   },
   {
     from: '/multifactor-authentication/factors/duo',


### PR DESCRIPTION
There were a few misses in #8803 that left a couple of links to the old page path (`/mfa/guides/configure-email-universal-login`). This PR fixes the links and adds a redirect rule that points to the new (valid) url.