### PR TITLE
Updates Callback URL variable

### DIFF
--- a/articles/connections/social/salesforce-community.md
+++ b/articles/connections/social/salesforce-community.md
@@ -49,7 +49,7 @@ While setting up your app, make sure you use the following settings:
 | Field | Value to Provide |
 | - | - |
 | API (Enable OAuth Settings) | Click `Enable OAuth Settings` |
-| Callback URL | `${manage_url}.auth0.com/login/callback` |
+| Callback URL | `https://${account.namespace}/login/callback` |
 | Selected OAuth Scopes | Add `Access your basic information` |
 
 <%= include('../../connections/_find-auth0-domain-redirects') %>

--- a/articles/connections/social/salesforce-sandbox.md
+++ b/articles/connections/social/salesforce-sandbox.md
@@ -44,7 +44,7 @@ While setting up your app, make sure you use the following settings:
 | Field | Value to Provide |
 | - | - |
 | API (Enable OAuth Settings) | Click `Enable OAuth Settings` |
-| Callback URL | `${manage_url}.auth0.com/login/callback` |
+| Callback URL | `https://${account.namespace}/login/callback` |
 | Selected OAuth Scopes | Add `Access your basic information` |
 
 <%= include('../../connections/_find-auth0-domain-redirects') %>

--- a/articles/connections/social/salesforce.md
+++ b/articles/connections/social/salesforce.md
@@ -44,7 +44,7 @@ While setting up your app, make sure you use the following settings:
 | Field | Value to Provide |
 | - | - |
 | API (Enable OAuth Settings) | Click `Enable OAuth Settings` |
-| Callback URL | `${manage_url}.auth0.com/login/callback` |
+| Callback URL | `https://${account.namespace}/login/callback` |
 | Selected OAuth Scopes | Add `Access your basic information` |
 
 <%= include('../../connections/_find-auth0-domain-redirects') %>


### PR DESCRIPTION
Similarly to https://github.com/auth0/docs/pull/9339 I found the old `${manage_url}.auth0.com/login/callback` and replaced it with `https://${account.namespace}/login/callback` to correct

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
