### PR TITLE
Tenant Settings redirects and sidebar updates

### DIFF
--- a/config/redirects.js
+++ b/config/redirects.js
@@ -1168,7 +1168,13 @@ module.exports = [
     to: '/applications/enable-android-app-links-support'
   },
   {
-    from: ['/dashboard/guides/applications/enable-universal-links','/clients/enable-universal-links','/applications/enable-universal-links','/applications/guides/enable-universal-links-dashboard'],
+    from: [
+      '/dashboard/guides/applications/enable-universal-links',
+      '/clients/enable-universal-links',
+      '/applications/enable-universal-links',
+      '/applications/guides/enable-universal-links-dashboard',
+      '/enable-universal-links-support-in-apple-xcode'
+    ],
     to: '/applications/enable-universal-links-support-in-apple-xcode'
   },
   {

--- a/config/redirects.js
+++ b/config/redirects.js
@@ -1134,6 +1134,14 @@ module.exports = [
   /* Applications */
 
   {
+    from: [
+      '/get-started/dashboard/application-settings',
+      '/best-practices/application-settings',
+      '/best-practices/app-settings-best-practices'
+    ],
+    to: '/applications/application-settings'
+  },
+  {
     from: ['/api-auth/dynamic-client-registration','/api-auth/dynamic-application-registration'],
     to: '/applications/dynamic-client-registration'
   },
@@ -1142,11 +1150,19 @@ module.exports = [
     to: '/applications'
   },
   {
+    from: [
+      '/dashboard/guides/applications/rotate-client-secret',
+      '/api/management/guides/applications/rotate-client-secret',
+      '/get-started/dashboard/rotate-client-secret'
+    ],
+    to: '/applications/rotate-client-secret'
+  },
+  {
     from: ['/dashboard/guides/applications/enable-android-app-links','/clients/enable-android-app-links','/applications/enable-android-app-links','/applications/guides/enable-android-app-links-dashboard'],
     to: '/applications/enable-android-app-links-support'
   },
   {
-    from: ['/dashboard/guides/applications/enable-universal-links','/clients/enable-universal-links','/applications/enable-universal-links','/applications/guides/enable-universal-links-dashboard','/enable-universal-links-support-in-apple-xcode'],
+    from: ['/dashboard/guides/applications/enable-universal-links','/clients/enable-universal-links','/applications/enable-universal-links','/applications/guides/enable-universal-links-dashboard'],
     to: '/applications/enable-universal-links-support-in-apple-xcode'
   },
   {
@@ -1391,10 +1407,6 @@ module.exports = [
   {
     from: ['/best-practices/search-best-practices','/users/search/best-practices'],
     to: '/best-practices/user-search-best-practices'
-  },
-  {
-    from: ['/best-practices/tenant-settings'],
-    to: '/best-practices/tenant-settings-best-practices'
   },
   {
     from: ['/best-practices/testing'],
@@ -2078,24 +2090,12 @@ module.exports = [
     to: '/get-started/dashboard'
   },
   {
-    from: ['/best-practices/application-settings','/best-practices/app-settings-best-practices'],
-    to: '/get-started/dashboard/application-settings'
-  },
-  {
-    from: ['/dashboard/guides/tenants/configure-device-user-code-settings'],
-    to: '/get-started/dashboard/configure-device-user-code-settings'
-  },
-  {
     from: ['/dashboard/guides/tenants/create-multiple-tenants'],
     to: '/get-started/dashboard/create-multiple-tenants'
   },
   {
     from: ['/dashboard/guides/tenants/enable-sso-tenant'],
     to: '/get-started/dashboard/enable-sso-for-legacy-tenants'
-  },
-  {
-    from: ['/dashboard/guides/tenants/configure-session-lifetime-settings','/api/management/guides/tenants/configure-session-lifetime-settings','/sso/current/configure-session-lifetime-limits'],
-    to: '/get-started/dashboard/configure-session-lifetime-settings'
   },
   {
     from: ['/dashboard/guides/apis/delete-permissions-apis'],
@@ -2150,10 +2150,6 @@ module.exports = [
     to: '/get-started/dashboard/application-settings'
   },
   {
-    from: ['/dashboard/reference/settings-tenant','/tutorials/dashboard-tenant-settings','/dashboard-account-settings','/dashboard/dashboard-tenant-settings','/configure'],
-    to: '/get-started/dashboard/tenant-settings'
-  },
-  {
     from: ['/dashboard-access/dashboard-roles','/dashboard-access/manage-dashboard-users','/dashboard/manage-dashboard-admins','/tutorials/manage-dashboard-admins','/get-started/dashboard/manage-dashboard-users'],
     to: '/dashboard-access'
   },
@@ -2164,10 +2160,6 @@ module.exports = [
   {
     from: ['/product-lifecycle/deprecations-and-migrations/migrate-to-manage-dashboard-new-roles'],
     to: '/product-lifecycle/deprecations-and-migrations/migrate-tenant-member-roles'
-  },
-  {
-    from: ['/dashboard/guides/applications/rotate-client-secret','/api/management/guides/applications/rotate-client-secret'],
-    to: '/get-started/dashboard/rotate-client-secret'
   },
   {
     from: ['/getting-started/the-basics','/getting-started/create-tenant'],
@@ -3811,6 +3803,10 @@ module.exports = [
     to: '/sessions/session-layers'
   },
   {
+    from: ['/get-started/dashboard/configure-session-lifetime-settings','/dashboard/guides/tenants/configure-session-lifetime-settings','/api/management/guides/tenants/configure-session-lifetime-settings','/sso/current/configure-session-lifetime-limits'],
+    to: '/sessions/configure-session-lifetime-settings'
+  },
+  {
     from: ['/sessions/concepts/cookie-attributes', '/sessions-and-cookies/samesite-cookie-attribute-changes'],
     to: '/sessions/cookies/samesite-cookie-attribute-changes'
   },
@@ -4655,15 +4651,28 @@ module.exports = [
   /* Configuration */
 
   {
-    from: ['/configuration-overview'],
+    from: ['/configuration-overview','/configure'],
     to: '/config' 
   },
   
   /* Tenant Settings */
 
   {
-    from: ['/dashboard/tenant-settings','/get-started/dashboard/tenant-settings'],
+    from: [
+      '/dashboard/tenant-settings',
+      '/get-started/dashboard/tenant-settings',
+      '/best-practices/tenant-settings-best-practices',
+      '/best-practices/tenant-settings',
+      '/dashboard/reference/settings-tenant',
+      '/tutorials/dashboard-tenant-settings',
+      '/dashboard-account-settings',
+      '/dashboard/dashboard-tenant-settings'
+    ],
     to: '/config/tenant-settings'
+  },
+  {
+    from: ['/get-started/dashboard/configure-device-user-code-settings','/dashboard/guides/tenants/configure-device-user-code-settings'],
+    to: '/config/tenant-settings/configure-device-user-code-settings'
   },
 
   /* Signing Keys */

--- a/config/redirects.js
+++ b/config/redirects.js
@@ -1135,6 +1135,8 @@ module.exports = [
 
   {
     from: [
+      '/clients/client-settings',
+      '/dashboard/reference/settings-application',
       '/get-started/dashboard/application-settings',
       '/best-practices/application-settings',
       '/best-practices/app-settings-best-practices'
@@ -2149,10 +2151,6 @@ module.exports = [
   {
     from: ['/dashboard/reference/settings-api','/api-auth/references/dashboard/api-settings'],
     to: '/get-started/dashboard/api-settings'
-  },
-  {
-    from: ['/dashboard/reference/settings-application','/clients/client-settings','/applications/application-settings'],
-    to: '/get-started/dashboard/application-settings'
   },
   {
     from: ['/dashboard-access/dashboard-roles','/dashboard-access/manage-dashboard-users','/dashboard/manage-dashboard-admins','/tutorials/manage-dashboard-admins','/get-started/dashboard/manage-dashboard-users'],

--- a/config/redirects.js
+++ b/config/redirects.js
@@ -1150,6 +1150,10 @@ module.exports = [
     to: '/applications'
   },
   {
+    from: ['/dev-lifecycle/work-with-auth0-locally','/dev-lifecycle/local-testing-and-development'],
+    to: '/applications/work-with-auth0-locally'
+  },
+  {
     from: [
       '/dashboard/guides/applications/rotate-client-secret',
       '/api/management/guides/applications/rotate-client-secret',
@@ -1624,17 +1628,6 @@ module.exports = [
       to: '/deploy/pre-deployment/how-to-run-production-checks/production-check-required-fixes'
   },
 
-  /* Dev Lifecycle */
-
-  {
-    from: ['/dev-lifecycle/local-testing-and-development'],
-    to: '/dev-lifecycle/work-with-auth0-locally'
-  },
-  {
-    from: ['/dev-lifecycle/setting-up-env'],
-    to: '/dev-lifecycle/set-up-multiple-environments'
-  },
-
   /* Email */
 
   {
@@ -2090,8 +2083,20 @@ module.exports = [
     to: '/get-started/dashboard'
   },
   {
-    from: ['/dashboard/guides/tenants/create-multiple-tenants'],
-    to: '/get-started/dashboard/create-multiple-tenants'
+    from: ['/get-started/learn-the-basics','/getting-started/the-basics','/getting-started/create-tenant'],
+    to: '/get-started/create-tenants'
+  },
+  {
+    from: ['/dev-lifecycle/child-tenants'],
+    to: '/get-started/create-tenants/child-tenants'
+  },
+  {
+    from: ['/dev-lifecycle/set-up-multiple-environments','/dev-lifecycle/setting-up-env'],
+    to: '/get-started/create-tenants/set-up-multiple-environments'
+  },
+  {
+    from: ['/get-started/dashboard/create-multiple-tenants','/dashboard/guides/tenants/create-multiple-tenants'],
+    to: '/get-started/create-tenants/create-multiple-tenants'
   },
   {
     from: ['/dashboard/guides/tenants/enable-sso-tenant'],
@@ -2160,10 +2165,6 @@ module.exports = [
   {
     from: ['/product-lifecycle/deprecations-and-migrations/migrate-to-manage-dashboard-new-roles'],
     to: '/product-lifecycle/deprecations-and-migrations/migrate-tenant-member-roles'
-  },
-  {
-    from: ['/getting-started/the-basics','/getting-started/create-tenant'],
-    to: '/get-started/learn-the-basics'
   },
 
   /* Hooks */

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -514,66 +514,61 @@ articles:
             url: /authorization/manage-permissions
           - title: Enable RBAC for APIs
             url: /authorization/rbac/enable-role-based-access-control-for-apis
-  - title: Configuration
+  - title: Configure
     url: /config
     children:
-      - title: Tenant Settings
+      - title: Tenants
         url: /config/tenant-settings
         children:
           - title: Dashboard Access
             url: /dashboard-access
+          - title: Create Multiple Tenants
+            url: /get-started/dashboard/create-multiple-tenants
+          - title: Request Child Tenants
+            url: /dev-lifecycle/child-tenants
+          - title: Work with Auth0 Locally
+            url: /dev-lifecycle/work-with-auth0-locally
+          - title: Set Up Multiple Environments
+            url: /dev-lifecycle/set-up-multiple-environments
           - title: Signing Keys
             url: /config/tenant-settings/signing-keys
-            children:
-              - title: Rotate Signing Keys
-                url: /config/tenant-settings/signing-keys/rotate-signing-keys
-                hidden: true 
-              - title: Revoke Signing Keys
-                url: /config/tenant-settings/signing-keys/revoke-signing-keys
-                hidden: true 
-              - title: View Signing Certificates
-                url: /config/tenant-settings/signing-keys/view-signing-certificates
-                hidden: true 
-          - title: Configure Session Lifetime Settings
-            url: /get-started/dashboard/configure-session-lifetime-settings
+          - title: Rotate Signing Keys
+            url: /config/tenant-settings/signing-keys/rotate-signing-keys
+          - title: Revoke Signing Keys
+            url: /config/tenant-settings/signing-keys/revoke-signing-keys
+          - title: View Signing Certificates
+            url: /config/tenant-settings/signing-keys/view-signing-certificates
           - title: Enable SSO for Legacy Tenants
             url: /get-started/dashboard/enable-sso-for-legacy-tenants
             hidden: true 
-          - title: Configure Device User Code Settings
-            url: /get-started/dashboard/configure-device-user-code-settings
-          - title: Dynamic Client Registration
-            url: /applications/dynamic-client-registration
-          - title: Create Multiple Tenants
-            url: /get-started/dashboard/create-multiple-tenants
-            hidden: true
-          - title: Child Tenant Request Process
-            url: /dev-lifecycle/child-tenants
-            hidden: true
-          - title: Best Practices
-            url: /best-practices/tenant-settings-best-practices
-      - title: Application Settings
-        url: /get-started/dashboard/application-settings
+          - title: Device User Codes
+            url: /config/tenant-settings/configure-device-user-code-settings
+      - title: Applications
+        url: /applications 
         children:
-          - title: Enable SSO for Legacy Applications
-            url: /sso/enable-sso-for-applications
-            hidden: true           
+          - title: Application Settings
+            url: /applications/application-settings          
           - title: Update Grant Types
             url: /applications/update-grant-types
           - title: Android App Links
             url: /applications/enable-android-app-links-support
           - title: Apple Universal Links
-            url: /enable-universal-links-support-in-apple-xcode
-          - title: Remove Applications
-            url: /applications/remove-applications
+            url: /applications/enable-universal-links-support-in-apple-xcode
           - title: Check Confidential or Public
             url: /applications/view-application-type
           - title: Rotate Client Secrets
-            url: /get-started/dashboard/rotate-client-secret
+            url: /applications/rotate-client-secret
+          - title: Change Application Signing Algorithms
+            url: /applications/change-application-signing-algorithms
           - title: Subdomain URL Placeholders
             url: /applications/wildcards-for-subdomains
           - title: Configure Application Metadata
             url: /applications/configure-application-metadata
-      - title: API Settings
+          - title: Remove Applications
+            url: /applications/remove-applications
+          - title: Dynamic Application Registration
+            url: /applications/dynamic-client-registration
+      - title: APIs
         url: /get-started/dashboard/api-settings
         children:
           - title: Signing Algorithms
@@ -672,6 +667,8 @@ articles:
             url: /sessions/session-layers
           - title: Session Lifetime Limits
             url: /sessions/session-lifetime-limits
+          - title: Configure Session Lifetime Settings
+            url: /sessions/configure-session-lifetime-settings
           - title: Non-Persistent Sessions
             url: /sessions/non-persistent-sessions
           - title: Manage Multi-Site Sessions with Auth0 SDK

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -7,7 +7,14 @@ articles:
       - title: Dashboard Overview
         url: /get-started/dashboard
       - title: Create Tenants
-        url: /get-started/learn-the-basics
+        url: /get-started/create-tenants
+        children:
+          - title: Create Multiple Tenants
+            url: /get-started/create-tenants/create-multiple-tenants
+          - title: Request Child Tenants
+            url: /get-started/create-tenants/child-tenants
+          - title: Set Up Multiple Environments
+            url: /get-started/create-tenants/set-up-multiple-environments
       - title: Create Applications
         url: /get-started/create-apps 
         children:
@@ -522,25 +529,18 @@ articles:
         children:
           - title: Dashboard Access
             url: /dashboard-access
-          - title: Create Multiple Tenants
-            url: /get-started/dashboard/create-multiple-tenants
-          - title: Request Child Tenants
-            url: /dev-lifecycle/child-tenants
-          - title: Work with Auth0 Locally
-            url: /dev-lifecycle/work-with-auth0-locally
-          - title: Set Up Multiple Environments
-            url: /dev-lifecycle/set-up-multiple-environments
           - title: Signing Keys
             url: /config/tenant-settings/signing-keys
-          - title: Rotate Signing Keys
-            url: /config/tenant-settings/signing-keys/rotate-signing-keys
-          - title: Revoke Signing Keys
-            url: /config/tenant-settings/signing-keys/revoke-signing-keys
-          - title: View Signing Certificates
-            url: /config/tenant-settings/signing-keys/view-signing-certificates
-          - title: Enable SSO for Legacy Tenants
-            url: /get-started/dashboard/enable-sso-for-legacy-tenants
-            hidden: true 
+            children:
+              - title: Rotate Signing Keys
+                url: /config/tenant-settings/signing-keys/rotate-signing-keys
+                hidden: true 
+              - title: Revoke Signing Keys
+                url: /config/tenant-settings/signing-keys/revoke-signing-keys
+                hidden: true 
+              - title: View Signing Certificates
+                url: /config/tenant-settings/signing-keys/view-signing-certificates
+                hidden: true 
           - title: Device User Codes
             url: /config/tenant-settings/configure-device-user-code-settings
       - title: Applications
@@ -568,6 +568,8 @@ articles:
             url: /applications/remove-applications
           - title: Dynamic Application Registration
             url: /applications/dynamic-client-registration
+          - title: Work with Auth0 Locally
+            url: /applications/work-with-auth0-locally
       - title: APIs
         url: /get-started/dashboard/api-settings
         children:
@@ -1373,9 +1375,6 @@ articles:
     children:
       - title: General Usage and Operations
         url: /best-practices/general-usage-and-operations-best-practices
-      - title: Application Settings
-        url: /best-practices/app-settings-best-practices
-        hidden: true
       - title: Connection Settings
         url: /best-practices/connection-settings-best-practices
       - title: Custom Databases and Scripts
@@ -1414,16 +1413,11 @@ articles:
         url: /best-practices/rules-best-practices
       - title: Search
         url: /best-practices/user-search-best-practices
-      - title: Tenant Settings
-        url: /best-practices/tenant-settings-best-practices
-        hidden: true
       - title: Tokens
         url: /best-practices/token-best-practices
   - title: Support
     url: /support
     children:
-      - title: Support Options
-        url: /support
       - title: Support Matrix
         url: /support/product-support-matrix
       - title: SLA

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -556,7 +556,7 @@ articles:
             url: /applications/enable-universal-links-support-in-apple-xcode
           - title: Check Confidential or Public
             url: /applications/view-application-type
-          - title: Rotate Client Secrets
+          - title: Rotate Client Secrets 
             url: /applications/rotate-client-secret
           - title: Change Application Signing Algorithms
             url: /applications/change-application-signing-algorithms

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -568,7 +568,7 @@ articles:
             url: /applications/remove-applications
           - title: Dynamic Application Registration
             url: /applications/dynamic-client-registration
-          - title: Work with Auth0 Locally
+          - title: Test Applications Locally
             url: /applications/work-with-auth0-locally
       - title: APIs
         url: /get-started/dashboard/api-settings

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -1097,6 +1097,7 @@ articles:
             url: /logs/export-log-events-with-extensions
           - title: Export Log Events with Rules
             url: /logs/export-log-events-with-rules
+            hidden: true 
       - title: Streams
         url: /monitor-auth0/streams
         children:


### PR DESCRIPTION
Sidebar changes
Rescue orphans
Redirects
Review links:
- https://auth0content-pr-9754.herokuapp.com/docs/get-started/create-tenants redirected from https://auth0.com/docs/get-started/learn-the-basics
- Sidebar should expand to show new children under Create Tenants
- https://auth0.com/docs/best-practices/tenant-settings-best-practices should redirect to https://auth0content-pr-9754.herokuapp.com/docs/config/tenant-settings and the Best Practices page (https://auth0content-pr-9754.herokuapp.com/docs/best-practices) does not include "Tenant Settings".
- All links to **Tenant Settings Best Practices** now go to **Tenant Settings**.

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
