### PR TITLE
Remove note about gradle plus sign

### DIFF
--- a/articles/quickstart/native/android-vnext/00-login.md
+++ b/articles/quickstart/native/android-vnext/00-login.md
@@ -47,10 +47,6 @@ dependencies {
 }
 ```
 
-::: note
-If Android Studio lints the `+` sign, or if you want to use a fixed version, check for the latest in [Maven](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22auth0%22%20g%3A%22com.auth0.android%22) or [JCenter](https://bintray.com/auth0/android/auth0).
-:::
-
 ::: panel Sync Project with Gradle Files
 Remember to synchronize using the Android Studio prompt or run `./gradlew clean build` from the command line. For more information about Gradle usage, check [their official documentation](http://tools.android.com/tech-docs/new-build-system/user-guide).
 :::


### PR DESCRIPTION
Removes the note regarding the "+" Gradle syntax, since https://github.com/auth0/docs/pull/9586 updated the example to use a fixed version.