### PR TITLE
Update Get started sidebar links

### DIFF
--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -6,21 +6,12 @@ articles:
         url: /get-started
       - title: Glossary
         url: /glossary
-      - title: Learn the Basics
+      - title: Create a Tenant
         url: /get-started/learn-the-basics
       - title: Dashboard Overview
         url: /get-started/dashboard
-      - title: Set Up An App
+      - title: Set Up an App
         url: /applications/set-up-an-application
-        children:
-          - title: Regular Web App
-            url: /applications/register-regular-web-applications
-          - title: Native App
-            url: /applications/set-up-an-application/register-native-applications
-          - title: Single-Page App
-            url: /applications/register-single-page-app
-          - title: Backend/Service
-            url: /applications/set-up-an-application/register-machine-to-machine-applications
       - title: Set Up an API
         url: /get-started/set-up-apis
       - title: Set Up Multiple Environments


### PR DESCRIPTION
Update Get started sidebar links

Added glossary link
Changed Learn the Basics to Create a Tenant (which were combined in Contentful Migration)
Fixed capitalization inconsistencies in titles

Review: https://auth0content-pr-9375.herokuapp.com/docs/get-started

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
