### PR TITLE
Fixed broken redirect - log stream filters

### DIFF
--- a/config/redirects.js
+++ b/config/redirects.js
@@ -2937,7 +2937,7 @@ module.exports = [
     to: '/logs/log-event-filters'
   },
   {
-    from: ['/logs/event-filters'],
+    from: ['/logs/streams/event-filters'],
     to: '/monitor-auth0/streams/event-filters'
   },
   {


### PR DESCRIPTION
Fixed broken redirect - log stream filters
Review link: https://auth0content-pr-9755.herokuapp.com/docs/logs/streams/event-filters redirects to: https://auth0content-pr-9755.herokuapp.com/docs/monitor-auth0/streams/event-filters

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
