### PR TITLE
Simplifying example for Machine-to-Machine Applications for Management API page

### DIFF
--- a/articles/api/management/v2/create-m2m-app.md
+++ b/articles/api/management/v2/create-m2m-app.md
@@ -30,7 +30,7 @@ Each machine-to-machine application that accesses an API must be granted a set o
 
 ## Example: Get All Connections Endpoint
 
-The [Get all connections](/api/management/v2#!/Connections/get_connections) endpoint accepts the `read:connections` scope, whilst the [Create a connection](/api/management/v2#!/Connections/post_connections) endpoint accepts the `write:connections` scope. Using that we now know that our machine-to-machine token should only need the `read:connections` scope in order to get that data.
+The [Get all connections](/api/management/v2#!/Connections/get_connections) endpoint accepts the `read:connections` scope, whilst the [Create a connection](/api/management/v2#!/Connections/post_connections) endpoint accepts the `write:connections` scope. Using that we now know that our machine-to-machine token should only need the `read:connections` scope in order to access data from that endpoint.
 
 If you have multiple applications that should access the Management API then you should create separate machine-to-machine applications for each application in Auth0, instead of just a single machine-to-machine application.
 ## Keep reading

--- a/articles/api/management/v2/create-m2m-app.md
+++ b/articles/api/management/v2/create-m2m-app.md
@@ -25,8 +25,7 @@ To create and authorize a Machine-to-Machine Application for the Management API:
 The application created in the steps above has been granted __all__ the Management API <dfn data-key="scope">scopes</dfn>. This means that it can access all endpoints.
 
 ::: panel How can I find out which scopes/permissions are required?
-Each [Auth0 Management API v2](/api/management/v2) endpoint requires specific scopes in the machine-to-machine token in order to get the data you want. Each endpoint
-in the [Management API Explorer](/api/management/v2#!) documentation has a section called scopes, listing all the scopes that the endpoint requires.
+Each [Auth0 Management API v2](/api/management/v2) endpoint requires specific scopes in the machine-to-machine token in order to get the data you want. Each endpoint in the [Management API Explorer](/api/management/v2#!) documentation has a section called scopes, listing all the scopes that the endpoint requires.
 :::
 
 ## Example: Get All Connections Endpoint

--- a/articles/api/management/v2/create-m2m-app.md
+++ b/articles/api/management/v2/create-m2m-app.md
@@ -30,7 +30,7 @@ Each machine-to-machine application that accesses an API must be granted a set o
 
 ## Example: Get All Connections Endpoint
 
-The [Get all connections](/api/management/v2#!/Connections/get_connections) endpoint accepts the `read:connections` scope while the [Create a connection](/api/management/v2#!/Connections/post_connections) endpoint accepts the `write:connections` scope. Our machine-to-machine token should only need the `read:connections` scope in order to access data from that endpoint.
+The [Get All Connections](/api/management/v2#!/Connections/get_connections) endpoint accepts the `read:connections` scope while the [Create a Connection](/api/management/v2#!/Connections/post_connections) endpoint accepts the `write:connections` scope. Our machine-to-machine token should only need the `read:connections` scope in order to access data from that endpoint.
 
 If you have multiple applications that should access the Management API then you should create separate machine-to-machine applications for each application in Auth0, instead of just a single machine-to-machine application.
 ## Keep reading

--- a/articles/api/management/v2/create-m2m-app.md
+++ b/articles/api/management/v2/create-m2m-app.md
@@ -30,7 +30,7 @@ Each machine-to-machine application that accesses an API must be granted a set o
 
 ## Example: Get All Connections Endpoint
 
-The [Get all connections](/api/management/v2#!/Connections/get_connections) endpoint requires the `read:connections` scope, whilst the [Create a connection](/api/management/v2#!/Connections/post_connections) endpoint requires the `write:connections` scope. Using that we now know that our machine-to-machine token should only require the `read:connections` scope in order to get that data.
+The [Get all connections](/api/management/v2#!/Connections/get_connections) endpoint accepts the `read:connections` scope, whilst the [Create a connection](/api/management/v2#!/Connections/post_connections) endpoint accepts the `write:connections` scope. Using that we now know that our machine-to-machine token should only need the `read:connections` scope in order to get that data.
 
 If you have multiple applications that should access the Management API then you should create separate machine-to-machine applications for each application in Auth0, instead of just a single machine-to-machine application.
 ## Keep reading

--- a/articles/api/management/v2/create-m2m-app.md
+++ b/articles/api/management/v2/create-m2m-app.md
@@ -32,7 +32,7 @@ Each machine-to-machine application that accesses an API must be granted a set o
 
 The [Get all connections](/api/management/v2#!/Connections/get_connections) endpoint requires the `read:connections` scope, whilst the [Create a connection](/api/management/v2#!/Connections/post_connections) endpoint requires the `write:connections` scope. Using that we now know that our machine-to-machine token should only require the `read:connections` scope in order to get that data.
 
-If you have multiple applications that should access the Management API then you should create separate machine-to-machine applications for each application in Auth0 instead of just a single machine-to-machine application.
+If you have multiple applications that should access the Management API then you should create separate machine-to-machine applications for each application in Auth0, instead of just a single machine-to-machine application.
 ## Keep reading
 
 * [Get Access Tokens for Testing](/api/management/v2/get-access-tokens-for-test)

--- a/articles/api/management/v2/create-m2m-app.md
+++ b/articles/api/management/v2/create-m2m-app.md
@@ -25,8 +25,15 @@ To create and authorize a Machine-to-Machine Application for the Management API:
 The application created in the steps above has been granted __all__ the Management API <dfn data-key="scope">scopes</dfn>. This means that it can access all endpoints.
 
 ::: panel How can I find out which scopes/permissions are required?
-Each machine-to-machine application that accesses an API must be granted a set of <dfn data-key="scope">scopes</dfn>. Scopes are permissions that should be granted by the owner. Each [Auth0 Management API v2](/api/management/v2) endpoint requires specific scopes. To see the required scopes/permissions for each endpoint, go to the [Management API Explorer](/api/management/v2#!) and find the endpoint you want to call. Each endpoint has a section called **Scopes** listing all the scopes that the endpoint requires. For example, the [Get all clients](/api/management/v2#!/Clients/get_clients) endpoint requires the scopes `read:clients` and `read:client_keys`.
+Each [Auth0 Management API v2](/api/management/v2) endpoint requires specific scopes in the machine-to-machine token in order to get the data you want. Each endpoint
+in the [Management API Explorer](/api/management/v2#!) documentation has a section called scopes, listing all the scopes that the endpoint requires.
 :::
+
+## Example: Get All Connections Endpoint
+
+The [Get all connections](/api/management/v2#!/Connections/get_connections) endpoint requires the `read:connections` scope, whilst the [Create a connection](/api/management/v2#!/Connections/post_connections) endpoint requires the `write:connections` scope. Using that we now know that our machine-to-machine token should only require the `read:connections` scope in order to get that data.
+
+We do recommend that if you have multiple applications that need access to the Management API that you create separate machine-to-machine applications for each application in Auth0 instead of one.
 
 ## Example: Get All Clients Endpoint
 

--- a/articles/api/management/v2/create-m2m-app.md
+++ b/articles/api/management/v2/create-m2m-app.md
@@ -25,21 +25,14 @@ To create and authorize a Machine-to-Machine Application for the Management API:
 The application created in the steps above has been granted __all__ the Management API <dfn data-key="scope">scopes</dfn>. This means that it can access all endpoints.
 
 ::: panel How can I find out which scopes/permissions are required?
-Each [Auth0 Management API v2](/api/management/v2) endpoint requires specific scopes in the machine-to-machine token in order to get the data you want. Each endpoint in the [Management API Explorer](/api/management/v2#!) documentation has a section called scopes, listing all the scopes that the endpoint requires.
+Each machine-to-machine application that accesses an API must be granted a set of <dfn data-key="scope">scopes</dfn>. Scopes are permissions that should be granted by the owner. Each [Auth0 Management API v2](/api/management/v2) endpoint requires specific scopes. To see the required scopes/permissions for each endpoint, go to the [Management API Explorer](/api/management/v2#!) and find the endpoint you want to call. Each endpoint has a section called **Scopes** listing all the scopes that the endpoint accepts.
 :::
 
 ## Example: Get All Connections Endpoint
 
 The [Get all connections](/api/management/v2#!/Connections/get_connections) endpoint requires the `read:connections` scope, whilst the [Create a connection](/api/management/v2#!/Connections/post_connections) endpoint requires the `write:connections` scope. Using that we now know that our machine-to-machine token should only require the `read:connections` scope in order to get that data.
 
-We do recommend that if you have multiple applications that need access to the Management API that you create separate machine-to-machine applications for each application in Auth0 instead of one.
-
-## Example: Get All Clients Endpoint
-
-The [Get all clients](/api/management/v2#!/Clients/get_clients) endpoint requires the scopes `read:clients` and `read:client_keys`, while the [Create an application](/api/management/v2#!/Clients/post_clients) endpoint requires the scope `create:clients`. From that we can deduce that if we need to read _and_ create applications, then our token should include three scopes: `read:clients`, `read:client_keys` and `create:clients`.
-
-If you have multiple applications that should access the Management API, and you need different sets of scopes per app, we recommend creating a new machine-to-machine application for each one. For example, if one application is to read and create users (`create:users`, `read:users`) and another to read and create applications (`create:clients`, `read:clients`) create two applications (one for user scopes, one for applications) instead of one.
-
+If you have multiple applications that should access the Management API then you should create separate machine-to-machine applications for each application in Auth0 instead of just a single machine-to-machine application.
 ## Keep reading
 
 * [Get Access Tokens for Testing](/api/management/v2/get-access-tokens-for-test)

--- a/articles/api/management/v2/create-m2m-app.md
+++ b/articles/api/management/v2/create-m2m-app.md
@@ -30,7 +30,7 @@ Each machine-to-machine application that accesses an API must be granted a set o
 
 ## Example: Get All Connections Endpoint
 
-The [Get all connections](/api/management/v2#!/Connections/get_connections) endpoint accepts the `read:connections` scope, whilst the [Create a connection](/api/management/v2#!/Connections/post_connections) endpoint accepts the `write:connections` scope. Using that we now know that our machine-to-machine token should only need the `read:connections` scope in order to access data from that endpoint.
+The [Get all connections](/api/management/v2#!/Connections/get_connections) endpoint accepts the `read:connections` scope while the [Create a connection](/api/management/v2#!/Connections/post_connections) endpoint accepts the `write:connections` scope. Our machine-to-machine token should only need the `read:connections` scope in order to access data from that endpoint.
 
 If you have multiple applications that should access the Management API then you should create separate machine-to-machine applications for each application in Auth0, instead of just a single machine-to-machine application.
 ## Keep reading


### PR DESCRIPTION
Currently the language and example used in this documentation is overly complicated for what it is trying to convey, here I try and simplifying the language and example so that:
- In the "panel How can I find out which scopes/permissions are required?" section, we get straight to the point.
- In the "Example: Get All Connections Endpoint" section, we include an accurate example and one that doesn't include scopes which are overly complex for what we're trying to convey in this documentation.