### PR TITLE
Update sidebar.yml

### DIFF
--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -2,7 +2,7 @@ articles:
   - title: Get Started 
     url: /get-started
     children:
-      - title: Auth0 Overview
+      - title: How You Can Use Auth0
         url: /get-started/auth0-overview
       - title: Dashboard Overview
         url: /get-started/dashboard

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -524,6 +524,18 @@ articles:
             url: /authorization/manage-permissions
           - title: Enable RBAC for APIs
             url: /authorization/rbac/enable-role-based-access-control-for-apis
+      - title: Protocols
+        url: /protocols
+        children: 
+          - title: OAuth0 2.0 Authorization Framework
+            url: /protocols/protocol-oauth2
+            hidden: true 
+          - title: OpenID Connect Protocol
+            url: /protocols/openid-connect-protocol
+            hidden: true 
+          - title: WS-Federation 
+            url: /protocols/configure-ws-fed-applications
+            hidden: true 
   - title: Configure
     url: /config
     children:


### PR DESCRIPTION
Changed title of Auth0 Overview to How You Can Use Auth0 in sidebar - https://auth0content-pr-9819.herokuapp.com/docs/get-started/auth0-overview
Added Protocols to Authorization in sidebar - https://auth0content-pr-9819.herokuapp.com/docs/protocols

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
