### PR TITLE
[SPA Quickstart] Add explanation that domain and audience should be configured for SPA backend

### DIFF
--- a/articles/quickstart/spa/_includes/_calling_api_create_backend.md
+++ b/articles/quickstart/spa/_includes/_calling_api_create_backend.md
@@ -25,7 +25,8 @@ const jwksRsa = require("jwks-rsa");
 // Create a new Express app
 const app = express();
 
-// Set up Auth0 configuration
+// Set up Auth0 configuration. These values should be
+// the domain and audience for the API that you want to call.
 const authConfig = {
   domain: "${account.namespace}",
   audience: "${apiIdentifier}"
@@ -58,3 +59,7 @@ app.listen(3001, () => console.log('API listening on 3001'));
 ```
 
 The above API has one available endpoint, `/api/external`, that returns a JSON response to the caller. This endpoint uses the `checkJwt` middleware to validate the supplied bearer token using your tenant's [JSON Web Key Set](https://auth0.com/docs/jwks). If the token is valid, the request is allowed to continue. Otherwise, the server returns a 401 Unauthorized response.
+
+:::note
+Ensure that the values for `domain` and `audience` in the code snippet above are correct for the API that you want to call.
+:::


### PR DESCRIPTION
<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->

Based on user feedback. This change is to highlight that the values in the backend server code should be reviewed to make sure they match the API to be called.