### PR TITLE
Add Support Center Users link to Sidebar

### DIFF
--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -1273,6 +1273,8 @@ articles:
         url: /support/sla
       - title: Tickets
         url: /support/open-and-manage-support-tickets
+      - title: Support Center Users
+        url: /support/support-center-users
       - title: Manage Subscription
         url: /support/manage-subscriptions
       - title: Operational Policies


### PR DESCRIPTION
Add Support Center Users link to sidebar
Review: https://auth0content-pr-9628.herokuapp.com/docs/support/support-center-users

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
