### PR TITLE
Update 01-login.md

### DIFF
--- a/articles/quickstart/spa/react/01-login.md
+++ b/articles/quickstart/spa/react/01-login.md
@@ -108,7 +108,10 @@ import { useAuth0 } from "@auth0/auth0-react";
 const LogoutButton = () => {
   const { logout } = useAuth0();
 
-  return <button onClick={() => logout()}>Log Out</button>;
+  return (
+    <button onClick={() => logout({ returnTo: window.location.origin })}>
+      Log Out
+    </button>;
 };
 
 export default LogoutButton;

--- a/articles/quickstart/spa/react/01-login.md
+++ b/articles/quickstart/spa/react/01-login.md
@@ -111,7 +111,8 @@ const LogoutButton = () => {
   return (
     <button onClick={() => logout({ returnTo: window.location.origin })}>
       Log Out
-    </button>;
+    </button>
+  );
 };
 
 export default LogoutButton;


### PR DESCRIPTION
Logout goes to essentially a random address (the first one on the list of allowed URLs, I believe) if you do not include the returnTo.  You already changed all the examples to use the return to param except this one.

I had copied this example and it caused me quite a bit of confusion when my deployed site redirected to localhost.