### PR TITLE
Update github path for Angular tutorial

### DIFF
--- a/articles/quickstart/spa/angular-next/01-login.md
+++ b/articles/quickstart/spa/angular-next/01-login.md
@@ -8,7 +8,7 @@ topics:
   - angular
   - login
 github:
-    path: 01-Login
+    path: Sample-01
 contentType: tutorial
 useCase: quickstart
 ---


### PR DESCRIPTION
This PR fixes the path to the GitHub sample in the Angular quickstart
