### PR TITLE
Fix closing backtick in NGINX quickstart

### DIFF
--- a/snippets/server-platforms/nginx-plus/use.md
+++ b/snippets/server-platforms/nginx-plus/use.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable MD041 -->
+
 ```
 # auth_jwt_claim_set $claim_name https://namespace/key;
 
@@ -25,4 +27,5 @@ server {
 
         access_log /var/log/nginx/access.log main_jwt;
     }
-}```
+}
+```


### PR DESCRIPTION
<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->

This fixes an issue with backticks not being formatted correctly in the NGINX
quickstart.
