### PR TITLE
[SDK-1838] Update URLs to React docs in Quickstart

### DIFF
--- a/articles/quickstart/spa/react/02-calling-an-api.md
+++ b/articles/quickstart/spa/react/02-calling-an-api.md
@@ -64,7 +64,7 @@ In the case of the Auth0 Management API, the `read:current_user` and `update:cur
 
 ## Get an Access Token 
 
-Once you configure `Auth0Provider`, you can easily get the access token using the [`getAccessTokenSilently()`](https://auth0.github.io/auth0-react/interfaces/auth0contextinterface.html#getaccesstokensilently) method from the [`useAuth0()`](https://auth0.github.io/auth0-react/globals.html#useauth0) custom React Hook wherever you need it. 
+Once you configure `Auth0Provider`, you can easily get the access token using the [`getAccessTokenSilently()`](https://auth0.github.io/auth0-react/interfaces/auth0_context.auth0contextinterface.html#getaccesstokensilently) method from the [`useAuth0()`](https://auth0.github.io/auth0-react/modules/use_auth0.html) custom React Hook wherever you need it. 
 
 Take this `Profile` component as an example:
 


### PR DESCRIPTION
This PR updates the QS links to refer to the new location of the corresponding docs after https://github.com/auth0/auth0-react/pull/192 gets merged.