### PR TITLE
[React quickstart] removes the possibility of returning false

### DIFF
--- a/articles/quickstart/spa/react/01-login.md
+++ b/articles/quickstart/spa/react/01-login.md
@@ -126,25 +126,32 @@ The Auth0 React SDK helps you retrieve the [profile information](https://auth0.c
 import React from "react";
 import { useAuth0 } from "@auth0/auth0-react";
 
-const Profile = () => {
+const UserProfile = () => {
   const { user, isAuthenticated, isLoading } = useAuth0();
 
   if (isLoading) {
     return <div>Loading ...</div>;
   }
 
-  return (
-    isAuthenticated && (
+  if (isAuthenticated) {
+    return (
       <div>
         <img src={user.picture} alt={user.name} />
         <h2>{user.name}</h2>
         <p>{user.email}</p>
       </div>
-    )
+    );
+  }
+
+  return (
+    <div>
+      <p>User Not Authenticated</p>
+    </div>
   );
 };
 
-export default Profile;
+export default UserProfile;
+
 ```
 
 The `user` property contains sensitive information and artifacts related to the user's identity. As such, its availability depends on the user's authentication status. To prevent any render errors, use the `isAuthenticated` property from `useAuth0()` to check if Auth0 has authenticated the user before React renders any component that consumes the `user` property. Ensure that the SDK has completed loading before accessing the `isAuthenticated` property, by checking that `isLoading` is `false`.

--- a/articles/quickstart/spa/react/01-login.md
+++ b/articles/quickstart/spa/react/01-login.md
@@ -126,32 +126,25 @@ The Auth0 React SDK helps you retrieve the [profile information](https://auth0.c
 import React from "react";
 import { useAuth0 } from "@auth0/auth0-react";
 
-const UserProfile = () => {
+const Profile = () => {
   const { user, isAuthenticated, isLoading } = useAuth0();
 
   if (isLoading) {
     return <div>Loading ...</div>;
   }
 
-  if (isAuthenticated) {
-    return (
+  return (
+    isAuthenticated ? (
       <div>
         <img src={user.picture} alt={user.name} />
         <h2>{user.name}</h2>
         <p>{user.email}</p>
       </div>
-    );
-  }
-
-  return (
-    <div>
-      <p>User Not Authenticated</p>
-    </div>
+    ) : ''
   );
 };
 
 export default Profile;
-
 ```
 
 The `user` property contains sensitive information and artifacts related to the user's identity. As such, its availability depends on the user's authentication status. To prevent any render errors, use the `isAuthenticated` property from `useAuth0()` to check if Auth0 has authenticated the user before React renders any component that consumes the `user` property. Ensure that the SDK has completed loading before accessing the `isAuthenticated` property, by checking that `isLoading` is `false`.

--- a/articles/quickstart/spa/react/01-login.md
+++ b/articles/quickstart/spa/react/01-login.md
@@ -150,7 +150,7 @@ const UserProfile = () => {
   );
 };
 
-export default UserProfile;
+export default Profile;
 
 ```
 


### PR DESCRIPTION
The code in its current form wont work because it might return 'false'. I have updated the code so that a JSX element is returned no matter what is the status of authentication.

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
