### PR TITLE
Added SPM installation instructions

### DIFF
--- a/articles/libraries/lock-ios/_includes/_dependencies.md
+++ b/articles/libraries/lock-ios/_includes/_dependencies.md
@@ -27,3 +27,21 @@ Then run `carthage bootstrap`.
 ::: note
 For more information about Carthage usage, check [their official documentation](https://github.com/Carthage/Carthage#if-youre-building-for-ios-tvos-or-watchos).
 :::
+
+### SPM
+
+If you are using the Swift Package Manager, open the following menu item in Xcode:
+
+**File > Swift Packages > Add Package Dependency...**
+
+In the **Choose Package Repository** prompt add this url: 
+
+```text
+https://github.com/auth0/Lock.swift.git
+```
+
+Then press **Next** and complete the remaining steps.
+
+::: note
+For further reference on SPM, check [its official documentation](https://developer.apple.com/documentation/xcode/adding_package_dependencies_to_your_app).
+:::


### PR DESCRIPTION
This PR adds installation instructions for the Swift Package Manager (SPM) to the Lock.swift documentation.