### PR TITLE
Add note to the Swift Quickstart about a skippable step iOS 12+

### DIFF
--- a/articles/quickstart/native/ios-swift/_includes/_login_centralized.md
+++ b/articles/quickstart/native/ios-swift/_includes/_login_centralized.md
@@ -74,7 +74,11 @@ To learn how to embed the Lock widget in your application, follow the [Embedded 
 
 <%= include('../../_includes/_ios_dependency_centralized') %>
 
-## Add the Callback
+## Add the Callback (iOS < 12 only)
+
+::: note
+Skip this step if your app targets iOS 12+ (e.g. if it uses the SwiftUI app lifecycle).
+:::
 
 For Auth0 to handle the authentication callback, update your `AppDelegate` file.
 


### PR DESCRIPTION
This PR adds a note to the Swift Quickstart about a step that can be skipped if the developer is targeting iOS 12 or above.