### PR TITLE
Update Custom Domains to remove the reference to Let's Encrypt

### DIFF
--- a/articles/custom-domains/_cloudflare-cname-flattening.md
+++ b/articles/custom-domains/_cloudflare-cname-flattening.md
@@ -1,3 +1,3 @@
 ::: panel Turn off Cloudflare CNAME Flattening
-Cloudflare uses a feature called CNAME Flattening, which affects Auth0 verification and certificate renewal in the way that it handles DNS records. With CNAME flatenning enabled Auth0 will be unable to renew your certificates. For details, see [Cloudflare documentation](https://support.cloudflare.com/hc/en-us/articles/200169056-Understand-and-configure-CNAME-Flattening).
+Cloudflare uses a feature called CNAME Flattening, which affects Auth0 verification and certificate renewal in the way that it handles DNS records. With CNAME flattening enabled, Auth0 will be unable to renew your certificates. For details, see [Cloudflare documentation](https://support.cloudflare.com/hc/en-us/articles/200169056-Understand-and-configure-CNAME-Flattening).
 :::

--- a/articles/custom-domains/_cloudflare-cname-flattening.md
+++ b/articles/custom-domains/_cloudflare-cname-flattening.md
@@ -1,3 +1,3 @@
 ::: panel Turn off Cloudflare CNAME Flattening
-Cloudflare uses a feature called CNAME Flattening, which affects Auth0 verification and certificate renewal in the way that it handles DNS records. We recommend that you turn off CNAME Flattening unless it's absolutely necessary. For details, see [Cloudflare documentation](https://support.cloudflare.com/hc/en-us/articles/200169056-Understand-and-configure-CNAME-Flattening).
+Cloudflare uses a feature called CNAME Flattening, which affects Auth0 verification and certificate renewal in the way that it handles DNS records. With CNAME flatenning enabled Auth0 will be unable to renew your certificates. For details, see [Cloudflare documentation](https://support.cloudflare.com/hc/en-us/articles/200169056-Understand-and-configure-CNAME-Flattening).
 :::

--- a/articles/custom-domains/_provide-domain-name.md
+++ b/articles/custom-domains/_provide-domain-name.md
@@ -1,16 +1,16 @@
 ## Provide your domain name to Auth0
 
-1. Go to [Dashboard > Tenant Settings](${manage_url}/#/tenant). 
+1. Go to [Dashboard > Tenant Settings](${manage_url}/#/tenant).
 2. Select the **Custom Domains** tab.
 
   <% if (platform === "auth0") { %>
   ![Tenant Settings](/media/articles/custom-domains/custom-domains.png)
-3. Enter your custom domain in the provided box, and select **Auth0-managed certificates**. 
+3. Enter your custom domain in the provided box, and select **Auth0-managed certificates**.
   <%  } %>
 
   <% if (platform === "self") { %>
   ![Tenant Settings](/media/articles/custom-domains/custom-domains-self-managed.png)
-3. Enter your custom domain in the provided box. 
+3. Enter your custom domain in the provided box.
   <% } %>
 4. Click **Add Domain**.
 

--- a/articles/custom-domains/_subscription.md
+++ b/articles/custom-domains/_subscription.md
@@ -1,3 +1,3 @@
 ::: panel Feature availability
-Auth0 custom domains are available with any paid [subscription plan](${manage_url}/#/tenant/billing/subscription). If you want to manage the SSL/TLS certificates yourself, you will need an **Enterprise** subscription. For more information refer to [Auth0 pricing plans](https://auth0.com/pricing).  
+Auth0 custom domains are available with any paid [subscription plan](${manage_url}/#/tenant/billing/subscription). If you want to manage the SSL/TLS certificates yourself, you will need an **Enterprise** subscription. For more information refer to [Auth0 pricing plans](https://auth0.com/pricing).
 :::

--- a/articles/custom-domains/additional-configuration.md
+++ b/articles/custom-domains/additional-configuration.md
@@ -57,8 +57,8 @@ If you use [Auth0.js](/libraries/auth0js) on the Universal Login page, you must 
 
 ```js
 var webAuth = new auth0.WebAuth({
-  clientID: config.clientID, 
-  domain: config.auth0Domain, 
+  clientID: config.clientID,
+  domain: config.auth0Domain,
   //code omitted for brevity
   overrides: {
   	__tenant: config.auth0Tenant,
@@ -74,10 +74,10 @@ For most, the Auth0.js and Lock libraries retrieve the tenant name (required for
 
 ## Embedded Lock
 
-If you use [Lock](/libraries/lock) v11 embedded in your application, you must update the code to use your custom domain when initializing Lock. You will also need to set the `configurationBaseUrl` to the appropriate CDN URL. 
+If you use [Lock](/libraries/lock) v11 embedded in your application, you must update the code to use your custom domain when initializing Lock. You will also need to set the `configurationBaseUrl` to the appropriate CDN URL.
 
 ::: note
-The CDN URL varies by region. Tenants created before 11 June 2020 should use `https://cdn.auth0.com` if the region is the United States, or add `eu` or `au` for Europe or Australia. If your tenant was created after 11 June 2020, use `https://cdn.us.auth0.com` if the region is the United States. 
+The CDN URL varies by region. Tenants created before 11 June 2020 should use `https://cdn.auth0.com` if the region is the United States, or add `eu` or `au` for Europe or Australia. If your tenant was created after 11 June 2020, use `https://cdn.us.auth0.com` if the region is the United States.
 :::
 
 ```js
@@ -114,7 +114,7 @@ Note that the Management API only accepts Auth0 domains. If you use a custom dom
 
 ## Use custom domains in emails
 
-If you want to use your custom domain with your Auth0 emails, you must enable this feature. 
+If you want to use your custom domain with your Auth0 emails, you must enable this feature.
 
 Go to [Dashboard > Tenant Settings > Custom Domains](${manage_url}/#/tenant/custom_domains), and enable the **Use Custom Domain in Emails** toggle. When the toggle is green, this feature is enabled.
 
@@ -127,7 +127,7 @@ If you want to use your custom domain with social identity providers, you must u
 ::: warning
 You cannot use [Auth0 developer keys](/connections/social/devkeys) with custom domains unless you are using the [New Universal Login Experience](/universal-login/new).
 :::
-  
+
 ## Configure G Suite connections
 
 If you want to use your custom domain with G Suite connections, you must update the Authorized redirect URI in your OAuth Client Settings. In the Google Developer Console, go to **Credentials**, choose your OAuth client in the list, and you will see a settings page with the app Client ID, secret, and other fields. In the **Authorized redirect URIs** field, add a URL in the format `https://<YOUR-CUSTOM-DOMAIN>/login/callback` that includes your custom domain (such as `https://login.northwind.com/login/callback`).
@@ -137,7 +137,7 @@ If you want to use your custom domain with G Suite connections, you must update 
 If you use Auth0 with a custom domain to issue Access Tokens for your APIs, you must validate the JWT issuer(s) against your custom domain. For example, if you use the [express-jwt](https://github.com/auth0/express-jwt) middleware, you must make the following change:
 
 ```js
-app.use(jwt({ 
+app.use(jwt({
   issuer: 'https://<YOUR-CUSTOM-DOMAIN>',
   algorithms: ["RS256"],
   //code omitted for brevity

--- a/articles/custom-domains/auth0-managed-certificates.md
+++ b/articles/custom-domains/auth0-managed-certificates.md
@@ -15,7 +15,7 @@ useCase:
 
 <%= include('./_subscription') %>
 
-If you want Auth0 to manage the certificates for your custom domain, you only need to add a CNAME record on the domain. Auth0 validates the record and then generates the certificate on Auth0 servers using Let’s Encrypt. These certificates are renewed automatically every three months. You can configure this easily, and you won't have to maintain the certificates yourself. 
+If you want Auth0 to manage the certificates for your custom domain, you only need to add a CNAME record on the domain. Auth0 validates the record and then generates the certificate on Auth0 servers. These certificates are renewed automatically every three months. You can configure this easily, and you won't have to maintain the certificates yourself.
 
 To set up your custom domain using Auth0-managed certificates, you must provide your domain name to Auth0 and verify that you own that domain. Once verified, you will need to configure your Auth0 features to start using your custom domain.
 
@@ -23,7 +23,7 @@ To set up your custom domain using Auth0-managed certificates, you must provide 
 
 ## Verify ownership
 
-Before you can use the domain with Auth0, you'll need to verify that you own it. 
+Before you can use the domain with Auth0, you'll need to verify that you own it.
 
 1. Go to [Dashboard > Tenant Settings](${manage_url}/#/tenant), and add the CNAME verification record listed in the Dashboard to your domain's DNS record.
 

--- a/articles/custom-domains/index.md
+++ b/articles/custom-domains/index.md
@@ -1,12 +1,12 @@
 ---
 title: Custom Domains
-description: Understand how Auth0 custom domains work so that you can map your tenant domain to a domain of your choosing instead of redirecting users to Auth0's domain. 
+description: Understand how Auth0 custom domains work so that you can map your tenant domain to a domain of your choosing instead of redirecting users to Auth0's domain.
 topics:
   - custom-domains
   - whitelisting
   - custom-domain features
   - certificates
-contentType: 
+contentType:
   - index
   - concept
 useCase: customize-domains
@@ -17,11 +17,11 @@ useCase: customize-domains
 
 Auth0 allows you to map the domain for your tenant to **one custom domain** of your choosing. This allows you to maintain a consistent experience for your users by keeping them on your domain instead of redirecting or using Auth0's domain. You must register and own the domain name to which you are mapping your Auth0 domain. For example, if your Auth0 domain is **northwind.auth0.com**, you can have your users to see, use, and remain on **login.northwind.com**.
 
-We recommend that you use custom domains with Universal Login for the most seamless and secure experience for your users. See [Universal Login](/universal-login) to determine if your use case requires custom domains. 
+We recommend that you use custom domains with Universal Login for the most seamless and secure experience for your users. See [Universal Login](/universal-login) to determine if your use case requires custom domains.
 
 ## Token issuance
 
-Auth0 issues tokens with the **iss** claim of whichever domain you used with the request. For example: 
+Auth0 issues tokens with the **iss** claim of whichever domain you used with the request. For example:
 
 | If you use | **iss** claim value with custom domain |
 | -- | -- |
@@ -85,7 +85,7 @@ Features not in the list are **not supported** by Auth0 with custom domains.
 
 ### Auth0-managed certificates
 
-With the [Auth0-managed certificate approach](/custom-domains/auth0-managed-certificates), Auth0 uses **Let’s Encrypt** to get certificates for your domain and then manages the SSL handshake directly with the client.
+With the [Auth0-managed certificate approach](/custom-domains/auth0-managed-certificates), Auth0 uses obtains certificates for your domain and then manages the SSL handshake directly with the client.
 
 ### Self-managed certificates
 

--- a/articles/custom-domains/index.md
+++ b/articles/custom-domains/index.md
@@ -85,7 +85,7 @@ Features not in the list are **not supported** by Auth0 with custom domains.
 
 ### Auth0-managed certificates
 
-With the [Auth0-managed certificate approach](/custom-domains/auth0-managed-certificates), Auth0 uses obtains certificates for your domain and then manages the SSL handshake directly with the client.
+With the [Auth0-managed certificate approach](/custom-domains/auth0-managed-certificates), Auth0 obtains certificates for your domain and then manages the SSL handshake directly with the client.
 
 ### Self-managed certificates
 

--- a/articles/custom-domains/self-managed-certificates.md
+++ b/articles/custom-domains/self-managed-certificates.md
@@ -1,13 +1,13 @@
 ---
 title: Configure Custom Domains with Self-Managed Certificates
-description: Learn how to configure custom domains where you are responsible for SSL/TLS certificates, the reverse proxy to handle SSL termination, and forwarding requests to Auth0. 
+description: Learn how to configure custom domains where you are responsible for SSL/TLS certificates, the reverse proxy to handle SSL termination, and forwarding requests to Auth0.
 topics:
   - custom-domains
   - certificates
   - reverse-proxy
   - SSL/TLS-certificates
 contentType: how-to
-useCase: 
+useCase:
   - configure-customize-domains
   - forward-requests-to-auth0
   - configure-reverse-proxy

--- a/articles/custom-domains/set-up-azure-cdn.md
+++ b/articles/custom-domains/set-up-azure-cdn.md
@@ -7,7 +7,7 @@ topics:
   - cdn
   - reverse-proxy
 contentType: how-to
-useCase: 
+useCase:
   - customize-domains
   - self-managed-certificates
 ---

--- a/articles/custom-domains/set-up-cloudflare.md
+++ b/articles/custom-domains/set-up-cloudflare.md
@@ -6,7 +6,7 @@ topics:
   - cloudflare
   - reverse-proxy
 contentType: how-to
-useCase: 
+useCase:
   - customize-domains
   - self-managed-certificates
 ---

--- a/articles/custom-domains/set-up-cloudfront.md
+++ b/articles/custom-domains/set-up-cloudfront.md
@@ -7,7 +7,7 @@ topics:
   - cloudfront
   - reverse-proxy
 contentType: how-to
-useCase: 
+useCase:
   - customize-domains
   - self-managed-certificates
 ---

--- a/articles/custom-domains/troubleshoot.md
+++ b/articles/custom-domains/troubleshoot.md
@@ -1,11 +1,11 @@
 ---
 title: Troubleshoot Custom Domains
-description: Learn how to troubleshoot issues with custom domains. 
+description: Learn how to troubleshoot issues with custom domains.
 topics:
   - custom-domains
   - certificates
 contentType: reference
-useCase: 
+useCase:
   - configure-customize-domains
   - configure-auth0-managed-certificates
 ---
@@ -56,7 +56,7 @@ When both the Auth0 domain and the app domain are in the same trusted or local i
 
 If you see any of these errors and you are using Embedded Login, you can move one of the sites out of the trusted or local intranet zone. To do this:
 
-1. Go to **Internet Options > Security**. 
+1. Go to **Internet Options > Security**.
 2. Select the **Local Intranet Zone** tab and go to Sites > Advanced. Add your domain.
 3. Return to the **Security** tab, and make sure the proper zone has been selected.
 4. Click **Custom Level** and look for **Access data sources across domains** under the **Miscellaneous** section. Check the radio button next to **Enable.**.


### PR DESCRIPTION
Update Custom Domains to remove the reference to Let's Encrypt, update that CNAME flattening cannot be used and also fix some of the spurious trailing spaces.

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
