### PR TITLE
Update add-siwa-to-native-app.md

### DIFF
--- a/articles/connections/nativesocial/add-siwa-to-native-app.md
+++ b/articles/connections/nativesocial/add-siwa-to-native-app.md
@@ -26,7 +26,10 @@ For a native app, the Sign in with Apple login flow works as follows:
 
 ![Sign In with Apple Authentication Flow](/media/articles/connections/social/apple/apple-siwa-authn-flow.png)
 
-* **Steps 1 & 2**: User authenticates via Apple's SDK on their iOS device, and receive an authorization code in the response. The user does not have to leave the app and use a browser to log in.
+* **Steps 1 & 2**: User authenticates via Apple's SDK on their iOS device, and receive an authorization code in the response. The user does not have to leave the app and use a browser to log in. 
+  ``` warning
+  Avoid using a nonce. It will cause the request to Apple to fail in step 4 and Auth0 will return a 400 error to the user: "Error from Apple connection."
+  ```
 * **Step 3**: The application calls Auth0's `/oauth/token` endpoint to exchange the Apple authorization code for Auth0 tokens.
 * **Step 4 & 5**: The Auth0 platform exchanges the Authorization code with Apple for tokens.  Auth0 validates the tokens, and uses the claims in the tokens to construct the identity of the user.
 * **Step 6**: Auth0 saves the user profile, executes rules and authorization, then issues Auth0 access tokens (refresh tokens and ID tokens) as requested. These tokens are used to protect your APIs and users managed by Auth0.

--- a/articles/connections/nativesocial/add-siwa-to-native-app.md
+++ b/articles/connections/nativesocial/add-siwa-to-native-app.md
@@ -27,9 +27,9 @@ For a native app, the Sign in with Apple login flow works as follows:
 ![Sign In with Apple Authentication Flow](/media/articles/connections/social/apple/apple-siwa-authn-flow.png)
 
 * **Steps 1 & 2**: User authenticates via Apple's SDK on their iOS device, and receive an authorization code in the response. The user does not have to leave the app and use a browser to log in. 
-  ``` warning
+  ::: warning
   Avoid using a nonce. It will cause the request to Apple to fail in step 4 and Auth0 will return a 400 error to the user: "Error from Apple connection."
-  ```
+  :::
 * **Step 3**: The application calls Auth0's `/oauth/token` endpoint to exchange the Apple authorization code for Auth0 tokens.
 * **Step 4 & 5**: The Auth0 platform exchanges the Authorization code with Apple for tokens.  Auth0 validates the tokens, and uses the claims in the tokens to construct the identity of the user.
 * **Step 6**: Auth0 saves the user profile, executes rules and authorization, then issues Auth0 access tokens (refresh tokens and ID tokens) as requested. These tokens are used to protect your APIs and users managed by Auth0.


### PR DESCRIPTION
Added note about not sending a nonce for Apple authentication with native apps.

Review: https://auth0content-pr-9459.herokuapp.com/docs/connections/nativesocial/apple

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
