### PR TITLE
Fixed redirect to /protocols/saml-protocol

### DIFF
--- a/config/redirects.js
+++ b/config/redirects.js
@@ -3229,10 +3229,6 @@ module.exports = [
     to: '/protocols/configure-ws-fed-applications'
   },
   {
-    from: ['/protocols/saml/saml-apps','/saml-apps','/protocols/saml/identity-providers','/samlp-providers','/protocols/saml/samlp-providers', '/protocols/saml'],
-    to: '/protocols/saml-protocol'
-  },
-  {
     from: ['/protocols/saml/saml-configuration/troubleshoot/auth0-as-idp','/protocols/saml/saml-configuration/troubleshoot','/protocols/saml/saml-configuration/troubleshoot/common-saml-errors','/protocols/saml/saml-configuration/troubleshoot/auth0-as-sp','/troubleshoot/troubleshoot-saml-configurations'],
     to: '/protocols/saml-protocol/troubleshoot-saml-configurations'
   },
@@ -3241,8 +3237,21 @@ module.exports = [
     to: '/protocols/state-parameters'
   },
   {
-    from: ['/protocols/saml/saml-configuration/supported-options-and-bindings','/protocols/saml/saml-configuration/design-considerations','/protocols/saml/saml-configuration-options','/saml-configuration','/protocols/saml/saml-configuration'],
-    to: '/protocols/saml-configuration-options'
+    from: [
+      '/saml-apps',
+      '/protocols/saml/identity-providers',
+      '/samlp-providers',
+      '/protocols/saml/samlp-providers',
+      '/protocols/saml',
+      '/protocols/saml/saml-apps',
+      '/protocols/saml/saml-configuration/supported-options-and-bindings',
+      '/protocols/saml/saml-configuration/design-considerations',
+      '/protocols/saml/saml-configuration-options',
+      '/saml-configuration',
+      '/protocols/saml/saml-configuration',
+      '/protocols/saml-configuration-options'
+    ],
+    to: '/protocols/saml-protocol'
   },
   {
     from: ['/protocols/saml/adfs'],


### PR DESCRIPTION
Fixed redirect

Review steps:

1. View deployment.
2. In the browser URL, after `https://auth0content-pr-9691.herokuapp.com/docs`,  type `/protocols/saml-configuration-options`.
It should redirect to `https://auth0content-pr-9691.herokuapp.com/docs/protocols/saml-protocol` with a doc titled **SAML Configuration Options**.

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
