### PR TITLE
Rails QS -- adding link for context

### DIFF
--- a/articles/quickstart/webapp/rails/01-login.md
+++ b/articles/quickstart/webapp/rails/01-login.md
@@ -106,7 +106,7 @@ end
 A user can now log into your application by visiting the `/auth/auth0` endpoint.
 
 ::: warning
-To prevent forged authentication requests, use the `link_to` or `button_to` helper methods with the `:post` method
+To [prevent forged authentication requests](https://github.com/cookpad/omniauth-rails_csrf_protection), use the `link_to` or `button_to` helper methods with the `:post` method
 :::
 
 ```erb


### PR DESCRIPTION
add link as context for preventing forged auth requests

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
