### PR TITLE
Fix minor typo in React Native QS

### DIFF
--- a/articles/quickstart/native/react-native/00-login.md
+++ b/articles/quickstart/native/react-native/00-login.md
@@ -72,7 +72,7 @@ android {
 ```
 
 ::: note
-The `applicationId` value will be auto-replaced on runtime with the package name or id of your application (e.g. `com.example.app`). You can change this value from the `build.gradle` file. You can also check it at the top of your `AndroidManifest.xml` file.
+The `applicationId` value will be auto-replaced at runtime with the package name or ID of your application (e.g. `com.example.app`). You can change this value from the `build.gradle` file. You can also check it at the top of your `AndroidManifest.xml` file.
 :::
 
 ### Configure iOS


### PR DESCRIPTION
This PR fixes a minor typo and a capitalization error in the React Native Quickstart.