### PR TITLE
Moved redirect to Token Best Practices

### DIFF
--- a/config/redirects.js
+++ b/config/redirects.js
@@ -41,7 +41,7 @@ module.exports = [
     to: '/'
   },
   {
-    from: ['/design','/design/web','/design/web-apps-vs-web-apis-cookies-vs-tokens','/design/browser-based-vs-native-experience-on-mobile','/tutorials/browser-based-vs-native-experience-on-mobile'],
+    from: ['/design','/design/web','/design/browser-based-vs-native-experience-on-mobile','/tutorials/browser-based-vs-native-experience-on-mobile'],
     to: '/'
   },
   {
@@ -1195,7 +1195,7 @@ module.exports = [
     to: '/best-practices/rules-testing-best-practices'
   },
   {
-    from: ['/tokens/concepts/token-best-practices'],
+    from: ['/tokens/concepts/token-best-practices','/design/web-apps-vs-web-apis-cookies-vs-tokens'],
     to: '/best-practices/token-best-practices'
   },
   {


### PR DESCRIPTION
Added redirect for /design/web-apps-vs-web-apis-cookies-vs-tokens.md to /best-practices/token-best-practices

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
