### PR TITLE
Updates to Angular quickstart from consumer feedback

### DIFF
--- a/articles/quickstart/spa/angular/01-login.md
+++ b/articles/quickstart/spa/angular/01-login.md
@@ -87,7 +87,7 @@ export class AuthButtonComponent {
 :::panel Checkpoint
 Add the `AuthButtonComponent` component to your application. When you click it, verify that your Angular application redirects you to the [Auth0 Universal Login](https://auth0.com/universal-login) page and that you can now log in or sign up using a username and password or a social provider.
 
-Once that's complete, verify that Auth0 redirects you to your application using the value of the `redirectUri` that you used to configure `AuthModule`.
+Once that's complete, verify that Auth0 redirects back to your application's homepage.
 :::
 
 ![Auth0 Universal Login](https://cdn.auth0.com/blog/universal-login/lightweight-login.png)

--- a/articles/quickstart/spa/angular/index.yml
+++ b/articles/quickstart/spa/angular/index.yml
@@ -6,6 +6,7 @@ author:
   community: false
 alias:
   - angular
+logo_name: angular2
 language:
   - Javascript
 framework:


### PR DESCRIPTION
- Removed reference to unused `redirectUri` param in checkpoint
- Angular icon should now reflect Angular 10 and not AngularJS
