### PR TITLE
Remove "$" from bash snippets

### DIFF
--- a/articles/connections/generic-oauth2-connection-examples.md
+++ b/articles/connections/generic-oauth2-connection-examples.md
@@ -104,7 +104,7 @@ This document covers examples of OAuth 1.0/2.0 Connections that you can create b
 Generate an RSA keypair with the following command (or any equivalent method):
 
 ```bash
-$ openssl genrsa -out EXAMPLE.key 2048 && openssl rsa -pubout -in EXAMPLE.key -out EXAMPLE.pub
+openssl genrsa -out EXAMPLE.key 2048 && openssl rsa -pubout -in EXAMPLE.key -out EXAMPLE.pub
 ```
 
 ### Step 2: Create a JIRA Application Link

--- a/articles/libraries/lock-android/v2/passwordless-magic-link.md
+++ b/articles/libraries/lock-android/v2/passwordless-magic-link.md
@@ -34,13 +34,13 @@ After you set the values make sure to click the "Save Changes" button. Next we'l
 You can use the following command to generate the fingerprint via the Java keytool:
 
 ```bash
-$ keytool -list -v -keystore my-release-key.keystore
+keytool -list -v -keystore my-release-key.keystore
 ```
 
 or to obtain the default debug key:
 
 ```bash
-$ keytool -list -v -keystore ~/.android/debug.keystore -alias androiddebugkey -storepass android -keypass android
+keytool -list -v -keystore ~/.android/debug.keystore -alias androiddebugkey -storepass android -keypass android
 ```
 
 The value required by the dashboard is the one listed as **SHA256**.

