### PR TITLE
Update _find-auth0-domain-redirects.md

### DIFF
--- a/articles/connections/_find-auth0-domain-redirects.md
+++ b/articles/connections/_find-auth0-domain-redirects.md
@@ -1,7 +1,5 @@
 ::: panel Find your Auth0 domain name for redirects
-If your Auth0 domain name is not shown above and you are not using our custom domains feature, your domain name is your tenant name, plus `.auth0.com`. For example, if your tenant name were `exampleco-enterprises`, your Auth0 domain name would be `exampleco-enterprises.auth0.com` and your redirect URI would be `https://exampleco-enterprises.auth0.com/login/callback`.
+If your Auth0 domain name is not shown above and you are not using our custom domains feature, your domain name is your tenant name, your regional subdomain (unless your tenant is in the US region and was created before June 2020), plus`.auth0.com`. For example, if your tenant name were `exampleco-enterprises`, your Auth0 domain name would be `exampleco-enterprises.us.auth0.com` and your redirect URI would be `https://exampleco-enterprises.us.auth0.com/login/callback`. (If your tenant is in the US and was created before June 2020, then your domain name would be `https://exampleco-enterprises.auth0.com`.)
 
-If you are using [custom domains](/custom-domains), your <dfn data-key="callback">redirect URI</dfn> will have the following format:
-
-`https://<YOUR CUSTOM DOMAIN>/login/callback`
+If you are using [custom domains](https://auth0.com/docs/custom-domains), your <dfn data-key="callback">redirect URI</dfn> will have the following format: `https://<YOUR CUSTOM DOMAIN>/login/callback`.
 :::


### PR DESCRIPTION
Panel in enterprise section outdated. Replaced verbatim with text from Google Social Connection panel: snippets/social/google/3.md

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
