### PR TITLE
Update the nextjs logo

### DIFF
--- a/articles/quickstart/webapp/nextjs/index.yml
+++ b/articles/quickstart/webapp/nextjs/index.yml
@@ -17,7 +17,6 @@ topics:
 contentType: tutorial
 useCase: quickstart
 seo_alias: nextjs
-logo_name: nodejs
 show_releases: true
 show_steps: true
 requirements:


### PR DESCRIPTION
We now have a nextjs badge https://github.com/auth0/auth0-docs/pull/1985

Removing the `logo_name` will make the QuickStart logo default to the folder name `nextjs`, which will pick up the new `nextjs` badge styles