### PR TITLE
Archive and redirect custom social extension to oauth2 custom connection

### DIFF
--- a/articles/architecture-scenarios/_includes/_authentication/_sso-legacy.md
+++ b/articles/architecture-scenarios/_includes/_authentication/_sso-legacy.md
@@ -1,7 +1,7 @@
 In a large scale re-structure it's not always possible&mdash;or practical&mdash;to update all your applications at once. In fact, our recommended best practice is to plan for an iterative-style approach when it comes to integrating with Auth0. If your applications already participate in Single Sign-on (SSO), and your legacy identity system supports protocols such as OIDC or SAML, then you have a couple of options available if you want to continue to provide SSO as you integrate with Auth0:  
 
 * Update your existing identity provider in your legacy SSO system to redirect to Auth0 for login (e.g., using [SAML](/protocols/saml/saml-configuration/auth0-as-identity-provider)), or
-* Have Auth0 redirect to your legacy SSO system to login. This requires configuring your legacy system as an IdP in Auth0 (i.e., either using [SAML](/protocols/saml/saml-configuration/auth0-as-service-provider) or [OIDC](/extensions/custom-social-extensions)).
+* Have Auth0 redirect to your legacy SSO system to login. This requires configuring your legacy system as an IdP in Auth0 (i.e., either using [SAML](/protocols/saml/saml-configuration/auth0-as-service-provider) or [OIDC](/connections/social/oauth2)).
 
 ::: panel Best Practice
 Supporting an SSO experience with your legacy system can add complexity, but may be worth it to generate a more seamless user experience as you integrate with Auth0. If you intend to go down this path, planning for it early can help ensure that it is possible to achieve. If you don't already have SSO at a centralized service, then the complexity to add it will unlikely be worth the benefits.

--- a/articles/connections/generic-oauth2-connection-examples.md
+++ b/articles/connections/generic-oauth2-connection-examples.md
@@ -12,10 +12,6 @@ useCase:
 
 # Generic OAuth 1.0 and 2.0 Examples
 
-::: note
-  The recommended method for creating custom Social Connections is to use Auth0's <a href="/extensions/custom-social-extensions">Custom Social Connections Extension</a>. The information in this article should be used for reference purposes only. 
-:::
-
 Adding [OAuth 1.0](/oauth1) and [OAuth 2.0](/oauth2) providers as Connections allow you to support providers that are not currently built-in to the [Auth0 Management Dashboard](${manage_url}), like [DigitalOcean](#digitalocean), [Tumblr](#tumblr), and more.
 
 This document covers examples of OAuth 1.0/2.0 Connections that you can create by making the appropriate `POST` call to the [Auth0 APIv2's Connections endpoint](/api/v2#!/Connections/post_connections). Please note that doing so requires an [APIv2 token](/api/v2/tokens) with `create:connections` <dfn data-key="scope">scope</dfn>.

--- a/config/redirects.js
+++ b/config/redirects.js
@@ -2962,8 +2962,8 @@ module.exports = [
     to: '/protocols/configure-applications-with-oidc-discovery'
   },
   {
-    from: ['/protocols/oidc/identity-providers/okta'],
-    to: '/protocols/configure-okta-as-oidc-identity-provider'
+    from: ['/protocols/oidc/identity-providers/okta','/protocols/configure-okta-as-oidc-identity-provider'],
+    to: '/protocols/configure-okta-as-oauth2-identity-provider'
   },
   {
     from: ['/integrations/configure-wsfed-application','/tutorials/configure-wsfed-application'],

--- a/config/redirects.js
+++ b/config/redirects.js
@@ -1538,7 +1538,7 @@ module.exports = [
   },
   {
     from: ['/extensions/custom-social-connections','/extensions/custom-social-extensions'],
-    to: '/connections/identity-providers-social'
+    to: '/connections/social/oauth2'
   },
   {
     from: ['/extensions/github-deploy'],


### PR DESCRIPTION
Custom social connection extension now exists in core product. Archived the page in GitHub and redirecting it to the replacement OAuth2 connection page.