### PR TITLE
Make version agnostic and fix typos

### DIFF
--- a/articles/quickstart/webapp/laravel/01-login.md
+++ b/articles/quickstart/webapp/laravel/01-login.md
@@ -20,15 +20,15 @@ github:
 
 <%= include('../../../_includes/_logout_url', { returnTo: 'http://localhost:3000' }) %>
 
-## Install and Configure Laravel 6
+## Install and Configure Laravel
 
 If you are installing Auth0 to an existing app, you can skip this section. Otherwise, walk through the Laravel guides below to get started with a sample project.
 
-1. **[Installation](https://laravel.com/docs/6.x#installation)**
+1. **[Installation](https://laravel.com/docs/#installation)**
     * Use any of the install methods listed to start a new project
     * PHP can be served any way that works for your development process (we use Homebrew-installed Apache and PHP)
     * Walk through the "Configuration" section completely
-2. **[Configuration](https://laravel.com/docs/6.x#configuration)**
+2. **[Configuration](https://laravel.com/docs/#configuration)**
     * Create a .env file, used later for critical and sensitive Auth0 connection values
     * Make sure `APP_DEBUG` is set to `true`
 
@@ -50,28 +50,6 @@ This will install:
 * The [Auth0 Laravel plugin](https://github.com/auth0/laravel-auth0) in `vendor\auth0\login`
 
 ### Enable Auth0 Login in Laravel
-
-First, we need to add the Auth0 Services to the list of Providers in `config/app.php`:
-
-```php
-// config/app.php
-
-'providers' => array(
-    // ...
-    Auth0\Login\LoginServiceProvider::class,
-);
-```
-
-If you want to use an `Auth0` facade, add an alias in the same file (not required, [more information on facades here](http://laravel.com/docs/6.x/facades)):
-
-```php
-// config/app.php
-
-'aliases' => [
-    // ...
-    'Auth0' => Auth0\Login\Facade\Auth0::class,
-];
-```
 
 Finally, you will need to bind a class that provides the app's User model each time a user is logged in or a JWT is decoded. You can use the `Auth0UserRepository` provided by this package or build your own (see the "Custom User Handling" section below).
 
@@ -132,7 +110,7 @@ In `laravel-auth0.php`, the global helper `env()` is used to retrieve these valu
 
 ### Set Up Routes
 
-The plugin works with the [Laravel authentication system](https://laravel.com/docs/6.x/authentication) by creating a callback route to handle the authentication data from the Auth0 server.
+The plugin works with the [Laravel authentication system](https://laravel.com/docs/authentication) by creating a callback route to handle the authentication data from the Auth0 server.
 
 First, we'll add our route and controller to `routes/web.php`. The route used here must match the `redirect_uri` configuration option set previously:
 
@@ -204,7 +182,7 @@ Route::get( '/logout', 'Auth\Auth0IndexController@logout' )->name( 'logout' )->m
 
 ### Integrate with Laravel authentication system
 
-The [Laravel authentication system](https://laravel.com/docs/6.x/authentication) needs a *User Object* given by a *User Provider*. With these two abstractions, the user entity can have any structure you like and can be stored anywhere. You configure the *User Provider* indirectly, by selecting a user provider in `config/auth.php`. The default provider is Eloquent, which persists the User model in a database using the ORM.
+The [Laravel authentication system](https://laravel.com/docs/authentication) needs a *User Object* given by a *User Provider*. With these two abstractions, the user entity can have any structure you like and can be stored anywhere. You configure the *User Provider* indirectly, by selecting a user provider in `config/auth.php`. The default provider is Eloquent, which persists the User model in a database using the ORM.
 
 The plugin comes with an authentication driver called `auth0` which defines a user structure that wraps the [Normalized User Profile](/users/normalized) defined by Auth0. This driver does not actually persist the User, it just stores it in session for future calls. This works fine for basic testing or if you don't really need to persist the user. For persistence in the database, see the "Custom User Handling" section below.
 
@@ -361,7 +339,7 @@ class CustomUserRepository extends Auth0UserRepository
      */
     public function getUserByDecodedJWT(array $decodedJwt) : Authenticatable
     {
-        $user = $this->upsertUser( (array) $jwt );
+        $user = $this->upsertUser( $decodedJwt );
         return new Auth0JWTUser( $user->getAttributes() );
     }
 


### PR DESCRIPTION
Makes the documentation version agnostic. Currently, it points to Laravel 7 for everything, however, the package and instructions will work throughout versions 5, 6, 7 and 8 which will be released next month, so there is no point of hardcoding it to a version that'll always make it seem like the wrong version for some people.

Also fixes a typo later on where the wrong variable name is referenced, and a cast is made unnecessarily.