### PR TITLE
Update 01-login.md

### DIFF
--- a/articles/quickstart/webapp/rails/01-login.md
+++ b/articles/quickstart/webapp/rails/01-login.md
@@ -111,7 +111,7 @@ To [prevent forged authentication requests](https://github.com/cookpad/omniauth-
 
 ```erb
   <!-- Place a login button anywhere on your application -->
-  ${"<%= button_to 'Login', 'auth/auth0', method: :post %>"}
+  ${"<%= button_to 'Login', '/auth/auth0', method: :post %>"}
 ```
 
 ## Add Logout to Your Application


### PR DESCRIPTION
Without the preceding slash on the button to login in, I get a rails InvalidAuthenticityToken error.

Also see: https://github.com/auth0-samples/auth0-rubyonrails-sample/pull/55