### PR TITLE
Laravel Quickstart: Address getUserByDecodedJWT() typo

### DIFF
--- a/articles/quickstart/webapp/laravel/01-login.md
+++ b/articles/quickstart/webapp/laravel/01-login.md
@@ -361,7 +361,7 @@ class CustomUserRepository extends Auth0UserRepository
      */
     public function getUserByDecodedJWT(array $decodedJwt) : Authenticatable
     {
-        $user = $this->upsertUser( (array) $jwt );
+        $user = $this->upsertUser( $decodedJwt );
         return new Auth0JWTUser( $user->getAttributes() );
     }
 


### PR DESCRIPTION
- **Fixes obsolete variable referenced from a previous quickstart example.** Should be `$decodedJwt` rather than `(array) $jwt` as that no longer points to anything, and we no longer need to typecast the variable.