### PR TITLE
[SDK-2095] Add note about using Default App with SPA and Native

### DIFF
--- a/articles/_includes/_new_app.md
+++ b/articles/_includes/_new_app.md
@@ -7,6 +7,12 @@ When you signed up for Auth0, a new application was created for you, or you coul
 ![App Dashboard](/media/articles/dashboard/client_settings.png)
 <% } %>
 
+<% if(typeof showClientSecret === 'undefined' || showClientSecret !== true) { %>
+::: note
+When using the Default App with a Native or Single Page Application, ensure to update the **Token Endpoint Authentication Method** to `None` and set the **Application Type** to either `SPA` or `Native`. 
+:::
+<% } %>
+
 You need the following information:
 
 * **Domain**


### PR DESCRIPTION
The Default App that gets generated for any new tenant doesn't work OOTB with public clients. In order for them to work using the Default App, the **Token Endpoint Authentication Mode** has to be set to `None` and the Application Type to either `SPA` or `Native`.

This change adds the same message to **all of our SPA and Native quickstarts** in a uniform way:
![image](https://user-images.githubusercontent.com/2146903/106630900-882e0700-657c-11eb-88a8-97a131f2f4aa.png)
