### PR TITLE
[SDK-1971] Add quickstart for ASPNET Core 2.1 Web API

### DIFF
--- a/articles/quickstart/backend/aspnet-core-webapi-2/01-authorization.md
+++ b/articles/quickstart/backend/aspnet-core-webapi-2/01-authorization.md
@@ -16,7 +16,7 @@ useCase: quickstart
 
 <%= include('../../../_includes/_api_auth_intro') %>
 
-<%= include('../_includes/_api_create_new', { sampleLink: 'https://github.com/auth0-samples/auth0-aspnetcore-webapi-samples/tree/master/Samples/hs256' }) %>
+<%= include('../_includes/_api_create_new', { sampleLink: 'https://github.com/auth0-samples/auth0-aspnetcore-webapi-samples/tree/netcore2.1/Samples/hs256' }) %>
 
 <%= include('../_includes/_api_auth_preamble') %>
 

--- a/articles/quickstart/backend/aspnet-core-webapi-2/01-authorization.md
+++ b/articles/quickstart/backend/aspnet-core-webapi-2/01-authorization.md
@@ -1,0 +1,208 @@
+---
+title: Authorization
+name: This tutorial demonstrates how to add authorization to your ASP.NET Core Web API using the standard JWT middleware.
+description: This tutorial demonstrates how to add authorization to an ASP.NET Core Web API using the standard JWT middleware.
+budicon: 500
+topics:
+    - quickstart
+    - backend
+    - aspnetcore
+    - web-api
+github:
+    path: Quickstart/01-Authorization
+contentType: tutorial
+useCase: quickstart
+---
+
+<%= include('../../../_includes/_api_auth_intro') %>
+
+<%= include('../_includes/_api_create_new', { sampleLink: 'https://github.com/auth0-samples/auth0-aspnetcore-webapi-samples/tree/master/Samples/hs256' }) %>
+
+<%= include('../_includes/_api_auth_preamble') %>
+
+## Configure the Sample project
+
+The sample code has an `appsettings.json` file which configures it to use the correct Auth0 **Domain** and **API Identifier** for your API. If you download the code from this page while logged in, it will be automatically filled. If you use the example from Github, you will need to fill it yourself.
+
+```json
+{
+  "Auth0": {
+    "Domain": "${account.namespace}",
+    "ApiIdentifier": "${apiIdentifier}"
+  }
+}
+```
+## Validate Access Tokens
+
+### Install dependencies
+
+The seed project references the new ASP.NET Core metapackage (`Microsoft.AspNetCore.All`), which includes all the NuGet packages that are a part of the ASP.NET Core 2.1 framework.
+
+If you are not using the `Microsoft.AspNetCore.All` metapackage, add the `Microsoft.AspNetCore.Authentication.JwtBearer` package to your application.
+
+```text
+Install-Package Microsoft.AspNetCore.Authentication.JwtBearer
+```
+
+### Configure the middleware
+
+The ASP.NET Core JWT Bearer authentication handler downloads the JSON Web Key Set (JWKS) file with the public key. The handler uses the JWKS file and the public key to verify the Access Token's signature.
+
+In your application, register the authentication services:
+
+1. Make a call to the `AddAuthentication` method. Configure the JWT Bearer tokens as the default authentication and challenge schemes.  
+2. Make a call to the `AddJwtBearer` method to register the JWT Bearer authentication scheme. Configure your Auth0 domain as the authority, and your Auth0 API identifier as the audience. In some cases the access token will not have a `sub` claim which will lead to `User.Identity.Name` being `null`. If you want to map a different claim to `User.Identity.Name` then add it to `options.TokenValidationParameters` within the `AddAuthentication()` call.
+
+```csharp
+// Startup.cs
+
+public void ConfigureServices(IServiceCollection services)
+{
+    // Some code omitted for brevity...
+
+    string domain = $"https://{Configuration["Auth0:Domain"]}/";
+    services.AddAuthentication(options =>
+    {
+        options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+        options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+    }).AddJwtBearer(options =>
+    {
+        options.Authority = domain;
+        options.Audience = Configuration["Auth0:ApiIdentifier"];
+        options.TokenValidationParameters = new TokenValidationParameters
+        {
+          NameClaimType = ClaimTypes.NameIdentifier
+        };
+    });
+}
+```
+
+To add the authentication middleware to the middleware pipeline, add a call to the `UseAuthentication` method:
+
+```csharp
+// Startup.cs
+
+public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+{
+    // Some code omitted for brevity...
+
+    app.UseAuthentication();
+
+    app.UseMvc(routes =>
+    {
+        routes.MapRoute(
+            name: "default",
+            template: "{controller=Home}/{action=Index}/{id?}");
+    });
+}
+```
+
+### Validate scopes
+
+To make sure that an Access Token contains the correct scope, use the [Policy-Based Authorization](https://docs.microsoft.com/en-us/aspnet/core/security/authorization/policies) in ASP.NET Core.
+
+Create a new authorization requirement called `HasScopeRequirement`. This requirement checks if the `scope` claim issued by your Auth0 tenant is present. If the `scope` claim exists, the requirement checks if the `scope` claim contains the requested scope.
+
+```csharp
+// HasScopeRequirement.cs
+
+public class HasScopeRequirement : IAuthorizationRequirement
+{
+    public string Issuer { get; }
+    public string Scope { get; }
+
+    public HasScopeRequirement(string scope, string issuer)
+    {
+        Scope = scope ?? throw new ArgumentNullException(nameof(scope));
+        Issuer = issuer ?? throw new ArgumentNullException(nameof(issuer));
+    }
+}
+```
+
+```csharp
+// HasScopeHandler.cs
+
+public class HasScopeHandler : AuthorizationHandler<HasScopeRequirement>
+{
+    protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, HasScopeRequirement requirement)
+    {
+        // If user does not have the scope claim, get out of here
+        if (!context.User.HasClaim(c => c.Type == "scope" && c.Issuer == requirement.Issuer))
+            return Task.CompletedTask;
+
+        // Split the scopes string into an array
+        var scopes = context.User.FindFirst(c => c.Type == "scope" && c.Issuer == requirement.Issuer).Value.Split(' ');
+
+        // Succeed if the scope array contains the required scope
+        if (scopes.Any(s => s == requirement.Scope))
+            context.Succeed(requirement);
+
+        return Task.CompletedTask;
+    }
+}
+```
+
+In your `ConfigureServices` method, add a call to the `AddAuthorization` method. To add policies for the scopes, call `AddPolicy` for each scope. Also ensure that you register the `HasScopeHandler` as a singleton:
+
+```csharp
+// Startup.cs
+
+public void ConfigureServices(IServiceCollection services)
+{
+    //...
+    
+    services.AddAuthorization(options =>
+    {
+        options.AddPolicy("read:messages", policy => policy.Requirements.Add(new HasScopeRequirement("read:messages", domain)));
+    });
+
+    // register the scope authorization handler
+    services.AddSingleton<IAuthorizationHandler, HasScopeHandler>();
+}
+```
+
+## Protect API Endpoints
+
+The JWT middleware integrates with the standard ASP.NET Core [Authentication](https://docs.microsoft.com/en-us/aspnet/core/security/authentication/) and [Authorization](https://docs.microsoft.com/en-us/aspnet/core/security/authorization/) mechanisms. 
+
+To secure an endpoint, you need to add the `[Authorize]` attribute to your controller action:
+
+```csharp
+// Controllers/ApiController.cs
+
+[Route("api")]
+public class ApiController : Controller
+{
+    [HttpGet]
+    [Route("private")]
+    [Authorize]
+    public IActionResult Private()
+    {
+        return Json(new
+        {
+            Message = "Hello from a private endpoint! You need to be authenticated to see this."
+        });
+    }
+}
+```
+
+To secure endpoints that require specific scopes, we need to make sure that the correct scope is present in the `access_token`. To do that, add the `Authorize` attribute to the `Scoped` action, passing `read:messages` as the `policy` parameter. 
+
+```csharp
+// Controllers/ApiController.cs
+
+[Route("api")]
+public class ApiController : Controller
+{
+    [HttpGet]
+    [Route("private-scoped")]
+    [Authorize("read:messages")]
+    public IActionResult Scoped()
+    {
+        return Json(new
+        {
+            Message = "Hello from a private endpoint! You need to be authenticated and have a scope of read:messages to see this."
+        });
+    }
+}
+```

--- a/articles/quickstart/backend/aspnet-core-webapi-2/02-using.md
+++ b/articles/quickstart/backend/aspnet-core-webapi-2/02-using.md
@@ -1,0 +1,14 @@
+---
+title: Using your API
+description: This tutorial will show you how to use your API.
+budicon: 500
+topics:
+    - quickstart
+    - backend
+    - aspnetcore
+    - web-api
+contentType: tutorial
+useCase: quickstart
+---
+
+<%= include('../_includes/_api_using') %>

--- a/articles/quickstart/backend/aspnet-core-webapi-2/03-troubleshooting.md
+++ b/articles/quickstart/backend/aspnet-core-webapi-2/03-troubleshooting.md
@@ -1,0 +1,200 @@
+---
+title: Troubleshooting
+name: Shows how to troubleshoot the JWT middleware configuration
+description: This document will help you troubleshoot your configuration if you get 401 (Unauthorized) response from your API.
+budicon: 500
+topics:
+    - quickstart
+    - backend
+    - aspnetcore
+    - web-api
+contentType: tutorial
+useCase: quickstart
+---
+
+If the configuration of your JSON Web Token (JWT) middleware does not match the JWT that was passed to the API, you get a 401 (Unauthorized) response from your API.
+
+This document will help you troubleshoot your JWT middleware configuration.
+
+## Check the Token Validation
+
+There are 5 criteria for validating a JWT token. 
+
+1. **Is the token formed properly?**
+Check if the structure of the token matches the structure of a JSON Web Token. Read more about the [JSON Web Token structure](/jwt#what-is-the-json-web-token-structure-).
+
+2. **Has the token been tampered with?** 
+The last part of a JWT is the signature. The signature is used to verify that the token was signed by the sender and not altered in any way.
+
+3. **Has the token been received in its validity period?**
+JWTs are only valid for a specified time, defined in the `exp` claim.
+
+4. **Is the token coming from the intended Authority?**
+Check the following two criteria: 
+
+    * **Signature verification**: Check if the JWT is correctly signed with the key issued by the issuing authority.
+
+    * **Issuer value**: The Issuer is defined in the `iss` claim. Check if this claim matches up with what your application expects.
+
+5. **Is the token intended for the current application?** 
+Check if the `aud` claim of the JWT matches with what your application expects.
+
+## Inspect a Token
+
+You can inspect a JWT with the [JWT.io](https://jwt.io/) website. Use the debugger on the website to check if your JWT is well formed. You can also inspect values of the various claims.
+
+The screenshot below shows the following information:
+* The token is signed with the RS256 algorithm
+* The issuer of the token is https://jerrie.auth0.com/
+* The audience of the token is https://rs256.test.api
+
+![Debugging a JWT on JWT.io](/media/articles/server-apis/aspnet-core-webapi/jwt-io-debugger-rs256.png)
+
+Check if the values of the JWT token match exactly the values in your JWT middleware registration. This includes the trailing slash for the Issuer.
+
+```csharp
+var options = new JwtBearerOptions
+{
+    Audience = "https://rs256.test.api",
+    Authority = "https://jerrie.auth0.com/"
+};
+app.UseJwtBearerAuthentication(options);
+```
+
+If your token is signed with the HS256 algorithm, the debugger view is different. 
+
+The screenshot below shows the following information:
+* The token is signed with the HS256 algorithm
+* The issuer of the token is https://jerrie.auth0.com/
+* The audience of the token is https://hs256.test.api
+
+![Debugging a JWT on JWT.io](/media/articles/server-apis/aspnet-core-webapi/jwt-io-debugger-hs256.png)
+
+If your token is signed with the HS256 algorithm, the middleware needs to be configured in the following way:
+
+```csharp
+var options = new JwtBearerOptions
+{
+    TokenValidationParameters =
+    {
+        ValidIssuer = "https://jerrie.auth0.com/",
+        ValidAudience = "https://hs256.test.api",
+        IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes("your api secret"))
+    }
+};
+app.UseJwtBearerAuthentication(options);
+```
+
+## Debug Configuration Issues Using Log Files 
+
+To debug potential configuration issues, inspect the log files for your application. For more information, refer to the [Logging in ASP.NET Core](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging) document.
+
+In this example, we run the application from the command line and inspect the console log output.
+
+### 1. Are you passing the JWT in the Authorization header?
+
+Check if you are passing the JWT as a Bearer token in the `Authorization` header of the HTTP request.
+
+If you are not passing the token, you will see the following warning:
+
+![Not specifying an Authorization Header](/media/articles/server-apis/aspnet-core-webapi/troubleshoot-no-authorization-header.png)
+
+Look for the following warning message:
+
+```text
+Authorization failed for the request at filter 'Microsoft.AspNetCore.Mvc.Authorization.AuthorizeFilter'
+```
+
+To resolve this issue, make sure you are passing the JWT as the Bearer token in the `Authorization` header of the HTTP request.
+
+### 2. Did you configure the JWT middleware for the correct signing algorithm?
+
+Make sure that the [signing algorithm](/tokens/concepts/signing-algorithms) you used to sign your token matches the signing algorithm configured in your middleware. 
+
+The following screenshots show two messages:
+* A warning message: "Authorization failed..." 
+* A message with more information
+
+The following example shows that the JWT is signed with the HS256 algorithm and the middleware is configured to expect RS256 tokens:
+
+![Wrong Signature Configured](/media/articles/server-apis/aspnet-core-webapi/troubleshoot-wrong-signature-rs256.png)
+
+Look for the following warning message:
+
+```text
+System.ArgumentException: IDX10634: Unable to create the SignatureProvider.
+
+SignatureAlgorithm: 'HS256', SecurityKey: 'Microsoft.IdentityModel.Tokens.RsaSecurityKey' is not supported.
+```
+
+The following example shows that the JWT is signed with the RS256 algorithm and the middleware is configured to expect HS256 tokens:
+
+![Wrong Signature Configured](/media/articles/server-apis/aspnet-core-webapi/troubleshoot-wrong-signature-hs256.png)
+
+Look for the following warning message:
+
+```text
+Bearer was not authenticated. Failure message: IDX10501: Signature validation failed. Unable to match 'kid': 'NTF...'
+```
+
+To resolve this issue, make sure that the algorithm for the JWT matches with the configuration of your middleware. 
+
+### 3. Has your token expired?
+
+Each JSON Web Token is valid until the time defined in the `exp` claim runs out. If you send an expired token, the token will be rejected:
+
+![Token Expired](/media/articles/server-apis/aspnet-core-webapi/troubleshoot-token-expired.png)
+
+Look for the following error message:
+
+```text
+IDX10223: Lifetime validation failed. The token is expired
+```
+
+To resolve this issue, check if the token you are sending has not expired.
+
+::: note
+The value of the `exp` claim is a numeric value representing the number of seconds from 1970-01-01T00:00:00Z UTC until the specified UTC date/time. If you want to see the date/time for the value, visit [EpochConverter](http://www.epochconverter.com/).
+:::
+
+### 4. Did you configure the correct issuer?
+
+The Issuer specified in your token must match exactly with your JWT middleware configuration. 
+
+![Issuer Validation Failed](/media/articles/server-apis/aspnet-core-webapi/troubleshoot-issuer-validation-failed.png)
+
+Look for the following warning message:
+
+::: note
+You will get this message only for the tokens signed with the HS256 algorithm.
+:::
+
+```text
+IDX10205: Issuer validation failed.
+```
+
+To resolve this issue, make sure that you specify the correct issuer for your JWT middleware. 
+
+For HS256 signed tokens, specify the correct value for the `ValidIssuer` property of `TokenValidationParameters`.
+
+::: note
+For RS256 tokens, the JWT middleware downloads the OIDC discovery document from `Authority` and configures the Issuer based on the `issuer` attribute specified in that document. 
+
+If you are using RS256 tokens, the system checks their signature before it checks the Issuer.
+:::
+
+### 5. Does the audience match your JWT middleware configuration?
+
+Check if the audience specified in your token matches your JWT middleware configuration.
+
+![Audience Validation Failed](/media/articles/server-apis/aspnet-core-webapi/troubleshoot-audience-validation-failed.png)
+
+Look for the following error message:
+
+```text
+IDX10214: Audience validation failed
+```
+
+To resolve this issue, make sure you specify the correct audience for your JWT middleware. Depending on how your JWT middleware was configured, do the following:
+* Set the correct `Audience` property of `JwtBearerOptions`
+* Set the `ValidAudience` property of `TokenValidationParameters`

--- a/articles/quickstart/backend/aspnet-core-webapi-2/download.md
+++ b/articles/quickstart/backend/aspnet-core-webapi-2/download.md
@@ -1,0 +1,15 @@
+To run the sample you need [.NET Core](https://www.microsoft.com/net/download) installed, and run the following commands:
+
+```bash
+dotnet restore
+dotnet run
+```
+
+The sample includes a [Docker](https://www.docker.com) image ready to run with the following command:
+
+```bash
+# In Linux / macOS
+sh exec.sh
+# In Windows' Powershell
+./exec.ps1
+```

--- a/articles/quickstart/backend/aspnet-core-webapi-2/index.yml
+++ b/articles/quickstart/backend/aspnet-core-webapi-2/index.yml
@@ -1,0 +1,50 @@
+title: ASP.NET Core Web API v2.1
+alias:
+  - asp.net core webapi
+  - aspnet core webapi
+  - asp.net core webapi 2.1
+language:
+  - C#
+framework:
+  - ASP.NET Core
+author:
+  name: Damien Guard
+  email: damien.guard@auth0.com
+  community: false
+thirdParty: false
+image: /media/platforms/asp.png
+topics:
+  - quickstart
+contentType: tutorial
+useCase: quickstart
+snippets:
+  dependencies: server-apis/aspnet-core-webapi/dependencies
+articles:
+  - 01-authorization
+  - 02-using
+  - 03-troubleshooting
+show_steps: true
+github:
+  org: auth0-samples
+  repo: auth0-aspnetcore-webapi-samples
+  branch: netcore2.1
+requirements:
+  - .NET Core SDK 2.1.300
+  - .NET Core 2.1.0
+  - ASP.NET Core 2.1.0
+  - Visual Studio 2017 15.7 or Visual Studio Code (Optional)
+next_steps:
+  - path: 01-authorization
+    list:
+    - text: Configure other identity providers
+      icon: 345
+      href: "/identityproviders"
+    - text: Enable multifactor authentication
+      icon: 345
+      href: "/multifactor-authentication"
+    - text: Learn about anomaly detection
+      icon: 345
+      href: "/anomaly-detection"
+    - text: Learn about rules
+      icon: 345
+      href: "/rules"


### PR DESCRIPTION
We used to have an ASPNET Core 2.1 Web API quickstarter and sample application. However, it got migrated to .NET Core 3.1 so we didnt have anything for ASPNET Core 2.1 anymore.

This PR brings back the Quickstart aspect of it and refers to the `netcore2.1` branch on the corresponding samples repository.

**Note**: this brings back the quickstarter as it was before migrating to 3.1.