### PR TITLE
Add APP_SESSION_SECRET to .env

### DIFF
--- a/articles/login/spa/authenticate-with-cookies.md
+++ b/articles/login/spa/authenticate-with-cookies.md
@@ -189,6 +189,7 @@ Create a `.env` file in the root of the project directory and populate it with t
 ISSUER_BASE_URL=<YOUR OIDC URL>
 CLIENT_ID=<YOUR OIDC CLIENT ID>
 BASE_URL=http://localhost:3000
+APP_SESSION_SECRET=<your secret value>
 ```
 ### Setting up an Auth0 app
 If you don't already have an Auth0 account, you can [sign up for a free Auth0 account here](https://auth0.com/signup).
@@ -207,6 +208,7 @@ These are the two values that need to be configured as part of the application. 
 ISSUER_BASE_URL=${account.namespace}
 CLIENT_ID=${account.clientId}
 BASE_URL=http://localhost:3000
+APP_SESSION_SECRET=<your secret value>
 ```
 ### Running the application
 With the server and environment configuration done, find your browser window that has the application open. If you've closed the browser and stopped the server, run the following from the terminal to restart the application


### PR DESCRIPTION
Newer versions of https://www.npmjs.com/package/express-openid-connect require you to set an APP_SESSION_SECRET

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
