### PR TITLE
PHP SDK 8.0: Link to beta quickstarts from stable quickstarts

### DIFF
--- a/articles/quickstart/backend/php/01-authorization.md
+++ b/articles/quickstart/backend/php/01-authorization.md
@@ -12,7 +12,7 @@ useCase: quickstart
 ---
 
 ::: panel Beta Available
-**A new pre-production beta release of PHP SDK is available.** Betas represent unstable code that is not ready for use in production applications. However, we'd encourage you to explore [the new release](https://github.com/auth0/auth0-php), [review the beta quickstarts](/quickstart/backend/php-beta), and engage with [the Auth0 Community](https://community.auth0.com/) in asking any questions or offering feedback.
+**A new pre-production beta release of PHP SDK is available.** Betas represent unstable code that is not ready for use in production applications. However, we'd encourage you to explore [the new release](https://github.com/auth0/auth0-php), [review the beta quickstarts](/quickstart/webapp/php-beta), [report any bugs](https://github.com/auth0/auth0-PHP/issues), and engage with [the Auth0 Community](https://community.auth0.com/) in asking questions and offering feedback.
 
 This guide covers the stable version of PHP SDK, and is suitable for production use.
 :::

--- a/articles/quickstart/backend/php/01-authorization.md
+++ b/articles/quickstart/backend/php/01-authorization.md
@@ -11,6 +11,12 @@ contentType: tutorial
 useCase: quickstart
 ---
 
+::: panel Beta Available
+**A new pre-production beta release of PHP SDK is available.** Betas represent unstable code that is not ready for use in production applications. However, we'd encourage you to explore [the new release](https://github.com/auth0/auth0-php), [review the beta quickstarts](/quickstart/backend/php-beta), and engage with [the Auth0 Community](https://community.auth0.com/) in asking any questions or offering feedback.
+
+This guide covers the stable version of PHP SDK, and is suitable for production use.
+:::
+
 <%= include('../../../_includes/_api_auth_intro') %>
 
 <%= include('../_includes/_api_create_new', { sampleLink: 'https://github.com/auth0-samples/auth0-php-api-samples/tree/master/02-Authenticate-HS256' }) %>

--- a/articles/quickstart/backend/php/01-authorization.md
+++ b/articles/quickstart/backend/php/01-authorization.md
@@ -254,4 +254,4 @@ $router->get('/api/private-scoped', function() use ($app){
 });
 ```
 
-The route `/api/private-scoped` will be accessible only if has a valid Access Token with the scope `read:messages`.
+The route `/api/private-scoped` will be accessible only if the request contains a valid Access Token with the scope `read:messages`.

--- a/articles/quickstart/webapp/php/01-login.md
+++ b/articles/quickstart/webapp/php/01-login.md
@@ -15,7 +15,7 @@ github:
 ---
 
 ::: panel Beta Available
-**A new pre-production beta release of PHP SDK is available.** Betas represent unstable code that is not ready for use in production applications. However, we'd encourage you to explore [the new release](https://github.com/auth0/auth0-php), [review the beta quickstarts](/quickstart/webapp/php-beta), and engage with [the Auth0 Community](https://community.auth0.com/) in asking any questions or offering feedback.
+**A new pre-production beta release of PHP SDK is available.** Betas represent unstable code that is not ready for use in production applications. However, we'd encourage you to explore [the new release](https://github.com/auth0/auth0-php), [review the beta quickstarts](/quickstart/webapp/php-beta), [report any bugs](https://github.com/auth0/auth0-PHP/issues), and engage with [the Auth0 Community](https://community.auth0.com/) in asking questions and offering feedback.
 
 This guide covers the stable version of PHP SDK, and is suitable for production use.
 :::

--- a/articles/quickstart/webapp/php/01-login.md
+++ b/articles/quickstart/webapp/php/01-login.md
@@ -13,6 +13,13 @@ useCase: quickstart
 github:
   path: 00-Starter-Seed
 ---
+
+::: panel Beta Available
+**A new pre-production beta release of PHP SDK is available.** Betas represent unstable code that is not ready for use in production applications. However, we'd encourage you to explore [the new release](https://github.com/auth0/auth0-php), [review the beta quickstarts](/quickstart/webapp/php-beta), and engage with [the Auth0 Community](https://community.auth0.com/) in asking any questions or offering feedback.
+
+This guide covers the stable version of PHP SDK, and is suitable for production use.
+:::
+
 <%= include('../_includes/_getting_started', { library: 'PHP', callback: 'http://localhost:3000/' }) %>
 
 <%= include('../../../_includes/_logout_url', { returnTo: 'http://localhost:3000' }) %>


### PR DESCRIPTION
This PR adds panels to the top of the webapp and backend PHP quickstart, notifying visitors that a new beta release is available, with links to the beta quickstarts for additional discoverability.