### PR TITLE
Example code: `.login`, not `.Login`

### DIFF
--- a/articles/libraries/lock-ios/v2/configuration.md
+++ b/articles/libraries/lock-ios/v2/configuration.md
@@ -132,7 +132,7 @@ The first screen to present to the user. The default is `.Login`, other options 
 
 ```swift
 .withOptions {
-  $0.initialScreen = .Login
+  $0.initialScreen = .login
 }
 ```
 


### PR DESCRIPTION
The `DatabaseScreen` enum case is `.login`, not `.Login`. The example code doesn't compile unless you change it to `.login`.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors
- Please include a short description
- If your PR is a work in progress, title it [DO NOT MERGE]
--->
