### PR TITLE
Reorder Get Started items in sidebar

### DIFF
--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -8,7 +8,7 @@ articles:
         url: /get-started/dashboard
       - title: Create Tenants
         url: /get-started/learn-the-basics
-      - title: Set Up Applications
+      - title: Register Applications
         url: /applications/set-up-an-application
       - title: Register APIs
         url: /get-started/set-up-apis

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -4,19 +4,19 @@ articles:
     children:
       - title: Auth0 Overview
         url: /get-started
-      - title: Glossary
-        url: /glossary
-      - title: Create a Tenant
-        url: /get-started/learn-the-basics
       - title: Dashboard Overview
         url: /get-started/dashboard
-      - title: Set Up an App
+      - title: Create Tenants
+        url: /get-started/learn-the-basics
+      - title: Set Up Applications
         url: /applications/set-up-an-application
-      - title: Set Up an API
+      - title: Register APIs
         url: /get-started/set-up-apis
       - title: Set Up Multiple Environments
         url: /dev-lifecycle/set-up-multiple-environments
         hidden: true
+      - title: Glossary
+        url: /glossary
   - title: Architecture Scenarios
     url: /architecture-scenarios
     children:


### PR DESCRIPTION
Reorder Get Started items in sidebar
Fixed titles to match docs
Moved Glossary to bottom
Moved Dashboard overview up

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
