### PR TITLE
Update support matrix with currently supported java quickstarts

### DIFF
--- a/articles/support/matrix.md
+++ b/articles/support/matrix.md
@@ -401,13 +401,8 @@ Auth0 support is limited to the most recent version of the OS listed (unless oth
       <td><div class="label label-primary">Supported</div></td>
     </tr>
     <tr>
-      <td><a href="/quickstart/webapp/java-spring-mvc">Java Spring MVC</a></td>
-      <td class="text-center"><a href="https://github.com/auth0-samples/auth0-spring-mvc-sample"><img src="https://cdn.auth0.com/website/auth0-docs/github-logo.svg"/></a></td>
-      <td><div class="label label-primary">Supported</div></td>
-    </tr>
-    <tr>
-      <td><a href="/quickstart/webapp/java-spring-security-mvc">Java Spring Security</a></td>
-      <td class="text-center"><a href="https://github.com/auth0-samples/auth0-spring-security-mvc-sample"><img src="https://cdn.auth0.com/website/auth0-docs/github-logo.svg"/></a></td>
+      <td><a href="/quickstart/webapp/java-spring-boot">Java Spring Boot</a></td>
+      <td class="text-center"><a href="https://github.com/auth0-samples/auth0-spring-boot-login-samples"><img src="https://cdn.auth0.com/website/auth0-docs/github-logo.svg"/></a></td>
       <td><div class="label label-primary">Supported</div></td>
     </tr>
     <tr>


### PR DESCRIPTION
After the recent removal of the `Java Spring MVC` and `Java Spring Security` quickstarts, and the addition of the `Java Spring Boot` quickstart, the support matrix requires an update.

The removed quickstarts have been removed but their repositories are still accessible. I couldn't find a "status" for this, so I removed them from the table.