### PR TITLE
Fix typo in Next.js QS

### DIFF
--- a/articles/quickstart/webapp/nextjs/01-login.md
+++ b/articles/quickstart/webapp/nextjs/01-login.md
@@ -61,7 +61,7 @@ export default handleAuth();
 This creates the following routes:
 
 - `/api/auth/login`: The route used to perform login with Auth0.
-- `/api/auth/login`: The route used to log the user out.
+- `/api/auth/logout`: The route used to log the user out.
 - `/api/auth/callback`: The route Auth0 will redirect the user to after a successful login.
 - `/api/auth/me`: The route to fetch the user profile from.
 


### PR DESCRIPTION
`login` -> `logout`