### PR TITLE
Fix broken link path - Remove Dashboard Users (Beta)

### DIFF
--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -537,7 +537,7 @@ articles:
           - title: Edit Dashboard Users
             url: /dashboard-access/dashboard-roles/edit-dashboard-users
           - title: Remove Dashboard Users
-            url: /dashboard-access/dashboard-roles/remove-tenant-users
+            url: /dashboard-access/dashboard-roles/remove-dashboard-users
       - title: Manage Dashboard Access with Multi-factor Authentication
         url: /dashboard-access/add-change-remove-mfa
       - title: Update Dashboard User Email Addresses


### PR DESCRIPTION
Fixed broken link

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
