### PR TITLE
TLS replaces SSL, so updating sidebar with new slug and title to matc…

### DIFF
--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -644,8 +644,8 @@ articles:
             url: /custom-domains/configure-custom-domains-with-auth0-managed-certificates
           - title: Self-Managed Certificates
             url: /custom-domains/configure-custom-domains-with-self-managed-certificates
-          - title: SSL (TLS) Versions and Ciphers
-            url: /custom-domains/ssl-tls
+          - title: TLS (SSL) Versions and Ciphers
+            url: /custom-domains/tls-ssl
             children:
               - title: Custom Domains
                 url: /custom-domains/


### PR DESCRIPTION
…h Contentful article

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
