### PR TITLE
Move Logs under Monitor in sidebar

### DIFF
--- a/config/redirects.js
+++ b/config/redirects.js
@@ -2902,8 +2902,8 @@ module.exports = [
     to: '/logs/retrieve-log-events-using-mgmt-api'
   },
   {
-    from: ['/logs/guides/view-log-data-dashboard'],
-    to: '/logs/view-log-events-in-the-dashboard'
+    from: ['/logs/guides/view-log-data-dashboard','/logs/view-log-events-in-the-dashboard'],
+    to: '/logs/view-log-events'
   },
   {
     from: ['/logs/export-log-events-with-log-streaming/splunk-dashboard'],

--- a/config/redirects.js
+++ b/config/redirects.js
@@ -2911,8 +2911,12 @@ module.exports = [
   },
   {
     from: ['/logs/references/log-event-filters','/logs/log-event-filters'],
-    to: '/monitor-auth0/streams/log-event-filters'
+    to: '/logs/log-event-filters'
   },
+  {
+    from: ['/logs/event-filters'],
+    to: '/monitor-auth0/streams/event-filters'
+  }
   {
     from: ['/logs/references/log-event-data','/logs/references/log-events-data','/logs/references/log-event-type-codes'],
     to: '/logs/log-event-type-codes'

--- a/config/redirects.js
+++ b/config/redirects.js
@@ -2850,8 +2850,12 @@ module.exports = [
     to: '/logs/streams/stream-logs-to-splunk'
   },
   {
-    from: ['/logs/export-log-events-with-log-streaming/stream-http-event-logs','/logs/streams/http-event'],
-    to: '/logs/streams/stream-http-event-logs'
+    from: [
+      '/logs/export-log-events-with-log-streaming/stream-http-event-logs',
+      '/logs/streams/http-event',
+      '/logs/streams/stream-http-event-logs'
+    ],
+    to: '/logs/streams/custom-log-streams'
   },
   {
     from: ['/logs/export-log-events-with-log-streaming/stream-logs-to-amazon-eventbridge','/logs/streams/aws-eventbridge','/integrations/aws-eventbridge','/logs/streams/amazon-eventbridge'],

--- a/config/redirects.js
+++ b/config/redirects.js
@@ -3100,14 +3100,6 @@ module.exports = [
     from: ['/monitoring/guides/monitor-using-SCOM'],
     to: '/monitor-auth0/monitor-using-scom'
   },
-  {
-    from: ['/monitoring/guides/track-leads-salesforce','/tutorials/tracking-new-leads-in-salesforce-and-raplead','/scenarios-rapleaf-salesforce', '/scenarios/rapleaf-salesforce'],
-    to: '/monitor-auth0/track-new-leads-in-salesforce'
-  },
-  {
-    from: ['/monitoring/guides/track-signups-salesforce','/tutorials/track-signups-enrich-user-profile-generate-leads','/scenarios-mixpanel-fullcontact-salesforce','/scenarios/mixpanel-fullcontact-salesforce'],
-    to: '/monitor-auth0/track-new-sign-ups-in-salesforce'
-  },
   
 
   /* Policies */
@@ -3561,6 +3553,26 @@ module.exports = [
   {
     from: ['/rules/references/user-object'],
     to: '/rules/user-object-in-rules'
+  },
+  {
+    from: [
+      '/monitoring/guides/track-leads-salesforce',
+      '/tutorials/tracking-new-leads-in-salesforce-and-raplead',
+      '/scenarios-rapleaf-salesforce',
+      '/scenarios/rapleaf-salesforce',
+      '/monitor-auth0/track-new-leads-in-salesforce'
+    ],
+    to: '/rules/use-cases/track-new-leads-in-salesforce'
+  },
+  {
+    from: [
+      '/monitoring/guides/track-signups-salesforce',
+      '/tutorials/track-signups-enrich-user-profile-generate-leads',
+      '/scenarios-mixpanel-fullcontact-salesforce',
+      '/scenarios/mixpanel-fullcontact-salesforce',
+      '/monitor-auth0/track-new-sign-ups-in-salesforce'
+    ],
+    to: '/rules/use-cases/track-new-sign-ups-in-salesforce'
   },
  
 

--- a/config/redirects.js
+++ b/config/redirects.js
@@ -2838,16 +2838,23 @@ module.exports = [
     to: '/logs'
   },
   {
-    from: ['/logs/export-log-events-with-log-streaming'],
-    to: '/logs/streams'
+    from: ['/logs/export-log-events-with-log-streaming','/logs/streams'],
+    to: '/monitor-auth0/streams'
   },
   {
-    from: ['/logs/export-log-events-with-log-streaming/stream-log-events-to-slack','/logs/streams/http-event-to-slack'],
-    to: '/logs/streams/stream-log-events-to-slack'
+    from: [
+      '/logs/export-log-events-with-log-streaming/stream-log-events-to-slack',
+      '/logs/streams/http-event-to-slack'
+    ],
+    to: '/monitor-auth0/streams/stream-log-events-to-slack'
   },
   {
-    from: ['/logs/export-log-events-with-log-streaming/stream-logs-to-splunk','/logs/streams/splunk'],
-    to: '/logs/streams/stream-logs-to-splunk'
+    from: [
+      '/logs/export-log-events-with-log-streaming/stream-logs-to-splunk',
+      '/logs/streams/splunk',
+      '/logs/streams/stream-logs-to-splunk'
+    ],
+    to: '/monitor-auth0/streams/stream-logs-to-splunk'
   },
   {
     from: [
@@ -2855,23 +2862,40 @@ module.exports = [
       '/logs/streams/http-event',
       '/logs/streams/stream-http-event-logs'
     ],
-    to: '/logs/streams/custom-log-streams'
+    to: '/monitor-auth0/streams/custom-log-streams'
   },
   {
-    from: ['/logs/export-log-events-with-log-streaming/stream-logs-to-amazon-eventbridge','/logs/streams/aws-eventbridge','/integrations/aws-eventbridge','/logs/streams/amazon-eventbridge'],
-    to: '/logs/streams/stream-logs-to-amazon-eventbridge'
+    from: [
+      '/logs/export-log-events-with-log-streaming/stream-logs-to-amazon-eventbridge',
+      '/logs/streams/aws-eventbridge',
+      '/integrations/aws-eventbridge',
+      '/logs/streams/amazon-eventbridge',
+      '/logs/streams/stream-logs-to-amazon-eventbridge'
+    ],
+    to: '/monitor-auth0/streams/stream-logs-to-amazon-eventbridge'
   },
   {
-    from: ['/logs/export-log-events-with-log-streaming/stream-logs-to-azure-event-grid','/logs/streams/azure-event-grid'],
-    to: '/logs/streams/stream-logs-to-azure-event-grid'
+    from: [
+      '/logs/export-log-events-with-log-streaming/stream-logs-to-azure-event-grid',
+      '/logs/streams/azure-event-grid',
+      '/logs/streams/stream-logs-to-azure-event-grid'
+    ],
+    to: '/monitor-auth0/streams/stream-logs-to-azure-event-grid'
   },
   {
-    from: ['/logs/export-log-events-with-log-streaming/stream-logs-to-datadog','/logs/streams/datadog'],
-    to: '/logs/streams/stream-logs-to-datadog'
+    from: [
+      '/logs/export-log-events-with-log-streaming/stream-logs-to-datadog',
+      '/logs/streams/datadog',
+      '/logs/streams/stream-logs-to-datadog'
+    ],
+    to: '/monitor-auth0/streams/stream-logs-to-datadog'
   },
   {
-    from: ['/logs/export-log-events-with-log-streaming/datadog-dashboard-templates'],
-    to: '/logs/streams/datadog-dashboard-templates'
+    from: [
+      '/logs/export-log-events-with-log-streaming/datadog-dashboard-templates',
+      '/logs/streams/datadog-dashboard-templates'
+    ],
+    to: '/monitor-auth0/streams/datadog-dashboard-templates'
   }, 
   {
     from: ['/logs/personally-identifiable-information-pii-in-auth0-logs'],
@@ -2886,8 +2910,8 @@ module.exports = [
     to: '/logs/log-data-retention'
   },
   {
-    from: ['/logs/references/log-event-filters'],
-    to: '/logs/log-event-filters'
+    from: ['/logs/references/log-event-filters','/logs/log-event-filters'],
+    to: '/monitor-auth0/streams/log-event-filters'
   },
   {
     from: ['/logs/references/log-event-data','/logs/references/log-events-data','/logs/references/log-event-type-codes'],
@@ -2906,8 +2930,19 @@ module.exports = [
     to: '/logs/view-log-events'
   },
   {
-    from: ['/logs/export-log-events-with-log-streaming/splunk-dashboard'],
-    to: '/logs/streams/splunk-dashboard'
+    from: [
+      '/logs/export-log-events-with-log-streaming/splunk-dashboard',
+      '/logs/streams/splunk-dashboard'
+    ],
+    to: '/monitor-auth0/streams/splunk-dashboard'
+  },
+  {
+    from: ['/logs/streams/stream-logs-to-sumo-logic'],
+    to: '/monitor-auth0/streams/stream-logs-to-sumo-logic'
+  },
+  {
+    from: ['/logs/streams/sumo-logic-dashboard'],
+    to: '/monitor-auth0/streams/sumo-logic-dashboard'
   },
 
   /* MFA */

--- a/config/redirects.js
+++ b/config/redirects.js
@@ -2916,7 +2916,7 @@ module.exports = [
   {
     from: ['/logs/event-filters'],
     to: '/monitor-auth0/streams/event-filters'
-  }
+  },
   {
     from: ['/logs/references/log-event-data','/logs/references/log-events-data','/logs/references/log-event-type-codes'],
     to: '/logs/log-event-type-codes'

--- a/config/redirects.js
+++ b/config/redirects.js
@@ -2910,7 +2910,7 @@ module.exports = [
     to: '/logs/log-data-retention'
   },
   {
-    from: ['/logs/references/log-event-filters','/logs/log-event-filters'],
+    from: ['/logs/references/log-event-filters'],
     to: '/logs/log-event-filters'
   },
   {

--- a/config/redirects.js
+++ b/config/redirects.js
@@ -2870,6 +2870,10 @@ module.exports = [
     to: '/logs/streams/datadog-dashboard-templates'
   }, 
   {
+    from: ['/logs/personally-identifiable-information-pii-in-auth0-logs'],
+    to: '/logs/pii-in-logs'
+  },
+  {
     from: ['/monitoring/guides/send-events-to-splunk','/monitoring/guides/send-events-to-keenio','/monitoring/guides/send-events-to-segmentio'],
     to: '/logs/export-log-events-with-rules'
   },

--- a/config/redirects.js
+++ b/config/redirects.js
@@ -2860,7 +2860,7 @@ module.exports = [
     from: [
       '/logs/export-log-events-with-log-streaming/stream-http-event-logs',
       '/logs/streams/http-event',
-      '/logs/streams/stream-http-event-logs'
+      '/logs/streams/stream-http-event-logs' 
     ],
     to: '/monitor-auth0/streams/custom-log-streams'
   },

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -1048,56 +1048,6 @@ articles:
             url: /integrations/marketing/salesforce-marketing-cloud
           - title: Watson Campaign Automation
             url: /integrations/marketing/watson-campaign-automation
-  - title: Logs
-    url: /logs
-    children:
-      - title: Log Streams
-        url: /logs/streams
-        children:
-          - title: HTTP Event Streams
-            url: /logs/streams/stream-http-event-logs
-            children: 
-            - title: HTTP Stream to Slack Example
-              url: /logs/streams/stream-log-events-to-slack
-              hidden: true 
-          - title: AWS EventBridge
-            url: /logs/streams/aws-eventbridge
-          - title: Azure Event Grid
-            url: /logs/streams/stream-logs-to-azure-event-grid
-          - title: Datadog
-            url: /logs/streams/stream-logs-to-datadog
-            children:
-              - title: Datadog Dashboard Templates
-                url: /logs/streams/datadog-dashboard-templates
-                hidden: true 
-          - title: Splunk
-            url: /logs/streams/stream-logs-to-splunk
-            children:
-              - title: Auth0 App for Splunk
-                url: /logs/streams/splunk-dashboard
-                hidden: true 
-          - title: Sumo Logic
-            url: /logs/streams/stream-logs-to-sumo-logic
-            children:
-              - title: Auth0 App for Sumo Logic
-                url: /logs/streams/sumo-logic-dashboard
-                hidden: true
-          - title: Log Stream Filters
-            url: /logs/streams/event-filters
-      - title: Log Data Retention
-        url: /logs/log-data-retention
-      - title: View Log Data in the Dashboard
-        url: /logs/view-log-events-in-the-dashboard
-      - title: Log Event Filters
-        url: /logs/log-event-filters
-      - title: Retrieve Logs Using the Management API
-        url: /logs/retrieve-log-events-using-mgmt-api
-      - title: Log Event Type Codes
-        url: /logs/log-event-type-codes
-      - title: Log Search Query Syntax
-        url: /logs/log-search-query-syntax
-      - title: Migrate from Logs Search v2 to v3
-        url: /product-lifecycle/deprecations-and-migrations/migrate-to-tenant-log-search-v3
   - title: Monitor
     url: /monitor-auth0
     children:
@@ -1109,6 +1059,56 @@ articles:
         url: /monitor-auth0/monitor-applications
       - title: Monitor Using SCOM
         url: /monitor-auth0/monitor-using-scom
+      - title: Logs
+        url: /logs
+        children:
+          - title: Log Streams
+            url: /logs/streams
+            children:
+              - title: HTTP Event Streams
+                url: /logs/streams/stream-http-event-logs
+                children: 
+                - title: HTTP Stream to Slack Example
+                  url: /logs/streams/stream-log-events-to-slack
+                  hidden: true 
+              - title: AWS EventBridge
+                url: /logs/streams/aws-eventbridge
+              - title: Azure Event Grid
+                url: /logs/streams/stream-logs-to-azure-event-grid
+              - title: Datadog
+                url: /logs/streams/stream-logs-to-datadog
+                children:
+                  - title: Datadog Dashboard Templates
+                    url: /logs/streams/datadog-dashboard-templates
+                    hidden: true 
+              - title: Splunk
+                url: /logs/streams/stream-logs-to-splunk
+                children:
+                  - title: Auth0 App for Splunk
+                    url: /logs/streams/splunk-dashboard
+                    hidden: true 
+              - title: Sumo Logic
+                url: /logs/streams/stream-logs-to-sumo-logic
+                children:
+                  - title: Auth0 App for Sumo Logic
+                    url: /logs/streams/sumo-logic-dashboard
+                    hidden: true
+              - title: Log Stream Filters
+                url: /logs/streams/event-filters
+          - title: Log Data Retention
+            url: /logs/log-data-retention
+          - title: View Log Data
+            url: /logs/view-log-events-in-the-dashboard
+          - title: Log Event Filters
+            url: /logs/log-event-filters
+          - title: Retrieve Logs
+            url: /logs/retrieve-log-events-using-mgmt-api
+          - title: Log Event Type Codes
+            url: /logs/log-event-type-codes
+          - title: Log Search Query Syntax
+            url: /logs/log-search-query-syntax
+          - title: Migrate from Logs Search v2 to v3
+            url: /product-lifecycle/deprecations-and-migrations/migrate-to-tenant-log-search-v3
   - title: Troubleshoot
     url: /troubleshoot
     children:

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -1085,40 +1085,40 @@ articles:
           - title: Export Log Events with Rules
             url: /logs/export-log-events-with-rules
       - title: Streams
-        url: /logs/streams
+        url: /monitor-auth0/streams
         children:
           - title: AWS EventBridge
-            url: /logs/streams/aws-eventbridge
+            url: /monitor-auth0/streams/aws-eventbridge
           - title: Azure Event Grid
-            url: /logs/streams/stream-logs-to-azure-event-grid
+            url: /monitor-auth0/streams/stream-logs-to-azure-event-grid
           - title: Datadog
-            url: /logs/streams/stream-logs-to-datadog
+            url: /monitor-auth0/streams/stream-logs-to-datadog
             children:
               - title: Datadog Dashboard Templates
-                url: /logs/streams/datadog-dashboard-templates
+                url: /monitor-auth0/streams/datadog-dashboard-templates
                 hidden: true 
           - title: Splunk
-            url: /logs/streams/stream-logs-to-splunk
+            url: /monitor-auth0/streams/stream-logs-to-splunk
             children:
               - title: Auth0 App for Splunk
-                url: /logs/streams/splunk-dashboard
+                url: /monitor-auth0/streams/splunk-dashboard
                 hidden: true 
           - title: Sumo Logic
-            url: /logs/streams/stream-logs-to-sumo-logic
+            url: /monitor-auth0/streams/stream-logs-to-sumo-logic
             children:
               - title: Auth0 App for Sumo Logic
-                url: /logs/streams/sumo-logic-dashboard
+                url: /monitor-auth0/streams/sumo-logic-dashboard
                 hidden: true
           - title: Create Custom Log Streams
-            url: /logs/streams/custom-log-streams
+            url: /monitor-auth0/streams/custom-log-streams
             children: 
             - title: Stream Logs to Slack Using Webhooks
-              url: /logs/streams/stream-log-events-to-slack
+              url: /monitor-auth0/streams/stream-log-events-to-slack
               hidden: true 
           - title: Check Log Stream Health
-            url: /logs/check-log-stream-health
+            url: /monitor-auth/streams/check-log-stream-health
           - title: Log Stream Filters
-            url: /logs/streams/event-filters
+            url: /monitor-auth0/streams/event-filters
   - title: Troubleshoot
     url: /troubleshoot
     children:

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -1070,41 +1070,6 @@ articles:
             url: /logs/view-log-events-in-the-dashboard
           - title: Retrieve Log Events
             url: /logs/retrieve-log-events-using-mgmt-api
-          - title: Log Streams
-            url: /logs/streams
-            children:
-              - title: AWS EventBridge
-                url: /logs/streams/aws-eventbridge
-              - title: Azure Event Grid
-                url: /logs/streams/stream-logs-to-azure-event-grid
-              - title: Datadog
-                url: /logs/streams/stream-logs-to-datadog
-                children:
-                  - title: Datadog Dashboard Templates
-                    url: /logs/streams/datadog-dashboard-templates
-                    hidden: true 
-              - title: Splunk
-                url: /logs/streams/stream-logs-to-splunk
-                children:
-                  - title: Auth0 App for Splunk
-                    url: /logs/streams/splunk-dashboard
-                    hidden: true 
-              - title: Sumo Logic
-                url: /logs/streams/stream-logs-to-sumo-logic
-                children:
-                  - title: Auth0 App for Sumo Logic
-                    url: /logs/streams/sumo-logic-dashboard
-                    hidden: true
-              - title: Create Custom Log Streams
-                url: /logs/streams/custom-log-streams
-                children: 
-                - title: Stream Logs to Slack Using Webhooks
-                  url: /logs/streams/stream-log-events-to-slack
-                  hidden: true 
-              - title: Check Log Stream Health
-                url: /logs/check-log-stream-health
-              - title: Log Stream Filters
-                url: /logs/streams/event-filters
           - title: Log Event Filters
             url: /logs/log-event-filters
           - title: Log Event Type Codes
@@ -1113,6 +1078,41 @@ articles:
             url: /logs/log-search-query-syntax
           - title: Migrate from Logs Search v2 to v3
             url: /product-lifecycle/deprecations-and-migrations/migrate-to-tenant-log-search-v3
+      - title: Streams
+        url: /logs/streams
+        children:
+          - title: AWS EventBridge
+            url: /logs/streams/aws-eventbridge
+          - title: Azure Event Grid
+            url: /logs/streams/stream-logs-to-azure-event-grid
+          - title: Datadog
+            url: /logs/streams/stream-logs-to-datadog
+            children:
+              - title: Datadog Dashboard Templates
+                url: /logs/streams/datadog-dashboard-templates
+                hidden: true 
+          - title: Splunk
+            url: /logs/streams/stream-logs-to-splunk
+            children:
+              - title: Auth0 App for Splunk
+                url: /logs/streams/splunk-dashboard
+                hidden: true 
+          - title: Sumo Logic
+            url: /logs/streams/stream-logs-to-sumo-logic
+            children:
+              - title: Auth0 App for Sumo Logic
+                url: /logs/streams/sumo-logic-dashboard
+                hidden: true
+          - title: Create Custom Log Streams
+            url: /logs/streams/custom-log-streams
+            children: 
+            - title: Stream Logs to Slack Using Webhooks
+              url: /logs/streams/stream-log-events-to-slack
+              hidden: true 
+          - title: Check Log Stream Health
+            url: /logs/check-log-stream-health
+          - title: Log Stream Filters
+            url: /logs/streams/event-filters
   - title: Troubleshoot
     url: /troubleshoot
     children:

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -1062,7 +1062,7 @@ articles:
       - title: Logs
         url: /logs
         children:
-          - title: PII in Logs
+          - title: PII in Logs 
             url: /logs/pii-in-logs
           - title: Log Data Retention
             url: /logs/log-data-retention

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -1067,7 +1067,7 @@ articles:
           - title: Log Data Retention
             url: /logs/log-data-retention
           - title: View Log Events
-            url: /logs/view-log-events-in-the-dashboard
+            url: /logs/view-log
           - title: Retrieve Log Events
             url: /logs/retrieve-log-events-using-mgmt-api
           - title: Log Event Filters
@@ -1076,8 +1076,14 @@ articles:
             url: /logs/log-event-type-codes
           - title: Log Search Query Syntax
             url: /logs/log-search-query-syntax
-          - title: Migrate from Logs Search v2 to v3
-            url: /product-lifecycle/deprecations-and-migrations/migrate-to-tenant-log-search-v3
+            children: 
+              - title: Migrate to Tenant Log Search v3
+                url: /product-lifecycle/deprecations-and-migrations/migrate-to-tenant-log-search-v3
+                hidden: true 
+          - title: Export Log Events with Extensions
+            url: /logs/export-log-events-with-extensions
+          - title: Export Log Events with Rules
+            url: /logs/export-log-events-with-rules
       - title: Streams
         url: /logs/streams
         children:

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -1095,6 +1095,8 @@ articles:
                     hidden: true
               - title: Log Stream Filters
                 url: /logs/streams/event-filters
+          - title: PII in Logs
+            url: /logs/pii-in-logs
           - title: Log Data Retention
             url: /logs/log-data-retention
           - title: View Log Data

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -1088,7 +1088,7 @@ articles:
         url: /monitor-auth0/streams
         children:
           - title: AWS EventBridge
-            url: /monitor-auth0/streams/aws-eventbridge
+            url: /monitor-auth0/streams/stream-logs-to-amazon-eventbridge
           - title: Azure Event Grid
             url: /monitor-auth0/streams/stream-logs-to-azure-event-grid
           - title: Datadog

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -1065,6 +1065,8 @@ articles:
           - title: Log Streams
             url: /logs/streams
             children:
+              - title: Check Log Stream Health
+                url: /logs/check-log-stream-health
               - title: HTTP Event Streams
                 url: /logs/streams/stream-http-event-logs
                 children: 

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -1062,17 +1062,17 @@ articles:
       - title: Logs
         url: /logs
         children:
+          - title: PII in Logs
+            url: /logs/pii-in-logs
+          - title: Log Data Retention
+            url: /logs/log-data-retention
+          - title: View Log Events
+            url: /logs/view-log-events-in-the-dashboard
+          - title: Retrieve Log Events
+            url: /logs/retrieve-log-events-using-mgmt-api
           - title: Log Streams
             url: /logs/streams
             children:
-              - title: Check Log Stream Health
-                url: /logs/check-log-stream-health
-              - title: HTTP Event Streams
-                url: /logs/streams/stream-http-event-logs
-                children: 
-                - title: HTTP Stream to Slack Example
-                  url: /logs/streams/stream-log-events-to-slack
-                  hidden: true 
               - title: AWS EventBridge
                 url: /logs/streams/aws-eventbridge
               - title: Azure Event Grid
@@ -1095,18 +1095,18 @@ articles:
                   - title: Auth0 App for Sumo Logic
                     url: /logs/streams/sumo-logic-dashboard
                     hidden: true
+              - title: Create Custom Log Streams
+                url: /logs/streams/custom-log-streams
+                children: 
+                - title: Stream Logs to Slack Using Webhooks
+                  url: /logs/streams/stream-log-events-to-slack
+                  hidden: true 
+              - title: Check Log Stream Health
+                url: /logs/check-log-stream-health
               - title: Log Stream Filters
                 url: /logs/streams/event-filters
-          - title: PII in Logs
-            url: /logs/pii-in-logs
-          - title: Log Data Retention
-            url: /logs/log-data-retention
-          - title: View Log Data
-            url: /logs/view-log-events-in-the-dashboard
           - title: Log Event Filters
             url: /logs/log-event-filters
-          - title: Retrieve Logs
-            url: /logs/retrieve-log-events-using-mgmt-api
           - title: Log Event Type Codes
             url: /logs/log-event-type-codes
           - title: Log Search Query Syntax

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -1116,7 +1116,7 @@ articles:
               url: /monitor-auth0/streams/stream-log-events-to-slack
               hidden: true 
           - title: Check Log Stream Health
-            url: /monitor-auth/streams/check-log-stream-health
+            url: /monitor-auth0/streams/check-log-stream-health
           - title: Log Stream Filters
             url: /monitor-auth0/streams/event-filters
   - title: Troubleshoot

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -1067,7 +1067,7 @@ articles:
           - title: Log Data Retention
             url: /logs/log-data-retention
           - title: View Log Events
-            url: /logs/view-log
+            url: /logs/view-log-events
           - title: Retrieve Log Events
             url: /logs/retrieve-log-events-using-mgmt-api
           - title: Log Event Filters


### PR DESCRIPTION
Move Logs section under Monitor section in sidebar to match Dashboard UI. Add orphan docs to sidebar.
Review link: https://auth0content-pr-9734.herokuapp.com/docs/monitor-auth0

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
