### PR TITLE
Change Office 365 SSO tutorial from deprecated tool

### DIFF
--- a/snippets/sso-integrations/office-365/6.md
+++ b/snippets/sso-integrations/office-365/6.md
@@ -7,7 +7,7 @@ Before you configure Auth0 with Azure AD:
 * Have one administrator account that you can use to sign in directly into Office 365.
 * Run Microsoft Azure AD Connect between your Active Directory and Office 365 to create your user accounts. You can download Azure AD Connect from [the Microsoft Download Center](https://www.microsoft.com/en-us/download/details.aspx?id=47594).
 
-::: Note
+:::note
 DirSync was deprecated by Microsoft on April 1, 2021. To learn how to upgrade from DirSync to Azure AD Connect, read [Azure AD Connect: Upgrade from DirSync](https://docs.microsoft.com/en-us/azure/active-directory/hybrid/how-to-dirsync-upgrade-get-started).
 :::
 

--- a/snippets/sso-integrations/office-365/6.md
+++ b/snippets/sso-integrations/office-365/6.md
@@ -5,7 +5,11 @@ Before you configure Auth0 with Azure AD:
 * Make sure you are using an Office 365 edition that supports this integration. Currently, **Midsize** Business and any **Enterprise** [editions of Office 365](https://office.microsoft.com/en-us/business/compare-office-365-for-business-plans-FX102918419.aspx) support SSO with Auth0. 
 * Verify your Office 365 domain through DNS. Follow [Mircrosoft's instructions](https://support.office.com/en-us/article/gather-the-information-you-need-to-create-office-365-dns-records-77f90d4a-dc7f-4f09-8972-c1b03ea85a67).
 * Have one administrator account that you can use to sign in directly into Office 365.
-* Run Microsoft DirSync tool between your Active Directory and Office 365 to create your user accounts. You can download DirSync from [the Office 365 Portal](https://portal.microsoftonline.com/).
+* Run Microsoft Azure AD Connect between your Active Directory and Office 365 to create your user accounts. You can download Azure AD Connect from [the Microsoft Download Center](https://www.microsoft.com/en-us/download/details.aspx?id=47594).
+
+::: Note
+DirSync was deprecated by Microsoft on April 1, 2021. To learn how to upgrade from DirSync to Azure AD Connect, read [Azure AD Connect: Upgrade from DirSync](https://docs.microsoft.com/en-us/azure/active-directory/hybrid/how-to-dirsync-upgrade-get-started).
+:::
 
 **Setup**
 1. Open the Microsoft Azure Active Directory Module for Windows PowerShell.

--- a/snippets/sso-integrations/office-365/6.md
+++ b/snippets/sso-integrations/office-365/6.md
@@ -5,7 +5,7 @@ Before you configure Auth0 with Azure AD:
 * Make sure you are using an Office 365 edition that supports this integration. Currently, **Midsize** Business and any **Enterprise** [editions of Office 365](https://office.microsoft.com/en-us/business/compare-office-365-for-business-plans-FX102918419.aspx) support SSO with Auth0. 
 * Verify your Office 365 domain through DNS. Follow [Mircrosoft's instructions](https://support.office.com/en-us/article/gather-the-information-you-need-to-create-office-365-dns-records-77f90d4a-dc7f-4f09-8972-c1b03ea85a67).
 * Have one administrator account that you can use to sign in directly into Office 365.
-* Run Microsoft Azure AD Connect between your Active Directory and Office 365 to create your user accounts. You can download Azure AD Connect from [the Microsoft Download Center](https://www.microsoft.com/en-us/download/details.aspx?id=47594).
+* Run Microsoft Azure AD Connect between your Active Directory and Office 365 to create your user accounts. You can [download Azure AD Connect from the Microsoft Download Center](https://www.microsoft.com/en-us/download/details.aspx?id=47594).
 
 :::note
 DirSync was deprecated by Microsoft on April 1, 2021. To learn how to upgrade from DirSync to Azure AD Connect, read [Azure AD Connect: Upgrade from DirSync](https://docs.microsoft.com/en-us/azure/active-directory/hybrid/how-to-dirsync-upgrade-get-started).


### PR DESCRIPTION
Replaces instructions to use deprecated DirSync tool with Azure AD Connect
