### PR TITLE
[SDK-1957] Add note about ConfigureSameSiteNoneCookies

### DIFF
--- a/articles/quickstart/webapp/aspnet-core-3/_includes/_login.md
+++ b/articles/quickstart/webapp/aspnet-core-3/_includes/_login.md
@@ -39,6 +39,7 @@ In the code sample below, only the `openid` scope is requested.
 
 public void ConfigureServices(IServiceCollection services)
 {
+    // Only needed when using HTTP to support cookies with SameSite=None
     services.ConfigureSameSiteNoneCookies();
 
     // Add authentication services
@@ -75,6 +76,10 @@ public void ConfigureServices(IServiceCollection services)
     services.AddControllersWithViews();
 }
 ```
+
+::: note
+The `ConfigureSameSiteNoneCookies` method used above was added as part of the [sample application](https://github.com/auth0-samples/auth0-aspnetcore-mvc-samples/blob/master/Quickstart/01-Login/Support/SameSiteServiceCollectionExtensions.cs) in order to make cookies with SameSite=None work over HTTP when using Chrome ([read more here](https://blog.chromium.org/2019/10/developers-get-ready-for-new.html)). We recommend using HTTPS instead of HTTP, which removes the need for the `ConfigureSameSiteNoneCookies` method.
+:::
 
 Next, add the authentication middleware. In the `Configure` method of the `Startup` class, call the `UseAuthentication` and `UseAuthorization` methods.
 


### PR DESCRIPTION
Add a short note about the use of ConfigureSameSiteNoneCookies, a link to a Chromuim blog post as well as a link to the implementatiom details.