### PR TITLE
Simplify Spring Security Dependencies

### DIFF
--- a/articles/quickstart/backend/java-spring-security5/01-authorization.md
+++ b/articles/quickstart/backend/java-spring-security5/01-authorization.md
@@ -60,11 +60,8 @@ plugins {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.security:spring-security-oauth2-resource-server'
-    implementation 'org.springframework.security:spring-security-oauth2-jose'
-    implementation 'org.springframework.security:spring-security-config'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
 }
 ```
 
@@ -83,23 +80,11 @@ If you are using Maven, add the Spring dependencies to your `pom.xml` file:
 <dependencies>
     <dependency>
         <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-security</artifactId>
-    </dependency>
-    <dependency>
-        <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
     <dependency>
         <groupId>org.springframework.security</groupId>
-        <artifactId>spring-security-oauth2-resource-server</artifactId>
-    </dependency>
-    <dependency>
-        <groupId>org.springframework.security</groupId>
-        <artifactId>spring-security-oauth2-jose</artifactId>
-    </dependency>
-    <dependency>
-        <groupId>org.springframework.security</groupId>
-        <artifactId>spring-security-config</artifactId>
+        <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
     </dependency>
 </dependencies>
 ```


### PR DESCRIPTION
This change accompanies https://github.com/auth0-samples/auth0-spring-security5-api-sample/pull/11 to simplify the required Spring Security dependencies, by using the starter `spring-boot-starter-oauth2-resource-server`.