### PR TITLE
Remove Postman and changelog links

### DIFF
--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -1486,6 +1486,7 @@ apis:
     url: /api
   - title: Testing with Postman
     url: /api/use-auth0-apis-with-postman-collections
+    hidden: true 
   - title: Authentication API
     url: /api/authentication
     external: true
@@ -1493,6 +1494,7 @@ apis:
   - title: Changes in Management API v2
     url: /api/management-api-changes-v1-to-v2
     forceFullReload: true
+    hidden: true 
   - title: Management API Explorer
     url: /api/management/v2/
     forceFullReload: true


### PR DESCRIPTION
Remove Postman and changelog links

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
