### PR TITLE
fix connection test step

### DIFF
--- a/articles/protocols/saml/adfs.md
+++ b/articles/protocols/saml/adfs.md
@@ -119,8 +119,8 @@ Before you test your integration, make sure that you've completed the following 
 * Create a user on the IdP that you can use to test your new connection.
 * [Enable your Connection](/connections) for at least one application.
 
-1. To test your connection, navigate to **Connections > Enterprise > ADFS**. 
-2. Click the ADFS row (or the hamburger icon to the right) to bring up a list of your ADFS connections. 
+1. To test your connection, navigate to **Connections > Enterprise > SAML**. 
+2. Click the ADFS row (or the hamburger icon to the right to bring up a list of your SAML connections). 
 3. Select the one you want to test and click the **play** button to test the connection.
 
 ## Keep reading


### PR DESCRIPTION
Here, ADFS is setup as SAML. so connection appears in **Connections > Enterprise > SAML** as opposed to ~~ADFS~~.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors
- Please include a short description
- If your PR is a work in progress, title it [DO NOT MERGE]
--->
