### PR TITLE
Specify beta version dependency [SDK-2245]

### DIFF
--- a/articles/quickstart/native/android-vnext/00-login.md
+++ b/articles/quickstart/native/android-vnext/00-login.md
@@ -43,7 +43,7 @@ android {
 }
 dependencies {
   // Add the Auth0 Android SDK
-  implementation 'com.auth0.android:auth0:2.+'
+implementation 'com.auth0.android:auth0:2.0.0-beta.0'
 }
 ```
 


### PR DESCRIPTION
Updates the Auth0.Android version dependency example to be explicit, as the wildcard matcher won't handle non-standard release numbers, like `2.0.0-beta.0`.
