### PR TITLE
SDK-1766: Update to remove archived items

### DIFF
--- a/articles/_includes/_libraries_support_frameworks.html
+++ b/articles/_includes/_libraries_support_frameworks.html
@@ -37,15 +37,5 @@
       <td>v3</td>
       <td><div class="label label-default">Supported</div></td>
     </tr>
-    <tr>
-      <td><a href="https://github.com/auth0/Auth0.Windows.UWP">Auth0 with UWP applications</a></td>
-      <td>v1</td>
-      <td><div class="label label-default">Community</div></td>
-    </tr>
-    <tr>
-      <td><a href="https://github.com/auth0/Auth0.WinformsWPF">Auth0 application for Winforms and WPF</a></td>
-      <td>v0.9</td>
-      <td><div class="label label-default">Community</div></td>
-    </tr>
   </tbody>
 </table>


### PR DESCRIPTION
We've already deprecated and later archived to read-only for the following libraries, so removing them from the page:
Auth0 with UWP applications	v1	COMMUNITY
Auth0 application for Winforms and WPF	v0.9	COMMUNITY

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors
- Please include a short description
- If your PR is a work in progress, title it [DO NOT MERGE]
--->
