### PR TITLE
Remove unused dependency reference from ASPNET Core Quickstart

### DIFF
--- a/articles/quickstart/webapp/aspnet-core/_includes/_login.md
+++ b/articles/quickstart/webapp/aspnet-core/_includes/_login.md
@@ -8,10 +8,9 @@
 
 To integrate Auth0 with ASP.NET Core you will use the Cookie and OpenID Connect (OIDC) authentication handlers.
 
-If you are adding this to your own existing project, then please make sure that you add the `Microsoft.AspNetCore.Authentication.Cookies` and `Microsoft.AspNetCore.Authentication.OpenIdConnect` packages to your application.
+If you are adding this to your own existing project, then please make sure that you add the `Microsoft.AspNetCore.Authentication.OpenIdConnect` package to your application.
 
 ```bash
-Install-Package Microsoft.AspNetCore.Authentication.Cookies
 Install-Package Microsoft.AspNetCore.Authentication.OpenIdConnect
 ```
 


### PR DESCRIPTION
The `Microsoft.AspNetCore.Authentication.Cookies` doesnt have to be installed anymore, even tho you still can there is no need to explicitly mention that as it's part of the .NET SDK.