### PR TITLE
Update requirements for Xamarin

### DIFF
--- a/articles/quickstart/native/xamarin/index.yml
+++ b/articles/quickstart/native/xamarin/index.yml
@@ -25,10 +25,10 @@ github:
   org: auth0-samples
   repo: auth0-xamarin-oidc-samples
 requirements:
-  - Visual Studio 2017 or Visual Studio for Mac
-  - Xamarin for Visual Studio 4.5
+  - Visual Studio 2017, 2019 or Visual Studio for Mac
+  - Xamarin for Visual Studio
   - Auth0.OidcClient.Android 3.1.3
-  - Auth0.OidcClient.iOS 3.1.3
+  - Auth0.OidcClient.iOS 3.2.0
 next_steps:
   - path: 01-login
     list:

--- a/articles/quickstart/native/xamarin/index.yml
+++ b/articles/quickstart/native/xamarin/index.yml
@@ -25,7 +25,7 @@ github:
   org: auth0-samples
   repo: auth0-xamarin-oidc-samples
 requirements:
-  - Visual Studio 2017, 2019 or Visual Studio for Mac
+  - Visual Studio 2017+ or Visual Studio for Mac
   - Xamarin for Visual Studio
   - Auth0.OidcClient.Android 3.1.3
   - Auth0.OidcClient.iOS 3.2.0


### PR DESCRIPTION
Bumped the requirements:

- Include VS2019
- Drop the version number from Xamarin (it comes installed through VS Installer, you don't have to google for a specific version and I am also not sure what Xamarin for VS 4.5 is about, I have Xamarin 16.8 installed).
- Bump SDK versions