### PR TITLE
[SDK-2798] Update Go Backend QS with go modules reference

### DIFF
--- a/articles/quickstart/backend/golang/01-authorization.md
+++ b/articles/quickstart/backend/golang/01-authorization.md
@@ -23,15 +23,14 @@ useCase: quickstart
 
 ## Validate Access Tokens
 
-### Install dependencies
+### Add dependencies
+
+This example uses Go Modules and will download automatically all the needed dependencies during the build process.
 
 The [**form3tech-oss/jwt-go**](https://github.com/form3tech-oss/jwt-go) package can be used to verify incoming JWTs. The [**auth0/go-jwt-middleware**](https://github.com/auth0/go-jwt-middleware) library can be used alongside it to fetch your Auth0 public key and complete the verification process. Finally, we'll use the [**gorilla/mux**](https://github.com/gorilla/mux) package to handle our routes and [**codegangsta/negroni**](https://github.com/urfave/negroni) for HTTP middleware.
 
 ```bash
-go get -d github.com/auth0/go-jwt-middleware
-go get -d github.com/form3tech-oss/jwt-go
-go get -d github.com/codegangsta/negroni
-go get -d github.com/gorilla/mux
+go mod vendor
 ```
 
 ### Create a middleware to validate Access Tokens

--- a/articles/quickstart/backend/golang/download.md
+++ b/articles/quickstart/backend/golang/download.md
@@ -1,7 +1,7 @@
 To run it from the command line:
 
 ```bash
-go get -d
+go mod vendor
 go run main.go
 ```
 

--- a/articles/quickstart/backend/golang/index.yml
+++ b/articles/quickstart/backend/golang/index.yml
@@ -27,7 +27,7 @@ github:
   org: auth0-samples
   repo: auth0-golang-api-samples
 requirements:
-  - Go 1.8.2
+  - Go 1.15+
 next_steps:
   - path: 01-authorization
     list:


### PR DESCRIPTION
<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
This PR updates our Go backend QS to reference the use of go modules when adding dependencies and as well the go version required for this was bumped to go 1.17+.

## Reference PR: 

- https://github.com/auth0-samples/auth0-golang-api-samples/pull/38

## Screenshots:

![image](https://user-images.githubusercontent.com/28300158/134310399-6b6f636c-e3c4-452b-a1d7-bd22489830e1.png)

![image](https://user-images.githubusercontent.com/28300158/134310467-0f49419f-cc58-4684-a76f-4be67b6a0b3f.png)
