### PR TITLE
Added installation instructions for SPM [SDK-2016]

### DIFF
--- a/articles/libraries/auth0-swift/index.md
+++ b/articles/libraries/auth0-swift/index.md
@@ -64,7 +64,7 @@ If you are using the Swift Package Manager, open the following menu item in Xcod
 
 In the **Choose Package Repository** prompt add this url: 
 
-```
+```text
 https://github.com/auth0/Auth0.swift.git
 ```
 

--- a/articles/libraries/auth0-swift/index.md
+++ b/articles/libraries/auth0-swift/index.md
@@ -56,6 +56,22 @@ Then run `carthage bootstrap`.
 For more information about Carthage usage, check [their official documentation](https://github.com/Carthage/Carthage#if-youre-building-for-ios-tvos-or-watchos).
 :::
 
+### SPM
+
+If you are using the Swift Package Manager, open the following menu item in Xcode:
+
+**File > Swift Packages > Add Package Dependency...**
+
+In the **Choose Package Repository** prompt add this url: 
+
+```
+https://github.com/auth0/Auth0.swift.git
+```
+
+Then press **Next** and complete the remaining steps.
+
+> For further reference on SPM, check [its official documentation](https://developer.apple.com/documentation/xcode/adding_package_dependencies_to_your_app).
+
 ## Adding Auth0 Credentials
 
 You will need to add an `Auth0.plist` file, containing your Auth0 client id and domain, to your main bundle. Here is an example of the file contents:

--- a/articles/libraries/auth0-swift/index.md
+++ b/articles/libraries/auth0-swift/index.md
@@ -22,9 +22,9 @@ Check out the [Auth0.swift repository](https://github.com/auth0/Auth0.swift) on 
 
 ## Requirements
 
-- iOS 9+
-- Xcode 10+
-- Swift 4+
+- iOS 9+ / macOS 10.11+ / tvOS 9.0+ / watchOS 2.0+
+- Xcode 11.4+ / 12.x
+- Swift 4.x / 5.x
 
 ## Installation
 


### PR DESCRIPTION
## Changes

This PR updates the Auth0.swift SDK documentation adding installation instructions for the Swift Package Manager (SPM). 

## References

SPM Support PR: https://github.com/auth0/Auth0.swift/pull/425