### PR TITLE
Change sidebar titles under Configuration section

### DIFF
--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -555,7 +555,7 @@ articles:
             url: /applications/view-application-type
           - title: Rotate Client Secret
             url: /get-started/dashboard/rotate-client-secret
-          - title: Wildcards for Subdomains
+          - title: Subdomain URL Placeholders
             url: /applications/wildcards-for-subdomains
           - title: Manage Application Metadata
             url: /applications/configure-application-metadata

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -559,7 +559,7 @@ articles:
             url: /applications/wildcards-for-subdomains
           - title: Configure Application Metadata
             url: /applications/configure-application-metadata
-          - title: Recommended Settings
+          - title: Best Practices
             url: /best-practices/app-settings-best-practices
       - title: API Configuration
         url: /get-started/dashboard/api-settings

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -551,9 +551,9 @@ articles:
             url: /enable-universal-links-support-in-apple-xcode
           - title: Remove Applications
             url: /applications/remove-applications
-          - title: View Application Type
+          - title: Check Confidential or Public
             url: /applications/view-application-type
-          - title: Rotate Client Secret
+          - title: Rotate Client Secrets
             url: /get-started/dashboard/rotate-client-secret
           - title: Subdomain URL Placeholders
             url: /applications/wildcards-for-subdomains
@@ -561,7 +561,7 @@ articles:
             url: /applications/configure-application-metadata
           - title: Best Practices
             url: /best-practices/app-settings-best-practices
-      - title: API Configuration
+      - title: API Settings
         url: /get-started/dashboard/api-settings
         children:
           - title: Signing Algorithms

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -527,8 +527,6 @@ articles:
             hidden: true 
           - title: Configure Device User Code Settings
             url: /get-started/dashboard/configure-device-user-code-settings
-          - title: Recommended Settings
-            url: /best-practices/tenant-settings-best-practices
           - title: Dynamic Client Registration
             url: /applications/dynamic-client-registration
           - title: Create Multiple Tenants
@@ -537,6 +535,8 @@ articles:
           - title: Child Tenant Request Process
             url: /dev-lifecycle/child-tenants
             hidden: true
+          - title: Best Practices
+            url: /best-practices/tenant-settings-best-practices
       - title: Application Settings
         url: /get-started/dashboard/application-settings
         children:

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -557,7 +557,7 @@ articles:
             url: /get-started/dashboard/rotate-client-secret
           - title: Subdomain URL Placeholders
             url: /applications/wildcards-for-subdomains
-          - title: Manage Application Metadata
+          - title: Configure Application Metadata
             url: /applications/configure-application-metadata
           - title: Recommended Settings
             url: /best-practices/app-settings-best-practices


### PR DESCRIPTION
Changed sidebar text text under Configuration to match doc titles.

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
