### PR TITLE
Added QS installation instructions for SPM [SDK-2015]

### DIFF
--- a/articles/quickstart/native/_includes/_ios_dependency_centralized.md
+++ b/articles/quickstart/native/_includes/_ios_dependency_centralized.md
@@ -29,3 +29,19 @@ Then run `carthage bootstrap`.
 ::: note
 For more information about Carthage usage, check [their official documentation](https://github.com/Carthage/Carthage#if-youre-building-for-ios-tvos-or-watchos).
 :::
+
+### SPM
+
+If you are using the Swift Package Manager, open the following menu item in Xcode:
+
+**File > Swift Packages > Add Package Dependency...**
+
+In the **Choose Package Repository** prompt add this url: 
+
+```
+https://github.com/auth0/Auth0.swift.git
+```
+
+Then press **Next** and complete the remaining steps.
+
+> For further reference on SPM, check [its official documentation](https://developer.apple.com/documentation/xcode/adding_package_dependencies_to_your_app).

--- a/articles/quickstart/native/_includes/_ios_dependency_centralized.md
+++ b/articles/quickstart/native/_includes/_ios_dependency_centralized.md
@@ -38,7 +38,7 @@ If you are using the Swift Package Manager, open the following menu item in Xcod
 
 In the **Choose Package Repository** prompt add this url: 
 
-```
+```text
 https://github.com/auth0/Auth0.swift.git
 ```
 

--- a/articles/quickstart/native/ios-swift/_includes/_prerequisite.md
+++ b/articles/quickstart/native/ios-swift/_includes/_prerequisite.md
@@ -1,7 +1,7 @@
 ::: panel System Requirements
 These tutorials and seed projects have been tested with the following:
 
-* CocoaPods 1.6 (Beta)
-* Xcode 10.1
-* iPhone 8 - iOS 12
+- Cocoapods 1.9
+- iOS 9+
+- Xcode 11.4+
 :::

--- a/articles/quickstart/native/ios-swift/index.yml
+++ b/articles/quickstart/native/ios-swift/index.yml
@@ -47,6 +47,6 @@ github:
   org: auth0-samples
   repo: auth0-ios-swift-sample
 requirements:
-  - CocoaPods 1.6 (Beta)
-  - Xcode 10.1
+  - Cocoapods 1.9
   - iOS 9+
+  - Xcode 11.4+

--- a/snippets/native-platforms/ios-facebook-login/facebook-install-auth0-sdk.md
+++ b/snippets/native-platforms/ios-facebook-login/facebook-install-auth0-sdk.md
@@ -26,6 +26,22 @@ Then run `carthage bootstrap`.
 For more information about Carthage usage, check [their official documentation](https://github.com/Carthage/Carthage#if-youre-building-for-ios-tvos-or-watchos).
 :::
 
+### SPM
+
+If you are using the Swift Package Manager, open the following menu item in Xcode:
+
+**File > Swift Packages > Add Package Dependency...**
+
+In the **Choose Package Repository** prompt add this url: 
+
+```
+https://github.com/auth0/Auth0.swift.git
+```
+
+Then press **Next** and complete the remaining steps.
+
+> For further reference on SPM, check [its official documentation](https://developer.apple.com/documentation/xcode/adding_package_dependencies_to_your_app).
+
 ::: panel Web Authentication
 If your iOS application plans to support Web Authentication, head over [here](/libraries/auth0-swift#web-based-auth-ios-only-) to learn how to configure the Callback and Logout URLs, and set up the Custom URL Scheme.
 :::

--- a/snippets/native-platforms/ios-facebook-login/facebook-install-auth0-sdk.md
+++ b/snippets/native-platforms/ios-facebook-login/facebook-install-auth0-sdk.md
@@ -34,7 +34,7 @@ If you are using the Swift Package Manager, open the following menu item in Xcod
 
 In the **Choose Package Repository** prompt add this url: 
 
-```
+```text
 https://github.com/auth0/Auth0.swift.git
 ```
 


### PR DESCRIPTION
## Changes

This PR updates the 3 Swift QuickStarts that feature Auth0.swift, adding installation instructions for the Swift Package Manager (SPM). 

## References

SPM Support PR: https://github.com/auth0/Auth0.swift/pull/425