### PR TITLE
Update RWA Quickstarts to use updated ULP screenshot

### DIFF
--- a/articles/quickstart/webapp/django/01-login.md
+++ b/articles/quickstart/webapp/django/01-login.md
@@ -314,4 +314,4 @@ python manage.py runserver 3000
 
 The application will be accessible on [http://localhost:3000](http://localhost:3000). Follow the Log In link to log in or sign up to your Auth0 tenant. Upon successful login or signup, you should be redirected to the user's profile page.
 
-![login page](/media/articles/web/hosted-login.png)
+![Auth0 Universal Login](https://cdn.auth0.com/blog/universal-login/lightweight-login.png)

--- a/articles/quickstart/webapp/java-ee/_includes/_login.md
+++ b/articles/quickstart/webapp/java-ee/_includes/_login.md
@@ -386,6 +386,6 @@ mvnw.cmd clean wildfly:run
 
 Point your browser to [http://localhost:3000](http://localhost:3000). Follow the **Log In** link to log in or sign up to your Auth0 tenant. 
 
-![login page](/media/articles/web/hosted-login.png)
+![Auth0 Universal Login](https://cdn.auth0.com/blog/universal-login/lightweight-login.png)
 
 Upon successful login, you will see the user's profile picture and a drop-down menu where the Log In link was. You can then view the user's profile page by clicking the **Profile** link. You can log out by clicking the **Logout** link in the drop-down menu.

--- a/articles/quickstart/webapp/java/_includes/_login.md
+++ b/articles/quickstart/webapp/java/_includes/_login.md
@@ -169,7 +169,7 @@ To run the sample from a terminal, change the directory to the root folder of th
 
 After a few seconds, the application will be accessible on `http://localhost:3000/`. Try to access the protected resource [http://localhost:3000/portal/home](http://localhost:3000/portal/home) and note how you're redirected by the `Auth0Filter` to the Auth0 Login Page. The widget displays all the social and database connections that you have defined for this application in the [dashboard](${manage_url}/#/).
 
-![Login using Lock](/media/articles/java/login-with-lock.png)
+![Auth0 Universal Login](https://cdn.auth0.com/blog/universal-login/lightweight-login.png)
 
 After a successful authentication, you'll be able to see the home page contents.
 

--- a/articles/quickstart/webapp/nodejs/01-login.md
+++ b/articles/quickstart/webapp/nodejs/01-login.md
@@ -373,4 +373,4 @@ block content
 
 Install the dependencies, start your app and point your browser to [http://localhost:3000](http://localhost:3000). Follow the **Log In** link to log in or sign up to your Auth0 tenant. Upon successful login or signup, you should be redirected to the user's profile page.
 
-![login page](/media/articles/web/hosted-login.png)
+![Auth0 Universal Login](https://cdn.auth0.com/blog/universal-login/lightweight-login.png)


### PR DESCRIPTION
Several of our quickstart articles show a screen capture of the login page. Some are showing classic ULP or even Lock. This PR updates the regular webapp Quickstarts that are using an outdated image to a current one (as used by Next.js and Spring Boot Quickstarts).

Note that this addresses regular webapps only. Additional updates will be required for native/mobile, but will require new screen captures for each platform, and can be done in a separate PR.
