### PR TITLE
Professional Services Sidebar and Redirects

### DIFF
--- a/config/redirects.js
+++ b/config/redirects.js
@@ -54,7 +54,7 @@ module.exports = [
   },
   {
     from: ['/deploy/checklist'],
-    to: '/deploy/deploy-checklist'
+    to: '/deploy/deploy-checklists'
   },
 
   /* QUICKSTARTS */

--- a/config/redirects.js
+++ b/config/redirects.js
@@ -54,7 +54,7 @@ module.exports = [
   },
   {
     from: ['/deploy/checklist'],
-    to: '/deploy/deploy-checklists'
+    to: '/deploy/deploy-checklist'
   },
 
   /* QUICKSTARTS */

--- a/config/redirects.js
+++ b/config/redirects.js
@@ -2855,24 +2855,16 @@ module.exports = [
     to: '/professional-services'
   },
   {
-    from: ['/services/architectural-design'],
-    to: '/professional-services/architectural-design-services'
+    from: ['/services/architectural-design','/professional-services/architectural-design-services','/professional-services/solution-design-services','/services/solution-design'],
+    to: '/professional-services/discover-design'
   },
   {
-    from: ['/services/custom-implementation','/services/implement'],
-    to: '/professional-services/custom-implementation-services'
+    from: ['/professional-services/custom-implementation-services','/services/custom-implementation','/services/implement'],
+    to: '/professional-services/implement'
   },
   {
-    from: ['/services/performance-scalability'],
-    to: '/professional-services/performance-and-scalability-services'
-  },
-  {
-    from: ['/services/solution-design'],
-    to: '/professional-services/solution-design-services'
-  },
-  {
-    from: ['/services/scenario-guidance','/services/code-review','/services/pair-programming'],
-    to: '/professional-services/advisory-sessions'
+    from: ['/services/performance-scalability','/professional-services/performance-and-scalability-services','/professional-services/advisory-sessions','/services/scenario-guidance','/services/code-review','/services/pair-programming'],
+    to: '/professional-services/maintain-improve'
   },
   {
     from: ['/services/packages'],

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -1173,8 +1173,8 @@ articles:
   - title: Professional Services
     url: /professional-services
     children:
-      - title: Design and Discover
-        url: /professional-services/design-discover
+      - title: Discover and Design
+        url: /professional-services/discover-design
       - title: Implement
         url: /professional-services/implement
       - title: Maintain and Improve

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -1173,17 +1173,13 @@ articles:
   - title: Professional Services
     url: /professional-services
     children:
-      - title: Architectural Design
-        url: /professional-services/architectural-design-services
-      - title: Solution Design
-        url: /professional-services/solution-design-services
-      - title: Custom Implementation
-        url: /professional-services/custom-implementation-services
-      - title: Performance and Scalability
-        url: /professional-services/performance-and-scalability-services
-      - title: Advisory Sessions
-        url: /professional-services/advisory-sessions
-      - title: Services Packages
+      - title: Design and Discover
+        url: /professional-services/design-discover
+      - title: Implement
+        url: /professional-services/implement
+      - title: Maintain and Improve
+        url: /professional-services/maintain-improve
+      - title: Packages
         url: /professional-services/packages
   - title: Auth0 Community
     external: true


### PR DESCRIPTION
Professional Services docs sidebar update and redirects

Review: https://auth0content-pr-9417.herokuapp.com/docs/professional-services

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
