### PR TITLE
Hide hybrid flow docs, remove links

### DIFF
--- a/articles/api-auth/grant/hybrid.md
+++ b/articles/api-auth/grant/hybrid.md
@@ -1,5 +1,6 @@
 ---
 description: Describes how to call APIs from applications using the Hybrid Flow
+public: false
 topics:
   - authorization-code
   - api-authorization

--- a/articles/api-auth/tutorials/hybrid-flow.md
+++ b/articles/api-auth/tutorials/hybrid-flow.md
@@ -1,6 +1,7 @@
 ---
 description: Learn how to execute the Hybrid Flow so your app can use an ID token to access information about the user while obtaining an authorization code that can be exchanged for an Access Token. 
 toc: true
+public: false
 topics:
   - api-authentication
   - oidc

--- a/articles/architecture-scenarios/spa-api/part-3.md
+++ b/articles/architecture-scenarios/spa-api/part-3.md
@@ -126,7 +126,7 @@ The contents of the authResult object returned by parseHash depend upon which au
 - __accessToken__: An Access Token for the API, specified by the __audience__.
 - __expiresIn__: A string containing the expiration time (in seconds) of the Access Token.
 
-Determine where best to [store the tokens](/tokens/concepts/token-storage). If your single-page app has a backend server at all, then tokens should be handled server-side using the [Authorization Code Flow](/flows/concepts/auth-code), [Authorization Code Flow with Proof Key for Code Exchange (PKCE)](/flows/concepts/auth-code-pkce), or [Hybrid Flow](/api-auth/grant/hybrid).
+Determine where best to [store the tokens](/tokens/concepts/token-storage). If your single-page app has a backend server at all, then tokens should be handled server-side using the [Authorization Code Flow](/flows/concepts/auth-code) or [Authorization Code Flow with Proof Key for Code Exchange (PKCE)](/flows/concepts/auth-code-pkce).
 
 If you have a single-page app (SPA) with no corresponding backend server, your SPA should request new tokens on login and store them in memory without any persistence. To make API calls, your SPA would then use the in-memory copy of the token.
 

--- a/articles/tokens/concepts/token-storage.md
+++ b/articles/tokens/concepts/token-storage.md
@@ -64,7 +64,6 @@ When the SPA calls multiple APIs that reside in a different domain, access and o
 -  If the SPA backend can handle the API calls, handle tokens server-side using:
     - [Authorization Code Flow](/flows/concepts/auth-code)
     - [Authorization Code Flow with Proof Key for Code Exchange (PKCE)](/flows/concepts/auth-code-pkce)
-    - [Hybrid Flow](/api-auth/grant/hybrid)
 
 - If the SPA backend cannot handle the API calls, the tokens should be stored in the SPA backend but the SPA needs to fetch the tokens from the backend to perform requests to the API. A protocol needs to be established between the backend and the SPA to allow the secure transfer of the token from the backend to the SPA.
 

--- a/articles/troubleshoot/guides/check-api-calls.md
+++ b/articles/troubleshoot/guides/check-api-calls.md
@@ -38,7 +38,6 @@ useCase: troubleshooting
 * [Call APIs Using the Authorization Code Flow](/flows/guides/auth-code/call-api-auth-code)
 * [Call APIs Using Authorization Code Flow with PKCE](/flows/guides/auth-code-pkce/call-api-auth-code-pkce)
 * [Call APIs Using Device Authorization Flow](/flows/guides/device-auth/call-api-device-auth)
-* [Call APIs Using Hybrid Flow](/api-auth/grant/hybrid)
 * [Call Identity Provider APIs](/connections/calling-an-external-idp-api)
 * [Call APIs with Auth0 Tokens](/api-auth/tutorials/adoption/api-tokens)
 * [Call APIs from Highly Trusted Applications](/api-auth/grant/password)


### PR DESCRIPTION
Hiding hybrid flow docs that were not migrated. Removing links to them that are 404ing in Link Checker.
