### PR TITLE
Added sidebar link to orphan

### DIFF
--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -168,6 +168,8 @@ articles:
             url: /flows/add-login-using-the-implicit-flow-with-form-post
           - title: Native App
             url: /flows/add-login-using-the-authorization-code-flow-with-pkce
+      - title: Authenticate Single-Page Apps with Cookies
+        url: /sessions-and-cookies/spa-authenticate-with-cookies
       - title: Multi-factor Authentication
         url: /mfa
         children:


### PR DESCRIPTION
Added sidebar link to "Authenticate SPAs with Cookies" under "Login"

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
