### PR TITLE
Split Java and Android instructions for generating code verifier

### DIFF
--- a/articles/api-auth/tutorials/authorization-code-grant-pkce.md
+++ b/articles/api-auth/tutorials/authorization-code-grant-pkce.md
@@ -33,6 +33,7 @@ First, you need to generate and store a `code_verifier`.
     <ul>
       <li class="active"><a href="#verifier-javascript" data-toggle="tab">JavaScript</a></li>
       <li><a href="#verifier-java" data-toggle="tab">Java</a></li>
+      <li><a href="#verifier-android" data-toggle="tab">Android</a></li>
       <li><a href="#verifier-swift" data-toggle="tab">Swift 3</a></li>
       <li><a href="#verifier-objc" data-toggle="tab">Objective-C</a></li>
     </ul>
@@ -50,6 +51,13 @@ First, you need to generate and store a `code_verifier`.
 var verifier = base64URLEncode(crypto.randomBytes(32));</code></pre>
     </div>
     <div id="verifier-java" class="tab-pane">
+      <pre>
+<code class="java hljs">SecureRandom sr = new SecureRandom();
+byte[] code = new byte[32];
+sr.nextBytes(code);
+String verifier = Base64.getUrlEncoder().withoutPadding().encodeToString(code);</code></pre>
+    </div>
+    <div id="verifier-android" class="tab-pane">
       <pre>
 <code class="java hljs">SecureRandom sr = new SecureRandom();
 byte[] code = new byte[32];


### PR DESCRIPTION
At the moment, the Java instructions listed for generating a code verifier for the PKCE flow are actually Android instructions (since the `java.util.Base64` class in Java has no constants, unlike `android.util.Base64`).

These changes fix that problem by separating the instructions for Java and Android.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors
- Please include a short description
- If your PR is a work in progress, title it [DO NOT MERGE]
--->
