### PR TITLE
Update xamarin quickstart to remove ProcessResponseAsync

### DIFF
--- a/articles/quickstart/native/xamarin/01-login.md
+++ b/articles/quickstart/native/xamarin/01-login.md
@@ -157,10 +157,6 @@ The returned login result will indicate whether authentication was successful an
 You can check the `IsError` property of the result to see whether the login has failed. The `ErrorMessage` will contain more information regarding the error which occurred.
 
 ```csharp
-// For Android
-var loginResult = await client.ProcessResponseAsync(intent.DataString, authorizeState);
-
-// For iOS
 var loginResult = await client.LoginAsync();
 
 if (loginResult.IsError)
@@ -174,7 +170,7 @@ if (loginResult.IsError)
 On successful login, the login result will contain the ID Token and Access Token in the `IdentityToken` and `AccessToken` properties respectively.
 
 ```csharp
-var loginResult = await client.ProcessResponseAsync(intent.DataString, authorizeState);
+var loginResult = await client.LoginAsync();
 
 if (!loginResult.IsError)
 {


### PR DESCRIPTION
As you can see here https://github.com/auth0-samples/auth0-xamarin-oidc-samples/blob/master/Quickstart/01-Login/Android/AndroidSample/MainActivity.cs#L56, Android also uses `LoginAsync` instead of `ProcessResponseAsync`.