### PR TITLE
Add `.env.local` instructions to download.md

### DIFF
--- a/articles/quickstart/webapp/nextjs/download.md
+++ b/articles/quickstart/webapp/nextjs/download.md
@@ -11,7 +11,17 @@ http://localhost:3000/api/auth/callback
 ```text
 http://localhost:3000
 ```
-3) Make sure [Node.JS LTS](https://nodejs.org/en/download/) is installed and execute the following commands in the root directory:
+
+3) Create a `.env.local` file under your root project directory that defines the necessary Auth0 configuration values:
+```sh
+AUTH0_SECRET='use [openssl rand -hex 32] to generate a 32 bytes value'
+AUTH0_BASE_URL='http://localhost:3000'
+AUTH0_ISSUER_BASE_URL='https://${account.namespace}'
+AUTH0_CLIENT_ID='${account.clientId}'
+AUTH0_CLIENT_SECRET='${account.clientSecret}'
+```
+
+4) Make sure [Node.JS LTS](https://nodejs.org/en/download/) is installed and execute the following commands in the root directory:
 ```bash
 npm install && npm run dev
 ```

--- a/articles/quickstart/webapp/nextjs/download.md
+++ b/articles/quickstart/webapp/nextjs/download.md
@@ -12,8 +12,8 @@ http://localhost:3000/api/auth/callback
 http://localhost:3000
 ```
 
-3) Create a `.env.local` file under your root project directory that defines the necessary Auth0 configuration values:
-```sh
+3) Create a `.env.local` file under your root project directory with the following Auth0 configuration values:
+```bash
 AUTH0_SECRET='use [openssl rand -hex 32] to generate a 32 bytes value'
 AUTH0_BASE_URL='http://localhost:3000'
 AUTH0_ISSUER_BASE_URL='https://${account.namespace}'


### PR DESCRIPTION
This PR adds instructions for creating the `.env.local` configuration file to `download.md`, which contains the instructions to be displayed on the download sample modal.