### PR TITLE
Add missing HasScopeHandler registration

### DIFF
--- a/articles/quickstart/backend/aspnet-core-webapi/01-authorization.md
+++ b/articles/quickstart/backend/aspnet-core-webapi/01-authorization.md
@@ -155,6 +155,8 @@ public void ConfigureServices(IServiceCollection services)
         options.AddPolicy("read:messages", policy => policy.Requirements.Add(new HasScopeRequirement("read:messages", domain)));
     });
 
+    services.AddSingleton<IAuthorizationHandler, HasScopeHandler>();
+
     //...
 }
 ```


### PR DESCRIPTION
The QS mentioned the registration of HasScopeHandler but it was not part of the code snippet.