### PR TITLE
URL slug redirect and sidebar update

### DIFF
--- a/config/redirects.js
+++ b/config/redirects.js
@@ -1346,8 +1346,8 @@ module.exports = [
     to: '/authorization/mitigate-replay-attacks-when-using-the-implicit-flow'
   },
   {
-    from: ['/api-auth/tutorials/represent-multiple-apis'],
-    to: '/authorization/represent-multiple-apis-using-a-single-logical-api'
+    from: ['/authorization/represent-multiple-apis-using-a-single-logical-api','/api-auth/tutorials/represent-multiple-apis'],
+    to: '/authorization/set-logical-api'
   },
   {
     from: ['/api-auth/tutorials/silent-authentication'],

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -576,7 +576,7 @@ articles:
             url: /config/api-settings/add-api-permissions
           - title: Delete API Permissions
             url: /config/api-settings/delete-api-permissions
-          - title: Set Logical API for Multiple APIs
+          - title: Configure Logical API for Multiple APIs
             url: /authorization/set-logical-api
       - title: Single Sign-On
         url: /sso

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -577,7 +577,7 @@ articles:
           - title: Delete API Permissions
             url: /config/api-settings/delete-api-permissions
           - title: Set Logical API for Multiple APIs
-            url: /authorization/represent-multiple-apis-using-a-single-logical-api
+            url: /authorization/set-logical-api
       - title: Single Sign-On
         url: /sso
         children:


### PR DESCRIPTION
Changed url-slug to https://auth0.com/docs/authorization/set-logical-api
Old link: https://auth0.com/docs/authorization/represent-multiple-apis-using-a-single-logical-api

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
