### PR TITLE
Fix AuthenticationService example in Angular Starter

### DIFF
--- a/articles/quickstart/spa/angular2/_includes/_centralized_login.md
+++ b/articles/quickstart/spa/angular2/_includes/_centralized_login.md
@@ -174,7 +174,7 @@ export class AuthService {
       // Response will be an array of user and login status
       authComplete$.subscribe(([user, loggedIn]) => {
         // Redirect to target route after callback processing
-        this.router.navigate([targetRoute]);
+        this.router.navigateByUrl(targetRoute);
       });
     }
   }


### PR DESCRIPTION
This PR updates the proposed Angular2+ Authentication Service in the Angular Starter to prevent issues with certain `targetRoute` value.

If the `targetRoute` contains query parameter, like `/target?param=foo`, then using `navigate([targetRoute])` will make the Angular Router encode this value to `/target%3Fparam%3Dfoo`, then try to see if this matches any of the declared route, which will probably not be the case, and will result in a navigation error (or a match on a fallback route if present).

**Calling `navigateByUrl(targetRoute)` prevents the `targetRoute` value to be encoded and fixes this behavior.**

Plus, since the array passed to `navigate(...)` will only ever contain one string element, you should as much call `navigateByUrl(...)` ; this is why this method exist after all.