### PR TITLE
Update dependency array for React Quickstart (Calling an API)

### DIFF
--- a/articles/quickstart/spa/react/02-calling-an-api.md
+++ b/articles/quickstart/spa/react/02-calling-an-api.md
@@ -129,7 +129,7 @@ useEffect(() => {
   };
 
   getUserMetadata();
-}, []);
+}, [getAccessTokenSilently, user?.sub]);
 ```
 
 You use a React Effect Hook to call an asynchronous `getUserMetadata()` function. The function first calls `getAccessTokenSilently()`, which returns a Promise that resolves to an access token that you can use to make a call to a protected API.


### PR DESCRIPTION
When running through the documentation on a brand new react project, I noticed the user metadata wasn't ever displaying because the useEffect was firing a single time before the user gets populated. By adding "getAccessTokenSilently" and "user?.sub" to the useEffect dependency array, I was able to get this code working reliably.

You can see in the console logs from the catch block that the first fire fails as the user has not yet been defined. When the user is updated, useEffect fires again which causes the metadata to populate properly.

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
