### PR TITLE
Correct Information for 3-Day Verification Window

### DIFF
--- a/articles/custom-domains/auth0-managed-certificates.md
+++ b/articles/custom-domains/auth0-managed-certificates.md
@@ -31,7 +31,7 @@ Before you can use the domain with Auth0, you'll need to verify that you own it.
 
 2. Click **Verify** to proceed.
 
-  It may take a few minutes before Auth0 is able to verify your CNAME record, depending on your DNS settings. If Auth0 was able to verify your domain name, you'll see a confirmation window. This means the verification process is complete, and within 1 to 2 minutes, your custom domain should be ready to use.
+  It may take a few minutes before Auth0 is able to verify your CNAME record, depending on your DNS settings. If Auth0 was able to verify your domain name, you'll see a confirmation window. This means the verification process is complete, and within 1 to 2 minutes, your custom domain should be ready to use. **<%= include('./_warning-repeat-steps') %>**
 
 ::: panel Add the CNAME verification record to your domain's DNS record
 Once added, the CNAME record must be present at all times to avoid issues during certificate renewal. If your DNS provider enables a proxy on the CNAME record by default, it will leave the custom domain in a pending state indefinitely. You may need to check your DNS provider settings and disable the proxy. The following steps may vary for your domain host provider.
@@ -53,8 +53,6 @@ Once added, the CNAME record must be present at all times to avoid issues during
 If Auth0 was able to verify your domain name, you'll see a confirmation window. This means the verification process is complete, and within 1 to 2 minutes, your custom domain should be ready to use.
 
   ![Domain Verification](/media/articles/custom-domains/domain-verification.png)
-
-<%= include('./_warning-repeat-steps') %>
 
 <%= include('./_additional-steps') %>
 


### PR DESCRIPTION
The documentation currently states that you have a 3-day window for Auth0 to verify CNAME entries AFTER the entries are added. 

The 3-day window starts as soon as "Add Domain" is clicked. Auth0 would not have a way to know when the CNAME entries were added.


<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
