### PR TITLE
Update 02-calling-an-api.md

### DIFF
--- a/articles/quickstart/spa/react/02-calling-an-api.md
+++ b/articles/quickstart/spa/react/02-calling-an-api.md
@@ -107,7 +107,7 @@ useEffect(() => {
 
     try {
       const accessToken = await getAccessTokenSilently({
-        audience: `https://<%= "${domain}" %>/api/v2`,
+        audience: `https://<%= "${domain}" %>/api/v2/`,
         scope: "read:current_user",
       });
 


### PR DESCRIPTION
Added a trailing slash to the `audience` param in the 3rd code sample; this was confusing developers as the issuer URL they get from the management API docs had this trailing slash on it.