### PR TITLE
Sidebar updates for best practices and support sections

### DIFF
--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -1397,8 +1397,10 @@ articles:
         url: /best-practices/deployment-best-practices
       - title: Performance
         url: /best-practices/performance-best-practices
+        hidden: true 
       - title: Debugging
         url: /best-practices/debugging-best-practices
+        hidden: true 
       - title: Error Handling
         url: /best-practices/error-handling-best-practices
       - title: Multi-Tenant Applications

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -1442,11 +1442,13 @@ articles:
   - title: Support
     url: /support
     children:
-      - title: Support Matrix
+      - title: How Auth0 Support Works
+        url: /support/support-overview
+      - title: Product Support Matrix
         url: /support/product-support-matrix
-      - title: SLA
+      - title: Service Levels
         url: /support/sla
-      - title: Tickets
+      - title: Support Tickets
         url: /support/open-and-manage-support-tickets
       - title: Support Center Users
         url: /support/support-center-users


### PR DESCRIPTION
Hide Redundant Rules Best Practice docs and change Support sidebar links and titles. 
Review links: 
- New doc: https://auth0content-pr-9818.herokuapp.com/docs/support/support-overview
- Support: https://auth0content-pr-9818.herokuapp.com/docs/support - should show table
- Best Practices: https://auth0content-pr-9818.herokuapp.com/docs/best-practices - should show table

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
