### PR TITLE
API Settings sidebar and redirects

### DIFF
--- a/config/redirects.js
+++ b/config/redirects.js
@@ -2136,10 +2136,6 @@ module.exports = [
     to: '/get-started/dashboard/enable-sso-for-legacy-tenants'
   },
   {
-    from: ['/dashboard/guides/apis/delete-permissions-apis'],
-    to: '/get-started/dashboard/delete-api-permissions'
-  },
-  {
     from: ['/dashboard/guides/connections/set-up-connections-social'],
     to: '/get-started/dashboard/set-up-social-connections'
   },
@@ -2168,20 +2164,12 @@ module.exports = [
     to: '/get-started/dashboard/create-sso-dashboard-application'
   },
   {
-    from: ['/dashboard/guides/apis/add-permissions-apis','/api/management/guides/apis/update-permissions-apis','/scopes/current/guides/define-scopes-using-dashboard','/scopes/current/guides/define-api-scope-dashboard'],
-    to: '/get-started/dashboard/add-api-permissions'
-  },
-  {
     from: ['/api/management/guides/connections/promote-connection-domain-level'],
     to: '/get-started/dashboard/promote-connections-to-domain-level'
   },
   {
     from: ['/api/management/guides/connections/retrieve-connection-options','/api/management/guides/retrieve-connection-options'],
     to: '/get-started/dashboard/retrieve-connection-options'
-  },
-  {
-    from: ['/dashboard/reference/settings-api','/api-auth/references/dashboard/api-settings'],
-    to: '/get-started/dashboard/api-settings'
   },
   {
     from: ['/dashboard-access/dashboard-roles','/dashboard-access/manage-dashboard-users','/dashboard/manage-dashboard-admins','/tutorials/manage-dashboard-admins','/get-started/dashboard/manage-dashboard-users'],
@@ -4691,6 +4679,31 @@ module.exports = [
   {
     from: ['/get-started/dashboard/configure-device-user-code-settings','/dashboard/guides/tenants/configure-device-user-code-settings'],
     to: '/config/tenant-settings/configure-device-user-code-settings'
+  },
+
+  /* API Settings */
+
+  {
+    from: [
+      '/api-auth/references/dashboard/api-settings',
+      '/dashboard/reference/settings-api',
+      '/get-started/dashboard/api-settings'
+    ],
+    to: '/config/api-settings'
+  },
+  {
+    from: [
+      '/dashboard/guides/apis/add-permissions-apis',
+      '/api/management/guides/apis/update-permissions-apis',
+      '/scopes/current/guides/define-scopes-using-dashboard',
+      '/scopes/current/guides/define-api-scope-dashboard',
+      '/get-started/dashboard/add-api-permissions'
+    ],
+    to: '/config/api-settings/add-api-permissions'
+  },
+  {
+    from: ['/dashboard/guides/apis/delete-permissions-apis','/get-started/dashboard/delete-api-permissions'],
+    to: '/config/api-settings/delete-api-permissions'
   },
 
   /* Signing Keys */

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -566,7 +566,7 @@ articles:
           - title: Test Applications Locally
             url: /applications/work-with-auth0-locally
       - title: APIs
-        url: /config/api-settings
+        url: /config/api-settings 
         children:
           - title: Signing Algorithms
             url: /tokens/signing-algorithms

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -566,11 +566,15 @@ articles:
           - title: Test Applications Locally
             url: /applications/work-with-auth0-locally
       - title: APIs
-        url: /get-started/dashboard/api-settings
+        url: /config/api-settings
         children:
           - title: Signing Algorithms
             url: /tokens/signing-algorithms
-          - title: Represent Multiple APIs with a Single API
+          - title: Add API Permissions
+            url: /config/api-settings/add-api-permissions
+          - title: Delete API Permissions
+            url: /config/api-settings/delete-api-permissions
+          - title: Set Logical API for Multiple APIs
             url: /authorization/represent-multiple-apis-using-a-single-logical-api
       - title: Single Sign-On
         url: /sso


### PR DESCRIPTION
API Settings sidebar and redirects
https://auth0content-pr-9807.herokuapp.com/docs/config/api-settings

Redirect from: https://auth0content-pr-9807.herokuapp.com/docs/get-started/dashboard/api-settings

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
