### PR TITLE
Fix: use absolute paths on images for SSO integration snippets

### DIFF
--- a/snippets/sso-integrations/ad-rms/3.md
+++ b/snippets/sso-integrations/ad-rms/3.md
@@ -1,16 +1,16 @@
 ### Create Auth0 SSO integration
 
 1. Navigate to [Auth0 Dashboard > SSO Integrations](${manage_url}/#/externalapps), and click **+ Create SSO Integration**.
-![Create SSO Integration](/media/articles/dashboard/sso-integrations/create.png)
+![Create SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create.png)
 
 2. Select **AD RMS**.
 
-![Select Service](/media/articles/dashboard/sso-integrations/create-select-service.png)
+![Select Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-select-service.png)
 
 3. Click **Continue** to grant the integration access to the listed permissions.
 
-![Authorize Service](/media/articles/dashboard/sso-integrations/create-authorize-ad-rms.png)
+![Authorize Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-authorize-ad-rms.png)
 
 4. Enter a name for your SSO Integration, and click **Save**.
 
-![Save Integration](/media/articles/dashboard/sso-integrations/create-save-ad-rms.png)
+![Save Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-save-ad-rms.png)

--- a/snippets/sso-integrations/ad-rms/5.md
+++ b/snippets/sso-integrations/ad-rms/5.md
@@ -2,7 +2,7 @@
 
 Before you continue, make sure you have your SSO integration Client ID. You will use the Client ID to replace the `SSO_CLIENT_ID` placeholders.
 
-![Locate Client ID](/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-ad-rms.png)
+![Locate Client ID](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-ad-rms.png)
 
 1. Add Federation Support to your AD RMS Cluster
 

--- a/snippets/sso-integrations/ad-rms/6.md
+++ b/snippets/sso-integrations/ad-rms/6.md
@@ -23,4 +23,4 @@
     </tbody>
 </table>
 
-![Configure SSO Integration](/media/articles/dashboard/sso-integrations/settings-ad-rms.png)
+![Configure SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-ad-rms.png)

--- a/snippets/sso-integrations/ad-rms/7.md
+++ b/snippets/sso-integrations/ad-rms/7.md
@@ -6,4 +6,4 @@ Choose the connections to use with your SSO integration. Users in enabled connec
 
 2. Toggle the sliders next to connection names to enable or disable them.
 
-![Enable/Disable Connections](/media/articles/dashboard/sso-integrations/settings-connections-ad-rms.png)
+![Enable/Disable Connections](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-connections-ad-rms.png)

--- a/snippets/sso-integrations/box/3.md
+++ b/snippets/sso-integrations/box/3.md
@@ -1,16 +1,16 @@
 ### Create Auth0 SSO integration
 
 1. Navigate to [Auth0 Dashboard > SSO Integrations](${manage_url}/#/externalapps), and click **+ Create SSO Integration**.
-![Create SSO Integration](/media/articles/dashboard/sso-integrations/create.png)
+![Create SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create.png)
 
 2. Select **Box**.
 
-![Select Service](/media/articles/dashboard/sso-integrations/create-select-service.png)
+![Select Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-select-service.png)
 
 3. Click **Continue** to grant the integration access to the listed permissions.
 
-![Authorize Service](/media/articles/dashboard/sso-integrations/create-authorize-box.png)
+![Authorize Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-authorize-box.png)
 
 4. Enter a name for your SSO Integration, and click **Save**.
 
-![Save Integration](/media/articles/dashboard/sso-integrations/create-save-box.png)
+![Save Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-save-box.png)

--- a/snippets/sso-integrations/box/5.md
+++ b/snippets/sso-integrations/box/5.md
@@ -6,7 +6,7 @@ The following steps only work for [Box Enterprise accounts](https://www.box.com/
 
 Before you continue, make sure you have your SSO integration Client ID. You will use the Client ID to replace the `SSO_CLIENT_ID` placeholders.
 
-![Locate Client ID](/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-box.png)
+![Locate Client ID](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-box.png)
 
 Configuring SAML SSO with Box requires you to call their support team. They will ask for a few pieces of information:
 

--- a/snippets/sso-integrations/box/6.md
+++ b/snippets/sso-integrations/box/6.md
@@ -6,4 +6,4 @@ Choose the connections to use with your SSO integration. Users in enabled connec
 
 2. Toggle the sliders next to connection names to enable or disable them.
 
-![Enable/Disable Connections](/media/articles/dashboard/sso-integrations/settings-connections-box.png)
+![Enable/Disable Connections](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-connections-box.png)

--- a/snippets/sso-integrations/cisco-webex/3.md
+++ b/snippets/sso-integrations/cisco-webex/3.md
@@ -1,16 +1,16 @@
 ### Create Auth0 SSO integration
 
 1. Navigate to [Auth0 Dashboard > SSO Integrations](${manage_url}/#/externalapps), and click **+ Create SSO Integration**.
-![Create SSO Integration](/media/articles/dashboard/sso-integrations/create.png)
+![Create SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create.png)
 
 2. Select **Cisco WebEx**.
 
-![Select Service](/media/articles/dashboard/sso-integrations/create-select-service.png)
+![Select Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-select-service.png)
 
 3. Click **Continue** to grant the integration access to the listed permissions.
 
-![Authorize Service](/media/articles/dashboard/sso-integrations/create-authorize-cisco-webex.png)
+![Authorize Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-authorize-cisco-webex.png)
 
 4. Enter a name for your SSO Integration, and click **Save**.
 
-![Save Integration](/media/articles/dashboard/sso-integrations/create-save-cisco-webex.png)
+![Save Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-save-cisco-webex.png)

--- a/snippets/sso-integrations/cisco-webex/5.md
+++ b/snippets/sso-integrations/cisco-webex/5.md
@@ -2,7 +2,7 @@
 
 Before you continue, make sure you have your SSO integration Client ID. You will use the Client ID to replace the `SSO_CLIENT_ID` placeholders.
 
-![Locate Client ID](/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-cisco-webex.png)
+![Locate Client ID](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-cisco-webex.png)
 
 Provide the following SAML protocol configuration parameters:
 

--- a/snippets/sso-integrations/cisco-webex/6.md
+++ b/snippets/sso-integrations/cisco-webex/6.md
@@ -6,4 +6,4 @@ Choose the connections to use with your SSO integration. Users in enabled connec
 
 2. Toggle the sliders next to connection names to enable or disable them.
 
-![Enable/Disable Connections](/media/articles/dashboard/sso-integrations/settings-connections-cisco-webex.png)
+![Enable/Disable Connections](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-connections-cisco-webex.png)

--- a/snippets/sso-integrations/cloudbees/3.md
+++ b/snippets/sso-integrations/cloudbees/3.md
@@ -1,16 +1,16 @@
 ### Create Auth0 SSO integration
 
 1. Navigate to [Auth0 Dashboard > SSO Integrations](${manage_url}/#/externalapps), and click **+ Create SSO Integration**.
-![Create SSO Integration](/media/articles/dashboard/sso-integrations/create.png)
+![Create SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create.png)
 
 2. Select **CloudBees**.
 
-![Select Service](/media/articles/dashboard/sso-integrations/create-select-service.png)
+![Select Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-select-service.png)
 
 3. Click **Continue** to grant the integration access to the listed permissions.
 
-![Authorize Service](/media/articles/dashboard/sso-integrations/create-authorize-cloudbees.png)
+![Authorize Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-authorize-cloudbees.png)
 
 4. Enter a name for your SSO Integration, and click **Save**.
 
-![Save Integration](/media/articles/dashboard/sso-integrations/create-save-cloudbees.png)
+![Save Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-save-cloudbees.png)

--- a/snippets/sso-integrations/cloudbees/5.md
+++ b/snippets/sso-integrations/cloudbees/5.md
@@ -2,7 +2,7 @@
 
 Before you continue, make sure you have your SSO integration Client ID. You will use the Client ID to replace the `SSO_CLIENT_ID` placeholders.
 
-![Locate Client ID](/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-cloudbees.png)
+![Locate Client ID](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-cloudbees.png)
 
 1. Log in to CloudBees as an administrator.
 

--- a/snippets/sso-integrations/cloudbees/6.md
+++ b/snippets/sso-integrations/cloudbees/6.md
@@ -6,4 +6,4 @@ Choose the connections to use with your SSO integration. Users in enabled connec
 
 2. Toggle the sliders next to connection names to enable or disable them.
 
-![Enable/Disable Connections](/media/articles/dashboard/sso-integrations/settings-connections-cloudbees.png)
+![Enable/Disable Connections](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-connections-cloudbees.png)

--- a/snippets/sso-integrations/concur/3.md
+++ b/snippets/sso-integrations/concur/3.md
@@ -1,16 +1,16 @@
 ### Create Auth0 SSO integration
 
 1. Navigate to [Auth0 Dashboard > SSO Integrations](${manage_url}/#/externalapps), and click **+ Create SSO Integration**.
-![Create SSO Integration](/media/articles/dashboard/sso-integrations/create.png)
+![Create SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create.png)
 
 2. Select **Concur****.
 
-![Select Service](/media/articles/dashboard/sso-integrations/create-select-service.png)
+![Select Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-select-service.png)
 
 3. Click **Continue** to grant the integration access to the listed permissions.
 
-![Authorize Service](/media/articles/dashboard/sso-integrations/create-authorize-concur.png)
+![Authorize Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-authorize-concur.png)
 
 4. Enter a name for your SSO Integration, and click **Save**.
 
-![Save Integration](/media/articles/dashboard/sso-integrations/create-save-concur.png)
+![Save Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-save-concur.png)

--- a/snippets/sso-integrations/concur/5.md
+++ b/snippets/sso-integrations/concur/5.md
@@ -2,7 +2,7 @@
 
 Before you continue, make sure you have your SSO integration Client ID. You will use the Client ID to replace the `SSO_CLIENT_ID` placeholders.
 
-![Locate Client ID](/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-concur.png)
+![Locate Client ID](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-concur.png)
 
 Concur requires you to contact their support team to setup SSO through SAML. [Download your Auth0 signing certificate](https://${account.namespace}/pem), and provide it to Concur.
 

--- a/snippets/sso-integrations/concur/6.md
+++ b/snippets/sso-integrations/concur/6.md
@@ -6,4 +6,4 @@ Choose the connections to use with your SSO integration. Users in enabled connec
 
 2. Toggle the sliders next to connection names to enable or disable them.
 
-![Enable/Disable Connections](/media/articles/dashboard/sso-integrations/settings-connections-concur.png)
+![Enable/Disable Connections](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-connections-concur.png)

--- a/snippets/sso-integrations/datadog/3.md
+++ b/snippets/sso-integrations/datadog/3.md
@@ -1,16 +1,16 @@
 ### Create Auth0 SSO integration
 
 1. Navigate to [Auth0 Dashboard > SSO Integrations](${manage_url}/#/externalapps), and click **+ Create SSO Integration**.
-![Create SSO Integration](/media/articles/dashboard/sso-integrations/create.png)
+![Create SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create.png)
 
 2. Select **Datadog**.
 
-![Select Service](/media/articles/dashboard/sso-integrations/create-select-service.png)
+![Select Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-select-service.png)
 
 3. Click **Continue** to grant the integration access to the listed permissions.
 
-![Authorize Service](/media/articles/dashboard/sso-integrations/create-authorize-datadog.png)
+![Authorize Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-authorize-datadog.png)
 
 4. Enter a name for your SSO Integration, and click **Save**.
 
-![Save Integration](/media/articles/dashboard/sso-integrations/create-save-datadog.png)
+![Save Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-save-datadog.png)

--- a/snippets/sso-integrations/datadog/5.md
+++ b/snippets/sso-integrations/datadog/5.md
@@ -2,7 +2,7 @@
 
 Before you continue, make sure you have your SSO integration Client ID. You will use the Client ID to replace the `SSO_CLIENT_ID` placeholders.
 
-![Locate Client ID](/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-datadog.png)
+![Locate Client ID](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-datadog.png)
 
 Provide the following SAML protocol configuration parameters:
 

--- a/snippets/sso-integrations/datadog/6.md
+++ b/snippets/sso-integrations/datadog/6.md
@@ -6,4 +6,4 @@ Choose the connections to use with your SSO integration. Users in enabled connec
 
 2. Toggle the sliders next to connection names to enable or disable them.
 
-![Enable/Disable Connections](/media/articles/dashboard/sso-integrations/settings-connections-datadog.png)
+![Enable/Disable Connections](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-connections-datadog.png)

--- a/snippets/sso-integrations/dropbox/3.md
+++ b/snippets/sso-integrations/dropbox/3.md
@@ -1,16 +1,16 @@
 ### Create Auth0 SSO integration
 
 1. Navigate to [Auth0 Dashboard > SSO Integrations](${manage_url}/#/externalapps), and click **+ Create SSO Integration**.
-![Create SSO Integration](/media/articles/dashboard/sso-integrations/create.png)
+![Create SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create.png)
 
 2. Select **Dropbox**.
 
-![Select Service](/media/articles/dashboard/sso-integrations/create-select-service.png)
+![Select Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-select-service.png)
 
 3. Click **Continue** to grant the integration access to the listed permissions.
 
-![Authorize Service](/media/articles/dashboard/sso-integrations/create-authorize-dropbox.png)
+![Authorize Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-authorize-dropbox.png)
 
 4. Enter a name for your SSO Integration, and click **Save**.
 
-![Save Integration](/media/articles/dashboard/sso-integrations/create-save-dropbox.png)
+![Save Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-save-dropbox.png)

--- a/snippets/sso-integrations/dropbox/5.md
+++ b/snippets/sso-integrations/dropbox/5.md
@@ -6,7 +6,7 @@ The following steps only work for [Dropbox Business accounts](https://www.dropbo
 
 Before you continue, make sure you have your SSO integration Client ID. You will use the Client ID to replace the `SSO_CLIENT_ID` placeholders.
 
-![Locate Client ID](/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-dropbox.png)
+![Locate Client ID](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-dropbox.png)
 
 1. Login as an Admin to your Dropbox Business account.
 

--- a/snippets/sso-integrations/dropbox/6.md
+++ b/snippets/sso-integrations/dropbox/6.md
@@ -6,4 +6,4 @@ Choose the connections to use with your SSO integration. Users in enabled connec
 
 2. Toggle the sliders next to connection names to enable or disable them.
 
-![Enable/Disable Connections](/media/articles/dashboard/sso-integrations/settings-connections-dropbox.png)
+![Enable/Disable Connections](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-connections-dropbox.png)

--- a/snippets/sso-integrations/dynamics-crm/3.md
+++ b/snippets/sso-integrations/dynamics-crm/3.md
@@ -1,16 +1,16 @@
 ### Create Auth0 SSO integration
 
 1. Navigate to [Auth0 Dashboard > SSO Integrations](${manage_url}/#/externalapps), and click **+ Create SSO Integration**.
-![Create SSO Integration](/media/articles/dashboard/sso-integrations/create.png)
+![Create SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create.png)
 
 2. Select **Dynamics CRM**.
 
-![Select Service](/media/articles/dashboard/sso-integrations/create-select-service.png)
+![Select Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-select-service.png)
 
 3. Click **Continue** to grant the integration access to the listed permissions.
 
-![Authorize Service](/media/articles/dashboard/sso-integrations/create-authorize-dynamics-crm.png)
+![Authorize Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-authorize-dynamics-crm.png)
 
 4. Enter a name for your SSO Integration, and click **Save**.
 
-![Save Integration](/media/articles/dashboard/sso-integrations/create-save-dynamics-crm.png)
+![Save Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-save-dynamics-crm.png)

--- a/snippets/sso-integrations/dynamics-crm/5.md
+++ b/snippets/sso-integrations/dynamics-crm/5.md
@@ -2,7 +2,7 @@
 
 Before you continue, make sure you have your SSO integration Client ID. You will use the Client ID to replace the `SSO_CLIENT_ID` placeholders.
 
-![Locate Client ID](/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-dynamics-crm.png)
+![Locate Client ID](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-dynamics-crm.png)
 
 Provide the following SAML protocol configuration parameters:
 

--- a/snippets/sso-integrations/dynamics-crm/6.md
+++ b/snippets/sso-integrations/dynamics-crm/6.md
@@ -6,4 +6,4 @@ Choose the connections to use with your SSO integration. Users in enabled connec
 
 2. Toggle the sliders next to connection names to enable or disable them.
 
-![Enable/Disable Connections](/media/articles/dashboard/sso-integrations/settings-connections-dynamics-crm.png)
+![Enable/Disable Connections](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-connections-dynamics-crm.png)

--- a/snippets/sso-integrations/echosign/3.md
+++ b/snippets/sso-integrations/echosign/3.md
@@ -1,16 +1,16 @@
 ### Create Auth0 SSO integration
 
 1. Navigate to [Auth0 Dashboard > SSO Integrations](${manage_url}/#/externalapps), and click **+ Create SSO Integration**.
-![Create SSO Integration](/media/articles/dashboard/sso-integrations/create.png)
+![Create SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create.png)
 
 2. Select **EchoSign**.
 
-![Select Service](/media/articles/dashboard/sso-integrations/create-select-service.png)
+![Select Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-select-service.png)
 
 3. Click **Continue** to grant the integration access to the listed permissions.
 
-![Authorize Service](/media/articles/dashboard/sso-integrations/create-authorize-echosign.png)
+![Authorize Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-authorize-echosign.png)
 
 4. Enter a name for your SSO Integration, and click **Save**.
 
-![Save Integration](/media/articles/dashboard/sso-integrations/create-save-echosign.png)
+![Save Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-save-echosign.png)

--- a/snippets/sso-integrations/echosign/5.md
+++ b/snippets/sso-integrations/echosign/5.md
@@ -2,7 +2,7 @@
 
 Before you continue, make sure you have your SSO integration Client ID. You will use the Client ID to replace the `SSO_CLIENT_ID` placeholders.
 
-![Locate Client ID](/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-echosign.png)
+![Locate Client ID](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-echosign.png)
 
 Provide the following SAML protocol configuration parameters:
 

--- a/snippets/sso-integrations/echosign/6.md
+++ b/snippets/sso-integrations/echosign/6.md
@@ -6,4 +6,4 @@ Choose the connections to use with your SSO integration. Users in enabled connec
 
 2. Toggle the sliders next to connection names to enable or disable them.
 
-![Enable/Disable Connections](/media/articles/dashboard/sso-integrations/settings-connections-echosign.png)
+![Enable/Disable Connections](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-connections-echosign.png)

--- a/snippets/sso-integrations/egencia/3.md
+++ b/snippets/sso-integrations/egencia/3.md
@@ -1,16 +1,16 @@
 ### Create Auth0 SSO integration
 
 1. Navigate to [Auth0 Dashboard > SSO Integrations](${manage_url}/#/externalapps), and click **+ Create SSO Integration**.
-![Create SSO Integration](/media/articles/dashboard/sso-integrations/create.png)
+![Create SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create.png)
 
 2. Select **Egencia**.
 
-![Select Service](/media/articles/dashboard/sso-integrations/create-select-service.png)
+![Select Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-select-service.png)
 
 3. Click **Continue** to grant the integration access to the listed permissions.
 
-![Authorize Service](/media/articles/dashboard/sso-integrations/create-authorize-egencia.png)
+![Authorize Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-authorize-egencia.png)
 
 4. Enter a name for your SSO Integration, and click **Save**.
 
-![Save Integration](/media/articles/dashboard/sso-integrations/create-save-egencia.png)
+![Save Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-save-egencia.png)

--- a/snippets/sso-integrations/egencia/5.md
+++ b/snippets/sso-integrations/egencia/5.md
@@ -2,7 +2,7 @@
 
 Before you continue, make sure you have your SSO integration Client ID. You will use the Client ID to replace the `SSO_CLIENT_ID` placeholders.
 
-![Locate Client ID](/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-egencia.png)
+![Locate Client ID](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-egencia.png)
 
 Provide the following SAML protocol configuration parameters:
 

--- a/snippets/sso-integrations/egencia/6.md
+++ b/snippets/sso-integrations/egencia/6.md
@@ -23,4 +23,4 @@
     </tbody>
 </table>
 
-![Configure SSO Integration](/media/articles/dashboard/sso-integrations/settings-egencia.png)
+![Configure SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-egencia.png)

--- a/snippets/sso-integrations/egencia/7.md
+++ b/snippets/sso-integrations/egencia/7.md
@@ -6,4 +6,4 @@ Choose the connections to use with your SSO integration. Users in enabled connec
 
 2. Toggle the sliders next to connection names to enable or disable them.
 
-![Enable/Disable Connections](/media/articles/dashboard/sso-integrations/settings-connections-egencia.png)
+![Enable/Disable Connections](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-connections-egencia.png)

--- a/snippets/sso-integrations/egnyte/3.md
+++ b/snippets/sso-integrations/egnyte/3.md
@@ -1,16 +1,16 @@
 ### Create Auth0 SSO integration
 
 1. Navigate to [Auth0 Dashboard > SSO Integrations](${manage_url}/#/externalapps), and click **+ Create SSO Integration**.
-![Create SSO Integration](/media/articles/dashboard/sso-integrations/create.png)
+![Create SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create.png)
 
 2. Select **Egnyte**.
 
-![Select Service](/media/articles/dashboard/sso-integrations/create-select-service.png)
+![Select Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-select-service.png)
 
 3. Click **Continue** to grant the integration access to the listed permissions.
 
-![Authorize Service](/media/articles/dashboard/sso-integrations/create-authorize-egnyte.png)
+![Authorize Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-authorize-egnyte.png)
 
 4. Enter a name for your SSO Integration, and click **Save**.
 
-![Save Integration](/media/articles/dashboard/sso-integrations/create-save-egnyte.png)
+![Save Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-save-egnyte.png)

--- a/snippets/sso-integrations/egnyte/5.md
+++ b/snippets/sso-integrations/egnyte/5.md
@@ -6,7 +6,7 @@ Important: SAML SSO is a feature included in only certain Egnyte plans.
 
 Before you continue, make sure you have your SSO integration Client ID. You will use the Client ID to replace the `SSO_CLIENT_ID` placeholders.
 
-![Locate Client ID](/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-egnyte.png)
+![Locate Client ID](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-egnyte.png)
 
 1. Log in as an Admin to Egnyte.
 

--- a/snippets/sso-integrations/egnyte/6.md
+++ b/snippets/sso-integrations/egnyte/6.md
@@ -23,4 +23,4 @@
     </tbody>
 </table>
 
-![Configure SSO Integration](/media/articles/dashboard/sso-integrations/settings-egnyte.png)
+![Configure SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-egnyte.png)

--- a/snippets/sso-integrations/egnyte/7.md
+++ b/snippets/sso-integrations/egnyte/7.md
@@ -6,4 +6,4 @@ Choose the connections to use with your SSO integration. Users in enabled connec
 
 2. Toggle the sliders next to connection names to enable or disable them.
 
-![Enable/Disable Connections](/media/articles/dashboard/sso-integrations/settings-connections-egnyte.png)
+![Enable/Disable Connections](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-connections-egnyte.png)

--- a/snippets/sso-integrations/eloqua/3.md
+++ b/snippets/sso-integrations/eloqua/3.md
@@ -1,16 +1,16 @@
 ### Create Auth0 SSO integration
 
 1. Navigate to [Auth0 Dashboard > SSO Integrations](${manage_url}/#/externalapps), and click **+ Create SSO Integration**.
-![Create SSO Integration](/media/articles/dashboard/sso-integrations/create.png)
+![Create SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create.png)
 
 2. Select **Eloqua**.
 
-![Select Service](/media/articles/dashboard/sso-integrations/create-select-service.png)
+![Select Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-select-service.png)
 
 3. Click **Continue** to grant the integration access to the listed permissions.
 
-![Authorize Service](/media/articles/dashboard/sso-integrations/create-authorize-eloqua.png)
+![Authorize Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-authorize-eloqua.png)
 
 4. Enter a name for your SSO Integration, and click **Save**.
 
-![Save Integration](/media/articles/dashboard/sso-integrations/create-save-eloqua.png)
+![Save Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-save-eloqua.png)

--- a/snippets/sso-integrations/eloqua/5.md
+++ b/snippets/sso-integrations/eloqua/5.md
@@ -2,7 +2,7 @@
 
 Before you continue, make sure you have your SSO integration Client ID. You will use the Client ID to replace the `SSO_CLIENT_ID` placeholders.
 
-![Locate Client ID](/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-eloqua.png)
+![Locate Client ID](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-eloqua.png)
 
 Provide the following SAML protocol configuration parameters:
 

--- a/snippets/sso-integrations/eloqua/6.md
+++ b/snippets/sso-integrations/eloqua/6.md
@@ -23,4 +23,4 @@
     </tbody>
 </table>
 
-![Configure SSO Integration](/media/articles/dashboard/sso-integrations/settings-eloqua.png)
+![Configure SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-eloqua.png)

--- a/snippets/sso-integrations/eloqua/7.md
+++ b/snippets/sso-integrations/eloqua/7.md
@@ -6,4 +6,4 @@ Choose the connections to use with your SSO integration. Users in enabled connec
 
 2. Toggle the sliders next to connection names to enable or disable them.
 
-![Enable/Disable Connections](/media/articles/dashboard/sso-integrations/settings-connections-eloqua.png)
+![Enable/Disable Connections](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-connections-eloqua.png)

--- a/snippets/sso-integrations/freshdesk/3.md
+++ b/snippets/sso-integrations/freshdesk/3.md
@@ -1,16 +1,16 @@
 ### Create Auth0 SSO integration
 
 1. Navigate to [Auth0 Dashboard > SSO Integrations](${manage_url}/#/externalapps), and click **+ Create SSO Integration**.
-![Create SSO Integration](/media/articles/dashboard/sso-integrations/create.png)
+![Create SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create.png)
 
 2. Select **Freshdesk**.
 
-![Select Service](/media/articles/dashboard/sso-integrations/create-select-service.png)
+![Select Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-select-service.png)
 
 3. Click **Continue** to grant the integration access to the listed permissions.
 
-![Authorize Service](/media/articles/dashboard/sso-integrations/create-authorize-freshdesk.png)
+![Authorize Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-authorize-freshdesk.png)
 
 4. Enter a name for your SSO Integration, and click **Save**.
 
-![Save Integration](/media/articles/dashboard/sso-integrations/create-save-freshdesk.png)
+![Save Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-save-freshdesk.png)

--- a/snippets/sso-integrations/freshdesk/5.md
+++ b/snippets/sso-integrations/freshdesk/5.md
@@ -2,7 +2,7 @@
 
 Before you continue, make sure you have your SSO integration Client ID. You will use the Client ID to replace the `SSO_CLIENT_ID` placeholders.
 
-![Locate Client ID](/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-freshdesk.png)
+![Locate Client ID](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-freshdesk.png)
 
 Provide the following SAML protocol configuration parameters:
 

--- a/snippets/sso-integrations/freshdesk/6.md
+++ b/snippets/sso-integrations/freshdesk/6.md
@@ -23,4 +23,4 @@
     </tbody>
 </table>
 
-![Configure SSO Integration](/media/articles/dashboard/sso-integrations/settings-freshdesk.png)
+![Configure SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-freshdesk.png)

--- a/snippets/sso-integrations/freshdesk/7.md
+++ b/snippets/sso-integrations/freshdesk/7.md
@@ -6,4 +6,4 @@ Choose the connections to use with your SSO integration. Users in enabled connec
 
 2. Toggle the sliders next to connection names to enable or disable them.
 
-![Enable/Disable Connections](/media/articles/dashboard/sso-integrations/settings-connections-Freshdesk.png)
+![Enable/Disable Connections](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-connections-Freshdesk.png)

--- a/snippets/sso-integrations/g-suite/3.md
+++ b/snippets/sso-integrations/g-suite/3.md
@@ -1,16 +1,16 @@
 ### Create Auth0 SSO integration
 
 1. Navigate to [Auth0 Dashboard > SSO Integrations](${manage_url}/#/externalapps), and click **+ Create SSO Integration**.
-![Create SSO Integration](/media/articles/dashboard/sso-integrations/create.png)
+![Create SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create.png)
 
 2. Select **G Suite**.
 
-![Select Service](/media/articles/dashboard/sso-integrations/create-select-service.png)
+![Select Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-select-service.png)
 
 3. Click **Continue** to grant the integration access to the listed permissions.
 
-![Authorize Service](/media/articles/dashboard/sso-integrations/create-authorize-g-suite.png)
+![Authorize Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-authorize-g-suite.png)
 
 4. Enter a name for your SSO Integration, and click **Save**.
 
-![Save Integration](/media/articles/dashboard/sso-integrations/create-save-g-suite.png)
+![Save Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-save-g-suite.png)

--- a/snippets/sso-integrations/g-suite/5.md
+++ b/snippets/sso-integrations/g-suite/5.md
@@ -2,7 +2,7 @@
 
 Before you continue, make sure you have your SSO integration Client ID. You will use the Client ID to replace the `SSO_CLIENT_ID` placeholders.
 
-![Locate Client ID](/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-g-suite.png)
+![Locate Client ID](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-g-suite.png)
 
 Provide the following SAML protocol configuration parameters:
 

--- a/snippets/sso-integrations/g-suite/6.md
+++ b/snippets/sso-integrations/g-suite/6.md
@@ -27,4 +27,4 @@
     </tbody>
 </table>
 
-![Configure SSO Integration](/media/articles/dashboard/sso-integrations/settings-g-suite.png)
+![Configure SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-g-suite.png)

--- a/snippets/sso-integrations/g-suite/7.md
+++ b/snippets/sso-integrations/g-suite/7.md
@@ -6,4 +6,4 @@ Choose the connections to use with your SSO integration. Users in enabled connec
 
 2. Toggle the sliders next to connection names to enable or disable them.
 
-![Enable/Disable Connections](/media/articles/dashboard/sso-integrations/settings-connections-g-suite.png)
+![Enable/Disable Connections](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-connections-g-suite.png)

--- a/snippets/sso-integrations/github-enterprise-cloud/3.md
+++ b/snippets/sso-integrations/github-enterprise-cloud/3.md
@@ -1,16 +1,16 @@
 ### Create Auth0 SSO integration
 
 1. Navigate to [Auth0 Dashboard > SSO Integrations](${manage_url}/#/externalapps), and click **+ Create SSO Integration**.
-![Create SSO Integration](/media/articles/dashboard/sso-integrations/create.png)
+![Create SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create.png)
 
 2. Select **GitHub Enterprise Cloud**.
 
-![Select Service](/media/articles/dashboard/sso-integrations/create-select-service.png)
+![Select Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-select-service.png)
 
 3. Click **Continue** to grant the integration access to the listed permissions.
 
-![Authorize Service](/media/articles/dashboard/sso-integrations/create-authorize-github-enterprise-cloud.png)
+![Authorize Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-authorize-github-enterprise-cloud.png)
 
 4. Enter a name for your SSO Integration, and click **Save**.
 
-![Save Integration](/media/articles/dashboard/sso-integrations/create-save-github-enterprise-cloud.png)
+![Save Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-save-github-enterprise-cloud.png)

--- a/snippets/sso-integrations/github-enterprise-cloud/5.md
+++ b/snippets/sso-integrations/github-enterprise-cloud/5.md
@@ -2,7 +2,7 @@
 
 Before you continue, make sure you have your SSO integration Client ID. You will use the Client ID to replace the `SSO_CLIENT_ID` placeholders.
 
-![Locate Client ID](/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-github-enterprise-cloud.png)
+![Locate Client ID](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-github-enterprise-cloud.png)
 
 Provide the following SAML protocol configuration parameters:
 

--- a/snippets/sso-integrations/github-enterprise-cloud/6.md
+++ b/snippets/sso-integrations/github-enterprise-cloud/6.md
@@ -27,4 +27,4 @@
     </tbody>
 </table>
 
-![Configure SSO Integration](/media/articles/dashboard/sso-integrations/settings-github-enterprise-cloud.png)
+![Configure SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-github-enterprise-cloud.png)

--- a/snippets/sso-integrations/github-enterprise-cloud/7.md
+++ b/snippets/sso-integrations/github-enterprise-cloud/7.md
@@ -6,4 +6,4 @@ Choose the connections to use with your SSO integration. Users in enabled connec
 
 2. Toggle the sliders next to connection names to enable or disable them.
 
-![Enable/Disable Connections](/media/articles/dashboard/sso-integrations/settings-connections-github-enterprise-cloud.png)
+![Enable/Disable Connections](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-connections-github-enterprise-cloud.png)

--- a/snippets/sso-integrations/github-enterprise-server/3.md
+++ b/snippets/sso-integrations/github-enterprise-server/3.md
@@ -1,16 +1,16 @@
 ### Create Auth0 SSO integration
 
 1. Navigate to [Auth0 Dashboard > SSO Integrations](${manage_url}/#/externalapps), and click **+ Create SSO Integration**.
-![Create SSO Integration](/media/articles/dashboard/sso-integrations/create.png)
+![Create SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create.png)
 
 2. Select **GitHub Enterprise Server**.
 
-![Select Service](/media/articles/dashboard/sso-integrations/create-select-service.png)
+![Select Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-select-service.png)
 
 3. Click **Continue** to grant the integration access to the listed permissions.
 
-![Authorize Service](/media/articles/dashboard/sso-integrations/create-authorize-github-enterprise-server.png)
+![Authorize Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-authorize-github-enterprise-server.png)
 
 4. Enter a name for your SSO Integration, and click **Save**.
 
-![Save Integration](/media/articles/dashboard/sso-integrations/create-save-github-enterprise-server.png)
+![Save Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-save-github-enterprise-server.png)

--- a/snippets/sso-integrations/github-enterprise-server/5.md
+++ b/snippets/sso-integrations/github-enterprise-server/5.md
@@ -2,7 +2,7 @@
 
 Before you continue, make sure you have your SSO integration Client ID. You will use the Client ID to replace the `SSO_CLIENT_ID` placeholders.
 
-![Locate Client ID](/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-github-enterprise-server.png)
+![Locate Client ID](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-github-enterprise-server.png)
 
 Provide the following SAML protocol configuration parameters:
 

--- a/snippets/sso-integrations/github-enterprise-server/6.md
+++ b/snippets/sso-integrations/github-enterprise-server/6.md
@@ -27,4 +27,4 @@
     </tbody>
 </table>
 
-![Configure SSO Integration](/media/articles/dashboard/sso-integrations/settings-github-enterprise-server.png)
+![Configure SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-github-enterprise-server.png)

--- a/snippets/sso-integrations/github-enterprise-server/7.md
+++ b/snippets/sso-integrations/github-enterprise-server/7.md
@@ -6,4 +6,4 @@ Choose the connections to use with your SSO integration. Users in enabled connec
 
 2. Toggle the sliders next to connection names to enable or disable them.
 
-![Enable/Disable Connections](/media/articles/dashboard/sso-integrations/settings-connections-github-enterprise-server.png)
+![Enable/Disable Connections](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-connections-github-enterprise-server.png)

--- a/snippets/sso-integrations/heroku/3.md
+++ b/snippets/sso-integrations/heroku/3.md
@@ -1,16 +1,16 @@
 ### Create Auth0 SSO integration
 
 1. Navigate to [Auth0 Dashboard > SSO Integrations](${manage_url}/#/externalapps), and click **+ Create SSO Integration**.
-![Create SSO Integration](/media/articles/dashboard/sso-integrations/create.png)
+![Create SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create.png)
 
 2. Select **Heroku**.
 
-![Select Service](/media/articles/dashboard/sso-integrations/create-select-service.png)
+![Select Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-select-service.png)
 
 3. Click **Continue** to grant the integration access to the listed permissions.
 
-![Authorize Service](/media/articles/dashboard/sso-integrations/create-authorize-heroku.png)
+![Authorize Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-authorize-heroku.png)
 
 4. Enter a name for your SSO Integration, and click **Save**.
 
-![Save Integration](/media/articles/dashboard/sso-integrations/create-save-heroku.png)
+![Save Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-save-heroku.png)

--- a/snippets/sso-integrations/heroku/5.md
+++ b/snippets/sso-integrations/heroku/5.md
@@ -2,7 +2,7 @@
 
 Before you continue, make sure you have your SSO integration Client ID. You will use the Client ID to replace the `SSO_CLIENT_ID` placeholders.
 
-![Locate Client ID](/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-heroku.png)
+![Locate Client ID](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-heroku.png)
 
 Provide the following SAML protocol configuration parameters:
 

--- a/snippets/sso-integrations/heroku/6.md
+++ b/snippets/sso-integrations/heroku/6.md
@@ -27,4 +27,4 @@
     </tbody>
 </table>
 
-![Configure SSO Integration](/media/articles/dashboard/sso-integrations/settings-heroku.png)
+![Configure SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-heroku.png)

--- a/snippets/sso-integrations/heroku/7.md
+++ b/snippets/sso-integrations/heroku/7.md
@@ -6,4 +6,4 @@ Choose the connections to use with your SSO integration. Users in enabled connec
 
 2. Toggle the sliders next to connection names to enable or disable them.
 
-![Enable/Disable Connections](/media/articles/dashboard/sso-integrations/settings-connections-heroku.png)
+![Enable/Disable Connections](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-connections-heroku.png)

--- a/snippets/sso-integrations/hosted-graphite/3.md
+++ b/snippets/sso-integrations/hosted-graphite/3.md
@@ -1,16 +1,16 @@
 ### Create Auth0 SSO integration
 
 1. Navigate to [Auth0 Dashboard > SSO Integrations](${manage_url}/#/externalapps), and click **+ Create SSO Integration**.
-![Create SSO Integration](/media/articles/dashboard/sso-integrations/create.png)
+![Create SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create.png)
 
 2. Select **Hosted Graphite**.
 
-![Select Service](/media/articles/dashboard/sso-integrations/create-select-service.png)
+![Select Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-select-service.png)
 
 3. Click **Continue** to grant the integration access to the listed permissions.
 
-![Authorize Service](/media/articles/dashboard/sso-integrations/create-authorize-hosted-graphite.png)
+![Authorize Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-authorize-hosted-graphite.png)
 
 4. Enter a name for your SSO Integration, and click **Save**.
 
-![Save Integration](/media/articles/dashboard/sso-integrations/create-save-hosted-graphite.png)
+![Save Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-save-hosted-graphite.png)

--- a/snippets/sso-integrations/hosted-graphite/5.md
+++ b/snippets/sso-integrations/hosted-graphite/5.md
@@ -2,7 +2,7 @@
 
 Before you continue, make sure you have your SSO integration Client ID. You will use the Client ID to replace the `SSO_CLIENT_ID` placeholders.
 
-![Locate Client ID](/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-hosted-graphite.png)
+![Locate Client ID](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-hosted-graphite.png)
 
 Provide the following SAML protocol configuration parameters:
 

--- a/snippets/sso-integrations/hosted-graphite/6.md
+++ b/snippets/sso-integrations/hosted-graphite/6.md
@@ -27,4 +27,4 @@
     </tbody>
 </table>
 
-![Configure SSO Integration](/media/articles/dashboard/sso-integrations/settings-hosted-graphite.png)
+![Configure SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-hosted-graphite.png)

--- a/snippets/sso-integrations/hosted-graphite/7.md
+++ b/snippets/sso-integrations/hosted-graphite/7.md
@@ -6,4 +6,4 @@ Choose the connections to use with your SSO integration. Users in enabled connec
 
 2. Toggle the sliders next to connection names to enable or disable them.
 
-![Enable/Disable Connections](/media/articles/dashboard/sso-integrations/settings-connections-hosted-graphite.png)
+![Enable/Disable Connections](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-connections-hosted-graphite.png)

--- a/snippets/sso-integrations/litmos/3.md
+++ b/snippets/sso-integrations/litmos/3.md
@@ -1,16 +1,16 @@
 ### Create Auth0 SSO integration
 
 1. Navigate to [Auth0 Dashboard > SSO Integrations](${manage_url}/#/externalapps), and click **+ Create SSO Integration**.
-![Create SSO Integration](/media/articles/dashboard/sso-integrations/create.png)
+![Create SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create.png)
 
 2. Select **Litmos**.
 
-![Select Service](/media/articles/dashboard/sso-integrations/create-select-service.png)
+![Select Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-select-service.png)
 
 3. Click **Continue** to grant the integration access to the listed permissions.
 
-![Authorize Service](/media/articles/dashboard/sso-integrations/create-authorize-litmos.png)
+![Authorize Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-authorize-litmos.png)
 
 4. Enter a name for your SSO Integration, and click **Save**.
 
-![Save Integration](/media/articles/dashboard/sso-integrations/create-save-litmos.png)
+![Save Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-save-litmos.png)

--- a/snippets/sso-integrations/litmos/5.md
+++ b/snippets/sso-integrations/litmos/5.md
@@ -2,7 +2,7 @@
 
 Before you continue, make sure you have your SSO integration Client ID. You will use the Client ID to replace the `SSO_CLIENT_ID` placeholders.
 
-![Locate Client ID](/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-litmos.png)
+![Locate Client ID](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-litmos.png)
 
 Provide the following SAML protocol configuration parameters:
 

--- a/snippets/sso-integrations/litmos/6.md
+++ b/snippets/sso-integrations/litmos/6.md
@@ -27,4 +27,4 @@
     </tbody>
 </table>
 
-![Configure SSO Integration](/media/articles/dashboard/sso-integrations/settings-litmos.png)
+![Configure SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-litmos.png)

--- a/snippets/sso-integrations/litmos/7.md
+++ b/snippets/sso-integrations/litmos/7.md
@@ -6,4 +6,4 @@ Choose the connections to use with your SSO integration. Users in enabled connec
 
 2. Toggle the sliders next to connection names to enable or disable them.
 
-![Enable/Disable Connections](/media/articles/dashboard/sso-integrations/settings-connections-litmos.png)
+![Enable/Disable Connections](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-connections-litmos.png)

--- a/snippets/sso-integrations/new-relic/3.md
+++ b/snippets/sso-integrations/new-relic/3.md
@@ -1,16 +1,16 @@
 ### Create Auth0 SSO integration
 
 1. Navigate to [Auth0 Dashboard > SSO Integrations](${manage_url}/#/externalapps), and click **+ Create SSO Integration**.
-![Create SSO Integration](/media/articles/dashboard/sso-integrations/create.png)
+![Create SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create.png)
 
 2. Select **New Relic**.
 
-![Select Service](/media/articles/dashboard/sso-integrations/create-select-service.png)
+![Select Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-select-service.png)
 
 3. Click **Continue** to grant the integration access to the listed permissions.
 
-![Authorize Service](/media/articles/dashboard/sso-integrations/create-authorize-new-relic.png)
+![Authorize Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-authorize-new-relic.png)
 
 4. Enter a name for your SSO Integration, and click **Save**.
 
-![Save Integration](/media/articles/dashboard/sso-integrations/create-save-new-relic.png)
+![Save Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-save-new-relic.png)

--- a/snippets/sso-integrations/new-relic/5.md
+++ b/snippets/sso-integrations/new-relic/5.md
@@ -2,7 +2,7 @@
 
 Before you continue, make sure you have your SSO integration Client ID. You will use the Client ID to replace the `SSO_CLIENT_ID` placeholders.
 
-![Locate Client ID](/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-new-relic.png)
+![Locate Client ID](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-new-relic.png)
 
 Provide the following SAML protocol configuration parameters:
 

--- a/snippets/sso-integrations/new-relic/6.md
+++ b/snippets/sso-integrations/new-relic/6.md
@@ -6,4 +6,4 @@ Choose the connections to use with your SSO integration. Users in enabled connec
 
 2. Toggle the sliders next to connection names to enable or disable them.
 
-![Enable/Disable Connections](/media/articles/dashboard/sso-integrations/settings-connections-new-relic.png)
+![Enable/Disable Connections](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-connections-new-relic.png)

--- a/snippets/sso-integrations/office-365/3.md
+++ b/snippets/sso-integrations/office-365/3.md
@@ -1,16 +1,16 @@
 ### Create Auth0 SSO integration
 
 1. Navigate to [Auth0 Dashboard > SSO Integrations](${manage_url}/#/externalapps), and click **+ Create SSO Integration**.
-![Create SSO Integration](/media/articles/dashboard/sso-integrations/create.png)
+![Create SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create.png)
 
 2. Select **Office 365**.
 
-![Select Service](/media/articles/dashboard/sso-integrations/create-select-service.png)
+![Select Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-select-service.png)
 
 3. Click **Continue** to grant the integration access to the listed permissions.
 
-![Authorize Service](/media/articles/dashboard/sso-integrations/create-authorize-office-365.png)
+![Authorize Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-authorize-office-365.png)
 
 4. Enter a name for your SSO Integration, and click **Save**.
 
-![Save Integration](/media/articles/dashboard/sso-integrations/create-save-office-365.png)
+![Save Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-save-office-365.png)

--- a/snippets/sso-integrations/office-365/5.md
+++ b/snippets/sso-integrations/office-365/5.md
@@ -2,7 +2,7 @@
 
 Before you continue, make sure you have your SSO integration Client ID. You will use the Client ID to replace the `SSO_CLIENT_ID` placeholders.
 
-![Locate Client ID](/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-office-365.png)
+![Locate Client ID](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-office-365.png)
 
 Provide the following SAML protocol configuration parameters:
 

--- a/snippets/sso-integrations/office-365/6.md
+++ b/snippets/sso-integrations/office-365/6.md
@@ -6,4 +6,4 @@ Choose the connections to use with your SSO integration. Users in enabled connec
 
 2. Toggle the sliders next to connection names to enable or disable them.
 
-![Enable/Disable Connections](/media/articles/dashboard/sso-integrations/settings-connections-office-365.png)
+![Enable/Disable Connections](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-connections-office-365.png)

--- a/snippets/sso-integrations/pluralsight/3.md
+++ b/snippets/sso-integrations/pluralsight/3.md
@@ -1,16 +1,16 @@
 ### Create Auth0 SSO integration
 
 1. Navigate to [Auth0 Dashboard > SSO Integrations](${manage_url}/#/externalapps), and click **+ Create SSO Integration**.
-![Create SSO Integration](/media/articles/dashboard/sso-integrations/create.png)
+![Create SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create.png)
 
 2. Select **Pluralsight**.
 
-![Select Service](/media/articles/dashboard/sso-integrations/create-select-service.png)
+![Select Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-select-service.png)
 
 3. Click **Continue** to grant the integration access to the listed permissions.
 
-![Authorize Service](/media/articles/dashboard/sso-integrations/create-authorize-pluralsight.png)
+![Authorize Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-authorize-pluralsight.png)
 
 4. Enter a name for your SSO Integration, and click **Save**.
 
-![Save Integration](/media/articles/dashboard/sso-integrations/create-save-pluralsight.png)
+![Save Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-save-pluralsight.png)

--- a/snippets/sso-integrations/pluralsight/5.md
+++ b/snippets/sso-integrations/pluralsight/5.md
@@ -2,7 +2,7 @@
 
 Before you continue, make sure you have your SSO integration Client ID. You will use the Client ID to replace the `SSO_CLIENT_ID` placeholders.
 
-![Locate Client ID](/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-pluralsight.png)
+![Locate Client ID](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-pluralsight.png)
 
 Provide the following SAML protocol configuration parameters:
 

--- a/snippets/sso-integrations/pluralsight/6.md
+++ b/snippets/sso-integrations/pluralsight/6.md
@@ -6,4 +6,4 @@ Choose the connections to use with your SSO integration. Users in enabled connec
 
 2. Toggle the sliders next to connection names to enable or disable them.
 
-![Enable/Disable Connections](/media/articles/dashboard/sso-integrations/settings-connections-pluralsight.png)
+![Enable/Disable Connections](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-connections-pluralsight.png)

--- a/snippets/sso-integrations/salesforce/3.md
+++ b/snippets/sso-integrations/salesforce/3.md
@@ -1,16 +1,16 @@
 ### Create Auth0 SSO integration
 
 1. Navigate to [Auth0 Dashboard > SSO Integrations](${manage_url}/#/externalapps), and click **+ Create SSO Integration**.
-![Create SSO Integration](/media/articles/dashboard/sso-integrations/create.png)
+![Create SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create.png)
 
 2. Select **Salesforce**.
 
-![Select Service](/media/articles/dashboard/sso-integrations/create-select-service.png)
+![Select Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-select-service.png)
 
 3. Click **Continue** to grant the integration access to the listed permissions.
 
-![Authorize Service](/media/articles/dashboard/sso-integrations/create-authorize-salesforce.png)
+![Authorize Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-authorize-salesforce.png)
 
 4. Enter a name for your SSO Integration, and click **Save**.
 
-![Save Integration](/media/articles/dashboard/sso-integrations/create-save-salesforce.png)
+![Save Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-save-salesforce.png)

--- a/snippets/sso-integrations/salesforce/5.md
+++ b/snippets/sso-integrations/salesforce/5.md
@@ -6,7 +6,7 @@ Important: This only works on certain [Salesforce editions](http://na15.salesfor
 
 Before you continue, make sure you have your SSO integration Client ID. You will use the Client ID to replace the `SSO_CLIENT_ID` placeholders.
 
-![Locate Client ID](/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-salesforce.png)
+![Locate Client ID](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-salesforce.png)
 
 1. Log in to Salesforce.
 

--- a/snippets/sso-integrations/salesforce/6.md
+++ b/snippets/sso-integrations/salesforce/6.md
@@ -27,4 +27,4 @@
     </tbody>
 </table>
 
-![Configure SSO Integration](/media/articles/dashboard/sso-integrations/settings-salesforce.png)
+![Configure SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-salesforce.png)

--- a/snippets/sso-integrations/salesforce/7.md
+++ b/snippets/sso-integrations/salesforce/7.md
@@ -6,4 +6,4 @@ Choose the connections to use with your SSO integration. Users in enabled connec
 
 2. Toggle the sliders next to connection names to enable or disable them.
 
-![Enable/Disable Connections](/media/articles/dashboard/sso-integrations/settings-connections-salesforce.png)
+![Enable/Disable Connections](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-connections-salesforce.png)

--- a/snippets/sso-integrations/sentry/3.md
+++ b/snippets/sso-integrations/sentry/3.md
@@ -1,16 +1,16 @@
 ### Create Auth0 SSO integration
 
 1. Navigate to [Auth0 Dashboard > SSO Integrations](${manage_url}/#/externalapps), and click **+ Create SSO Integration**.
-![Create SSO Integration](/media/articles/dashboard/sso-integrations/create.png)
+![Create SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create.png)
 
 2. Select **Sentry**.
 
-![Select Service](/media/articles/dashboard/sso-integrations/create-select-service.png)
+![Select Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-select-service.png)
 
 3. Click **Continue** to grant the integration access to the listed permissions.
 
-![Authorize Service](/media/articles/dashboard/sso-integrations/create-authorize-sentry.png)
+![Authorize Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-authorize-sentry.png)
 
 4. Enter a name for your SSO Integration, and click **Save**.
 
-![Save Integration](/media/articles/dashboard/sso-integrations/create-save-sentry.png)
+![Save Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-save-sentry.png)

--- a/snippets/sso-integrations/sentry/5.md
+++ b/snippets/sso-integrations/sentry/5.md
@@ -2,7 +2,7 @@
 
 Before you continue, make sure you have your SSO integration Client ID. You will use the Client ID to replace the `SSO_CLIENT_ID` placeholders.
 
-![Locate Client ID](/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-sentry.png)
+![Locate Client ID](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-sentry.png)
 
 1. Login to your Sentry organization's **Auth settings** page as an admin.
 

--- a/snippets/sso-integrations/sentry/6.md
+++ b/snippets/sso-integrations/sentry/6.md
@@ -27,4 +27,4 @@
     </tbody>
 </table>
 
-![Configure SSO Integration](/media/articles/dashboard/sso-integrations/settings-sentry.png)
+![Configure SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-sentry.png)

--- a/snippets/sso-integrations/sentry/7.md
+++ b/snippets/sso-integrations/sentry/7.md
@@ -6,4 +6,4 @@ Choose the connections to use with your SSO integration. Users in enabled connec
 
 2. Toggle the sliders next to connection names to enable or disable them.
 
-![Enable/Disable Connections](/media/articles/dashboard/sso-integrations/settings-connections-sentry.png)
+![Enable/Disable Connections](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-connections-sentry.png)

--- a/snippets/sso-integrations/sharepoint/3.md
+++ b/snippets/sso-integrations/sharepoint/3.md
@@ -1,16 +1,16 @@
 ### Create Auth0 SSO integration
 
 1. Navigate to [Auth0 Dashboard > SSO Integrations](${manage_url}/#/externalapps), and click **+ Create SSO Integration**.
-![Create SSO Integration](/media/articles/dashboard/sso-integrations/create.png)
+![Create SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create.png)
 
 2. Select **SharePoint**.
 
-![Select Service](/media/articles/dashboard/sso-integrations/create-select-service.png)
+![Select Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-select-service.png)
 
 3. Click **Continue** to grant the integration access to the listed permissions.
 
-![Authorize Service](/media/articles/dashboard/sso-integrations/create-authorize-sharepoint.png)
+![Authorize Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-authorize-sharepoint.png)
 
 4. Enter a name for your SSO Integration, and click **Save**.
 
-![Save Integration](/media/articles/dashboard/sso-integrations/create-save-sharepoint.png)
+![Save Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-save-sharepoint.png)

--- a/snippets/sso-integrations/sharepoint/5.md
+++ b/snippets/sso-integrations/sharepoint/5.md
@@ -2,7 +2,7 @@
 
 Before you continue, make sure you have your SSO integration Client ID. You will use the Client ID to replace the `SSO_CLIENT_ID` placeholders.
 
-![Locate Client ID](/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-sharepoint.png)
+![Locate Client ID](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-sharepoint.png)
 
 1. Open a SharePoint Powershell session, and install the Auth0 PowerShell Module:
 `iex ((new-object net.webclient).DownloadString("https://cdn.auth0.com/sharepoint/install.ps1"))`

--- a/snippets/sso-integrations/sharepoint/6.md
+++ b/snippets/sso-integrations/sharepoint/6.md
@@ -27,4 +27,4 @@
     </tbody>
 </table>
 
-![Configure SSO Integration](/media/articles/dashboard/sso-integrations/settings-sharepoint.png)
+![Configure SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-sharepoint.png)

--- a/snippets/sso-integrations/sharepoint/7.md
+++ b/snippets/sso-integrations/sharepoint/7.md
@@ -6,4 +6,4 @@ Choose the connections to use with your SSO integration. Users in enabled connec
 
 2. Toggle the sliders next to connection names to enable or disable them.
 
-![Enable/Disable Connections](/media/articles/dashboard/sso-integrations/settings-connections-sharepoint.png)
+![Enable/Disable Connections](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-connections-sharepoint.png)

--- a/snippets/sso-integrations/slack/3.md
+++ b/snippets/sso-integrations/slack/3.md
@@ -1,16 +1,16 @@
 ### Create Auth0 SSO integration
 
 1. Navigate to [Auth0 Dashboard > SSO Integrations](${manage_url}/#/externalapps), and click **+ Create SSO Integration**.
-![Create SSO Integration](/media/articles/dashboard/sso-integrations/create.png)
+![Create SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create.png)
 
 2. Select **Slack**.
 
-![Select Service](/media/articles/dashboard/sso-integrations/create-select-service.png)
+![Select Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-select-service.png)
 
 3. Click **Continue** to grant the integration access to the listed permissions.
 
-![Authorize Service](/media/articles/dashboard/sso-integrations/create-authorize-slack.png)
+![Authorize Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-authorize-slack.png)
 
 4. Enter a name for your SSO Integration, and click **Save**.
 
-![Save Integration](/media/articles/dashboard/sso-integrations/create-save-slack.png)
+![Save Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-save-slack.png)

--- a/snippets/sso-integrations/slack/5.md
+++ b/snippets/sso-integrations/slack/5.md
@@ -2,7 +2,7 @@
 
 Before you continue, make sure you have your SSO integration Client ID. You will use the Client ID to replace the `SSO_CLIENT_ID` placeholders.
 
-![Locate Client ID](/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-slack.png)
+![Locate Client ID](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-slack.png)
 
 1. Log in to [Slack Authentication Settings](https://slack.com/admin/auth) as an administrator.
 

--- a/snippets/sso-integrations/slack/6.md
+++ b/snippets/sso-integrations/slack/6.md
@@ -23,4 +23,4 @@
     </tbody>
 </table>
 
-![Configure SSO Integration](/media/articles/dashboard/sso-integrations/settings-slack.png)
+![Configure SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-slack.png)

--- a/snippets/sso-integrations/slack/7.md
+++ b/snippets/sso-integrations/slack/7.md
@@ -6,4 +6,4 @@ Choose the connections to use with your SSO integration. Users in enabled connec
 
 2. Toggle the sliders next to connection names to enable or disable them.
 
-![Enable/Disable Connections](/media/articles/dashboard/sso-integrations/settings-connections-slack.png)
+![Enable/Disable Connections](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-connections-slack.png)

--- a/snippets/sso-integrations/springcm/3.md
+++ b/snippets/sso-integrations/springcm/3.md
@@ -1,16 +1,16 @@
 ### Create Auth0 SSO integration
 
 1. Navigate to [Auth0 Dashboard > SSO Integrations](${manage_url}/#/externalapps), and click **+ Create SSO Integration**.
-![Create SSO Integration](/media/articles/dashboard/sso-integrations/create.png)
+![Create SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create.png)
 
 2. Select **SpringCM**.
 
-![Select Service](/media/articles/dashboard/sso-integrations/create-select-service.png)
+![Select Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-select-service.png)
 
 3. Click **Continue** to grant the integration access to the listed permissions.
 
-![Authorize Service](/media/articles/dashboard/sso-integrations/create-authorize-springcm.png)
+![Authorize Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-authorize-springcm.png)
 
 4. Enter a name for your SSO Integration, and click **Save**.
 
-![Save Integration](/media/articles/dashboard/sso-integrations/create-save-springcm.png)
+![Save Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-save-springcm.png)

--- a/snippets/sso-integrations/springcm/5.md
+++ b/snippets/sso-integrations/springcm/5.md
@@ -2,7 +2,7 @@
 
 Before you continue, make sure you have your SSO integration Client ID. You will use the Client ID to replace the `SSO_CLIENT_ID` placeholders.
 
-![Locate Client ID](/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-springcm.png)
+![Locate Client ID](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-springcm.png)
 
 1. Log in to SpringCM as an admin.
 

--- a/snippets/sso-integrations/springcm/6.md
+++ b/snippets/sso-integrations/springcm/6.md
@@ -23,4 +23,4 @@
     </tbody>
 </table>
 
-![Configure SSO Integration](/media/articles/dashboard/sso-integrations/settings-springcm.png)
+![Configure SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-springcm.png)

--- a/snippets/sso-integrations/springcm/7.md
+++ b/snippets/sso-integrations/springcm/7.md
@@ -6,4 +6,4 @@ Choose the connections to use with your SSO integration. Users in enabled connec
 
 2. Toggle the sliders next to connection names to enable or disable them.
 
-![Enable/Disable Connections](/media/articles/dashboard/sso-integrations/settings-connections-springcm.png)
+![Enable/Disable Connections](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-connections-springcm.png)

--- a/snippets/sso-integrations/sprout-video/3.md
+++ b/snippets/sso-integrations/sprout-video/3.md
@@ -1,16 +1,16 @@
 ### Create Auth0 SSO integration
 
 1. Navigate to [Auth0 Dashboard > SSO Integrations](${manage_url}/#/externalapps), and click **+ Create SSO Integration**.
-![Create SSO Integration](/media/articles/dashboard/sso-integrations/create.png)
+![Create SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create.png)
 
 2. Select **Sprout Video**.
 
-![Select Service](/media/articles/dashboard/sso-integrations/create-select-service.png)
+![Select Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-select-service.png)
 
 3. Click **Continue** to grant the integration access to the listed permissions.
 
-![Authorize Service](/media/articles/dashboard/sso-integrations/create-authorize-sprout-video.png)
+![Authorize Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-authorize-sprout-video.png)
 
 4. Enter a name for your SSO Integration, and click **Save**.
 
-![Save Integration](/media/articles/dashboard/sso-integrations/create-save-sprout-video.png)
+![Save Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-save-sprout-video.png)

--- a/snippets/sso-integrations/sprout-video/5.md
+++ b/snippets/sso-integrations/sprout-video/5.md
@@ -2,7 +2,7 @@
 
 Before you continue, make sure you have your SSO integration Client ID. You will use the Client ID to replace the `SSO_CLIENT_ID` placeholders.
 
-![Locate Client ID](/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-sprout-video.png)
+![Locate Client ID](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-sprout-video.png)
 
 Provide the following SAML protocol configuration parameters:
 

--- a/snippets/sso-integrations/sprout-video/6.md
+++ b/snippets/sso-integrations/sprout-video/6.md
@@ -23,4 +23,4 @@
     </tbody>
 </table>
 
-![Configure SSO Integration](/media/articles/dashboard/sso-integrations/settings-sprout-video.png)
+![Configure SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-sprout-video.png)

--- a/snippets/sso-integrations/sprout-video/7.md
+++ b/snippets/sso-integrations/sprout-video/7.md
@@ -6,4 +6,4 @@ Choose the connections to use with your SSO integration. Users in enabled connec
 
 2. Toggle the sliders next to connection names to enable or disable them.
 
-![Enable/Disable Connections](/media/articles/dashboard/sso-integrations/settings-connections-sprout-video.png)
+![Enable/Disable Connections](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-connections-sprout-video.png)

--- a/snippets/sso-integrations/tableau-online/3.md
+++ b/snippets/sso-integrations/tableau-online/3.md
@@ -1,16 +1,16 @@
 ### Create Auth0 SSO integration
 
 1. Navigate to [Auth0 Dashboard > SSO Integrations](${manage_url}/#/externalapps), and click **+ Create SSO Integration**.
-![Create SSO Integration](/media/articles/dashboard/sso-integrations/create.png)
+![Create SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create.png)
 
 2. Select **Tableau Online**.
 
-![Select Service](/media/articles/dashboard/sso-integrations/create-select-service.png)
+![Select Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-select-service.png)
 
 3. Click **Continue** to grant the integration access to the listed permissions.
 
-![Authorize Service](/media/articles/dashboard/sso-integrations/create-authorize-tableau-online.png)
+![Authorize Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-authorize-tableau-online.png)
 
 4. Enter a name for your SSO Integration, and click **Save**.
 
-![Save Integration](/media/articles/dashboard/sso-integrations/create-save-tableau-online.png)
+![Save Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-save-tableau-online.png)

--- a/snippets/sso-integrations/tableau-online/5.md
+++ b/snippets/sso-integrations/tableau-online/5.md
@@ -2,7 +2,7 @@
 
 Before you continue, make sure you have your SSO integration Client ID. You will use the Client ID to replace the `SSO_CLIENT_ID` placeholders.
 
-![Locate Client ID](/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-tableau-online.png)
+![Locate Client ID](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-tableau-online.png)
 
 Provide the following SAML protocol configuration parameters:
 

--- a/snippets/sso-integrations/tableau-online/6.md
+++ b/snippets/sso-integrations/tableau-online/6.md
@@ -35,4 +35,4 @@
     </tbody>
 </table>
 
-![Configure SSO Integration](/media/articles/dashboard/sso-integrations/settings-tableau-online.png)
+![Configure SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-tableau-online.png)

--- a/snippets/sso-integrations/tableau-online/7.md
+++ b/snippets/sso-integrations/tableau-online/7.md
@@ -6,4 +6,4 @@ Choose the connections to use with your SSO integration. Users in enabled connec
 
 2. Toggle the sliders next to connection names to enable or disable them.
 
-![Enable/Disable Connections](/media/articles/dashboard/sso-integrations/settings-connections-tableau-online.png)
+![Enable/Disable Connections](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-connections-tableau-online.png)

--- a/snippets/sso-integrations/tableau-server/3.md
+++ b/snippets/sso-integrations/tableau-server/3.md
@@ -1,16 +1,16 @@
 ### Create Auth0 SSO integration
 
 1. Navigate to [Auth0 Dashboard > SSO Integrations](${manage_url}/#/externalapps), and click **+ Create SSO Integration**.
-![Create SSO Integration](/media/articles/dashboard/sso-integrations/create.png)
+![Create SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create.png)
 
 2. Select **Tableau Server**.
 
-![Select Service](/media/articles/dashboard/sso-integrations/create-select-service.png)
+![Select Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-select-service.png)
 
 3. Click **Continue** to grant the integration access to the listed permissions.
 
-![Authorize Service](/media/articles/dashboard/sso-integrations/create-authorize-tableau-server.png)
+![Authorize Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-authorize-tableau-server.png)
 
 4. Enter a name for your SSO Integration, and click **Save**.
 
-![Save Integration](/media/articles/dashboard/sso-integrations/create-save-tableau-server.png)
+![Save Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-save-tableau-server.png)

--- a/snippets/sso-integrations/tableau-server/5.md
+++ b/snippets/sso-integrations/tableau-server/5.md
@@ -2,7 +2,7 @@
 
 Before you continue, make sure you have your SSO integration Client ID. You will use the Client ID to replace the `SSO_CLIENT_ID` placeholders.
 
-![Locate Client ID](/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-tableau-server.png)
+![Locate Client ID](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-tableau-server.png)
 
 Provide the following SAML protocol configuration parameters:
 

--- a/snippets/sso-integrations/tableau-server/6.md
+++ b/snippets/sso-integrations/tableau-server/6.md
@@ -35,4 +35,4 @@
     </tbody>
 </table>
 
-![Configure SSO Integration](/media/articles/dashboard/sso-integrations/settings-tableau-server.png)
+![Configure SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-tableau-server.png)

--- a/snippets/sso-integrations/tableau-server/7.md
+++ b/snippets/sso-integrations/tableau-server/7.md
@@ -6,4 +6,4 @@ Choose the connections to use with your SSO integration. Users in enabled connec
 
 2. Toggle the sliders next to connection names to enable or disable them.
 
-![Enable/Disable Connections](/media/articles/dashboard/sso-integrations/settings-connections-tableau-server.png)
+![Enable/Disable Connections](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-connections-tableau-server.png)

--- a/snippets/sso-integrations/workday/3.md
+++ b/snippets/sso-integrations/workday/3.md
@@ -1,16 +1,16 @@
 ### Create Auth0 SSO integration
 
 1. Navigate to [Auth0 Dashboard > SSO Integrations](${manage_url}/#/externalapps), and click **+ Create SSO Integration**.
-![Create SSO Integration](/media/articles/dashboard/sso-integrations/create.png)
+![Create SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create.png)
 
 2. Select **Workday**.
 
-![Select Service](/media/articles/dashboard/sso-integrations/create-select-service.png)
+![Select Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-select-service.png)
 
 3. Click **Continue** to grant the integration access to the listed permissions.
 
-![Authorize Service](/media/articles/dashboard/sso-integrations/create-authorize-workday.png)
+![Authorize Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-authorize-workday.png)
 
 4. Enter a name for your SSO Integration, and click **Save**.
 
-![Save Integration](/media/articles/dashboard/sso-integrations/create-save-workday.png)
+![Save Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-save-workday.png)

--- a/snippets/sso-integrations/workday/5.md
+++ b/snippets/sso-integrations/workday/5.md
@@ -2,7 +2,7 @@
 
 Before you continue, make sure you have your SSO integration Client ID. You will use the Client ID to replace the `SSO_CLIENT_ID` placeholders.
 
-![Locate Client ID](/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-workday.png)
+![Locate Client ID](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-workday.png)
 
 Provide the following SAML protocol configuration parameters:
 

--- a/snippets/sso-integrations/workday/6.md
+++ b/snippets/sso-integrations/workday/6.md
@@ -23,4 +23,4 @@
     </tbody>
 </table>
 
-![Configure SSO Integration](/media/articles/dashboard/sso-integrations/settings-workday.png)
+![Configure SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-workday.png)

--- a/snippets/sso-integrations/workday/7.md
+++ b/snippets/sso-integrations/workday/7.md
@@ -6,4 +6,4 @@ Choose the connections to use with your SSO integration. Users in enabled connec
 
 2. Toggle the sliders next to connection names to enable or disable them.
 
-![Enable/Disable Connections](/media/articles/dashboard/sso-integrations/settings-connections-workday.png)
+![Enable/Disable Connections](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-connections-workday.png)

--- a/snippets/sso-integrations/workpath/3.md
+++ b/snippets/sso-integrations/workpath/3.md
@@ -1,16 +1,16 @@
 ### Create Auth0 SSO integration
 
 1. Navigate to [Auth0 Dashboard > SSO Integrations](${manage_url}/#/externalapps), and click **+ Create SSO Integration**.
-![Create SSO Integration](/media/articles/dashboard/sso-integrations/create.png)
+![Create SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create.png)
 
 2. Select **Workpath**.
 
-![Select Service](/media/articles/dashboard/sso-integrations/create-select-service.png)
+![Select Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-select-service.png)
 
 3. Click **Continue** to grant the integration access to the listed permissions.
 
-![Authorize Service](/media/articles/dashboard/sso-integrations/create-authorize-workpath.png)
+![Authorize Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-authorize-workpath.png)
 
 4. Enter a name for your SSO Integration, and click **Save**.
 
-![Save Integration](/media/articles/dashboard/sso-integrations/create-save-workpath.png)
+![Save Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-save-workpath.png)

--- a/snippets/sso-integrations/workpath/5.md
+++ b/snippets/sso-integrations/workpath/5.md
@@ -2,7 +2,7 @@
 
 Before you continue, make sure you have your SSO integration Client ID. You will use the Client ID to replace the `SSO_CLIENT_ID` placeholders.
 
-![Locate Client ID](/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-workpath.png)
+![Locate Client ID](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-workpath.png)
 
 Provide the following SAML protocol configuration parameters:
 

--- a/snippets/sso-integrations/workpath/6.md
+++ b/snippets/sso-integrations/workpath/6.md
@@ -27,4 +27,4 @@
     </tbody>
 </table>
 
-![Configure SSO Integration](/media/articles/dashboard/sso-integrations/settings-workpath.png)
+![Configure SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-workpath.png)

--- a/snippets/sso-integrations/workpath/7.md
+++ b/snippets/sso-integrations/workpath/7.md
@@ -6,4 +6,4 @@ Choose the connections to use with your SSO integration. Users in enabled connec
 
 2. Toggle the sliders next to connection names to enable or disable them.
 
-![Enable/Disable Connections](/media/articles/dashboard/sso-integrations/settings-connections-workpath.png)
+![Enable/Disable Connections](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-connections-workpath.png)

--- a/snippets/sso-integrations/zendesk/3.md
+++ b/snippets/sso-integrations/zendesk/3.md
@@ -1,16 +1,16 @@
 ### Create Auth0 SSO integration
 
 1. Navigate to [Auth0 Dashboard > SSO Integrations](${manage_url}/#/externalapps), and click **+ Create SSO Integration**.
-![Create SSO Integration](/media/articles/dashboard/sso-integrations/create.png)
+![Create SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create.png)
 
 2. Select **Zendesk**.
 
-![Select Service](/media/articles/dashboard/sso-integrations/create-select-service.png)
+![Select Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-select-service.png)
 
 3. Click **Continue** to grant the integration access to the listed permissions.
 
-![Authorize Service](/media/articles/dashboard/sso-integrations/create-authorize-zendesk.png)
+![Authorize Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-authorize-zendesk.png)
 
 4. Enter a name for your SSO Integration, and click **Save**.
 
-![Save Integration](/media/articles/dashboard/sso-integrations/create-save-zendesk.png)
+![Save Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-save-zendesk.png)

--- a/snippets/sso-integrations/zendesk/5.md
+++ b/snippets/sso-integrations/zendesk/5.md
@@ -6,7 +6,7 @@ This integration uses SAML, which works with only [certain versions of Zendesk](
 
 Before you continue, make sure you have your SSO integration Client ID. You will use the Client ID to replace the `SSO_CLIENT_ID` placeholders.
 
-![Locate Client ID](/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-zendesk.png)
+![Locate Client ID](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-zendesk.png)
 
 1. Log in to Zendesk as an administrator.
 

--- a/snippets/sso-integrations/zendesk/6.md
+++ b/snippets/sso-integrations/zendesk/6.md
@@ -23,4 +23,4 @@
     </tbody>
 </table>
 
-![Configure SSO Integration](/media/articles/dashboard/sso-integrations/settings-zendesk.png)
+![Configure SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-zendesk.png)

--- a/snippets/sso-integrations/zendesk/7.md
+++ b/snippets/sso-integrations/zendesk/7.md
@@ -6,4 +6,4 @@ Choose the connections to use with your SSO integration. Users in enabled connec
 
 2. Toggle the sliders next to connection names to enable or disable them.
 
-![Enable/Disable Connections](/media/articles/dashboard/sso-integrations/settings-connections-zendesk.png)
+![Enable/Disable Connections](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-connections-zendesk.png)

--- a/snippets/sso-integrations/zoom/3.md
+++ b/snippets/sso-integrations/zoom/3.md
@@ -1,16 +1,16 @@
 ### Create Auth0 SSO integration
 
 1. Navigate to [Auth0 Dashboard > SSO Integrations](${manage_url}/#/externalapps), and click **+ Create SSO Integration**.
-![Create SSO Integration](/media/articles/dashboard/sso-integrations/create.png)
+![Create SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create.png)
 
 2. Select **Zoom**.
 
-![Select Service](/media/articles/dashboard/sso-integrations/create-select-service.png)
+![Select Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-select-service.png)
 
 3. Click **Continue** to grant the integration access to the listed permissions.
 
-![Authorize Service](/media/articles/dashboard/sso-integrations/create-authorize-zoom.png)
+![Authorize Service](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-authorize-zoom.png)
 
 4. Enter a name for your SSO Integration, and click **Save**.
 
-![Save Integration](/media/articles/dashboard/sso-integrations/create-save-zoom.png)
+![Save Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/create-save-zoom.png)

--- a/snippets/sso-integrations/zoom/5.md
+++ b/snippets/sso-integrations/zoom/5.md
@@ -6,7 +6,7 @@ SAML SSO is available on only [the business edition of Zoom](http://zoom.us/pric
 
 Before you continue, make sure you have your SSO integration Client ID. You will use the Client ID to replace the `SSO_CLIENT_ID` placeholders.
 
-![Locate Client ID](/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-zoom.png)
+![Locate Client ID](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-tutorial-clientid-zoom.png)
 
 1. [Log in to Zoom](https://zoom.us/) as an administrator.
 

--- a/snippets/sso-integrations/zoom/6.md
+++ b/snippets/sso-integrations/zoom/6.md
@@ -23,4 +23,4 @@
     </tbody>
 </table>
 
-![Configure SSO Integration](/media/articles/dashboard/sso-integrations/settings-zoom.png)
+![Configure SSO Integration](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-zoom.png)

--- a/snippets/sso-integrations/zoom/7.md
+++ b/snippets/sso-integrations/zoom/7.md
@@ -6,4 +6,4 @@ Choose the connections to use with your SSO integration. Users in enabled connec
 
 2. Toggle the sliders next to connection names to enable or disable them.
 
-![Enable/Disable Connections](/media/articles/dashboard/sso-integrations/settings-connections-zoom.png)
+![Enable/Disable Connections](https://auth0.com/docs/media/articles/dashboard/sso-integrations/settings-connections-zoom.png)


### PR DESCRIPTION
- use absolute paths on images for SSO integration snippets to prevent broken images when snippets are consumed in Manhattan 