### PR TITLE
Add section to Connections Enterprise SAML doc

### DIFF
--- a/articles/connections/enterprise/saml.md
+++ b/articles/connections/enterprise/saml.md
@@ -187,15 +187,21 @@ Use the `metadataUrl` option to provide the URL of the document:
 
 When providing the URL, content is downloaded only once; the connection will not automatically reconfigure if the content of the URL changes in the future.
 
-##### Refresh an existing connection with metadata URL
+##### Refresh existing connection information with metadata URL
 
-You can create a batch process to do a periodic refresh. The process can run every few weeks and perform a PATCH call against specific connections. This process will only work if the connection was created with `metadataUrl` manually. Using this process, you use the metadata URL to create a new temp connection, then compare the properties of old and new connection and if anything is different, update it; then delete the temp connection. 
+::: note
+This process will only work if the connection was created with `metadataUrl` manually. 
+:::
+
+If you are have a B2B implementation, and federate to Auth0 with your own SAML identity provider, you may need to refresh the connection information stored in Auth0. For example, signing certificate changes, endpoint URL changes, or new assertion fields. Auth0 does this automatically for ADFS connections but not with SAML connections. 
+
+You can create a batch process (kron job) to do a periodic refresh. The process can run every few weeks and perform a PATCH call to `/api/v2/connections/CONNECTION_ID` endpoint and pass a body containing `{options: {metadataUrl: '$URL'}}` where `$URL` is the same metadata URL with which you created the connection. You use the metadata URL to create a new temp connection and compare the properties of the old and new connection, and if anything is different, update it then delete the temp connection. 
 
 1. Create SAML connection with `options.metadataUrl`. The connection object will be populated with information from the metadata.
 
 2. Update metadata content in the URL.
 
-3. Send a PATCH to connections with `{options: {metadataUrl: 'URL'}}`. Now the connection object is updated with the new metadata content. 
+3. Send a PATCH to connections with `{options: {metadataUrl: '$URL'}}`. Now the connection object is updated with the new metadata content. 
 
 ## Specify a custom Entity ID
 

--- a/articles/connections/enterprise/saml.md
+++ b/articles/connections/enterprise/saml.md
@@ -187,6 +187,16 @@ Use the `metadataUrl` option to provide the URL of the document:
 
 When providing the URL, content is downloaded only once; the connection will not automatically reconfigure if the content of the URL changes in the future.
 
+##### Refresh an existing connection with metadata URL
+
+You can create a batch process to do a periodic refresh. The process can run every few weeks and perform a PATCH call against specific connections. This process will only work if the connection was created with `metadataUrl` manually. Using this process, you use the metadata URL to create a new temp connection, then compare the properties of old and new connection and if anything is different, update it; then delete the temp connection. 
+
+1. Create SAML connection with `options.metadataUrl`. The connection object will be populated with information from the metadata.
+
+2. Update metadata content in the URL.
+
+3. Send a PATCH to connections with `{options: {metadataUrl: 'URL'}}`. Now the connection object is updated with the new metadata content. 
+
 ## Specify a custom Entity ID
 
 To specify a custom Entity ID, use the Management API to override the default `urn:auth0:YOUR_TENANT:YOUR_CONNECTION_NAME.` Set the `connection.options.entityID` property when the connection is first created or by updating an existing connection. 

--- a/articles/connections/enterprise/saml.md
+++ b/articles/connections/enterprise/saml.md
@@ -193,15 +193,15 @@ When providing the URL, content is downloaded only once; the connection will not
 This process will only work if the connection was created with `metadataUrl` manually. 
 :::
 
-If you are have a B2B implementation, and federate to Auth0 with your own SAML identity provider, you may need to refresh the connection information stored in Auth0. For example, signing certificate changes, endpoint URL changes, or new assertion fields. Auth0 does this automatically for ADFS connections but not with SAML connections. 
+If you have a B2B implementation and federate to Auth0 with your own SAML identity provider, you may need to refresh connection information stored in Auth0, such as signing certificate changes, endpoint URL changes, or new assertion fields. Auth0 does this automatically for ADFS connections, but not for SAML connections. 
 
-You can create a batch process (kron job) to do a periodic refresh. The process can run every few weeks and perform a PATCH call to `/api/v2/connections/CONNECTION_ID` endpoint and pass a body containing `{options: {metadataUrl: '$URL'}}` where `$URL` is the same metadata URL with which you created the connection. You use the metadata URL to create a new temp connection and compare the properties of the old and new connection, and if anything is different, update it then delete the temp connection. 
+You can create a batch process (cron job) to do a periodic refresh. The process can run every few weeks and perform a PATCH call to `/api/v2/connections/CONNECTION_ID` endpoint, passing a body containing `{options: {metadataUrl: '$URL'}}` where `$URL` is the same metadata URL with which you created the connection. You use the metadata URL to create a new temporary connection, then compare the properties of the old and new connections. If anything is different, update the new connection and then delete the temporary connection.
 
 1. Create SAML connection with `options.metadataUrl`. The connection object will be populated with information from the metadata.
 
 2. Update metadata content in the URL.
 
-3. Send a PATCH to connections with `{options: {metadataUrl: '$URL'}}`. Now the connection object is updated with the new metadata content. 
+3. Send a PATCH to the `/api/v2/connections/CONNECTION_ID` endpoint with `{options: {metadataUrl: '$URL'}}`. Now the connection object is updated with the new metadata content.
 
 ## Specify a custom Entity ID
 


### PR DESCRIPTION
From DOCS-1184
Review link: https://auth0content-pr-9826.herokuapp.com/docs/connections/enterprise/saml#refresh-an-existing-connection-with-metadata-url

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
