### PR TITLE
Fixed links to Bot Detection doc

### DIFF
--- a/config/redirects.js
+++ b/config/redirects.js
@@ -852,8 +852,8 @@ module.exports = [
     to: '/anomaly-detection/customize-blocked-account-emails'
   },
   {
-    from: ['/anomaly-detection/guides/prevent-credential-stuffing-attacks','/anomaly-detection/bot-and-credential-stuffing-protection'],
-    to: '/anomaly-detection/bot-protection'
+    from: ['/anomaly-detection/bot-protection','/anomaly-detection/guides/prevent-credential-stuffing-attacks','/anomaly-detection/bot-and-credential-stuffing-protection'],
+    to: '/anomaly-detection/bot-detection'
   },
   {
     from: ['/anomaly-detection/references/anomaly-detection-restrictions-limitations', '/anomaly-detection/guides/set-anomaly-detection-preferences','/anomaly-detection/guides/enable-disable-brute-force-protection'],

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -396,8 +396,8 @@ articles:
       - title: Anomaly Detection
         url: /anomaly-detection
         children:
-          - title: Bot Protection
-            url: /anomaly-detection/bot-protection
+          - title: Bot Detection
+            url: /anomaly-detection/bot-detection
           - title: Breached Passwords
             url: /anomaly-detection/breached-password-security
           - title: Brute Force Attacks


### PR DESCRIPTION
Fixed links to Bot Detection doc

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
