### PR TITLE
Changed redirect for spa-redirect to customize-email-templates

### DIFF
--- a/config/redirects.js
+++ b/config/redirects.js
@@ -1386,8 +1386,8 @@ module.exports = [
     to: '/auth0-email-services/send-email-invitations-for-application-signup'
   },
   {
-    from: ['/email/spa-redirect'],
-    to: '/auth0-email-services/spa-redirect'
+    from: ['/email/spa-redirect', '/auth0-email-services/spa-redirect'],
+    to: '/auth0-email-services/customize-email-templates'
   },
  
   /* Extensions */


### PR DESCRIPTION
spa-redirects file was archived
duplicate content in customize-email-templates
changed redirect from spa-redirects to customize-email-templates

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
