### PR TITLE
[MFA-1012] Removing non existant parameter

### DIFF
--- a/articles/api/authentication/_multifactor-authentication.md
+++ b/articles/api/authentication/_multifactor-authentication.md
@@ -106,7 +106,6 @@ If OTP is supported by the user and you don't want to request a different factor
 | `client_id` <br/><span class="label label-danger">Required</span> | Your application's Client ID. |
 | `client_secret` | Your application's Client Secret. **Required** when the **Token Endpoint Authentication Method** field at your [Application Settings](${manage_url}/#/applications) is `Post` or `Basic`. |
 | `challenge_type` | A whitespace-separated list of the challenges types accepted by your application. Accepted challenge types are `oob` or `otp`. Excluding this parameter means that your client application accepts all supported challenge types. |
-| `oob_channel` | The channel to use for OOB. Can only be provided when `challenge_type` is `oob`. Accepted values are `sms`, `voice`, or `auth0`. Excluding this parameter means that your client application will accept **all** supported OOB channels. |
 | `authenticator_id` | The ID of the authenticator to challenge. You can get the ID by querying the list of available authenticators for the user as explained on [List authenticators](#list-authenticators) below. |
 
 ### Remarks


### PR DESCRIPTION
Fixing: https://auth0.com/docs/api/authentication#multi-factor-authentication
Removing the reference to a non existing parameter: oob_channel for the endpoint `mfa/challenge`. 

https://auth0team.atlassian.net/browse/MFA-1012

https://auth0team.atlassian.net/servicedesk/customer/portal/9/DR-1012

As it can be seen here: https://github.com/auth0/auth0-server/blob/03a3289c9c37e8f2adfe1af89c9363fddca9a8e7/lib/auth/protocols/oauth2/exchange/components/mfa_challenge.js#L26-L27