### PR TITLE
Update ASPNET Owin MVC QS to use CookieManager

### DIFF
--- a/articles/quickstart/webapp/aspnet-owin/_includes/_login.md
+++ b/articles/quickstart/webapp/aspnet-owin/_includes/_login.md
@@ -63,6 +63,10 @@ public void Configuration(IAppBuilder app)
         // Configure SameSite as needed for your app. Lax works well for most scenarios here but
         // you may want to set SameSiteMode.None for HTTPS
         CookieSameSite = SameSiteMode.Lax,
+
+        // More information on why the CookieManager needs to be set can be found here: 
+        // https://github.com/aspnet/AspNetKatana/wiki/System.Web-response-cookie-integration-issues
+        CookieManager = new SameSiteCookieManager(new SystemWebCookieManager())
     });
 
     // Configure Auth0 authentication
@@ -86,6 +90,8 @@ public void Configuration(IAppBuilder app)
             NameClaimType = "name"
         },
 
+        // More information on why the CookieManager needs to be set can be found here: 
+        // https://docs.microsoft.com/en-us/aspnet/samesite/owin-samesite
         CookieManager = new SameSiteCookieManager(new SystemWebCookieManager()),
 
         Notifications = new OpenIdConnectAuthenticationNotifications


### PR DESCRIPTION
This aligns the QS with the changes made in https://github.com/auth0-samples/auth0-aspnet-owin-mvc-samples/pull/41. 

**Reason for this change from the [original issue](https://github.com/auth0-samples/auth0-aspnet-owin-mvc-samples/issues/40):**

Microsoft's OWIN implementation (Katana) does some funny business where sometimes the cookies set by an OWIN middleware are lost, not sent in the response (details are https://github.com/aspnet/AspNetKatana/wiki/System.Web-response-cookie-integration-issues). One of the symptoms is that immediately after a successful callback processing there's no session create, and the user still looks unauthenticated.

One of the suggested workarounds is to use the SytemWebCookieManager, which is already used for the OIDC middleware (together with the SameSiteCookieManager), but it's not configured for the Cookie Authentication middleware.

We'll need to add it here:
```
  app.UseCookieAuthentication(new CookieAuthenticationOptions
  {
      AuthenticationType = CookieAuthenticationDefaults.AuthenticationType,
      LoginPath = new PathString("/Account/Login"),
      CookieSameSite = SameSiteMode.Lax,
      // specify the cookie manager
      CookieManager = new SameSiteCookieManager(new SystemWebCookieManager()),
  });
```

I added a link to the explanation why it's needed for extra context, see https://github.com/aspnet/AspNetKatana/wiki/System.Web-response-cookie-integration-issues.

I also added a link to get more context about the other CookieManager that is being set with the OpenID Connect middleware.