### PR TITLE
Update rules to redirect to the new android quickstart

### DIFF
--- a/config/redirects.js
+++ b/config/redirects.js
@@ -60,7 +60,7 @@ module.exports = [
   /* QUICKSTARTS */
 
   {
-    from: ['/android-tutorial', '/native-platforms/android'],
+    from: ['/android-tutorial', '/native-platforms/android', '/quickstart/native/android-vnext'],
     to: '/quickstart/native/android'
   },
   {


### PR DESCRIPTION
Redirect to the new android quickstart from the temporary folder