### PR TITLE
Add Email Template Descriptions link in Sidebar

### DIFF
--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -548,6 +548,8 @@ articles:
             url: /auth0-email-services/manage-email-flow
           - title: Customizing Your Emails
             url: /auth0-email-services/customize-email-templates
+          - title: Email Template Descriptions
+            url: /auth0-email-services/email-template-descriptions
           - title: Use your own SMTP Email Provider
             url: /auth0-email-services/configure-external-smtp-email-providers
           - title: Liquid Syntax in Email Templates


### PR DESCRIPTION
Added Email Template Descriptions link in Sidebar

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
