### PR TITLE
added instructions for windows server 2019

### DIFF
--- a/articles/connections/enterprise/adfs.md
+++ b/articles/connections/enterprise/adfs.md
@@ -1,5 +1,5 @@
 ---
-title: Connect Your App to ADFS
+title: Connect Your App to ADFS 
 connection: ADFS
 image: /media/connections/adfs.png
 public: true

--- a/articles/connections/enterprise/adfs.md
+++ b/articles/connections/enterprise/adfs.md
@@ -21,6 +21,7 @@ toc: true
 useCase:
     - customize-connections
     - add-idp
+    
 ---
 # Connect Your App to ADFS
 
@@ -88,38 +89,40 @@ $rSet = New-ADFSClaimRuleSet –ClaimRule '=> issue(Type = "http://schemas.micro
 Set-ADFSRelyingPartyTrust –TargetName $realm –IssuanceAuthorizationRules $rSet.ClaimRulesString
 ```
 
-## Manual setup
-
-::: note
-These instructions use the Microsoft Windows Server 2016 management console. Different versions have different user interface details. Please consult your Windows Server documentation.
-:::
+## Manual setup part 1: Add a Relying Party Trust
 
 1. Open the ADFS Management Console.
 1. On the right side of the console, click **Add Relying Party Trust**.
 1. Click **Start**.
 1. Select **Enter data about the relying party manually** and click **Next**.
-1. Enter a name (such as `${account.appName}`) and click **Next**.
+1. Type a name (such as `${account.appName}`) and click **Next**.
 1. Use the default (`ADFS 2.0 profile`) and click **Next**.
 1. Use the default (`no encryption certificate`) and click **Next**.
-1. Check **Enable support for the WS-Federation...** and enter the following value in the textbox:
+1. Check **Enable support for the WS-Federation...** and type this value in the textbox:
 
     `https://${account.namespace}/login/callback` or if you are using a [custom domain](/custom-domains), use `https://<YOUR CUSTOM DOMAIN>/login/callback`
 
 1. Click **Next**.
-1. Add a Relying Party Trust identifier with the following value:
+1. Add a Relying Party Trust identifier with this value:
 
     `urn:auth0:${account.tenant}`
 
 1. Click **Add** and then **Next**.
 1. Leave the default `Permit all users...` and click **Next**.
 1. Click **Next** and then **Close**.
-1. In the console tree, under ADFS, click **Relying Party Trusts**. 
-1. On the right side of the console, find the relying party trust you just created. Right-click it and click **Edit Claim Issuance Policy**.
-1. In the Edit Claim Issuance Policy Window, under Issuance Transform Rules, click **Add Rule...**.
-1. Leave the default `Send LDAP Attributes as Claims`.
-1. Give the rule a name that describes what it does. 
-1. Under Attribute Store, select **Active Directory**.
-1. Select these mappings under `Mapping of LDAP attributes to outgoing claim types` and click **Finish**.
+
+## Manual setup part 2: Add a claim issuance policy rule
+
+1. If you're using Windows Server 2019, the Edit Claim Issuance Polcy dialog box automatically opens when you finish the Add Relying Party Trust wizard. If you're using Windows 2012 or 2016, follow these steps:
+    |  In Windows Server 2012  | In Windows Server 2016 |
+    | --- | --- |
+    | In the Actions panel on the right side of the console, find the Relying Party Trust you just created. Beneath it, click **Edit Claim Issuance Policy**. | In the console tree, under ADFS, click **Relying Party Trusts**. On the right side of the console, find the Relying Party Trust you just created. Right-click it and click **Edit Claim Issuance Policy**. |
+
+2. In the Edit Claim Issuance Policy Window, under Issuance Transform Rules, click **Add Rule...**.
+3. Leave the default `Send LDAP Attributes as Claims`.
+4. Give the rule a name that describes what it does. 
+5. Under Attribute Store, select **Active Directory**.
+6. Select these mappings under `Mapping of LDAP attributes to outgoing claim types` and click **Finish**.
 
     | LDAP Attribute | Outgoing Claim Type |
     | --- | --- |

--- a/articles/connections/enterprise/adfs.md
+++ b/articles/connections/enterprise/adfs.md
@@ -1,5 +1,5 @@
 ---
-title: Connect Your App to ADFS 
+title: Connect Your App to ADFS
 connection: ADFS
 image: /media/connections/adfs.png
 public: true


### PR DESCRIPTION
The manual setup instructions now cover 2012, 2016, and 2019.
