### PR TITLE
add rails > 5.2 notes about change in credentials

### DIFF
--- a/articles/quickstart/webapp/rails/01-login.md
+++ b/articles/quickstart/webapp/rails/01-login.md
@@ -82,6 +82,33 @@ end
 This tutorial uses omniauth-auth0, a custom [OmniAuth strategy](https://github.com/intridea/omniauth#omniauth-standardized-multi-provider-authentication).
 :::
 
+#### For Rails 5.2 and greater
+
+Starting in Rails 5.2, the default storage location is 
+```config/credentials.yml.enc```. This is an encrypted file, which you can
+ edit using this Rails command ```EDITOR=vim bin/rails credentials:edit```.
+
+You will also have to change ```auth0.rb``` in ```config/initializers``` to:
+
+```ruby
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider(
+    :auth0,
+    Rails.application.credentials.auth0_client_id,
+    Rails.application.credentials.auth0_client_secret,
+    Rails.application.credentials.auth0_domain,
+    callback_path: '/auth/auth0/callback',
+    authorize_params: {
+      scope: 'openid email profile'
+    }
+  )
+end
+```
+
+For more information about setting and using secrets, check out [this portion
+](https://guides.rubyonrails.org/security.html#custom-credentials) of the
+ Rails documentation.
+
 ### Add the Auth0 Callback Handler
 
 Use the following command to create the controller that will handle the Auth0 callback:

--- a/articles/quickstart/webapp/rails/01-login.md
+++ b/articles/quickstart/webapp/rails/01-login.md
@@ -85,8 +85,8 @@ This tutorial uses omniauth-auth0, a custom [OmniAuth strategy](https://github.c
 #### For Rails 5.2 and greater
 
 Starting in Rails 5.2, the default storage location is 
-```config/credentials.yml.enc```. This is an encrypted file, which you can
- edit using this Rails command ```EDITOR=vim bin/rails credentials:edit```.
+```config/credentials.yml.enc```. Instead of creating a secrets.yml, we should edit this encrypted file using this Rails command ```EDITOR=vim
+ bin/rails credentials:edit```.
 
 You will also have to change ```auth0.rb``` in ```config/initializers``` to:
 
@@ -104,6 +104,10 @@ Rails.application.config.middleware.use OmniAuth::Builder do
   )
 end
 ```
+
+:::note
+Note the change from ```Rails.application.secrets``` to ```Rails.application.credentials```
+:::
 
 For more information about setting and using secrets, check out [this portion
 ](https://guides.rubyonrails.org/security.html#custom-credentials) of the


### PR DESCRIPTION
The newer rails projects will use a different credential storage system then is referenced by the Quickstart. After recently setting up a new Rails 6 app, this was the only discrepancy between versions that I experienced.

 Given as it's a security sensitive step, I felt it was probably better to be as explicit as seemed necessary. We don't want to accidentally lead a new dev down a misinformed path. 

Should I also update the requirements to list be > Rails 5.2 ? 