### PR TITLE
Bump minimum supported PHP version to reflect current state of 7.3

### DIFF
--- a/articles/_includes/_libraries_support_sdks.html
+++ b/articles/_includes/_libraries_support_sdks.html
@@ -54,7 +54,7 @@
     </tr>
     <tr>
       <td><a href="https://github.com/auth0/auth0-php">Auth0 PHP</a></td>
-      <td>v5</td>
+      <td>v7.3</td>
       <td><div class="label label-primary">Supported</div></td>
     </tr>
   </tbody>

--- a/articles/libraries/auth0-php/index.md
+++ b/articles/libraries/auth0-php/index.md
@@ -18,7 +18,7 @@ The Auth0-PHP repository is [hosted on GitHub](https://github.com/auth0/auth0-PH
 
 ## Requirements
 
-- PHP 7.1 or later
+- PHP 7.3 or later
 - [Composer](https://getcomposer.org/doc/00-intro.md)
 
 ## Installation

--- a/articles/quickstart/backend/php/index.yml
+++ b/articles/quickstart/backend/php/index.yml
@@ -26,7 +26,7 @@ github:
   org: auth0-samples
   repo: auth0-php-api-samples
 requirements:
-  - PHP 7.1 or greater
+  - PHP 7.3 or greater
   - Composer
 next_steps:
   - path: 01-authorization

--- a/articles/quickstart/webapp/php/index.yml
+++ b/articles/quickstart/webapp/php/index.yml
@@ -23,7 +23,7 @@ github:
   branch: master
 requirements:
   - Apache 2.4.4
-  - PHP 7.1 and up
+  - PHP 7.3 and up
   - Auth0-PHP 7.0 and up
 next_steps:
   - path: 01-login


### PR DESCRIPTION
[The Libraries landing page](https://auth0.com/docs/libraries) currently lists us supporting PHP 5+ with our PHP SDK, but this is out of date. We're now targeting PHP 7.3 as our minimum for this SDK.