### PR TITLE
Fix add credentials link to Microsoft Azure AD doc

### DIFF
--- a/articles/connections/enterprise/azure-active-directory/v2/index.md
+++ b/articles/connections/enterprise/azure-active-directory/v2/index.md
@@ -72,7 +72,7 @@ During this process, Microsoft generates an **Application (client) ID** for your
 
 ### Create a client secret
 
-To create a client secret, see Microsoft's [Quickstart: Configure a client application to access web APIs - Add Credentials to your web application](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-configure-app-access-web-apis#add-credentials-to-your-web-application). 
+To create a client secret, see Microsoft's [Quickstart: Configure a client application to access web APIs - Add Credentials to your web application](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app#add-credentials). 
 
 Once generated, **make note of this value**.
 


### PR DESCRIPTION
The link to the Microsoft documentation to add credentials to an application links to a page unrelated, called 
Configure a client application to access a web API
https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-configure-app-access-web-apis

The link should be pointing to this section Add credentials on this page instead
https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app#add-credentials

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->

The page and section affected can be found here:
https://auth0.com/docs/connections/enterprise/azure-active-directory/v2#create-a-client-secret
