### PR TITLE
Changed sidebar item wording

### DIFF
--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -912,7 +912,7 @@ articles:
             url: /extensions/deploy-cli-tool/install-and-configure-the-deploy-cli-tool
           - title: Call Deploy CLI
             url: /extensions/deploy-cli-tool/call-deploy-cli-tool-programmatically
-          - title: Incorporate into Build
+          - title: Incorporate into CI/CD Environment
             url: /extensions/deploy-cli-tool/incorporate-deploy-cli-into-build-environment
           - title: Import/Export Directory Structure
             url: /extensions/deploy-cli-tool/import-export-tenant-configuration-to-directory-structure


### PR DESCRIPTION
Changed sidebar text wording per Docs Request (803) from Sandrino.
Changed from "Incorporate into Build" to "Incorporate into CI/CD Environment"

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
