### PR TITLE
Rails Web App Quickstart updates

### DIFF
--- a/articles/quickstart/webapp/rails/01-login.md
+++ b/articles/quickstart/webapp/rails/01-login.md
@@ -51,11 +51,15 @@ Add your Auth0 configuration to the `secrets.yml` file for later use:
 
 ```yaml
 development:
-  secret_key_base: d2b31d76ebec2f43b57eca7ee896e88b03177bddbb6511f7301c96e516ebf84a090520a8f6575e4047c693ebc6a96784afe18bc9b34b85827eb17b4ad0758639
+  secret_key_base: <YOUR APPLICATION SECRET KEY>
   auth0_domain: ${account.namespace}
   auth0_client_id: ${account.clientId}
   auth0_client_secret: <YOUR AUTH0 CLIENT SECRET>
 ```
+
+:::note
+`secret_key_base` is not used for authentication but should already exist as part of your Rails app.
+:::
 
 Create a file named `auth0.rb` under `config/initializers` and configure the **OmniAuth** middleware in it.
 

--- a/articles/quickstart/webapp/rails/01-login.md
+++ b/articles/quickstart/webapp/rails/01-login.md
@@ -47,15 +47,25 @@ If you are using Windows, uncomment the `tzinfo-data` gem in the Gemfile.
 
 ### Initialize OmniAuth Auth0
 
+Add Auth0 configurations to the `secrets.yml` file for later use:
+
+```yaml
+development:
+  secret_key_base: d2b31d76ebec2f43b57eca7ee896e88b03177bddbb6511f7301c96e516ebf84a090520a8f6575e4047c693ebc6a96784afe18bc9b34b85827eb17b4ad0758639
+  auth0_domain: ${account.namespace}
+  auth0_client_id: ${account.clientId}
+  auth0_client_secret: <YOUR AUTH0 CLIENT SECRET>
+```
+
 Create a file named `auth0.rb` under `config/initializers` and configure the **OmniAuth** middleware in it.
 
 ```ruby
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider(
     :auth0,
-    '${account.clientId}',
-    'YOUR_CLIENT_SECRET',
-    '${account.namespace}',
+    Rails.application.secrets.auth0_client_id,
+    Rails.application.secrets.auth0_client_secret,
+    Rails.application.secrets.auth0_domain,
     callback_path: '/auth/auth0/callback',
     authorize_params: {
       scope: 'openid email profile'

--- a/articles/quickstart/webapp/rails/01-login.md
+++ b/articles/quickstart/webapp/rails/01-login.md
@@ -47,7 +47,7 @@ If you are using Windows, uncomment the `tzinfo-data` gem in the Gemfile.
 
 ### Initialize OmniAuth Auth0
 
-Add Auth0 configurations to the `secrets.yml` file for later use:
+Add your Auth0 configuration to the `secrets.yml` file for later use:
 
 ```yaml
 development:


### PR DESCRIPTION
This PR changes the code snippet for configuring OmniAuth to move the Auth0
values and secrets into the `secrets.yml` file.

This serves a purpose later in the tutorial for the Logout section, where the
values are retrieved from the secrets config. But without this change, it's
never mentioned where those secrets are configured, so someone copying and
pasting the snippet would not be able to complete the quickstart.
