### PR TITLE
Update React Quickstart to mention scopes on the API

### DIFF
--- a/articles/quickstart/spa/react/02-calling-an-api.md
+++ b/articles/quickstart/spa/react/02-calling-an-api.md
@@ -47,7 +47,7 @@ ReactDOM.render(
 ```
 
 :::note
-As Auth0 is only able to issue Tokens for custom scopes that exist on your API, ensure the scopes used above are defined when [setting up an API](https://auth0.com/docs/getting-started/set-up-api) with Auth0.
+As Auth0 is only able to issue tokens for custom scopes that exist on your API, ensure the scopes used above are defined when [setting up an API](https://auth0.com/docs/getting-started/set-up-api) with Auth0.
 :::
 
 Auth0 uses the value of the `audience` prop to determine which resource server (API) the user is authorizing your React application to access. 

--- a/articles/quickstart/spa/react/02-calling-an-api.md
+++ b/articles/quickstart/spa/react/02-calling-an-api.md
@@ -47,7 +47,7 @@ ReactDOM.render(
 ```
 
 :::note
-As Auth0 is only able to issue tokens for custom scopes that exist on your API, ensure the scopes used above are defined when [setting up an API](https://auth0.com/docs/getting-started/set-up-api) with Auth0.
+As Auth0 can only issue tokens for custom scopes that exist on your API, ensure that you define the scopes used above when [setting up an API](https://auth0.com/docs/getting-started/set-up-api) with Auth0.
 :::
 
 Auth0 uses the value of the `audience` prop to determine which resource server (API) the user is authorizing your React application to access. 

--- a/articles/quickstart/spa/react/02-calling-an-api.md
+++ b/articles/quickstart/spa/react/02-calling-an-api.md
@@ -46,6 +46,10 @@ ReactDOM.render(
 );
 ```
 
+:::note
+As Auth0 is only able to issue Tokens for custom scopes that exist on your API, ensure the scopes used above are defined when [setting up an API](https://auth0.com/docs/getting-started/set-up-api) with Auth0.
+:::
+
 Auth0 uses the value of the `audience` prop to determine which resource server (API) the user is authorizing your React application to access. 
 
 :::note


### PR DESCRIPTION
The React Quickstart mentions using custom scopes but has no reference to configuring these in your API with Auth0.
I added a small info box that references https://auth0.com/docs/get-started/dashboard/api-settings