### PR TITLE
Hide removed addon docs

### DIFF
--- a/articles/addons/azure-blob-storage.md
+++ b/articles/addons/azure-blob-storage.md
@@ -2,6 +2,7 @@
 addon: Azure Blob Storage
 title: Azure Blob Storage Add-on
 thirdParty: true
+public: false
 url: /addons/azure-blob-storage
 alias:
   - azure blob storage

--- a/articles/addons/azure-mobile-services.md
+++ b/articles/addons/azure-mobile-services.md
@@ -2,6 +2,7 @@
 addon: Windows Azure Mobile Services
 title: Windows Azure Mobile Services Add-on
 thirdParty: true
+public: false
 url: /addons/azure-mobile-services
 image: /media/platforms/azure.png
 snippets:

--- a/articles/addons/azure-sb.md
+++ b/articles/addons/azure-sb.md
@@ -2,6 +2,7 @@
 addon: Azure Service Bus
 title: Azure Service Bus Add-on
 thirdParty: true
+public: false
 url: /addons/azure-sb
 alias:
   - Azure Service Bus

--- a/articles/addons/index.md
+++ b/articles/addons/index.md
@@ -2,6 +2,7 @@
 url: /addons
 title: Add-ons
 description: Learn about add-ons and how they are related to Auth0-registered Applications.
+public: false
 topics:
   - applications
   - add-ons

--- a/articles/addons/salesforce-sandbox.md
+++ b/articles/addons/salesforce-sandbox.md
@@ -2,6 +2,7 @@
 addon: Salesforce (sandbox)
 title: Salesforce (Sandbox) Add-on
 thirdParty: true
+public: false
 url: /addons/salesforce-sandbox
 alias:
   - salesforce

--- a/articles/addons/salesforce.md
+++ b/articles/addons/salesforce.md
@@ -5,6 +5,7 @@ alias:
   - salesforce
 url: addons/salesforce  
 thirdParty: true
+public: false
 image: /media/addons/salesforce.svg
 description: Learn how to use Auth0 to authenticate and authorize your Salesforce services.
 topics:

--- a/articles/addons/sap-odata.md
+++ b/articles/addons/sap-odata.md
@@ -6,6 +6,7 @@ alias:
 url: /addons/sap-odata
 image: /media/addons/sap_api.svg
 description: Learn how to use Auth0 to authenticate and authorize your SAP OData services.
+public: false
 topics:
   - sap
   - addons

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -1096,6 +1096,7 @@ articles:
 
       - title: Add-ons
         url: /addons
+        hidden: true
 
 ## ------------------------------------------------------------
 ## Integrations


### PR DESCRIPTION
Hides entire Add-ons section and removes it from the sidebar.

- https://docs-content-staging-pr-9253.herokuapp.com/docs/addons

No longer in sidebar. Still shows in search results, but shouldn't on prod (or perhaps disappears after delay; functionality works).