### PR TITLE
[SDK-2013] Update PHP SDK version reference to current version

### DIFF
--- a/articles/quickstart/webapp/php/index.yml
+++ b/articles/quickstart/webapp/php/index.yml
@@ -23,8 +23,8 @@ github:
   branch: master
 requirements:
   - Apache 2.4.4
-  - PHP 5.6.14 and up
-  - Auth0-PHP 5.0 and up
+  - PHP 7.1 and up
+  - Auth0-PHP 7.0 and up
 next_steps:
   - path: 01-login
     list:

--- a/snippets/server-platforms/php/dependencies.md
+++ b/snippets/server-platforms/php/dependencies.md
@@ -1,5 +1,5 @@
 To install dependencies, run the following
 
 ```bash
-composer require auth0/auth0-php:"~5.0"
+composer require auth0/auth0-php:"~7.0"
 ```


### PR DESCRIPTION
Quickstart fix: the PHP SDK version we are referencing is out of date, should be bumped to the current V7 release.