### PR TITLE
DXDP-1589-Update the api url in sections.yml

### DIFF
--- a/config/sections.yml
+++ b/config/sections.yml
@@ -17,7 +17,7 @@
 
 - id: "apis"
   title: "Auth0 APIs"
-  url: "/api/info"
+  url: "/api"
   folder: "api"
 
 - id: "libraries"


### PR DESCRIPTION
Remove the trailing /info so redirect is no longer needed on the menu item (redirect is only partially working)

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
