### PR TITLE
Update basecamp.md

### DIFF
--- a/articles/connections/social/basecamp.md
+++ b/articles/connections/social/basecamp.md
@@ -43,7 +43,7 @@ Register an app in Basecamp and generate credentials for it through the [Basecam
 
 | Field | Value to Provide |
 | - | - |
-| Redirect URI | `${manage_url}.auth0.com/login/callback` |
+| Redirect URI | `https://${account.namespace}/login/callback` |
 | Products | Select the Basecamp products with which you want your app to integrate. |
 
 <%= include('../_find-auth0-domain-redirects') %>


### PR DESCRIPTION
Update basecamp.md to correct Redirect URI configuration. Previously we supplied 

 `${manage_url}.auth0.com/login/callback`

This string results in an incorrect Redirect URI that causes Basecamp connection configurations to error out when Try Connection is used, e.g., https://manage.auth0.com/dashboard/us/hackauth0n.auth0.com/login/callback in my case 

Changing this to match the Fitbit.md doc I found thus: 

 `https://${account.namespace}/login/callback`

I believe fixes the problem and provides the correct Redirect URI of https://hackauth0n.auth0.com/login/callback

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
