### PR TITLE
Add passwordless webauthn device biometrics and email or sms docs to sidebar

### DIFF
--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -1,4 +1,4 @@
-articles: 
+articles:
   - title: Get Started
     url: /get-started
     children:

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -1,4 +1,4 @@
-articles:
+articles: 
   - title: Get Started
     url: /get-started
     children:

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -224,6 +224,11 @@ articles:
             url: /universal-login/classic-experience/mfa-classic-experience
           - title: Passwordless
             url: /universal-login/configure-universal-login-with-passwordless
+            children:
+              - title: WebAuthn with Device Biometrics
+                url: /universal-login/configure-universal-login-with-passwordless/webauthn-device-biometrics
+              - title: Email or SMS
+                url: /universal-login/configure-universal-login-with-passwordless/email-or-sms
           - title: Identifier-First Authentication
             url: /universal-login/identifier-first
           - title: Error Pages


### PR DESCRIPTION

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
