### PR TITLE
Update redirects.js

### DIFF
--- a/config/redirects.js
+++ b/config/redirects.js
@@ -2657,8 +2657,8 @@ module.exports = [
     to: '/policies/billing-policy'
   },
   {
-    from: ['/policies/dashboard-authentication'],
-    to: '/policies/dashboard-authentication-policy'
+    from: ['/policies/dashboard-authentication','/policies/restore-deleted-tenant','/policies/unsupported-requests'],
+    to: '/policies'
   },
   {
     from: ['/policies/data-export','/policies/data-transfer'],
@@ -3345,7 +3345,7 @@ module.exports = [
   /* Support */
 
   {
-    from: ['/policies/unsupported-requests','/policies/requests','/premium-support'],
+    from: ['/policies/requests','/premium-support'],
     to: '/support'
   },
   {
@@ -3385,7 +3385,7 @@ module.exports = [
     to: '/support/open-and-manage-support-tickets'
   },
   {
-    from: ['/support/delete-reset-tenant','/tutorials/delete-reset-tenant','/policies/restore-deleted-tenant'],
+    from: ['/support/delete-reset-tenant','/tutorials/delete-reset-tenant'],
     to: '/support/delete-or-reset-tenant'
   },
 


### PR DESCRIPTION
Added link to parent for deleted doc: dashboard-authentication-policy.md
Moved links to updated doc for /policies/unsupported-requests.md and /policies/restore-deleted-tenant.md to /policies

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
