### PR TITLE
Add security redirects

### DIFF
--- a/config/redirects.js
+++ b/config/redirects.js
@@ -388,10 +388,6 @@ module.exports = [
     to: '/troubleshoot/guides/generate-har-files'
   },
   {
-    from: ['/blacklist-attributes', '/security/blacklist-user-attributes'],
-    to: '/security/blacklisting-attributes'
-  },
-  {
     from: '/office365-deprecated',
     to: '/tutorials/office365-connection-deprecation-guide'
   },
@@ -594,10 +590,6 @@ module.exports = [
   {
     from: '/tutorials/azure-tutorial',
     to: '/integrations/azure-tutorial',
-  },
-  {
-    from: '/tutorials/blacklisting-attributes',
-    to: '/security/blacklisting-attributes',
   },
   {
     from: '/tutorials/integrating-with-slack',
@@ -3602,7 +3594,7 @@ module.exports = [
     to: '/private-cloud/private-cloud-operations'
   },
 
-  /* PROFESSIONAL SERVICES */
+  /* Professional Services */
 
   {
     from: ['/services','/auth0-professional-services'],
@@ -3652,7 +3644,101 @@ module.exports = [
     to: '/scopes/sample-use-cases-scopes-and-claims'
   },
 
-  /* SESSIONS */
+  /* Security */
+
+  {
+    from: ['/security/blacklisting-attributes','/tutorials/blacklisting-attributes','/blacklist-attributes'],
+    to: '/security/blacklist-user-attributes'
+  },
+  {
+    from: ['/guides/ip-whitelist'],
+    to: '/security/whitelist-ip-addresses'
+  },
+  {
+    from: ['/security/common-threats'],
+    to: '/security/prevent-common-cybersecurity-threats'
+  },
+  {
+    from: ['/policies/endpoints'],
+    to: '/security/public-cloud-service-endpoints'
+  },
+
+  /* SECURITY BULLETINS */
+
+  {
+    from: ['/security/bulletins/cve-2020-15125'],
+    to: '/security/cve-2020-15125'
+  },
+  {
+    from: ['/security/bulletins/cve-2020-15084'],
+    to: '/security/cve-2020-15084'
+  },
+  {
+    from: ['/security/bulletins/2020-03-31_wpauth0'],
+    to: '/security/2020-03-31-wpauth0'
+  },
+  {
+    from: ['/security/bulletins/cve-2020-5263'],
+    to: '/security/cve-2020-5263'
+  },
+  {
+    from: ['/security/bulletins/2019-01-10_rules'],
+    to: '/security/2019-01-10-rules'
+  },
+  {
+    from: ['/security/bulletins/2019-09-05_scopes'],
+    to: '/security/2019-09-05-scopes'
+  },
+  {
+    from: ['/security/bulletins/cve-2019-20174'],
+    to: '/security/cve-2019-20174'
+  },
+  {
+    from: ['/security/bulletins/cve-2019-20173'],
+    to: '/security/cve-2019-20173'
+  },
+  {
+    from: ['/security/bulletins/cve-2019-16929'],
+    to: '/security/cve-2019-16929'
+  },
+  {
+    from: ['/security/bulletins/cve-2019-13483'],
+    to: '/security/cve-2019-13483'
+  },
+  {
+    from: ['/security/bulletins/cve-2019-7644'],
+    to: '/security/cve-2019-7644'
+  },
+  {
+    from: ['/security/bulletins/cve-2018-15121'],
+    to: '/security/cve-2018-15121'
+  },
+  {
+    from: ['/security/bulletins/cve-2018-11537'],
+    to: '/security/cve-2018-11537'
+  },
+  {
+    from: ['/security/bulletins/cve-2018-7307'],
+    to: '/security/cve-2018-7307'
+  },
+  {
+    from: ['/security/bulletins/cve-2018-6874'],
+    to: '/security/cve-2018-6874'
+  },
+  {
+    from: ['/security/bulletins/cve-2018-6873'],
+    to: '/security/cve-2018-6873'
+  },
+  {
+    from: ['/security/bulletins/cve-2017-16897'],
+    to: '/security/cve-2017-16897'
+  },
+  {
+    from: ['/security/bulletins/cve-2017-17068'],
+    to: '/security/cve-2017-17068'
+  },
+
+  /* Sessions */
 
   {
     from: ['/sessions'],

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -700,7 +700,7 @@ articles:
                 hidden: true
 
       - title: Whitelist IP Addresses
-        url: /guides/ip-whitelist
+        url: /security/whitelist-ip-addresses
 
 ## ------------------------------------------------------------
 ## Manage Users
@@ -778,7 +778,7 @@ articles:
             url: /users/references/link-accounts-server-side-scenario
 
       - title: Blacklist User Attributes
-        url: /security/blacklisting-attributes
+        url: /security/blacklist-user-attributes
 
       - title: Import & Export Users
         url: /users/concepts/overview-user-migration
@@ -1655,29 +1655,6 @@ articles:
     url: "/security"
     children:
 
-      - title: "Bulletins"
-        url: "/security/bulletins"
-        children:
-          - title: "CVE 2018-6874"
-            url: "/security/bulletins/cve-2018-6874"
-            hidden: true
-
-          - title: "CVE 2018-6873"
-            url: "/security/bulletins/cve-2018-6873"
-            hidden: true
-
-          - title: "CVE 2018-7307"
-            url: "/security/bulletins/cve-2018-7307"
-            hidden: true
-
-          - title: "CVE 2017-16897"
-            url: "/security/bulletins/cve-2017-16897"
-            hidden: true
-
-          - title: "CVE 2017-17068"
-            url: "/security/bulletins/cve-2017-17068"
-            hidden: true
-
       - title: "Tokens"
         url: "/tokens"
         children:
@@ -1800,13 +1777,13 @@ articles:
             url: "/tokens/guides/revoke-tokens"
 
       - title: "Cookies"
-        url: "/sessions/concepts/cookies"
+        url: "/sessions-and-cookies/cookies"
 
       - title: "Common Threats"
-        url: "/security/common-threats"
+        url: "/security/prevent-common-cybersecurity-threats"
 
       - title: "Blacklist User Attributes"
-        url: "/security/blacklisting-attributes"
+        url: "/security/blacklist-user-attributes"
 
   - title: "Data Privacy"
     url: "/compliance"
@@ -1972,7 +1949,7 @@ articles:
             url: "/policies/data-transfer"
 
           - title: "Endpoints"
-            url: "/policies/endpoints"
+            url: "/security/public-cloud-service-endpoints"
 
           - title: "Load Testing"
             url: "/policies/load-testing"

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -700,7 +700,7 @@ articles:
                 hidden: true
 
       - title: Whitelist IP Addresses
-        url: /security/whitelist-ip-addresses
+        url: /guides/ip-whitelist
 
 ## ------------------------------------------------------------
 ## Manage Users
@@ -778,7 +778,7 @@ articles:
             url: /users/references/link-accounts-server-side-scenario
 
       - title: Blacklist User Attributes
-        url: /security/blacklist-user-attributes
+        url: /security/blacklisting-attributes
 
       - title: Import & Export Users
         url: /users/concepts/overview-user-migration
@@ -1655,6 +1655,29 @@ articles:
     url: "/security"
     children:
 
+      - title: "Bulletins"
+        url: "/security/bulletins"
+        children:
+          - title: "CVE 2018-6874"
+            url: "/security/bulletins/cve-2018-6874"
+            hidden: true
+
+          - title: "CVE 2018-6873"
+            url: "/security/bulletins/cve-2018-6873"
+            hidden: true
+
+          - title: "CVE 2018-7307"
+            url: "/security/bulletins/cve-2018-7307"
+            hidden: true
+
+          - title: "CVE 2017-16897"
+            url: "/security/bulletins/cve-2017-16897"
+            hidden: true
+
+          - title: "CVE 2017-17068"
+            url: "/security/bulletins/cve-2017-17068"
+            hidden: true
+
       - title: "Tokens"
         url: "/tokens"
         children:
@@ -1777,13 +1800,13 @@ articles:
             url: "/tokens/guides/revoke-tokens"
 
       - title: "Cookies"
-        url: "/sessions-and-cookies/cookies"
+        url: "/sessions/concepts/cookies"
 
       - title: "Common Threats"
-        url: "/security/prevent-common-cybersecurity-threats"
+        url: "/security/common-threats"
 
       - title: "Blacklist User Attributes"
-        url: "/security/blacklist-user-attributes"
+        url: "/security/blacklisting-attributes"
 
   - title: "Data Privacy"
     url: "/compliance"
@@ -1949,7 +1972,7 @@ articles:
             url: "/policies/data-transfer"
 
           - title: "Endpoints"
-            url: "/security/public-cloud-service-endpoints"
+            url: "/policies/endpoints"
 
           - title: "Load Testing"
             url: "/policies/load-testing"


### PR DESCRIPTION
Added security redirects including security bulletins

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
