### PR TITLE
added security bulletin: cve-2020-15240

### DIFF
--- a/articles/security/bulletins/cve-2020-15240.md
+++ b/articles/security/bulletins/cve-2020-15240.md
@@ -1,0 +1,34 @@
+---
+title: Auth0 Security Bulletin CVE 2020-15240
+description: Security Update for omniauth-auth0 library (CVE 2020-15240)
+toc: true
+topics:
+  - security
+  - security-bulletins
+contentType:
+  - reference
+useCase:
+  - development
+---
+# Security Update for omniauth-auth0 Library
+
+**Published**: October 21st, 2020
+
+**CVE number**: CVE-2020-15240
+
+## Overview
+Versions after and including `2.3.0` are improperly validating the JWT token signature when using the `JWTValidator.verify` method.  Improper validation of the JWT token signature when not using the default Authorization Code Flow can allow an attacker to bypass authentication and authorization.
+
+
+## Am I affected?
+You are affected by this vulnerability if all of the following conditions apply:
+
+- You are using `omniauth-auth0`.
+- You are using `JWTValidator.verify` method directly OR you are not authenticating using the SDK’s default Authorization Code Flow.
+
+
+## How to fix that?
+Upgrade to version `2.4.1`.
+
+## Will this update impact my users?
+The fix provided in this version will not affect your users.

--- a/articles/security/bulletins/index.md
+++ b/articles/security/bulletins/index.md
@@ -27,6 +27,7 @@ Each bulletin contains a description of the vulnerability, how to identify if yo
 
 | **Date** | **Bulletin number** | **Title** | **Affected software** |
 |-|-|-|-|
+| October 21, 2020 | [CVE-2020-15240](/security/bulletins/cve-2020-15240) | Security Update for omniauth-auth0 >= 2.3.0 | [omniauth-auth0](https://github.com/auth0/omniauth-auth0) |
 | August 16, 2020 | [CVE-2020-15119](/security/bulletins/cve-2020-15119) | Security Update for Auth0 Lock <= 11.25.1 | [Auth0 Lock](https://github.com/auth0/lock) |
 | July 28, 2020 | [CVE-2020-15125](/security/bulletins/cve-2020-15125) | Auth0 Security Bulletin for node-auth0 <= 2.27.0 | [node-auth0](https://github.com/auth0/node-auth0) |
 | June 30, 2020 | [CVE 2020-15084](/security/bulletins/cve-2020-15084) | Auth0 Security Bulletin for express-jwt versions < 6.0.0 | [express-jwt](https://github.com/auth0/express-jwt) |


### PR DESCRIPTION
<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
This PR adds a security bulletin for:
https://github.com/auth0/omniauth-auth0/security/advisories/GHSA-58r4-h6v8-jcvm