### PR TITLE
Take Android vnext quickstart out of beta

### DIFF
--- a/articles/quickstart/native/android-vnext/00-login.md
+++ b/articles/quickstart/native/android-vnext/00-login.md
@@ -39,7 +39,7 @@ In your app's `build.gradle` dependencies section, add the following:
 ```groovy
 dependencies {
   // Add the Auth0 Android SDK
-  implementation 'com.auth0.android:auth0:2.0.0-beta.0'
+  implementation 'com.auth0.android:auth0:2.+'
 }
 ```
 
@@ -65,7 +65,7 @@ Add manifest placeholders required by the SDK. The placeholders are used interna
 
 To add the manifest placeholders, add the next line:
 
-```xml
+```groovy
 // app/build.gradle
 
 apply plugin: 'com.android.application'
@@ -151,7 +151,7 @@ private fun loginWithBrowser() {
             override fun onSuccess(credentials: Credentials) {
               // Get the access token from the credentials object.
               // This can be used to call APIs
-              val accessToken = credentials.accessToken!!
+              val accessToken = credentials.accessToken
             }
         })
 }
@@ -183,7 +183,7 @@ Add a `logout` method to your app to remove the user's session and log them out 
 private fun logout() {
   WebAuthProvider.logout(account)
     .withScheme("demo")
-    .start(this, object: Callback<Void, AuthenticationException> {
+    .start(this, object: Callback<Void?, AuthenticationException> {
       override fun onSuccess(payload: Void?) {
         // The user has been logged out!
       }
@@ -220,7 +220,7 @@ The following demonstrates a function that can be used to retrieve the user's pr
 private fun showUserProfile(accessToken: String) {
   var client = AuthenticationAPIClient(account)
 
-  // If an access token is available, call `userInfo` and get the profile from Auth0.
+  // With the access token, call `userInfo` and get the profile from Auth0.
   client.userInfo(accessToken)
     .start(object : Callback<UserProfile, AuthenticationException> {
         override fun onFailure(exception: AuthenticationException) {

--- a/articles/quickstart/native/android-vnext/01-user-metadata.md
+++ b/articles/quickstart/native/android-vnext/01-user-metadata.md
@@ -29,7 +29,7 @@ As an example of using the SDK to call APIs that may require custom scopes and a
 
 In [the previous chapter](/quickstart/native/android-vnext/00-login#show-user-profile-information), you saw how to access [basic user profile information](https://auth0.com/docs/users/user-profiles) using the `/userinfo` endpoint. This profile information may not include everything about a user that you might need. For example, in order to access the user's metadata, you must make an API call to the Management API using the user ID and the access token. With the Android SDK, this is done using the `UsersAPIClient` object.
 
-To be able to correctly read and update the user metadata, ensure the authorization server allows you to read and edit the current user profile by specifying the `profile email read:current_user update:current_user_metadata` scopes. In addition, specify the audience for the [Auth0 Management API](https://auth0.com/docs/api), which happens to include the User Info audience as well.
+To be able to correctly read and update the user metadata, ensure the authorization server allows you to read and edit the current user profile by specifying the `openid profile email read:current_user update:current_user_metadata` scopes. In addition, specify the audience for the [Auth0 Management API](https://auth0.com/docs/api), which happens to include the User Info audience as well.
 
 Find the code in your project that initializes the `WebAuthProvider` class, and make the following changes if necessary:
 

--- a/articles/quickstart/native/android-vnext/index.yml
+++ b/articles/quickstart/native/android-vnext/index.yml
@@ -13,7 +13,6 @@ topics:
   - quickstart
 contentType: tutorial
 useCase: quickstart
-beta: true
 snippets:
   dependencies: native-platforms/android/dependencies
   setup: native-platforms/android/setup


### PR DESCRIPTION
The SDK was launched today and is out of beta. This PR fixes some snippets and removes the beta indicator.