### PR TITLE
Add Custom Domain item to sidebar

### DIFF
--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -670,7 +670,7 @@ articles:
           - title: Self-Managed Certificates
             url: /custom-domains/configure-custom-domains-with-self-managed-certificates
             children:
-              - title: Google Cloud Platform  Reverse Proxy
+              - title: Google Cloud Platform Reverse Proxy
                 url: /custom-domains/configure-custom-domains-with-self-managed-certificates/configure-gcp-as-reverse-proxy
               - title: Cloudflare Reverse Proxy
                 url: /custom-domains/configure-custom-domains-with-self-managed-certificates/configure-cloudflare-for-use-as-reverse-proxy

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -670,7 +670,7 @@ articles:
           - title: Self-Managed Certificates
             url: /custom-domains/configure-custom-domains-with-self-managed-certificates
             children:
-              - title: Google Cloud Platform Reverse Proxy
+              - title: Google Cloud Platform  Reverse Proxy
                 url: /custom-domains/configure-custom-domains-with-self-managed-certificates/configure-gcp-as-reverse-proxy
               - title: Cloudflare Reverse Proxy
                 url: /custom-domains/configure-custom-domains-with-self-managed-certificates/configure-cloudflare-for-use-as-reverse-proxy

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -670,6 +670,8 @@ articles:
           - title: Self-Managed Certificates
             url: /custom-domains/configure-custom-domains-with-self-managed-certificates
             children:
+              - title: Google Cloud Platform Reverse Proxy
+                url: /custom-domains/configure-custom-domains-with-self-managed-certificates/configure-gcp-as-reverse-proxy
               - title: Cloudflare Reverse Proxy
                 url: /custom-domains/configure-custom-domains-with-self-managed-certificates/configure-cloudflare-for-use-as-reverse-proxy
               - title: Cloudfront Reverse Proxy


### PR DESCRIPTION
Added GCP with Load Balancing Reverse Proxy to sidebar under Custom Domains > Self-Managed Certificates

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
