### PR TITLE
Retitle documentation to read Authorization

### DIFF
--- a/articles/quickstart/backend/rails/01-authorization.md
+++ b/articles/quickstart/backend/rails/01-authorization.md
@@ -1,5 +1,5 @@
 ---
-title: Authentication
+title: Authorization
 description: This tutorial demonstrates how to add authorization to a Ruby on Rails API.
 topics:
     - quickstart


### PR DESCRIPTION
This documentation article is about implementing authorization on a Ruby on Rails REST API, however it's titled as *Authentication*, and not *Authorization*. Because this title appears in the navigation of Auth0's documentation, a user will be choosing this article thinking they're going to read about auth'n instead of auth'z, which the article is about.

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
