### PR TITLE
Fix broken MD link

### DIFF
--- a/articles/extensions/github-deploy.md
+++ b/articles/extensions/github-deploy.md
@@ -29,8 +29,7 @@ Set the following configuration variables:
 * **BRANCH**: The branch that the extension will monitor for commits.
 * **HOST**: The public accessible GitHub Enterprise _(version 2.11.3 and later)_ hostname, no value is required when using github.com (optional).
 * **API_PATH**: GitHub Enterprise API path prefix, no value is required when using github.com (optional).
-* **TOKEN**: Your GitHub Personal Access Token. Follow the instructions at [Creating an Access Token]
-(https://help.github.com/articles/creating-an-access-token-for-command-line-use/#creating-a-token) to create a token with `repo` scope.
+* **TOKEN**: Your GitHub Personal Access Token. Follow the instructions at [Creating an Access Token](https://help.github.com/articles/creating-an-access-token-for-command-line-use/#creating-a-token) to create a token with `repo` scope.
 * **BASE_DIR**: The base directory, where all your tenant settings are stored
 * **AUTO_REDEPLOY**: If enabled, the extension redeploys the last successful configuration in the event of a deployment failure. Manual deployments and validation errors does not trigger auto-redeployment
 * **SLACK_INCOMING_WEBHOOK_URL**: The Webhook URL for Slack, used to receive Slack notifications for successful and failed deployments (optional).


### PR DESCRIPTION
The newline caused the link to render as literal text, this turns it back into a link