### PR TITLE
Private Cloud Naming updates

### DIFF
--- a/config/redirects.js
+++ b/config/redirects.js
@@ -1365,7 +1365,7 @@ module.exports = [
     to: '/deploy/private-cloud/private-cloud-onboarding/private-cloud-remote-access-options'
   },
   {
-    from: ['/private-cloud/private-cloud-onboarding/standard-private-cloud-infrastructure-requirements','/private-saas-deployment/private-cloud','/private-cloud/standard-private-cloud', '/private-cloud/private-cloud-onboarding/customer-hosted-managed-private-cloud-infrastructure-requirements', '/private-saas-deployment/onboarding/managed-private-cloud/infrastructure','/private-cloud/onboarding/managed-private-cloud/infrastructure','/private-saas-deployment/managed-private-cloud','/private-cloud/onboarding/managed-private-cloud','/private-saas-deployment/onboarding/managed-private-cloud','/private-cloud/onboarding/managed-private-cloud','/appliance/infrastructure','/appliance/infrastructure/security'], 
+    from: ['/private-cloud/private-cloud-onboarding/standard-private-cloud-infrastructure-requirements','/private-saas-deployment/private-cloud','/private-cloud/standard-private-cloud','/private-saas-deployment/onboarding/managed-private-cloud/infrastructure','/private-cloud/onboarding/managed-private-cloud/infrastructure','/private-saas-deployment/managed-private-cloud','/private-cloud/onboarding/managed-private-cloud','/private-saas-deployment/onboarding/managed-private-cloud','/private-cloud/onboarding/managed-private-cloud','/appliance/infrastructure','/appliance/infrastructure/security'], 
     to: '/deploy/private-cloud/private-cloud-onboarding/standard-private-cloud-infrastructure-requirements'
   },
   {

--- a/config/redirects.js
+++ b/config/redirects.js
@@ -1338,7 +1338,52 @@ module.exports = [
     to: '/custom-domains/configure-custom-domains-with-self-managed-certificates/configure-aws-cloudfront-for-use-as-reverse-proxy'
   },
 
+  /* Deploy */
   
+  {
+    from: ['/get-started/deployment-options', '/getting-started/deployment-models','/overview/deployment-models','/deployment'],
+    to: '/deploy'
+  },
+  {
+    from: ['/private-cloud'],
+    to: '/deploy/private-cloud'
+  },
+  {
+    from: ['/private-cloud/private-cloud-onboarding'],
+    to: '/deploy/private-cloud/private-cloud-onboarding'
+  },
+  {
+    from: ['/private-cloud/private-cloud-onboarding/customer-hosted-managed-private-cloud-infrastructure-requirements'],
+    to: '/deploy/private-cloud/private-cloud-onboarding/customer-hosted-managed-private-cloud-infrastructure-requirements'
+  },
+  {
+    from: ['/private-cloud/private-cloud-onboarding/private-cloud-ip-domain-and-port-list'],
+    to: '/deploy/private-cloud/private-cloud-onboarding/private-cloud-ip-domain-and-port-list'
+  },
+  {
+    from: ['/private-cloud/private-cloud-onboarding/private-cloud-remote-access-options'],
+    to: '/deploy/private-cloud/private-cloud-onboarding/private-cloud-remote-access-options'
+  },
+  {
+    from: ['/private-cloud/private-cloud-operations'],
+    to: '/deploy/private-cloud/private-cloud-operations'
+  },
+  {
+    from: ['/private-cloud/private-cloud-migrations'],
+    to: '/deploy/private-cloud/private-cloud-migrations'
+  },
+  {
+    from: ['/private-cloud/private-cloud-migrations/migrate-from-public-cloud-to-private-cloud'],
+    to: '/deploy/private-cloud/private-cloud-migrations/migrate-from-public-cloud-to-private-cloud'
+  },
+  {
+    from: ['/private-cloud/private-cloud-migrations/migrate-from-standard-private-cloud-to-managed-private-cloud'],
+    to: '/private-cloud/private-cloud-migrations/migrate-from-standard-private-cloud-to-managed-private-cloud'
+  },
+  {
+    from: ['/private-cloud/private-cloud-migrations/migrate-private-cloud-custom-domains'],
+    to: '/deploy/private-cloud/private-cloud-migrations/migrate-private-cloud-custom-domains'
+  },
 
   /* Dev Lifecycle */
 
@@ -1715,10 +1760,6 @@ module.exports = [
   {
     from: ['/getting-started/set-up-api','/dashboard/reference/views-api'],
     to: '/get-started/set-up-apis'
-  },
-  {
-    from: ['/getting-started/deployment-models','/overview/deployment-models','/deployment'],
-    to: '/get-started/deployment-options'
   },
   {
     from: ['/dashboard','/getting-started/dashboard-overview'],

--- a/config/redirects.js
+++ b/config/redirects.js
@@ -1345,11 +1345,11 @@ module.exports = [
     to: '/deploy'
   },
   {
-    from: ['/private-cloud'],
+    from: ['/private-cloud/private-cloud-deployments/private-cloud-addon-options','/private-saas-deployment/add-ons','/private-cloud/add-ons','/appliance/infrastructure/internet-restricted-deployment','/private-saas-deployment','/private-cloud/managed-private-cloud','/private-cloud','/appliance','/appliance/checksum','/appliance/proxy-updater','/appliance/update','/updating-appliance','/enterprise/private-cloud/overview','/appliance/dashboard/instrumentation','/appliance/instrumentation','/appliance/appliance-overview'],
     to: '/deploy/private-cloud'
   },
   {
-    from: ['/private-cloud/private-cloud-onboarding'],
+    from: ['/services/private-cloud-configuration','/services/private-saas-configuration','/private-saas-deployment/onboarding','/private-saas-deployment/onboarding/private-cloud','/private-cloud/onboarding','/private-cloud/onboarding/private-cloud','/enterprise-support','/onboarding/appliance-outage','/onboarding/enterprise-support','/private-cloud/managed-private-cloud/zones','/private-cloud/managed-private-cloud/raci', '/private-cloud/private-cloud-onboarding'],
     to: '/deploy/private-cloud/private-cloud-onboarding'
   },
   {
@@ -1357,15 +1357,19 @@ module.exports = [
     to: '/deploy/private-cloud/private-cloud-onboarding/customer-hosted-managed-private-cloud-infrastructure-requirements'
   },
   {
-    from: ['/private-cloud/private-cloud-onboarding/private-cloud-ip-domain-and-port-list'],
+    from: ['/private-cloud/private-cloud-onboarding/private-cloud-ip-domain-and-port-list','/private-saas-deployment/onboarding/managed-private-cloud/ip-domain-port-list','/private-cloud/onboarding/managed-private-cloud/ip-domain-port-list', '/appliance/infrastructure/ip-domain-port-list'],
     to: '/deploy/private-cloud/private-cloud-onboarding/private-cloud-ip-domain-and-port-list'
   },
   {
-    from: ['/private-cloud/private-cloud-onboarding/private-cloud-remote-access-options'],
+    from: ['/private-cloud/private-cloud-onboarding/private-cloud-remote-access-options','/private-cloud/onboarding/managed-private-cloud/remote-access-options','/private-cloud/private-cloud-onboarding/private-cloud-remote-access-options'],
     to: '/deploy/private-cloud/private-cloud-onboarding/private-cloud-remote-access-options'
   },
   {
-    from: ['/private-cloud/private-cloud-operations'],
+    from: ['/private-cloud/private-cloud-onboarding/standard-private-cloud-infrastructure-requirements','/private-saas-deployment/private-cloud','/private-cloud/standard-private-cloud', '/private-cloud/private-cloud-onboarding/customer-hosted-managed-private-cloud-infrastructure-requirements', '/private-saas-deployment/onboarding/managed-private-cloud/infrastructure','/private-cloud/onboarding/managed-private-cloud/infrastructure','/private-saas-deployment/managed-private-cloud','/private-cloud/onboarding/managed-private-cloud','/private-saas-deployment/onboarding/managed-private-cloud','/private-cloud/onboarding/managed-private-cloud','/appliance/infrastructure','/appliance/infrastructure/security'], 
+    to: '/deploy/private-cloud/private-cloud-onboarding/standard-private-cloud-infrastructure-requirements'
+  },
+  {
+    from: ['/private-cloud/private-cloud-operations','/services/private-saas-management','/services/private-cloud-management'],
     to: '/deploy/private-cloud/private-cloud-operations'
   },
   {
@@ -1378,11 +1382,31 @@ module.exports = [
   },
   {
     from: ['/private-cloud/private-cloud-migrations/migrate-from-standard-private-cloud-to-managed-private-cloud'],
-    to: '/private-cloud/private-cloud-migrations/migrate-from-standard-private-cloud-to-managed-private-cloud'
+    to: '/deploy/private-cloud/private-cloud-migrations/migrate-from-standard-private-cloud-to-managed-private-cloud'
   },
   {
-    from: ['/private-cloud/private-cloud-migrations/migrate-private-cloud-custom-domains'],
+    from: ['/private-cloud/private-cloud-migrations/migrate-private-cloud-custom-domains','/appliance/custom-domains','/private-saas-deployment/custom-domain-migration','/private-cloud/custom-domain-migration','/private-cloud/migrate-private-cloud-custom-domains'], 
     to: '/deploy/private-cloud/private-cloud-migrations/migrate-private-cloud-custom-domains'
+  },
+  {
+    from: ['/pre-deployment/how-to-run-production-checks','/pre-deployment/how-to-run-test'],
+    to: '/deploy/pre-deployment/how-to-run-production-checks'
+  },
+  {
+      from: ['/pre-deployment/pre-launch-tips','/pre-deployment/prelaunch-tips'],
+      to: '/deploy/pre-deployment/pre-launch-tips'
+  },
+  {
+      from: ['/pre-deployment/how-to-run-production-checks/production-checks-best-practices','/pre-deployment/tests/best-practice'],
+      to: '/deploy/pre-deployment/how-to-run-production-checks/production-checks-best-practices'
+  },
+  {
+      from: ['/pre-deployment/how-to-run-production-checks/production-check-recommended-fixes','/pre-deployment/tests/recommended'],
+      to: '/deploy/pre-deployment/how-to-run-production-checks/production-check-recommended-fixes'
+  },
+  {
+      from: ['/pre-deployment/how-to-run-production-checks/production-check-required-fixes','/pre-deployment/tests/required'],
+      to: '/deploy/pre-deployment/how-to-run-production-checks/production-check-required-fixes'
   },
 
   /* Dev Lifecycle */
@@ -2816,69 +2840,6 @@ module.exports = [
     from: ['/policies/penetration-testing'],
     to: '/policies/penetration-testing-policy'
   },
-
-  /* Pre-deployment */
-
-  {
-    from: ['/pre-deployment/how-to-run-test'],
-    to: '/pre-deployment/how-to-run-production-checks'
-  },
-  {
-      from: ['/pre-deployment/prelaunch-tips'],
-      to: '/pre-deployment/pre-launch-tips'
-  },
-  {
-      from: ['/pre-deployment/tests/best-practice'],
-      to: '/pre-deployment/how-to-run-production-checks/production-checks-best-practices'
-  },
-  {
-      from: ['/pre-deployment/tests/recommended'],
-      to: '/pre-deployment/how-to-run-production-checks/production-check-recommended-fixes'
-  },
-  {
-      from: ['/pre-deployment/tests/required'],
-      to: '/pre-deployment/how-to-run-production-checks/production-check-required-fixes'
-  },
-
-  /* Private Cloud */
-
-  {
-    from: ['/appliance','/appliance/checksum','/appliance/proxy-updater','/appliance/update','/updating-appliance','/enterprise/private-cloud/overview','/appliance/dashboard/instrumentation','/appliance/instrumentation','/appliance/appliance-overview'],
-    to: '/private-cloud'
-  },
-  {
-    from: ['/services/private-cloud-configuration','/services/private-saas-configuration','/private-saas-deployment/onboarding','/private-saas-deployment/onboarding/private-cloud','/private-cloud/onboarding','/private-cloud/onboarding/private-cloud','/enterprise-support','/onboarding/appliance-outage','/onboarding/enterprise-support','/private-cloud/managed-private-cloud/zones','/private-cloud/managed-private-cloud/raci'], 
-    to: '/private-cloud/private-cloud-onboarding'
-  },
-  {
-    from: ['/private-saas-deployment/onboarding/managed-private-cloud/ip-domain-port-list','/private-cloud/onboarding/managed-private-cloud/ip-domain-port-list', '/appliance/infrastructure/ip-domain-port-list'],
-    to: '/private-cloud/private-cloud-onboarding/private-cloud-ip-domain-and-port-list'
-  },
-  {
-    from: ['/private-saas-deployment/private-cloud','/private-cloud/standard-private-cloud', '/private-cloud/private-cloud-onboarding/customer-hosted-managed-private-cloud-infrastructure-requirements', '/private-saas-deployment/onboarding/managed-private-cloud/infrastructure','/private-cloud/onboarding/managed-private-cloud/infrastructure','/private-saas-deployment/managed-private-cloud','/private-cloud/onboarding/managed-private-cloud','/private-saas-deployment/onboarding/managed-private-cloud','/private-cloud/onboarding/managed-private-cloud','/appliance/infrastructure','/appliance/infrastructure/security'], 
-    to: '/private-cloud/private-cloud-onboarding/standard-private-cloud-infrastructure-requirements'
-  },
-  {
-    from: ['/appliance/infrastructure/internet-restricted-deployment','/private-saas-deployment','/private-cloud/managed-private-cloud',], 
-    to: '/private-cloud/private-cloud-deployments'
-  },
-  {
-    from: ['/private-saas-deployment/add-ons','/private-cloud/add-ons'], 
-    to: '/private-cloud/private-cloud-deployments/private-cloud-addon-options'
-  },
-  {
-    from: ['/appliance/custom-domains','/private-saas-deployment/custom-domain-migration','/private-cloud/custom-domain-migration','/private-cloud/migrate-private-cloud-custom-domains'], 
-    to: '/private-cloud/private-cloud-migrations/migrate-private-cloud-custom-domains'
-  },
-  {
-    from: ['/services/private-saas-management','/services/private-cloud-management'],
-    to: '/private-cloud/private-cloud-operations'
-  },
-  {
-    from: ['/private-cloud/onboarding/managed-private-cloud/remote-access-options'],
-    to: '/private-cloud/private-cloud-onboarding/private-cloud-remote-access-options'
-  }, 
-
 
 
   /* Product-Lifecycle */

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -155,7 +155,7 @@ articles:
           - title: Troubleshoot Deploy CLI
             url: /extensions/deploy-cli-tool/troubleshoot-the-deploy-cli-tool
             hidden: true
-      - title: Private Cloud Options
+      - title: Private Cloud  Options
         url: /deploy/private-cloud
         children:
           - title: Onboarding

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -120,51 +120,18 @@ articles:
         url: /architecture-scenarios/checklists
       - title: Implementation Resources
         url: /architecture-scenarios/implementation-resources
-  - title: Deploy
+  - title: Deployment Options
     url: /deploy
     children:
-      - title: Deployment Options
-        url: /get-started/deployment-options
-        children:
-        - title: Private Cloud
-          url: /private-cloud
-          children:
-            - title: Operations
-              url: /private-cloud/private-cloud-operations
-            - title: Migrations
-              url: /private-cloud/private-cloud-migrations
-              children:
-                - title: Standard to Managed
-                  url: /private-cloud/private-cloud-migrations/migrate-from-standard-private-cloud-to-managed-private-cloud
-                - title: Custom Domains
-                  url: /private-cloud/private-cloud-migrations/migrate-private-cloud-custom-domains
-                - title: Public to Private
-                  url: /private-cloud/private-cloud-migrations/migrate-from-public-cloud-to-private-cloud
-            - title: Onboarding
-              url: /private-cloud/private-cloud-onboarding
-              children:
-                - title: Infrastructure Requirements
-                  url: /private-cloud/private-cloud-onboarding/standard-private-cloud-infrastructure-requirements
-                - title: IP/Domain and Port List
-                  url: /private-cloud/private-cloud-onboarding/private-cloud-ip-domain-and-port-list
-                - title: Remote Access Options
-                  url: /private-cloud/private-cloud-onboarding/private-cloud-remote-access-options
-            - title: Deployments
-              url: /private-cloud/private-cloud-deployments
-              children:
-                - title: Limitations
-                  url: /private-cloud/private-cloud-deployments/private-cloud-limitations
-                - title: Addon Options
-                  url: /private-cloud/private-cloud-deployments/private-cloud-addon-options
       - title: Deployment Checklist
         url: /deploy/deploy-checklist
       - title: Pre-Deployment
-        url: /pre-deployment
+        url: /deploy/pre-deployment
         children:
           - title: Run Checks
-            url: /pre-deployment/how-to-run-production-checks
+            url: /deploy/pre-deployment/how-to-run-production-checks
           - title: Pre-Launch Tips
-            url: /pre-deployment/pre-launch-tips
+            url: /deploy/pre-deployment/pre-launch-tips
       - title: Deploy CLI Tool
         url: /extensions/deploy-cli-tool
         children:
@@ -188,6 +155,29 @@ articles:
           - title: Troubleshoot Deploy CLI
             url: /extensions/deploy-cli-tool/troubleshoot-the-deploy-cli-tool
             hidden: true
+      - title: Private Cloud
+        url: /private-cloud
+        children:
+          - title: Onboarding
+            url: /private-cloud/private-cloud-onboarding
+            children:
+              - title: Infrastructure Requirements
+                url: /private-cloud/private-cloud-onboarding/standard-private-cloud-infrastructure-requirements
+              - title: IP/Domain and Port List
+                url: /private-cloud/private-cloud-onboarding/private-cloud-ip-domain-and-port-list
+              - title: Remote Access Options
+                url: /private-cloud/private-cloud-onboarding/private-cloud-remote-access-options
+          - title: Operations
+            url: /private-cloud/private-cloud-operations
+          - title: Migrations
+            url: /private-cloud/private-cloud-migrations
+            children:
+              - title: Standard to Managed
+                url: /private-cloud/private-cloud-migrations/migrate-from-standard-private-cloud-to-managed-private-cloud
+              - title: Custom Domains
+                url: /private-cloud/private-cloud-migrations/migrate-private-cloud-custom-domains
+              - title: Public to Private
+                url: /private-cloud/private-cloud-migrations/migrate-from-public-cloud-to-private-cloud
   - title: Login
     url: /login
     children:

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -156,33 +156,33 @@ articles:
             url: /extensions/deploy-cli-tool/troubleshoot-the-deploy-cli-tool
             hidden: true
       - title: Private Cloud Options
-        url: /private-cloud
+        url: /deploy/private-cloud
         children:
           - title: Onboarding
-            url: /private-cloud/private-cloud-onboarding
+            url: /deploy/private-cloud/private-cloud-onboarding
             children:
               - title: Infrastructure Requirements
-                url: /private-cloud/private-cloud-onboarding/customer-hosted-managed-private-cloud-infrastructure-requirements
+                url: /deploy/private-cloud/private-cloud-onboarding/customer-hosted-managed-private-cloud-infrastructure-requirements
                 hidden: true 
               - title: IP/Domain and Port List
-                url: /private-cloud/private-cloud-onboarding/private-cloud-ip-domain-and-port-list
+                url: /deploy/private-cloud/private-cloud-onboarding/private-cloud-ip-domain-and-port-list
                 hidden: true 
               - title: Remote Access Options
-                url: /private-cloud/private-cloud-onboarding/private-cloud-remote-access-options
+                url: /deploy/private-cloud/private-cloud-onboarding/private-cloud-remote-access-options
                 hidden: true 
           - title: Operations
-            url: /private-cloud/private-cloud-operations
+            url: /deploy/private-cloud/private-cloud-operations
           - title: Migrations
-            url: /private-cloud/private-cloud-migrations
+            url: /deploy/private-cloud/private-cloud-migrations
             children:
               - title: Public to Private
-                url: /private-cloud/private-cloud-migrations/migrate-from-public-cloud-to-private-cloud
+                url: /deploy/private-cloud/private-cloud-migrations/migrate-from-public-cloud-to-private-cloud
                 hidden: true 
               - title: Performance to Performance Plus
-                url: /private-cloud/private-cloud-migrations/migrate-from-standard-private-cloud-to-managed-private-cloud
+                url: /deploy/private-cloud/private-cloud-migrations/migrate-from-standard-private-cloud-to-managed-private-cloud
                 hidden: true 
               - title: Custom Domains
-                url: /private-cloud/private-cloud-migrations/migrate-private-cloud-custom-domains
+                url: /deploy/private-cloud/private-cloud-migrations/migrate-private-cloud-custom-domains
                 hidden: true 
   - title: Login
     url: /login

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -120,7 +120,7 @@ articles:
         url: /architecture-scenarios/checklists
       - title: Implementation Resources
         url: /architecture-scenarios/implementation-resources
-  - title: Deployment Options
+  - title: Deploy
     url: /deploy
     children:
       - title: Deployment Checklist
@@ -162,7 +162,7 @@ articles:
             url: /private-cloud/private-cloud-onboarding
             children:
               - title: Infrastructure Requirements
-                url: /private-cloud/private-cloud-onboarding/standard-private-cloud-infrastructure-requirements
+                url: /private-cloud/private-cloud-onboarding/customer-hosted-managed-private-cloud-infrastructure-requirements
               - title: IP/Domain and Port List
                 url: /private-cloud/private-cloud-onboarding/private-cloud-ip-domain-and-port-list
               - title: Remote Access Options
@@ -172,12 +172,12 @@ articles:
           - title: Migrations
             url: /private-cloud/private-cloud-migrations
             children:
-              - title: Standard to Managed
+              - title: Public to Private
+                url: /private-cloud/private-cloud-migrations/migrate-from-public-cloud-to-private-cloud
+              - title: Performance to Performance Plus
                 url: /private-cloud/private-cloud-migrations/migrate-from-standard-private-cloud-to-managed-private-cloud
               - title: Custom Domains
                 url: /private-cloud/private-cloud-migrations/migrate-private-cloud-custom-domains
-              - title: Public to Private
-                url: /private-cloud/private-cloud-migrations/migrate-from-public-cloud-to-private-cloud
   - title: Login
     url: /login
     children:

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -128,7 +128,7 @@ articles:
       - title: Pre-Deployment
         url: /deploy/pre-deployment
         children:
-          - title: Run Checks
+          - title: Run Production Checks
             url: /deploy/pre-deployment/how-to-run-production-checks
           - title: Pre-Launch Tips
             url: /deploy/pre-deployment/pre-launch-tips
@@ -155,7 +155,7 @@ articles:
           - title: Troubleshoot Deploy CLI
             url: /extensions/deploy-cli-tool/troubleshoot-the-deploy-cli-tool
             hidden: true
-      - title: Private Cloud
+      - title: Private Cloud Options
         url: /private-cloud
         children:
           - title: Onboarding
@@ -163,10 +163,13 @@ articles:
             children:
               - title: Infrastructure Requirements
                 url: /private-cloud/private-cloud-onboarding/customer-hosted-managed-private-cloud-infrastructure-requirements
+                hidden: true 
               - title: IP/Domain and Port List
                 url: /private-cloud/private-cloud-onboarding/private-cloud-ip-domain-and-port-list
+                hidden: true 
               - title: Remote Access Options
                 url: /private-cloud/private-cloud-onboarding/private-cloud-remote-access-options
+                hidden: true 
           - title: Operations
             url: /private-cloud/private-cloud-operations
           - title: Migrations
@@ -174,10 +177,13 @@ articles:
             children:
               - title: Public to Private
                 url: /private-cloud/private-cloud-migrations/migrate-from-public-cloud-to-private-cloud
+                hidden: true 
               - title: Performance to Performance Plus
                 url: /private-cloud/private-cloud-migrations/migrate-from-standard-private-cloud-to-managed-private-cloud
+                hidden: true 
               - title: Custom Domains
                 url: /private-cloud/private-cloud-migrations/migrate-private-cloud-custom-domains
+                hidden: true 
   - title: Login
     url: /login
     children:

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -120,6 +120,74 @@ articles:
         url: /architecture-scenarios/checklists
       - title: Implementation Resources
         url: /architecture-scenarios/implementation-resources
+  - title: Deploy
+    url: /deploy
+    children:
+      - title: Deployment Options
+        url: /get-started/deployment-options
+        children:
+        - title: Private Cloud
+          url: /private-cloud
+          children:
+            - title: Operations
+              url: /private-cloud/private-cloud-operations
+            - title: Migrations
+              url: /private-cloud/private-cloud-migrations
+              children:
+                - title: Standard to Managed
+                  url: /private-cloud/private-cloud-migrations/migrate-from-standard-private-cloud-to-managed-private-cloud
+                - title: Custom Domains
+                  url: /private-cloud/private-cloud-migrations/migrate-private-cloud-custom-domains
+                - title: Public to Private
+                  url: /private-cloud/private-cloud-migrations/migrate-from-public-cloud-to-private-cloud
+            - title: Onboarding
+              url: /private-cloud/private-cloud-onboarding
+              children:
+                - title: Infrastructure Requirements
+                  url: /private-cloud/private-cloud-onboarding/standard-private-cloud-infrastructure-requirements
+                - title: IP/Domain and Port List
+                  url: /private-cloud/private-cloud-onboarding/private-cloud-ip-domain-and-port-list
+                - title: Remote Access Options
+                  url: /private-cloud/private-cloud-onboarding/private-cloud-remote-access-options
+            - title: Deployments
+              url: /private-cloud/private-cloud-deployments
+              children:
+                - title: Limitations
+                  url: /private-cloud/private-cloud-deployments/private-cloud-limitations
+                - title: Addon Options
+                  url: /private-cloud/private-cloud-deployments/private-cloud-addon-options
+      - title: Deployment Checklist
+        url: /deploy/deploy-checklist
+      - title: Pre-Deployment
+        url: /pre-deployment
+        children:
+          - title: Run Checks
+            url: /pre-deployment/how-to-run-production-checks
+          - title: Pre-Launch Tips
+            url: /pre-deployment/pre-launch-tips
+      - title: Deploy CLI Tool
+        url: /extensions/deploy-cli-tool
+        children:
+          - title: Install Deploy CLI
+            url: /extensions/deploy-cli-tool/install-and-configure-the-deploy-cli-tool
+          - title: Call Deploy CLI
+            url: /extensions/deploy-cli-tool/call-deploy-cli-tool-programmatically
+          - title: Incorporate into CI/CD Environment
+            url: /extensions/deploy-cli-tool/incorporate-deploy-cli-into-build-environment
+          - title: Import/Export Directory Structure
+            url: /extensions/deploy-cli-tool/import-export-tenant-configuration-to-directory-structure
+          - title: Import/Export YAML File
+            url: /extensions/deploy-cli-tool/import-export-tenant-configuration-to-yaml-file
+          - title: Environment Variables
+            url: /extensions/deploy-cli-tool/environment-variables-and-keyword-mappings
+          - title: Deploy CLI Options
+            url: /extensions/deploy-cli-tool/deploy-cli-tool-options
+          - title: What's New
+            url: /extensions/deploy-cli/references/whats-new
+            hidden: true
+          - title: Troubleshoot Deploy CLI
+            url: /extensions/deploy-cli-tool/troubleshoot-the-deploy-cli-tool
+            hidden: true
   - title: Login
     url: /login
     children:
@@ -909,43 +977,6 @@ articles:
         url: /monitor-auth0/monitor-applications
       - title: Monitor Using SCOM
         url: /monitor-auth0/monitor-using-scom
-  - title: Deploy
-    url: /deploy
-    children:
-      - title: Deployment Options
-        url: /get-started/deployment-options
-      - title: Deploy Checklist
-        url: /deploy/deploy-checklist
-      - title: Pre-Deployment
-        url: /pre-deployment
-        children:
-          - title: Run Checks
-            url: /pre-deployment/how-to-run-production-checks
-          - title: Pre-Launch Tips
-            url: /pre-deployment/pre-launch-tips
-      - title: Deploy CLI Tool
-        url: /extensions/deploy-cli-tool
-        children:
-          - title: Install Deploy CLI
-            url: /extensions/deploy-cli-tool/install-and-configure-the-deploy-cli-tool
-          - title: Call Deploy CLI
-            url: /extensions/deploy-cli-tool/call-deploy-cli-tool-programmatically
-          - title: Incorporate into CI/CD Environment
-            url: /extensions/deploy-cli-tool/incorporate-deploy-cli-into-build-environment
-          - title: Import/Export Directory Structure
-            url: /extensions/deploy-cli-tool/import-export-tenant-configuration-to-directory-structure
-          - title: Import/Export YAML File
-            url: /extensions/deploy-cli-tool/import-export-tenant-configuration-to-yaml-file
-          - title: Environment Variables
-            url: /extensions/deploy-cli-tool/environment-variables-and-keyword-mappings
-          - title: Deploy CLI Options
-            url: /extensions/deploy-cli-tool/deploy-cli-tool-options
-          - title: What's New
-            url: /extensions/deploy-cli/references/whats-new
-            hidden: true
-          - title: Troubleshoot Deploy CLI
-            url: /extensions/deploy-cli-tool/troubleshoot-the-deploy-cli-tool
-            hidden: true
   - title: Troubleshoot
     url: /troubleshoot
     children:
@@ -1002,36 +1033,6 @@ articles:
         url: /troubleshoot/generate-and-analyze-har-files
       - title: Authentication API Debugger
         url: /extensions/authentication-api-debugger-extension
-  - title: Private Cloud
-    url: /private-cloud
-    children:
-      - title: Operations
-        url: /private-cloud/private-cloud-operations
-      - title: Migrations
-        url: /private-cloud/private-cloud-migrations
-        children:
-          - title: Standard to Managed
-            url: /private-cloud/private-cloud-migrations/migrate-from-standard-private-cloud-to-managed-private-cloud
-          - title: Custom Domains
-            url: /private-cloud/private-cloud-migrations/migrate-private-cloud-custom-domains
-          - title: Public to Private
-            url: /private-cloud/private-cloud-migrations/migrate-from-public-cloud-to-private-cloud
-      - title: Onboarding
-        url: /private-cloud/private-cloud-onboarding
-        children:
-          - title: Infrastructure Requirements
-            url: /private-cloud/private-cloud-onboarding/standard-private-cloud-infrastructure-requirements
-          - title: IP/Domain and Port List
-            url: /private-cloud/private-cloud-onboarding/private-cloud-ip-domain-and-port-list
-          - title: Remote Access Options
-            url: /private-cloud/private-cloud-onboarding/private-cloud-remote-access-options
-      - title: Deployments
-        url: /private-cloud/private-cloud-deployments
-        children:
-          - title: Limitations
-            url: /private-cloud/private-cloud-deployments/private-cloud-limitations
-          - title: Addon Options
-            url: /private-cloud/private-cloud-deployments/private-cloud-addon-options
   - title: Product Lifecycle
     url: /product-lifecycle
     children:


### PR DESCRIPTION
Initial sidebar structure changes
Moved Deploy up
Moved PSaaS under Deploy

Review: https://auth0content-pr-9552.herokuapp.com/docs/deploy and all links in sidebar should be correct

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
