### PR TITLE
Update Angular Quickstart to mention scopes on the API

### DIFF
--- a/articles/quickstart/spa/angular/02-calling-an-api.md
+++ b/articles/quickstart/spa/angular/02-calling-an-api.md
@@ -99,7 +99,7 @@ AuthModule.forRoot({
 ```
 
 :::note
-As Auth0 is only able to issue Tokens for custom scopes that exist on your API, ensure the scopes used above are defined when [setting up an API](https://auth0.com/docs/getting-started/set-up-api) with Auth0.
+As Auth0 is only able to issue tokens for custom scopes that exist on your API, ensure the scopes used above are defined when [setting up an API](https://auth0.com/docs/getting-started/set-up-api) with Auth0.
 :::
 
 Please [refer to the docs](https://github.com/auth0/auth0-angular#configure-authhttpinterceptor-to-attach-access-tokens) for more information on the available options for the HTTP interceptor.

--- a/articles/quickstart/spa/angular/02-calling-an-api.md
+++ b/articles/quickstart/spa/angular/02-calling-an-api.md
@@ -98,6 +98,10 @@ AuthModule.forRoot({
 })
 ```
 
+:::note
+As Auth0 is only able to issue Tokens for custom scopes that exist on your API, ensure the scopes used above are defined when [setting up an API](https://auth0.com/docs/getting-started/set-up-api) with Auth0.
+:::
+
 Please [refer to the docs](https://github.com/auth0/auth0-angular#configure-authhttpinterceptor-to-attach-access-tokens) for more information on the available options for the HTTP interceptor.
 
 ## Make an API Call

--- a/articles/quickstart/spa/angular/02-calling-an-api.md
+++ b/articles/quickstart/spa/angular/02-calling-an-api.md
@@ -99,7 +99,7 @@ AuthModule.forRoot({
 ```
 
 :::note
-As Auth0 is only able to issue tokens for custom scopes that exist on your API, ensure the scopes used above are defined when [setting up an API](https://auth0.com/docs/getting-started/set-up-api) with Auth0.
+As Auth0 can only issue tokens for custom scopes that exist on your API, ensure that you define the scopes used above when [setting up an API](https://auth0.com/docs/getting-started/set-up-api) with Auth0.
 :::
 
 Please [refer to the docs](https://github.com/auth0/auth0-angular#configure-authhttpinterceptor-to-attach-access-tokens) for more information on the available options for the HTTP interceptor.


### PR DESCRIPTION
The Angular Quickstart mentions using custom scopes but has no reference to configuring these in your API with Auth0.
I added a small info box that references https://auth0.com/docs/get-started/dashboard/api-settings