### PR TITLE
Update sidebar.yml

### DIFF
--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -525,8 +525,6 @@ articles:
       - title: Tenants
         url: /config/tenant-settings
         children:
-          - title: Dashboard Access
-            url: /dashboard-access
           - title: Signing Keys
             url: /config/tenant-settings/signing-keys
             children:
@@ -732,7 +730,7 @@ articles:
           - title: Migrate from Search v2 to V3
             url: /users/search/v3/migrate-search-v2-v3
             hidden: true
-  - title: Manage Dashboard Access
+  - title: Dashboard Access
     url: /dashboard-access
     children:
       - title: Dashboard Access by Role


### PR DESCRIPTION
- Removed Dashboard access from under Config - Tenants 
https://auth0content-pr-9776.herokuapp.com/docs/config/tenant-settings

- Removed the word "Manage" from Manage Dashboard Access (Title will change in contentful later)
https://auth0content-pr-9776.herokuapp.com/docs/dashboard-access

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
