### PR TITLE
Laravel API: Authorization - PHP 8 and Laravel 8

### DIFF
--- a/articles/quickstart/backend/laravel/01-authorization.md
+++ b/articles/quickstart/backend/laravel/01-authorization.md
@@ -125,7 +125,7 @@ class CheckJWT
     {
         $auth0 = \App::make('auth0');
 
-        $accessToken = $request->bearerToken() ? "";
+        $accessToken = $request->bearerToken() ?? "";
         try {
             $tokenInfo = $auth0->decodeJWT($accessToken);
             $user = $this->userRepository->getUserByDecodedJWT($tokenInfo);

--- a/articles/quickstart/backend/laravel/01-authorization.md
+++ b/articles/quickstart/backend/laravel/01-authorization.md
@@ -125,7 +125,7 @@ class CheckJWT
     {
         $auth0 = \App::make('auth0');
 
-        $accessToken = $request->bearerToken();
+        $accessToken = $request->bearerToken() ? "";
         try {
             $tokenInfo = $auth0->decodeJWT($accessToken);
             $user = $this->userRepository->getUserByDecodedJWT($tokenInfo);
@@ -263,7 +263,7 @@ class CheckScope
     {
         $auth0 = \App::make('auth0');
 
-        $accessToken = $request->bearerToken();
+        $accessToken = $request->bearerToken() ?? "";
         try {
             $tokenInfo = $auth0->decodeJWT($accessToken);
             $user = $this->userRepository->getUserByDecodedJWT($tokenInfo);


### PR DESCRIPTION
Some changes I needed to do on my stack to get the middleware working with laravel 8 and php 8.

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
