### PR TITLE
Change logo to node while I figure out how to add a new logo

### DIFF
--- a/articles/quickstart/webapp/nextjs/index.yml
+++ b/articles/quickstart/webapp/nextjs/index.yml
@@ -17,6 +17,7 @@ topics:
 contentType: tutorial
 useCase: quickstart
 seo_alias: nextjs
+logo_name: nodejs
 show_releases: true
 show_steps: true
 requirements:


### PR DESCRIPTION
Change the Next.js logo in https://auth0.com/docs/quickstart/webapp to the green 'js' logo.

This is temporary while I figure out how to craete/add a new logo for Next.js