### PR TITLE
Pass the issuer as an array of strings [ESD-12786]

### DIFF
--- a/articles/quickstart/backend/nodejs/01-authorization.md
+++ b/articles/quickstart/backend/nodejs/01-authorization.md
@@ -59,7 +59,7 @@ const checkJwt = jwt({
 
   // Validate the audience and the issuer.
   audience: '${apiIdentifier}',
-  issuer: `https://${account.namespace}/`,
+  issuer: [`https://${account.namespace}/`],
   algorithms: ['RS256']
 });
 ```


### PR DESCRIPTION
Update the quickstart making it clear that multiple issuer values could be passed