### PR TITLE
Add Glossary link to sidebar

### DIFF
--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -4,6 +4,8 @@ articles:
     children:
       - title: Auth0 Overview
         url: /get-started
+      - title: Glossary
+        url: /glossary
       - title: Learn the Basics
         url: /get-started/learn-the-basics
       - title: Dashboard Overview


### PR DESCRIPTION
Add glossary link to sidebar

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
