### PR TITLE
Update download instructions for Android sample [ESD-12922]

### DIFF
--- a/articles/architecture-scenarios/mobile-api/mobile-implementation-android.md
+++ b/articles/architecture-scenarios/mobile-api/mobile-implementation-android.md
@@ -119,7 +119,7 @@ Open the app's `AndroidManifest.xml` and add the `LoginActivity`:
 
                 <data
                     android:host="@string/auth0_domain"
-                    android:pathPrefix="/android/com.auth0.samples/callback"
+                    android:pathPrefix="/android/com.auth0.androidsample/callback"
                     android:scheme="demo" />
             </intent-filter>
 </activity>

--- a/articles/quickstart/native/android/download.md
+++ b/articles/quickstart/native/android/download.md
@@ -3,13 +3,13 @@
 To run the sample first set the **Callback URL** in the [Application Settings](${manage_url}/#/applications/${account.clientId}/settings) to
 
 ```text
-demo://${account.namespace}/android/com.auth0.samples/callback
+demo://${account.namespace}/android/com.auth0.androidsample/callback
 ```
 
 To run the sample first set the **Logout URL** in the [Application Settings](${manage_url}/#/applications/${account.clientId}/settings) to
 
 ```text
-demo://${account.namespace}/android/com.auth0.samples/callback
+demo://${account.namespace}/android/com.auth0.androidsample/callback
 ```
 
 Then, to run it from the **command line**:


### PR DESCRIPTION
This PR updates the download instructions for the Android sample apps, as the package name in the new sample is `com.auth0.androidsample` instead of `com.auth0.samples`.

See https://github.com/auth0-samples/auth0-android-sample/blob/master/00-Login-Kt/app/build.gradle#L11.
See related PR from same ESD ticket: https://github.com/auth0-samples/auth0-android-sample/pull/107