### PR TITLE
fix: group id for spring-boot-starter-oauth2-resource-server

### DIFF
--- a/articles/quickstart/backend/java-spring-security5/01-authorization.md
+++ b/articles/quickstart/backend/java-spring-security5/01-authorization.md
@@ -83,7 +83,7 @@ If you are using Maven, add the Spring dependencies to your `pom.xml` file:
         <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
     <dependency>
-        <groupId>org.springframework.security</groupId>
+        <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
     </dependency>
 </dependencies>


### PR DESCRIPTION
The groupId for `spring-boot-starter-oauth2-resource-server` is `org.springframework.boot`.
It matches the gradle spec above.
https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-oauth2-resource-server

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