--- a/articles/login/spa/authenticate-with-cookies.md
+++ b/articles/login/spa/authenticate-with-cookies.md
@@ -55,15 +55,15 @@ Once Node is installed, [download or clone the source code](https://github.com/a
 
 ```bash
 // Clone the tutorial respository using SSH
-$ git clone git@github.com:auth0-blog/spa-cookie-demo
+git clone git@github.com:auth0-blog/spa-cookie-demo
 // ... or if you use HTTPS:
-$ git clone https://github.com/auth0-blog/spa-cookie-demo.git
+git clone https://github.com/auth0-blog/spa-cookie-demo.git
 // Move into the project directory
-$ cd spa-cookie-demo
+cd spa-cookie-demo
 ```
 The `master` branch represents the state of the application before any authentication is added. If you would like to refer to the final version of the application, `checkout` the `with-oidc` branch:
 ```bash
-$ git checkout with-oidc
+git checkout with-oidc
 ```
 ### Initialize the Node.js application
 Install the application dependencies by running `npm install` from your terminal window. To run the application, use `npm run dev`. This starts the Express server. Go to [http://localhost:3000](http://localhost:3000) in your browser to view the application.
@@ -77,7 +77,7 @@ Note that you were able to make the API call without being logged in. Let's fix 
 ### Adding authentication middleware
 Inside the terminal, run the following command to install the additional libraries:
 ```bash
-$ npm install express-session express-openid-connect
+npm install express-session express-openid-connect
 ```
 - [`express-openid-connect`](https://www.npmjs.com/package/express-openid-connect) — OpenID Connect middleware for Express. Creates authentication sessions and protects application routes
 - [`express-session`](https://www.npmjs.com/package/express-session) — session middleware for Express; required by `express-openid-connect`
@@ -211,7 +211,7 @@ BASE_URL=http://localhost:3000
 ### Running the application
 With the server and environment configuration done, find your browser window that has the application open. If you've closed the browser and stopped the server, run the following from the terminal to restart the application
 ```bash
-$ npm run dev
+npm run dev
 ```
 Then open [http://localhost:3000](http://localhost:3000) in the browser. From a user interface perspective, the application should look the same. However, this time when the **Call API** button is clicked, you should receive a warning that the user is not logged in. Also note that you do not see the "Hello, World" message as before, since the call to the API has been rejected.
 ![User Is Not Logged In](/media/articles/login/spa/image6.png)

--- a/articles/logs/streams/http-event-to-slack.md
+++ b/articles/logs/streams/http-event-to-slack.md
@@ -135,14 +135,14 @@ If you are testing this locally or hosting this endpoint yourself, these can be 
 Once configured locally or deployed to your host, you can test the endpoint and its connection to Slack with the following:
 
 ```bash
-$ npm install # If running yourself
+npm install # If running yourself
 added XX packages from XX contributors in XX.XXs
 
-$ npm start # If running yourself 
+npm start # If running yourself 
 Listening on port 3000
 
 # Replace the Authorization header below
-$ curl \
+curl \
   --header "Authorization: AUTH0_LOG_STREAM_TOKEN_VALUE" \
   --header "Content-Type: application/json" \
   --request POST \

--- a/articles/quickstart/backend/django/01-authorization.md
+++ b/articles/quickstart/backend/django/01-authorization.md
@@ -40,9 +40,9 @@ This guide assumes you already have a Django application set up. If that is not 
 The sample project was created with the following commands:
 
 ```bash
-$ django-admin startproject apiexample
-$ cd apiexample
-$ python manage.py startapp auth0authorization
+django-admin startproject apiexample
+cd apiexample
+python manage.py startapp auth0authorization
 ```
 
 ### Add a Django remote user

--- a/articles/quickstart/backend/laravel/01-authorization.md
+++ b/articles/quickstart/backend/laravel/01-authorization.md
@@ -35,7 +35,7 @@ Protecting your Laravel API requires a middleware which will check for and verif
 :::
 
 ```bash
-$ composer require auth0/login
+composer require auth0/login
 ```
 
 ### Configure the plugin
@@ -43,7 +43,7 @@ $ composer require auth0/login
 The **laravel-auth0** plugin comes with a configuration file that can be generated using [Artisan](https://laravel.com/docs/5.7/artisan). First, generate the configuration file from the command line:
 
 ```bash
-$ php artisan vendor:publish --provider "Auth0\Login\LoginServiceProvider"
+php artisan vendor:publish --provider "Auth0\Login\LoginServiceProvider"
 ```
 
 After the file is generated, it will be located at `config/laravel-auth0.php`. Edit this file to add the configuration values needed to verify incoming tokens:
@@ -194,7 +194,7 @@ If you see a button to **Create & Authorize Test Application**, you'll need to c
 Now, let's turn on the Laravel test server:
 
 ```bash
-$ php artisan serve --port=3010
+php artisan serve --port=3010
 ```
 
 Send a `GET` request to the public route  - `http://localhost:3010/api/public` - and you should receive back:

--- a/articles/quickstart/native/ionic4/01-login.md
+++ b/articles/quickstart/native/ionic4/01-login.md
@@ -23,7 +23,7 @@ Use the following commands to add your desired platform(s) (e.g., `ios` or `andr
 
 ```bash
 # Add platform (e.g., ios or android)
-$ ionic cordova platform add {platform}
+ionic cordova platform add {platform}
 ```
 
 <%= include('../../../_includes/_callback_url') %>

--- a/articles/quickstart/spa/vanillajs/02-calling-an-api.md
+++ b/articles/quickstart/spa/vanillajs/02-calling-an-api.md
@@ -185,7 +185,7 @@ module.exports = app;
 With this in place, run the application using `npm run dev`. In another terminal window, use the `curl` tool to make a request to this API endpoint and observe the results:
 
 ```bash
-$ curl -I localhost:3000/api/external
+curl -I localhost:3000/api/external
 ```
 
 You should find that a 401 Unauthorized result is returned, because it requires a valid access token:

--- a/articles/quickstart/spa/vanillajs/_includes/_centralized_login.md
+++ b/articles/quickstart/spa/vanillajs/_includes/_centralized_login.md
@@ -94,7 +94,7 @@ In this section you will create a basic web server using [ExpressJS](https://exp
 Run the following command in the same folder as the `index.html` file you created earlier:
 
 ```bash
-$ npm init -y
+npm init -y
 ```
 
 This will initialize a new NPM project and get us ready to install dependencies.
@@ -104,13 +104,13 @@ This will initialize a new NPM project and get us ready to install dependencies.
 In the terminal, install the dependencies that are necessary to get the server up and running:
 
 ```bash
-$ npm install express
+npm install express
 ```
 
 Also install [`nodemon`](https://npmjs.org/package/nodemon) so that our server can be restarted on any code changes:
 
 ```bash
-$ npm install -D nodemon
+npm install -D nodemon
 ```
 
 Finally, open the `package.json` file and modify the "scripts" entry to look like the following:

--- a/articles/quickstart/webapp/django/01-login.md
+++ b/articles/quickstart/webapp/django/01-login.md
@@ -49,9 +49,9 @@ This guide assumes you already have a Django application set up. If that is not 
 The sample project was created with the following commands:
 
 ```bash
-$ django-admin startproject webappexample
-$ cd webappexample
-$ python manage.py startapp auth0login
+django-admin startproject webappexample
+cd webappexample
+python manage.py startapp auth0login
 ```
 
 ### Django Settings
@@ -99,7 +99,7 @@ SOCIAL_AUTH_AUTH0_SCOPE = [
 The `social_django` application defined in `INSTALLED_APPS` requires a database. Run the following command to create all the required databases for the applications defined in `INSTALLED_APPS`:
 
 ```bash
-$ python manage.py migrate
+python manage.py migrate
 ```
 
 ### Create the Auth0 Authentication Backend

--- a/articles/quickstart/webapp/rails/01-login.md
+++ b/articles/quickstart/webapp/rails/01-login.md
@@ -26,7 +26,7 @@ gem 'omniauth-auth0', '~> 3.0'
 gem 'omniauth-rails_csrf_protection', '~> 1.0' # prevents forged authentication requests
 ```
 
-Once your gems are added, install the gems with `$ bundle install`:
+Once your gems are added, install the gems with `bundle install`:
 
 ### Initialize Auth0 Configuration
 

--- a/articles/security/bulletins/cve-2018-11537.md
+++ b/articles/security/bulletins/cve-2018-11537.md
@@ -38,7 +38,7 @@ Developers using the angular-jwt library need to upgrade to the latest version: 
 Updated package is available on [NPM](https://npmjs.com):
 
 ```bash
-$ npm install angular-jwt@0.1.10
+npm install angular-jwt@0.1.10
 ```
 
 To make it easier to keep up with security updates in the future, please make sure your `package.json` file is updated to take patch and minor level updates of our libraries:


### PR DESCRIPTION
These snippets should not include the "$" character at the beginning. When that's the case and the text is copied and ran in a terminal, the command fails.