### PR TITLE
Add link to older releases for Android Quickstart

### DIFF
--- a/articles/quickstart/native/android/index.yml
+++ b/articles/quickstart/native/android/index.yml
@@ -13,6 +13,7 @@ topics:
   - quickstart
 contentType: tutorial
 useCase: quickstart
+show_releases: true
 snippets:
   dependencies: native-platforms/android/dependencies
   setup: native-platforms/android/setup


### PR DESCRIPTION
Adds a link to previous releases of the Android Quickstart samples, for those wishing to view the tutorial Quickstarts for v1. This should generate a link to https://github.com/auth0-samples/auth0-android-sample/releases, from which they can view all the samples and tutorial documents from the auth0.android-v1 release.
