### PR TITLE
Replace ASP.NET Core 3.x with ASP.NET Core in Web App Quickstart

### DIFF
--- a/articles/quickstart/webapp/aspnet-core/01-login.md
+++ b/articles/quickstart/webapp/aspnet-core/01-login.md
@@ -1,6 +1,6 @@
 ---
 title: Login
-description: This tutorial demonstrates how to add user login to an ASP.NET Core 3.x application.
+description: This tutorial demonstrates how to add user login to an ASP.NET Core application.
 budicon: 448
 topics:
   - quickstarts


### PR DESCRIPTION
This PR removes the explicit reference to ASP.NET Core 3.x  as the quickstart also works for 5.