### PR TITLE
Predeployment Tests - add to sidebar

### DIFF
--- a/config/redirects.js
+++ b/config/redirects.js
@@ -1652,6 +1652,10 @@ module.exports = [
       from: ['/pre-deployment/how-to-run-production-checks/production-check-required-fixes','/pre-deployment/tests/required'],
       to: '/deploy/pre-deployment/how-to-run-production-checks/production-check-required-fixes'
   },
+  {
+    from: ['/support/predeployment-tests','/support/testing'],
+    to: '/deploy/pre-deployment/predeployment-tests'
+  },
 
   /* Email */
 
@@ -3881,10 +3885,6 @@ module.exports = [
   {
     from: ['/tutorials/removing-auth0-exporting-data','/support/removing-auth0-exporting-data','/moving-out'],
     to: '/support/export-data'
-  },
-  {
-    from: ['/support/testing'],
-    to: '/support/predeployment-tests'
   },
   {
     from: ['/support/cancel-paid-subscriptions','/tutorials/cancel-paid-subscriptions','/cancel-paid-subscriptions'],

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -160,15 +160,17 @@ articles:
     children:
       - title: Deployment Options
         url: /deploy/deploy-options
-      - title: Deployment Checklist
-        url: /deploy/deploy-checklist
-      - title: Pre-Deployment
+      - title: Pre-Deployment Checks
         url: /deploy/pre-deployment
         children:
           - title: Run Production Checks
             url: /deploy/pre-deployment/how-to-run-production-checks
+          - title: Run Deployment Tests
+            url: /deploy/pre-deployment/predeployment-tests
           - title: Pre-Launch Tips
             url: /deploy/pre-deployment/pre-launch-tips
+      - title: Deployment Checklist
+        url: /deploy/deploy-checklist
       - title: Deploy CLI Tool
         url: /deploy/deploy-cli-tool
         children:

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -160,6 +160,35 @@ articles:
     children:
       - title: Deployment Options
         url: /deploy/deploy-options
+      - title: Private Cloud Deployment
+        url: /deploy/private-cloud
+        children:
+          - title: Onboarding
+            url: /deploy/private-cloud/private-cloud-onboarding
+            children:
+              - title: Infrastructure Requirements
+                url: /deploy/private-cloud/private-cloud-onboarding/customer-hosted-managed-private-cloud-infrastructure-requirements
+                hidden: true 
+              - title: IP/Domain and Port List
+                url: /deploy/private-cloud/private-cloud-onboarding/private-cloud-ip-domain-and-port-list
+                hidden: true 
+              - title: Remote Access Options
+                url: /deploy/private-cloud/private-cloud-onboarding/private-cloud-remote-access-options
+                hidden: true 
+          - title: Operations
+            url: /deploy/private-cloud/private-cloud-operations
+          - title: Migrations
+            url: /deploy/private-cloud/private-cloud-migrations
+            children:
+              - title: Public to Private
+                url: /deploy/private-cloud/private-cloud-migrations/migrate-from-public-cloud-to-private-cloud
+                hidden: true 
+              - title: Performance to Performance Plus
+                url: /deploy/private-cloud/private-cloud-migrations/migrate-from-standard-private-cloud-to-managed-private-cloud
+                hidden: true 
+              - title: Custom Domains
+                url: /deploy/private-cloud/private-cloud-migrations/migrate-private-cloud-custom-domains
+                hidden: true 
       - title: Pre-Deployment Checks
         url: /deploy/pre-deployment
         children:
@@ -194,35 +223,6 @@ articles:
           - title: Troubleshoot Deploy CLI
             url: /deploy/deploy-cli-tool/troubleshoot-the-deploy-cli-tool
             hidden: true
-      - title: Private Cloud Options
-        url: /deploy/private-cloud
-        children:
-          - title: Onboarding
-            url: /deploy/private-cloud/private-cloud-onboarding
-            children:
-              - title: Infrastructure Requirements
-                url: /deploy/private-cloud/private-cloud-onboarding/customer-hosted-managed-private-cloud-infrastructure-requirements
-                hidden: true 
-              - title: IP/Domain and Port List
-                url: /deploy/private-cloud/private-cloud-onboarding/private-cloud-ip-domain-and-port-list
-                hidden: true 
-              - title: Remote Access Options
-                url: /deploy/private-cloud/private-cloud-onboarding/private-cloud-remote-access-options
-                hidden: true 
-          - title: Operations
-            url: /deploy/private-cloud/private-cloud-operations
-          - title: Migrations
-            url: /deploy/private-cloud/private-cloud-migrations
-            children:
-              - title: Public to Private
-                url: /deploy/private-cloud/private-cloud-migrations/migrate-from-public-cloud-to-private-cloud
-                hidden: true 
-              - title: Performance to Performance Plus
-                url: /deploy/private-cloud/private-cloud-migrations/migrate-from-standard-private-cloud-to-managed-private-cloud
-                hidden: true 
-              - title: Custom Domains
-                url: /deploy/private-cloud/private-cloud-migrations/migrate-private-cloud-custom-domains
-                hidden: true 
   - title: Login
     url: /login
     children:


### PR DESCRIPTION
Add to Deploy in sidebar
Change parent in Contentful
Add redirect from old path
Review links: 
- https://auth0content-pr-9799.herokuapp.com/docs/deploy
- redirect from: https://auth0.com/docs/support/predeployment-tests to https://auth0.com/docs/deploy/pre-deployment/predeployment-tests

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
