### PR TITLE
[SDK-2574] Remove Auth0 SDK listing from Spring 5 API Quickstart metadata

### DIFF
--- a/articles/quickstart/backend/java-spring-security5/index.yml
+++ b/articles/quickstart/backend/java-spring-security5/index.yml
@@ -25,10 +25,6 @@ show_steps: true
 github:
   org: auth0-samples
   repo: auth0-spring-security5-api-sample
-sdk:
-  name: auth0-spring-security-api
-  url: https://github.com/auth0/auth0-spring-security-api
-  logo: spring
 requirements:
   - Java 8 or above
 next_steps:


### PR DESCRIPTION
The [Auth0 Libraries page](https://auth0.com/docs/libraries#backend) currently lists the "Spring Security 5 Java API" as a backend library. This is incorrect; Spring 5 customers should use the OOTB OAuth2 support in Spring as demonstrated in the [Spring 5 API Quickstart](https://auth0.com/docs/quickstart/backend/java-spring-security5).

This is happening because the Spring 5 API Quickstart incorrectly lists the `auth0-spring-security-api` SDK in its `index.yml`. The Libraries page uses that to build the library contents page.

This change removes the `sdk` entry from the `index.yml` file, which will remove the "Spring Security 5 Java API" entry from the backend libraries page.