### PR TITLE
[React Quickstart] Update chapter 2 to allow choosing an API when downloading the sample

### DIFF
--- a/articles/quickstart/spa/react/02-calling-an-api.md
+++ b/articles/quickstart/spa/react/02-calling-an-api.md
@@ -10,6 +10,9 @@ topics:
 github:
   path: Sample-01
 contentType: tutorial
+sample_download_required_data:
+  - client
+  - api
 useCase: quickstart
 ---
 <!-- markdownlint-disable MD002 MD034 MD041 -->


### PR DESCRIPTION
This is something that other SPA quickstarts have, but was omitted from React.

It enables this:

![image](https://user-images.githubusercontent.com/766403/107034475-abd89380-67ae-11eb-8a28-83d2a5b62875.png)
