### PR TITLE
Make it clear that Auth0 uses Twilio for SMS by default

### DIFF
--- a/articles/connections/passwordless/_includes/_introduction-sms.md
+++ b/articles/connections/passwordless/_includes/_introduction-sms.md
@@ -1,4 +1,6 @@
-With an SMS connection, the user is asked to enter a phone number, to which Auth0 sends a one-time-use code using [Twilio](https://www.twilio.com). The user then enters the code into your application. If you are using Universal Login, make sure you [configure Universal Login with Passwordless](/dashboard/guides/universal-login/configure-login-page-passwordless).
+With an SMS connection, the user is asked to enter a phone number. By default, Auth0 uses [Twilio](https://www.twilio.com) to send a one-time-use code to that phone number. (If you have a custom SMS gateway, you can [modify your connection to use that instead of Twilio](/connections/passwordless/guides/use-sms-gateway-passwordless.)
+
+The user then enters the code into your application. If you are using Universal Login, make sure you [configure Universal Login with Passwordless](/dashboard/guides/universal-login/configure-login-page-passwordless).
 
 If the phone number attached to the code matches an existing user, Auth0 authenticates the user:
 


### PR DESCRIPTION
Fixes #9540.