### PR TITLE
Fix note in Auth0.swift SDK

### DIFF
--- a/articles/quickstart/native/ios-swift/_includes/_login_centralized.md
+++ b/articles/quickstart/native/ios-swift/_includes/_login_centralized.md
@@ -74,10 +74,10 @@ To learn how to embed the Lock widget in your application, follow the [Embedded 
 
 <%= include('../../_includes/_ios_dependency_centralized') %>
 
-## Add the Callback (iOS < 12 only)
+## Add the Callback (iOS < 11 only)
 
 ::: note
-Skip this step if your app targets iOS 12+ (e.g. if it uses the SwiftUI app lifecycle).
+Skip this step if your app targets iOS 11+ (e.g. if it uses the SwiftUI app lifecycle).
 :::
 
 For Auth0 to handle the authentication callback, update your `AppDelegate` file.


### PR DESCRIPTION
This PR fixes the iOS version indicated to skip the "Add the Callback" step, given that older iOS versions cannot use either `ASWebAuthenticationSession` or `SFAuthenticationSession` and need to capture the callback URL in a different way.