### PR TITLE
Update the API to use to authenticate user after getting a code

### DIFF
--- a/articles/api/authentication/_passwordless.md
+++ b/articles/api/authentication/_passwordless.md
@@ -100,7 +100,7 @@ You have three options for [passwordless authentication](/connections/passwordle
 
 ### Remarks
 
-- If you sent a verification code, using either email or SMS, after you get the code, you have to authenticate the user using the [/passwordless/verify endpoint](#authenticate-user), using `email` or `phone_number` as the `username`, and the verification code as the `password`.
+- If you sent a verification code, using either email or SMS, after you get the code, you have to authenticate the user using the [/oauth/token endpoint](#authenticate-user), using `email` or `phone_number` as the `username`, and the verification code as the `otp`.
 - This endpoint is designed to be called from the client-side, and is subject to [rate limits](/policies/rate-limit-policy/authentication-api-endpoint-rate-limits).
 - The sample auth0.js script uses the library version 8. If you are using auth0.js version 7, please see this [reference guide](/libraries/auth0js/v7).
 


### PR DESCRIPTION
Updated the API to use to authenticate user after getting a code (in the Remarks section explaining how to get a code) from /passwordless/verify to /oauth/token

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
