### PR TITLE
Fix snippet in Touch ID / Face ID QS

### DIFF
--- a/articles/libraries/auth0-swift/touchid-authentication.md
+++ b/articles/libraries/auth0-swift/touchid-authentication.md
@@ -31,7 +31,7 @@ Before retrieving credentials, you can also engage the biometric authentication 
 Begin by setting up the Credentials Manager. Then enable biometrics. You can also pass in a title to show in the prompt.
 
 ```swift
-let credentialsManager = CredentialsManager(authentication: Auth0.authentication())
+var credentialsManager = CredentialsManager(authentication: Auth0.authentication())
 credentialsManager.enableBiometrics(withTitle: "Touch ID / Face ID Login")
 ```
 


### PR DESCRIPTION
This PR fixes a code snippet in the Auth0.swift Touch ID / Face ID Quickstart.
The `CredentialsManager` is a struct, not a class and the methods featured in that Quickstart are `mutating`, therefore requiring the use of `var` instead of `let`(constant).