### PR TITLE
Sidebar updates

### DIFF
--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -1097,7 +1097,7 @@ articles:
               - title: Disable Refresh Token Rotation
                 url: /tokens/refresh-tokens/disable-refresh-token-rotation
                 hidden: true
-          - title: Refresh Token Expiration
+          - title: Refresh  Token Expiration
             url: /tokens/refresh-tokens/configure-refresh-token-expiration
           - title: Delegation Tokens
             url: /tokens/delegation-tokens

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -1097,7 +1097,7 @@ articles:
               - title: Disable Refresh Token Rotation
                 url: /tokens/refresh-tokens/disable-refresh-token-rotation
                 hidden: true
-          - title: Refresh  Token Expiration
+          - title: Refresh Token Expiration
             url: /tokens/refresh-tokens/configure-refresh-token-expiration
           - title: Delegation Tokens
             url: /tokens/delegation-tokens

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -1074,28 +1074,31 @@ articles:
                 url: /tokens/access-tokens/validate-access-tokens
                 hidden: true
           - title: Refresh Tokens
-            url: /tokens/access-tokens/refresh-tokens
+            url: /tokens/refresh-tokens
             children:
               - title: Get Refresh Tokens
-                url: /tokens/access-tokens/refresh-tokens/get-refresh-tokens
+                url: /tokens/refresh-tokens/get-refresh-tokens
                 hidden: true
               - title: Use Refresh Tokens
-                url: /tokens/access-tokens/refresh-tokens/use-refresh-tokens
+                url: /tokens/refresh-tokens/use-refresh-tokens
                 hidden: true
               - title: Revoke Refresh Tokens
-                url: /tokens/access-tokens/refresh-tokens/revoke-refresh-tokens
+                url: /tokens/refresh-tokens/revoke-refresh-tokens
                 hidden: true
+              - title: Configure Refresh Token Expiration
+                url: /tokens/refresh-tokens/configure-refresh-token-expiration
+                hidden: true 
           - title: Refresh Token Rotation
-            url: /tokens/access-tokens/refresh-tokens/refresh-token-rotation
+            url: /tokens/refresh-tokens/refresh-token-rotation
             children:
               - title: Configure Refresh Token Rotation
-                url: /tokens/access-tokens/refresh-tokens/configure-refresh-token-rotation
+                url: /tokens/refresh-tokens/configure-refresh-token-rotation
                 hidden: true
               - title: Use Refresh Token Rotation
-                url: /tokens/access-tokens/refresh-tokens/refresh-token-rotation/use-refresh-token-rotation
+                url: /tokens/refresh-tokens/refresh-token-rotation/use-refresh-token-rotation
                 hidden: true
               - title: Disable Refresh Token Rotation
-                url: /tokens/access-tokens/refresh-tokens/disable-refresh-token-rotation
+                url: /tokens/refresh-tokens/disable-refresh-token-rotation
                 hidden: true
           - title: Delegation Tokens
             url: /tokens/delegation-tokens

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -1085,9 +1085,6 @@ articles:
               - title: Revoke Refresh Tokens
                 url: /tokens/refresh-tokens/revoke-refresh-tokens
                 hidden: true
-              - title: Configure Refresh Token Expiration
-                url: /tokens/refresh-tokens/configure-refresh-token-expiration
-                hidden: true 
           - title: Refresh Token Rotation
             url: /tokens/refresh-tokens/refresh-token-rotation
             children:
@@ -1100,6 +1097,8 @@ articles:
               - title: Disable Refresh Token Rotation
                 url: /tokens/refresh-tokens/disable-refresh-token-rotation
                 hidden: true
+          - title: Refresh Token Expiration
+            url: /tokens/refresh-tokens/configure-refresh-token-expiration
           - title: Delegation Tokens
             url: /tokens/delegation-tokens
             hidden: true


### PR DESCRIPTION
Fixed bad paths for all refresh token docs
Added new hidden link for configure-refresh-token-expiration
Review: https://auth0content-pr-9524.herokuapp.com/docs/tokens

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
