### PR TITLE
[SDK-1978] Update UWP quickstart to use Edge

### DIFF
--- a/articles/quickstart/native/windows-uwp-csharp/01-login.md
+++ b/articles/quickstart/native/windows-uwp-csharp/01-login.md
@@ -21,31 +21,11 @@ useCase: quickstart
 
 <%= include('../../../_includes/_callback_url') %>
 
-For UWP applications, the callback URL needs to be in the format **ms-app://SID**, where **SID** is the **Package SID** for your application. Assuming you have associated your application with and application on the Windows Store, you can go to the Windows Developer Centre, go to the settings for your application, and then go to the App management > App identity section, where you will see the **Package SID** listed.
+::: note
+If you are following along with the sample project you downloaded from the top of this page, you should set the **Allowed Callback URLs** to `https://${account.namespace}/mobile`.
+:::
 
-Alternatively - or if you have not associated your application with the Store yet - you can obtain the value by calling the `Windows.Security.Authentication.Web.WebAuthenticationBroker.GetCurrentApplicationCallbackUri()` method. So for example, in the `OnLaunched` method of your application, you can add the following line of code:
-
-```csharp
-// App.xaml.cs
-
-protected override void OnLaunched(LaunchActivatedEventArgs e)
-{
-#if DEBUG
-    if (System.Diagnostics.Debugger.IsAttached)
-    {
-        System.Diagnostics.Debug.WriteLine(Windows.Security.Authentication.Web.WebAuthenticationBroker.GetCurrentApplicationCallbackUri());
-    }
-#endif
-
-    // rest of code omitted for brevity
-}
-```
-
-This will print out the callback URL to your Debug window in Visual Studio. This is a bit of a painful process to obtain this URL, but it is important to use this URL otherwise the authentication process will not function correctly.
-
-<%= include('../../../_includes/_logout_url') %>
-
-The logout URL you need to add to the **Allowed Logout URLs** field is the same as the callback URL obtained in the previous step. For more information check Web authenticator broker [documentation](https://docs.microsoft.com/en-us/windows/uwp/security/web-authentication-broker#connecting-with-single-sign-on-sso).
+<%= include('../../../_includes/_logout_url', { returnTo: 'https://' + account.namespace + '/mobile' }) %>
 
 ## Integrate Auth0 in your Application
 
@@ -78,10 +58,6 @@ The returned login result will indicate whether authentication was successful, a
 You can check the `IsError` property of the result to see whether the login has failed. The `ErrorMessage` will contain more information regarding the error which occurred.
 
 ```csharp
-// MainPage.xaml.cs
-
-var loginResult = await client.LoginAsync();
-
 if (loginResult.IsError)
 {
     Debug.WriteLine($"An error occurred during login: {loginResult.Error}")
@@ -93,10 +69,6 @@ if (loginResult.IsError)
 On successful login, the login result will contain the ID Token and Access Token in the `IdentityToken` and `AccessToken` properties respectively.
 
 ```csharp
-// MainPage.xaml.cs
-
-var loginResult = await client.LoginAsync();
-
 if (!loginResult.IsError)
 {
     Debug.WriteLine($"id_token: {loginResult.IdentityToken}");
@@ -111,8 +83,6 @@ On successful login, the login result will contain the user information in the `
 To obtain information about the user, you can query the claims. You can for example obtain the user's name and email address from the `name` and `email` claims:
 
 ```csharp
-// MainPage.xaml.cs
-
 if (!loginResult.IsError)
 {
     Debug.WriteLine($"name: {loginResult.User.FindFirst(c => c.Type == "name")?.Value}");
@@ -127,8 +97,6 @@ The exact claims returned will depend on the scopes that were requested. For mor
 You can obtain a list of all the claims contained in the ID Token by iterating through the `Claims` collection:
 
 ```csharp
-// MainPage.xaml.cs
-
 if (!loginResult.IsError)
 {
     foreach (var claim in loginResult.User.Claims)
@@ -143,7 +111,5 @@ if (!loginResult.IsError)
 To log the user out call the `LogoutAsync` method.
 
 ```csharp
-// MainPage.xaml.cs
-
 await client.LogoutAsync();
 ```

--- a/snippets/native-platforms/windows-uwp-csharp/setup.md
+++ b/snippets/native-platforms/windows-uwp-csharp/setup.md
@@ -3,11 +3,9 @@
 
 using Auth0.OidcClient;
 
-Auth0ClientOptions clientOptions = new Auth0ClientOptions
+var client = new Auth0Client(new Auth0ClientOptions
 {
     Domain = "${account.namespace}",
     ClientId = "${account.clientId}"
-};
-client = new Auth0Client(clientOptions);
-clientOptions.PostLogoutRedirectUri = clientOptions.RedirectUri;
+});
 ```


### PR DESCRIPTION
The way UWP uses callback urls has been changed through this commit https://github.com/auth0/auth0-oidc-client-net/commit/5821130421447aad74facde6395f4e814003edd1.

The quickstart appears to have been broken ever since as it lists the `ms-app://` callback urls, while that commit changes it to use `https://{AUTH0_DOMAIN}/mobile`.

This PR updates the quickstart to use the corresponding redirect urls.