### PR TITLE
Remove Angular version from quickstart meta

### DIFF
--- a/articles/quickstart/spa/angular2/01-login.md
+++ b/articles/quickstart/spa/angular2/01-login.md
@@ -1,10 +1,11 @@
 ---
 title: Login
-description: This tutorial demonstrates how to add user login to an Angular (versions 2 and above) application using Auth0.
+description: This tutorial demonstrates how to add user login to an Angular application using Auth0.
 budicon: 448
 topics:
   - quickstarts
   - spa
+  - angular
   - angular2
   - login
 github:


### PR DESCRIPTION
The article is for Angular 7+ but the title mentions Angular 2, which would be incompatible.

I removed the version entirely as we already have Angular 7+ requirements further down the page.