### PR TITLE
[SDK-1965] Update ASPNET Core Web API Quickstart

### DIFF
--- a/articles/quickstart/backend/_includes/_api_create_new.md
+++ b/articles/quickstart/backend/_includes/_api_create_new.md
@@ -12,5 +12,5 @@ In the [APIs](${manage_url}/#/apis) section of the Auth0 dashboard, click **Crea
 <%= include('./_api_jwks_description') %>
 <% }  %>
 
-### Define Permissions
+### Define permissions
 <%= include('./_api_scopes_access_resources') %>

--- a/articles/quickstart/backend/_includes/_api_troubleshooting.md
+++ b/articles/quickstart/backend/_includes/_api_troubleshooting.md
@@ -4,7 +4,7 @@ If you configured JWT validation correctly, you will be able to get proper respo
 
 This document will help you troubleshoot your JWT middleware configuration.
 
-## How does a token get validated?
+## How Does a Token Get Validated?
 
 In terms of validating a JWT, there are various things to consider:
 
@@ -22,7 +22,7 @@ In terms of validating a JWT, there are various things to consider:
 
 5. **Is the token intended for the current application?** So does the `aud` claim of the JWT match with what your application is expecting?
 
-## Inspecting a token
+## Inspecting a Token
 
 A quick way to inspect a JWT is by using the [JWT.io](https://jwt.io/) website. It has a handy debugger which allows you to quickly check that a JWT is well-formed, and also inspect the values of the various claims.
 

--- a/articles/quickstart/backend/_includes/_api_using.md
+++ b/articles/quickstart/backend/_includes/_api_using.md
@@ -1,4 +1,4 @@
-## Calling the API from your application
+## Calling the API From Your Application
 
 You can call the API from your application by passing an Access Token in the `Authorization` header of your HTTP request as a Bearer token.
 

--- a/articles/quickstart/backend/_includes/_api_using.md
+++ b/articles/quickstart/backend/_includes/_api_using.md
@@ -5,7 +5,7 @@ You can call the API from your application by passing an Access Token in the `Au
 ```har
 {
   "method": "GET",
-  "url": "http://localhost:3010/api/private",
+  "url": "http://localhost:5000/api/private",
   "headers": [
     { "name": "Authorization", "value": "Bearer YOUR_ACCESS_TOKEN" }
   ]
@@ -67,7 +67,7 @@ You can make a request to the `/api/private` endpoint without passing any Access
 ```har
 {
   "method": "GET",
-  "url": "http://localhost:3010/api/private"
+  "url": "http://localhost:5000/api/private"
 }
 ```
 
@@ -80,7 +80,7 @@ Once again, make the same request but this time pass along the Access Token as a
 ```har
 {
   "method": "GET",
-  "url": "http://localhost:3010/api/private",
+  "url": "http://localhost:5000/api/private",
   "headers": [
     { "name": "Authorization", "value": "Bearer YOUR_ACCESS_TOKEN" }
   ]
@@ -98,7 +98,7 @@ To test the endpoint that requires a scope, pass the Access Token containing the
 ```har
 {
   "method": "GET",
-  "url": "http://localhost:3010/api/private-scoped",
+  "url": "http://localhost:5000/api/private-scoped",
   "headers": [
     { "name": "Authorization", "value": "Bearer YOUR_ACCESS_TOKEN" }
   ]

--- a/articles/quickstart/backend/aspnet-core-webapi/01-authorization.md
+++ b/articles/quickstart/backend/aspnet-core-webapi/01-authorization.md
@@ -34,7 +34,7 @@ The sample code has an `appsettings.json` file which configures it to use the co
 ```
 ## Validate Access Tokens
 
-### Install Dependencies
+### Install dependencies
 
 The seed project already contains a reference to the `Microsoft.AspNetCore.Authentication.JwtBearer`, which is needed in order to validate Access Tokens.
 However, if you are not using the seed project, add the package to your application by installing it using Nuget:
@@ -43,7 +43,7 @@ However, if you are not using the seed project, add the package to your applicat
 Install-Package Microsoft.AspNetCore.Authentication.JwtBearer
 ```
 
-### Configure the Middleware
+### Configure the middleware
 
 The ASP.NET Core JWT Bearer authentication handler downloads the JSON Web Key Set (JWKS) file with the public key. The handler uses the JWKS file and the public key to verify the Access Token's signature.
 
@@ -96,7 +96,7 @@ public void Configure(IApplicationBuilder app, IHostingEnvironment env)
 }
 ```
 
-### Validate Scopes
+### Validate scopes
 
 To make sure that an Access Token contains the correct scope, use the [Policy-Based Authorization](https://docs.microsoft.com/en-us/aspnet/core/security/authorization/policies) in ASP.NET Core.
 

--- a/articles/quickstart/backend/aspnet-core-webapi/01-authorization.md
+++ b/articles/quickstart/backend/aspnet-core-webapi/01-authorization.md
@@ -20,7 +20,7 @@ useCase: quickstart
 
 <%= include('../_includes/_api_auth_preamble') %>
 
-## Configure the Sample project
+## Configure the Sample Project
 
 The sample code has an `appsettings.json` file which configures it to use the correct Auth0 **Domain** and **API Identifier** for your API. If you download the code from this page while logged in, it will be automatically filled. If you use the example from Github, you will need to fill it yourself.
 
@@ -34,7 +34,7 @@ The sample code has an `appsettings.json` file which configures it to use the co
 ```
 ## Validate Access Tokens
 
-### Install dependencies
+### Install Dependencies
 
 The seed project already contains a reference to the `Microsoft.AspNetCore.Authentication.JwtBearer`, which is needed in order to validate Access Tokens.
 However, if you are not using the seed project, add the package to your application by installing it using Nuget:
@@ -43,7 +43,7 @@ However, if you are not using the seed project, add the package to your applicat
 Install-Package Microsoft.AspNetCore.Authentication.JwtBearer
 ```
 
-### Configure the middleware
+### Configure the Middleware
 
 The ASP.NET Core JWT Bearer authentication handler downloads the JSON Web Key Set (JWKS) file with the public key. The handler uses the JWKS file and the public key to verify the Access Token's signature.
 
@@ -75,7 +75,7 @@ public void ConfigureServices(IServiceCollection services)
 }
 ```
 
-To add the authentication middleware to the middleware pipeline, add a call to the `UseAuthentication` method in your Startup's Configure method:
+To add the authentication and authorization middleware to the middleware pipeline, add a call to the `UseAuthentication` and `UseAuthorization` methods in your Startup's Configure method:
 
 ```csharp
 // Startup.cs
@@ -85,6 +85,7 @@ public void Configure(IApplicationBuilder app, IHostingEnvironment env)
     // Some code omitted for brevity...
 
     app.UseAuthentication();
+    app.UseAuthorization();
 
     app.UseMvc(routes =>
     {
@@ -95,7 +96,7 @@ public void Configure(IApplicationBuilder app, IHostingEnvironment env)
 }
 ```
 
-### Validate scopes
+### Validate Scopes
 
 To make sure that an Access Token contains the correct scope, use the [Policy-Based Authorization](https://docs.microsoft.com/en-us/aspnet/core/security/authorization/policies) in ASP.NET Core.
 
@@ -183,7 +184,7 @@ public class ApiController : ControllerBase
 }
 ```
 
-To secure endpoints that require specific scopes, we need to make sure that the correct scope is present in the `access_token`. To do that, add an action named `Scoped`, apply the `Authorize` attribute and pass `read:messages` as the `policy` parameter. 
+To secure endpoints that require specific scopes, we need to make sure that the correct scope is present in the `access_token`. To do that, add the `Authorize` attribute to the `Scoped` action and pass `read:messages` as the `policy` parameter. 
 
 ```csharp
 // Controllers/ApiController.cs

--- a/articles/quickstart/backend/aspnet-core-webapi/01-authorization.md
+++ b/articles/quickstart/backend/aspnet-core-webapi/01-authorization.md
@@ -28,7 +28,7 @@ The sample code has an `appsettings.json` file which configures it to use the co
 {
   "Auth0": {
     "Domain": "${account.namespace}",
-    "ApiIdentifier": "${apiIdentifier}"
+    "Audience": "${apiIdentifier}"
   }
 }
 ```
@@ -36,9 +36,8 @@ The sample code has an `appsettings.json` file which configures it to use the co
 
 ### Install dependencies
 
-The seed project references the new ASP.NET Core metapackage (`Microsoft.AspNetCore.All`), which includes all the NuGet packages that are a part of the ASP.NET Core 2.0 framework.
-
-If you are not using the `Microsoft.AspNetCore.All` metapackage, add the `Microsoft.AspNetCore.Authentication.JwtBearer` package to your application.
+The seed project already contains a reference to the `Microsoft.AspNetCore.Authentication.JwtBearer`, which is needed in order to validate Access Tokens.
+However, if you are not using the seed project, add the package to your application by installing it using Nuget:
 
 ```text
 Install-Package Microsoft.AspNetCore.Authentication.JwtBearer
@@ -50,7 +49,7 @@ The ASP.NET Core JWT Bearer authentication handler downloads the JSON Web Key Se
 
 In your application, register the authentication services:
 
-1. Make a call to the `AddAuthentication` method. Configure the JWT Bearer tokens as the default authentication and challenge schemes.  
+1. Make a call to the `AddAuthentication` method. Configure JwtBearerDefaults.AuthenticationScheme as the default schemes.  
 2. Make a call to the `AddJwtBearer` method to register the JWT Bearer authentication scheme. Configure your Auth0 domain as the authority, and your Auth0 API identifier as the audience. In some cases the access token will not have a `sub` claim which will lead to `User.Identity.Name` being `null`. If you want to map a different claim to `User.Identity.Name` then add it to `options.TokenValidationParameters` within the `AddAuthentication()` call.
 
 ```csharp
@@ -61,23 +60,22 @@ public void ConfigureServices(IServiceCollection services)
     // Some code omitted for brevity...
 
     string domain = $"https://{Configuration["Auth0:Domain"]}/";
-    services.AddAuthentication(options =>
-    {
-        options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
-        options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
-    }).AddJwtBearer(options =>
-    {
-        options.Authority = domain;
-        options.Audience = Configuration["Auth0:ApiIdentifier"];
-        options.TokenValidationParameters = new TokenValidationParameters
+    services
+        .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+        .AddJwtBearer(options =>
         {
-          NameClaimType = ClaimTypes.NameIdentifier
-        };
-    });
+            options.Authority = domain;
+            options.Audience = Configuration["Auth0:Audience"];
+            // If the access token does not have a `sub` claim, `User.Identity.Name` will be `null`. Map it to a different claim by setting the NameClaimType below.
+            options.TokenValidationParameters = new TokenValidationParameters
+            {
+                NameClaimType = ClaimTypes.NameIdentifier
+            };
+        });
 }
 ```
 
-To add the authentication middleware to the middleware pipeline, add a call to the `UseAuthentication` method:
+To add the authentication middleware to the middleware pipeline, add a call to the `UseAuthentication` method in your Startup's Configure method:
 
 ```csharp
 // Startup.cs
@@ -142,35 +140,21 @@ public class HasScopeHandler : AuthorizationHandler<HasScopeRequirement>
 }
 ```
 
-In your `ConfigureServices` method, add a call to the `AddAuthorization` method. To add policies for the scopes, call `AddPolicy` for each scope. Also ensure that you register the `HasScopeHandler` as a singleton:
+In your Startup's `ConfigureServices` method, add a call to the `AddAuthorization` method. To add policies for the scopes, call `AddPolicy` for each scope. Also ensure that you register the `HasScopeHandler` as a singleton:
 
 ```csharp
 // Startup.cs
 
 public void ConfigureServices(IServiceCollection services)
 {
-    string domain = $"https://{Configuration["Auth0:Domain"]}/";
-    services.AddAuthentication(options =>
-    {
-        options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
-        options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+    //...
 
-    }).AddJwtBearer(options =>
-    {
-        options.Authority = domain;
-        options.Audience = Configuration["Auth0:ApiIdentifier"];
-    });
-    
     services.AddAuthorization(options =>
     {
         options.AddPolicy("read:messages", policy => policy.Requirements.Add(new HasScopeRequirement("read:messages", domain)));
     });
 
-    // register the scope authorization handler
-    services.AddSingleton<IAuthorizationHandler, HasScopeHandler>();
-    
-    // Add framework services.
-    services.AddMvc();
+    //...
 }
 ```
 
@@ -184,14 +168,14 @@ To secure an endpoint, you need to add the `[Authorize]` attribute to your contr
 // Controllers/ApiController.cs
 
 [Route("api")]
-public class ApiController : Controller
+[ApiController]
+public class ApiController : ControllerBase
 {
-    [HttpGet]
-    [Route("private")]
+    [HttpGet("private")]
     [Authorize]
     public IActionResult Private()
     {
-        return Json(new
+        return Ok(new
         {
             Message = "Hello from a private endpoint! You need to be authenticated to see this."
         });
@@ -199,7 +183,7 @@ public class ApiController : Controller
 }
 ```
 
-To secure endpoints that require specific scopes, we need to make sure that the correct scope is present in the `access_token`. To do that, add the `Authorize` attribute to the `Scoped` action, passing `read:messages` as the `policy` parameter. 
+To secure endpoints that require specific scopes, we need to make sure that the correct scope is present in the `access_token`. To do that, add an action named `Scoped`, apply the `Authorize` attribute and pass `read:messages` as the `policy` parameter. 
 
 ```csharp
 // Controllers/ApiController.cs
@@ -207,12 +191,11 @@ To secure endpoints that require specific scopes, we need to make sure that the 
 [Route("api")]
 public class ApiController : Controller
 {
-    [HttpGet]
-    [Route("private-scoped")]
+    [HttpGet("private-scoped")]
     [Authorize("read:messages")]
     public IActionResult Scoped()
     {
-        return Json(new
+        return Ok(new
         {
             Message = "Hello from a private endpoint! You need to be authenticated and have a scope of read:messages to see this."
         });

--- a/articles/quickstart/backend/aspnet-core-webapi/01-authorization.md
+++ b/articles/quickstart/backend/aspnet-core-webapi/01-authorization.md
@@ -49,7 +49,7 @@ The ASP.NET Core JWT Bearer authentication handler downloads the JSON Web Key Se
 
 In your application, register the authentication services:
 
-1. Make a call to the `AddAuthentication` method. Configure JwtBearerDefaults.AuthenticationScheme as the default schemes.  
+1. Make a call to the `AddAuthentication` method. Configure `JwtBearerDefaults.AuthenticationScheme` as the default schemes.  
 2. Make a call to the `AddJwtBearer` method to register the JWT Bearer authentication scheme. Configure your Auth0 domain as the authority, and your Auth0 API identifier as the audience. In some cases the access token will not have a `sub` claim which will lead to `User.Identity.Name` being `null`. If you want to map a different claim to `User.Identity.Name` then add it to `options.TokenValidationParameters` within the `AddAuthentication()` call.
 
 ```csharp
@@ -75,7 +75,7 @@ public void ConfigureServices(IServiceCollection services)
 }
 ```
 
-To add the authentication and authorization middleware to the middleware pipeline, add a call to the `UseAuthentication` and `UseAuthorization` methods in your Startup's Configure method:
+To add the authentication and authorization middleware to the middleware pipeline, add a call to the `UseAuthentication` and `UseAuthorization` methods in your Startup's `Configure` method:
 
 ```csharp
 // Startup.cs

--- a/articles/quickstart/backend/aspnet-core-webapi/03-troubleshooting.md
+++ b/articles/quickstart/backend/aspnet-core-webapi/03-troubleshooting.md
@@ -107,7 +107,7 @@ Authorization failed for the request at filter 'Microsoft.AspNetCore.Mvc.Authori
 
 To resolve this issue, make sure you are passing the JWT as the Bearer token in the `Authorization` header of the HTTP request.
 
-## 2. Did you Configure the JWT Middleware for the Correct Signing Algorithm?
+### 2. Did you configure the JWT middleware for the correct signing algorithm?
 
 Make sure that the [signing algorithm](/tokens/concepts/signing-algorithms) you used to sign your token matches the signing algorithm configured in your middleware. 
 
@@ -139,7 +139,7 @@ Bearer was not authenticated. Failure message: IDX10501: Signature validation fa
 
 To resolve this issue, make sure that the algorithm for the JWT matches with the configuration of your middleware. 
 
-## 3. Has Your Token Expired?
+### 3. Has your token expired?
 
 Each JSON Web Token is valid until the time defined in the `exp` claim runs out. If you send an expired token, the token will be rejected:
 
@@ -157,7 +157,7 @@ To resolve this issue, check if the token you are sending has not expired.
 The value of the `exp` claim is a numeric value representing the number of seconds from 1970-01-01T00:00:00Z UTC until the specified UTC date/time. If you want to see the date/time for the value, visit [EpochConverter](http://www.epochconverter.com/).
 :::
 
-## 4. Did You Configure the Correct Issuer?
+### 4. Did you configure the correct issuer?
 
 The Issuer specified in your token must match exactly with your JWT middleware configuration. 
 
@@ -183,7 +183,7 @@ For RS256 tokens, the JWT middleware downloads the OIDC discovery document from 
 If you are using RS256 tokens, the system checks their signature before it checks the Issuer.
 :::
 
-## 5. Does the Audience Match Your JWT Middleware Configuration?
+### 5. Does the audience match your JWT middleware configuration?
 
 Check if the audience specified in your token matches your JWT middleware configuration.
 

--- a/articles/quickstart/backend/aspnet-core-webapi/03-troubleshooting.md
+++ b/articles/quickstart/backend/aspnet-core-webapi/03-troubleshooting.md
@@ -91,7 +91,7 @@ To debug potential configuration issues, inspect the log files for your applicat
 
 In this example, we run the application from the command line and inspect the console log output.
 
-### 1. Are you Passing the JWT in the Authorization Header?
+### 1. Are you passing the JWT in the Authorization header?
 
 Check if you are passing the JWT as a Bearer token in the `Authorization` header of the HTTP request.
 

--- a/articles/quickstart/backend/aspnet-core-webapi/03-troubleshooting.md
+++ b/articles/quickstart/backend/aspnet-core-webapi/03-troubleshooting.md
@@ -91,7 +91,7 @@ To debug potential configuration issues, inspect the log files for your applicat
 
 In this example, we run the application from the command line and inspect the console log output.
 
-### 1. Are you passing the JWT in the Authorization header?
+### 1. Are you Passing the JWT in the Authorization Header?
 
 Check if you are passing the JWT as a Bearer token in the `Authorization` header of the HTTP request.
 
@@ -107,7 +107,7 @@ Authorization failed for the request at filter 'Microsoft.AspNetCore.Mvc.Authori
 
 To resolve this issue, make sure you are passing the JWT as the Bearer token in the `Authorization` header of the HTTP request.
 
-## 2. Did you configure the JWT middleware for the correct signing algorithm?
+## 2. Did you Configure the JWT Middleware for the Correct Signing Algorithm?
 
 Make sure that the [signing algorithm](/tokens/concepts/signing-algorithms) you used to sign your token matches the signing algorithm configured in your middleware. 
 
@@ -139,7 +139,7 @@ Bearer was not authenticated. Failure message: IDX10501: Signature validation fa
 
 To resolve this issue, make sure that the algorithm for the JWT matches with the configuration of your middleware. 
 
-## 3. Has your token expired?
+## 3. Has Your Token Expired?
 
 Each JSON Web Token is valid until the time defined in the `exp` claim runs out. If you send an expired token, the token will be rejected:
 
@@ -157,7 +157,7 @@ To resolve this issue, check if the token you are sending has not expired.
 The value of the `exp` claim is a numeric value representing the number of seconds from 1970-01-01T00:00:00Z UTC until the specified UTC date/time. If you want to see the date/time for the value, visit [EpochConverter](http://www.epochconverter.com/).
 :::
 
-## 4. Did you configure the correct Issuer?
+## 4. Did You Configure the Correct Issuer?
 
 The Issuer specified in your token must match exactly with your JWT middleware configuration. 
 
@@ -183,7 +183,7 @@ For RS256 tokens, the JWT middleware downloads the OIDC discovery document from 
 If you are using RS256 tokens, the system checks their signature before it checks the Issuer.
 :::
 
-## 5. Does the audience match your JWT middleware configuration?
+## 5. Does the Audience Match Your JWT Middleware Configuration?
 
 Check if the audience specified in your token matches your JWT middleware configuration.
 

--- a/articles/quickstart/backend/aspnet-core-webapi/index.yml
+++ b/articles/quickstart/backend/aspnet-core-webapi/index.yml
@@ -1,8 +1,8 @@
-title: ASP.NET Core Web API v2.0
+title: ASP.NET Core Web API v3.1
 alias:
   - asp.net core webapi
   - aspnet core webapi
-  - asp.net core webapi 2.0
+  - asp.net core webapi 3.1
 language:
   - C#
 framework:
@@ -29,9 +29,9 @@ github:
   repo: auth0-aspnetcore-webapi-samples
   branch: master
 requirements:
-  - .NET Core SDK 2.1.300
-  - .NET Core 2.1.0
-  - ASP.NET Core 2.1.0
+  - .NET Core SDK 3.1.101
+  - .NET Core 3.1.1
+  - ASP.NET Core 3.1.1
   - Visual Studio 2017 15.7 or Visual Studio Code (Optional)
 next_steps:
   - path: 01-authorization

--- a/snippets/api-auth/hs256/csharp.md
+++ b/snippets/api-auth/hs256/csharp.md
@@ -6,24 +6,20 @@ title: C#
 public class Startup
 {
   public void ConfigureServices(IServiceCollection services)
-  {
-    services.AddMvc();
-    
+  { 
     // 1. Add Authentication Services
-    services.AddAuthentication(options =>
-    {
-        options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
-        options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
-
-    }).AddJwtBearer(options =>
-    {
-      options.TokenValidationParameters = new TokenValidationParameters
+    services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+      .AddJwtBearer(options =>
       {
-          ValidIssuer = "https://${'<%= tenantDomain %>'}/",
-          ValidAudience = "${'<%= api.identifier %>'}",
-          IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes("${'<%= api.signing_secret %>'}"))
-      };
-    });
+        options.TokenValidationParameters = new TokenValidationParameters
+        {
+            ValidIssuer = "https://${'<%= tenantDomain %>'}/",
+            ValidAudience = "${'<%= api.identifier %>'}",
+            IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes("${'<%= api.signing_secret %>'}"))
+        };
+      });
+
+    services.AddControllers();
   }
 
   public void Configure(IApplicationBuilder app, IHostingEnvironment env)
@@ -39,14 +35,15 @@ public class Startup
 
     app.UseStaticFiles();
 
-    // 2. Enable authentication middleware
-    app.UseAuthentication();
+    app.UseRouting();
 
-    app.UseMvc(routes =>
+    // 2. Enable authentication and authorization middleware
+    app.UseAuthentication();
+    app.UseAuthorization();
+
+    app.UseEndpoints(endpoints =>
     {
-        routes.MapRoute(
-            name: "default",
-            template: "{controller=Home}/{action=Index}/{id?}");
+        endpoints.MapControllers();
     });
   }
 }


### PR DESCRIPTION
- Update the Quickstart to be in sync with the sample that has been updated to .NET Core 3.1
- Update the mentioned port, as none of the applications uses port 3010.
- Added a few minor updated and rewordings