### PR TITLE
Update redirects.js

### DIFF
--- a/config/redirects.js
+++ b/config/redirects.js
@@ -1393,6 +1393,10 @@ module.exports = [
     to: '/deploy/private-cloud/private-cloud-migrations/migrate-private-cloud-custom-domains'
   },
   {
+    from: ['/pre-deployment'],
+    to: '/deploy/pre-deployment'
+  },
+  {
     from: ['/pre-deployment/how-to-run-production-checks','/pre-deployment/how-to-run-test'],
     to: '/deploy/pre-deployment/how-to-run-production-checks'
   },


### PR DESCRIPTION
DR-968: Added missing redirect for /docs/pre-deployment to /docs/deploy/pre-deployment

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
