### PR TITLE
Update Dropbox installation guide

### DIFF
--- a/snippets/social/dropbox/0.md
+++ b/snippets/social/dropbox/0.md
@@ -1,5 +1,2 @@
 # Connect Apps to Dropbox
 You can add functionality to your web app that allows your users to log in with Dropbox. 
-::: note
-This connection will only work with <dfn data-key="lock">Lock</dfn> version 9.2 or higher.
-:::


### PR DESCRIPTION
We probably don't need to mention a version of Lock from 4+ years ago
