### PR TITLE
Base 64-compatible characters

### DIFF
--- a/articles/api-auth/tutorials/nonce.md
+++ b/articles/api-auth/tutorials/nonce.md
@@ -29,7 +29,7 @@ One way to generate a cryptographically random nonce is to use a tool like [Nano
 
 ```js
 function randomString(length) {
-    var charset = '0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._'
+    var charset = '0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz+/'
     result = ''
 
     while (length > 0) {


### PR DESCRIPTION
To make the function `randomString()` function more convenient, replaced special characters `.-_` (which are not allowed by base 64) by `+/` (which are allowed).
See https://base64.guru/learn/base64-characters

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
