### PR TITLE
Redirect auth0-react quickstart to react

### DIFF
--- a/config/redirects.js
+++ b/config/redirects.js
@@ -255,6 +255,10 @@ module.exports = [
     from: '/quickstart/native/react-native-android',
     to: '/quickstart/native/react-native'
   },
+  {
+    from: '/quickstart/spa/auth0-react',
+    to: '/quickstart/spa/react'
+  },
 
   /* --- Renamed quickstart articles --- */
 


### PR DESCRIPTION
This PR redirects the React quickstart from the old beta location at
/quickstart/spa/auth0-react to the live one at /quickstart/spa/react.
