### PR TITLE
Deploy CLI Tools redirect

### DIFF
--- a/config/redirects.js
+++ b/config/redirects.js
@@ -3555,7 +3555,13 @@ module.exports = [
   /* Deploy CLI Tool */
 
   {
-    from: ['/extensions/deploy-cli-tool','/extensions/deploy-cli'],
+    from: [
+      '/extensions/deploy-cli-tool',
+      '/extensions/deploy-cli', 
+      '/extensions/deploy-cli/references/whats-new',
+      '/extensions/deploy-cli/references/whats-new-v2',
+      '/deploy/deploy-cli-tool/whats-new-in-deploy-cli-tool'
+    ],
     to: '/deploy/deploy-cli-tool'
   },
   {
@@ -3615,15 +3621,6 @@ module.exports = [
     ],
     to: '/deploy/deploy-cli-tool/environment-variables-and-keyword-mappings'
   },
-  {
-    from: [
-      '/extensions/deploy-cli/references/whats-new',
-      '/extensions/deploy-cli/references/whats-new-v2',
-      '/extensions/deploy-cli-tool/whats-new-in-deploy-cli-tool'
-    ],
-    to: '/deploy/deploy-cli-tool/whats-new-in-deploy-cli-tool'
-  },
-
 
 
   /* Get Started */


### PR DESCRIPTION
Archived What's New in Deploy CLI Tool and redirected it to the Deploy CLI Tool docs that has a section that describes previous versions.

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
