### PR TITLE
[SDK-1957] Mention cookie policy when using HTTPS

### DIFF
--- a/articles/quickstart/webapp/aspnet-core-3/_includes/_login.md
+++ b/articles/quickstart/webapp/aspnet-core-3/_includes/_login.md
@@ -39,8 +39,14 @@ In the code sample below, only the `openid` scope is requested.
 
 public void ConfigureServices(IServiceCollection services)
 {
-    // Only needed when using HTTP to support cookies with SameSite=None
+    // Cookie configuration for HTTP to support cookies with SameSite=None
     services.ConfigureSameSiteNoneCookies();
+
+    // Cookie configuration for HTTPS
+    // services.Configure<CookiePolicyOptions>(options =>
+    // {
+    //    options.MinimumSameSitePolicy = SameSiteMode.None
+    // })
 
     // Add authentication services
     services.AddAuthentication(options => {

--- a/articles/quickstart/webapp/aspnet-core-3/_includes/_login.md
+++ b/articles/quickstart/webapp/aspnet-core-3/_includes/_login.md
@@ -46,7 +46,7 @@ public void ConfigureServices(IServiceCollection services)
     // services.Configure<CookiePolicyOptions>(options =>
     // {
     //    options.MinimumSameSitePolicy = SameSiteMode.None
-    // })
+    // });
 
     // Add authentication services
     services.AddAuthentication(options => {


### PR DESCRIPTION
As the quickstart mentions we dont need the `ConfigureSameSiteNoneCookies` method when using HTTPS, I added a snippet of what we should use with HTTPS instead.