### PR TITLE
Security Sidebar link update

### DIFF
--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -1251,8 +1251,10 @@ articles:
         url: /security/prevent-common-cybersecurity-threats
       - title: General Security Tips
         url: /security/general-security-tips
-      - title: Add User Attributes to DenyList
+      - title: Add User Attributes to Deny List
         url: /security/denylist-user-attributes
+      - title: Add IP Addresses to Allow List
+        url: /security/allowlist-ip-addresses
   - title: Data Privacy
     url: /compliance
     children:

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -614,8 +614,6 @@ articles:
             url: /protocols/saml-protocol/customize-saml-assertions
           - title: Deprovision Users
             url: /protocols/saml-protocol/deprovision-users-in-saml-integrations
-      - title: Add IP Addresses to AllowList
-        url: /security/allowlist-ip-addresses
   - title: Manage Users
     url: /users
     children:
@@ -1253,7 +1251,7 @@ articles:
         url: /security/general-security-tips
       - title: Add User Attributes to Deny List
         url: /security/denylist-user-attributes
-      - title: Add IP Addresses to Allow List
+      - title: Auth0 IP Addresses for Allow Lists
         url: /security/allowlist-ip-addresses
   - title: Data Privacy
     url: /compliance


### PR DESCRIPTION
Added missing doc to sidebar under Security

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
