### PR TITLE
added sec bulletin cve-2020-15125.md

### DIFF
--- a/articles/security/bulletins/cve-2020-15125.md
+++ b/articles/security/bulletins/cve-2020-15125.md
@@ -1,0 +1,37 @@
+---
+title: Auth0 Security Bulletin CVE 2020-15125
+description: Security Update for node-auth0 library (CVE 2020-15125)
+toc: true
+topics:
+  - security
+  - security-bulletins
+  - auth0js
+contentType:
+  - reference
+useCase:
+  - development
+---
+# Security Update for node-auth0 Library
+
+**Published**: July 28, 2020
+
+**CVE number**: CVE-2020-15125
+
+**Credit**: Omar Diab http://github.com/osdiab
+
+## Overview
+Versions before and including `2.27.0` use a block list of specific keys that should be sanitized from the request object contained in the error object. When a request to Auth0 management API fails, the key for `Authorization` header is not sanitized and the `Authorization` header value can be logged exposing a bearer token.
+
+
+## Am I affected?
+You are affected by this vulnerability if all of the following conditions apply:
+
+- You are using auth0 npm package
+- You are using a Machine to Machine application authorized to use Auth0's management API https://auth0.com/docs/flows/concepts/client-credentials
+
+
+## How to fix that?
+Upgrade to version `2.27.1`
+
+## Will this update impact my users?
+The fix provided in patch will not affect your users.

--- a/articles/security/bulletins/index.md
+++ b/articles/security/bulletins/index.md
@@ -27,6 +27,7 @@ Each bulletin contains a description of the vulnerability, how to identify if yo
 
 | **Date** | **Bulletin number** | **Title** | **Affected software** |
 |-|-|-|-|
+| July 28, 2020 | [CVE-2020-15125](/security/bulletins/cve-2020-15125) | Auth0 Security Bulletin for node-auth0 <= 2.27.0 | [node-auth0](https://github.com/auth0/node-auth0) |
 | June 30, 2020 | [CVE 2020-15084](/security/bulletins/cve-2020-15084) | Auth0 Security Bulletin for express-jwt versions < 6.0.0 | [express-jwt](https://github.com/auth0/express-jwt) |
 | April 09, 2020 | [CVE 2020-5263](/security/bulletins/cve-2020-5263) | Auth0 Security Bulletin for auth0.js versions <= 9.13.1 | [Auth0.js](/libraries/auth0js) |
 | March 31, 2020 | [Auth0 Bulletin](/security/bulletins/2020-03-31_wpauth0) | Auth0 Security Bulletin for WordPress Plugin for Auth0 versions < 4.0.0 | [WordPress Plugin for Auth0](https://github.com/auth0/wp-auth0) |


### PR DESCRIPTION
<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->

Added new security bulletin.