### PR TITLE
Add new logo attribute to Quickstarts

### DIFF
--- a/articles/quickstart/backend/aspnet-core-webapi-2/index.yml
+++ b/articles/quickstart/backend/aspnet-core-webapi-2/index.yml
@@ -1,4 +1,7 @@
 title: ASP.NET Core Web API v2.1
+# TODO remove 'image' once new QS page is live. Then only use 'logo'.
+image: /media/platforms/asp.png
+logo: dotnet
 alias:
   - asp.net core webapi
   - aspnet core webapi
@@ -12,7 +15,6 @@ author:
   email: damien.guard@auth0.com
   community: false
 thirdParty: false
-image: /media/platforms/asp.png
 topics:
   - quickstart
 contentType: tutorial

--- a/articles/quickstart/backend/aspnet-core-webapi/index.yml
+++ b/articles/quickstart/backend/aspnet-core-webapi/index.yml
@@ -1,4 +1,7 @@
 title: ASP.NET Core Web API
+# TODO remove 'image' once new QS page is live. Then only use 'logo'.
+image: /media/platforms/asp.png
+logo: dotnet
 alias:
   - asp.net core webapi
   - aspnet core webapi
@@ -13,7 +16,6 @@ author:
   email: damien.guard@auth0.com
   community: false
 thirdParty: false
-image: /media/platforms/asp.png
 topics:
   - quickstart
 contentType: tutorial

--- a/articles/quickstart/backend/django/index.yml
+++ b/articles/quickstart/backend/django/index.yml
@@ -1,4 +1,7 @@
 title: Django API
+# TODO remove 'image' once new QS page is live. Then only use 'logo'.
+image: /media/platforms/django.png
+logo: django
 alias:
   - Django
 languages:
@@ -8,7 +11,6 @@ author:
   email: luciano.balmaceda@auth0.com
   community: false
 thirdParty: false
-image: /media/platforms/django.png
 topics:
   - quickstart
 contentType: tutorial

--- a/articles/quickstart/backend/golang/index.yml
+++ b/articles/quickstart/backend/golang/index.yml
@@ -1,4 +1,7 @@
 title: Go
+# TODO remove 'image' once new QS page is live. Then only use 'logo'.
+image: /media/platforms/golang.png
+logo: golang
 thirdParty: false
 alias:
   - go
@@ -9,7 +12,6 @@ author:
   name: Jim Anderson
   email: jim.anderson@auth0.com
   community: false
-image: /media/platforms/golang.png
 topics:
   - quickstart
 contentType: tutorial

--- a/articles/quickstart/backend/java-spring-security5/index.yml
+++ b/articles/quickstart/backend/java-spring-security5/index.yml
@@ -1,4 +1,7 @@
 title: Spring Boot API
+# TODO remove 'image' once new QS page is live. Then only use 'logo'.
+image: /media/platforms/java.png
+logo: spring
 thirdParty: false
 author:
   name: Jim Anderson
@@ -11,7 +14,6 @@ languages:
   - Java
 framework:
   - Spring
-image: /media/platforms/java.png
 topics:
   - quickstart
 contentType: tutorial

--- a/articles/quickstart/backend/laravel/index.yml
+++ b/articles/quickstart/backend/laravel/index.yml
@@ -1,4 +1,7 @@
 title: Laravel API
+# TODO remove 'image' once new QS page is live. Then only use 'logo'.
+image: /media/platforms/php.png
+logo: laravel
 thirdParty: false
 alias:
   - laravel
@@ -10,7 +13,6 @@ author:
   name: Josh Cunningham
   email: josh.cunningham@auth0.com
   community: false
-image: /media/platforms/php.png
 topics:
   - quickstart
 contentType: tutorial

--- a/articles/quickstart/backend/nodejs/index.yml
+++ b/articles/quickstart/backend/nodejs/index.yml
@@ -1,4 +1,7 @@
 title: Node (Express) API
+# TODO remove 'image' once new QS page is live. Then only use 'logo'.
+image: /media/platforms/node.png
+logo: nodejs
 thirdParty: false
 alias:
   - node
@@ -11,7 +14,6 @@ author:
   name: David Patrick
   email: david.patrick@auth0.com
   community: false
-image: /media/platforms/node.png
 topics:
   - quickstart
 contentType: tutorial

--- a/articles/quickstart/backend/php/index.yml
+++ b/articles/quickstart/backend/php/index.yml
@@ -1,4 +1,7 @@
 title: PHP API
+# TODO remove 'image' once new QS page is live. Then only use 'logo'.
+image: /media/platforms/php.png
+logo: php
 seo_alias: php
 alias:
   - php
@@ -9,7 +12,6 @@ author:
   email: evan.sims@auth0.com
   community: false
 thirdParty: false
-image: /media/platforms/php.png
 topics:
   - quickstart
 contentType: tutorial

--- a/articles/quickstart/backend/python/index.yml
+++ b/articles/quickstart/backend/python/index.yml
@@ -1,4 +1,7 @@
 title: Python API
+# TODO remove 'image' once new QS page is live. Then only use 'logo'.
+image: /media/platforms/python.png
+logo: python
 alias:
   - python
 languages:
@@ -8,7 +11,6 @@ author:
   email: luciano.balmaceda@auth0.com
   community: false
 thirdParty: false
-image: /media/platforms/python.png
 topics:
   - quickstart
 contentType: tutorial

--- a/articles/quickstart/backend/rails/index.yml
+++ b/articles/quickstart/backend/rails/index.yml
@@ -1,4 +1,7 @@
 title: Ruby On Rails API
+# TODO remove 'image' once new QS page is live. Then only use 'logo'.
+image: /media/platforms/rails.png
+logo: rails
 alias:
   - rails
   - ror
@@ -11,7 +14,6 @@ author:
   email: josh.cunningham@auth0.com
   community: false
 thirdParty: false
-image: /media/platforms/rails.png
 topics:
   - quickstart
 contentType: tutorial

--- a/articles/quickstart/backend/webapi-owin/index.yml
+++ b/articles/quickstart/backend/webapi-owin/index.yml
@@ -1,4 +1,7 @@
 title: ASP.NET Web API (OWIN)
+# TODO remove 'image' once new QS page is live. Then only use 'logo'.
+image: /media/platforms/asp.png
+logo: dotnet
 alias:
   - owin
 languages:
@@ -10,7 +13,6 @@ author:
   name: Damien Guard
   email: damien.guard@auth0.com
   community: false
-image: /media/platforms/asp.png
 topics:
   - quickstart
 contentType: tutorial

--- a/articles/quickstart/native/android-facebook-login/index.yml
+++ b/articles/quickstart/native/android-facebook-login/index.yml
@@ -1,4 +1,8 @@
 title: Android - Facebook Login
+# TODO remove 'image' and 'logo_name' once new QS page is live. Then only use 'logo'.s
+image: /media/platforms/android.png
+logo_name: android
+logo: android
 alias:
   - Android
 language:
@@ -8,8 +12,6 @@ author:
   name: Luciano Balmaceda
   email: luciano.balmaceda@auth0.com
   community: false
-logo_name: android
-image: /media/platforms/android.png
 topics:
   - quickstart
 contentType: tutorial

--- a/articles/quickstart/native/android/index.yml
+++ b/articles/quickstart/native/android/index.yml
@@ -1,4 +1,7 @@
 title: Android
+# TODO remove 'image' once new QS page is live. Then only use 'logo'.
+image: /media/platforms/android.png
+logo: android
 alias:
   - Android
 language:
@@ -8,7 +11,6 @@ author:
   name: Luciano Balmaceda
   email: luciano.balmaceda@auth0.com
   community: false
-image: /media/platforms/android.png
 topics:
   - quickstart
 contentType: tutorial

--- a/articles/quickstart/native/cordova/index.yml
+++ b/articles/quickstart/native/cordova/index.yml
@@ -1,4 +1,7 @@
 title: Cordova
+# TODO remove 'image' once new QS page is live. Then only use 'logo'.
+image: /media/platforms/phonegap.png
+logo: cordova
 author:
   name: David Patrick
   email: david.patrick@auth0.com
@@ -8,7 +11,6 @@ language:
 framework:
   - Cordova
 hybrid: true
-image: /media/platforms/phonegap.png
 topics:
   - quickstart
 contentType: tutorial

--- a/articles/quickstart/native/device/index.yml
+++ b/articles/quickstart/native/device/index.yml
@@ -1,10 +1,12 @@
 title: Device Authorization Flow
+# TODO remove 'image' once new QS page is live. Then only use 'logo'.
+image: /media/platforms/device.svg
+logo: auth0
 author:
   name: Rachel Khoriander
   email: rachel.khoriander@auth0.com
   community: false
 hybrid: false
-image: /media/platforms/device.svg
 topics:
   - quickstart
 contentType: tutorial

--- a/articles/quickstart/native/ionic-angular/index.yml
+++ b/articles/quickstart/native/ionic-angular/index.yml
@@ -1,5 +1,8 @@
 title: Ionic & Capacitor (Angular)
+# TODO remove 'image' and 'logo_name' once new QS page is live. Then only use 'logo'.
+image: /media/platforms/ionic.jpeg
 logo_name: ionic
+logo: ionic
 author:
   name: Steve Hobbs
   email: steve.hobbs@auth0.com
@@ -16,7 +19,6 @@ framework:
   - Capacitor
   - Angular
 hybrid: true
-image: /media/platforms/ionic.jpeg
 topics:
   - quickstart
 contentType: tutorial

--- a/articles/quickstart/native/ionic-react/index.yml
+++ b/articles/quickstart/native/ionic-react/index.yml
@@ -1,5 +1,8 @@
 title: Ionic & Capacitor (React)
+# TODO remove 'image' once new QS page is live. Then only use 'logo'.
+image: /media/platforms/ionic.jpeg
 logo_name: ionic
+logo: ionic
 author:
   name: Steve Hobbs
   email: steve.hobbs@auth0.com
@@ -16,7 +19,6 @@ framework:
   - Capacitor
   - React
 hybrid: true
-image: /media/platforms/ionic.jpeg
 topics:
   - quickstart
 contentType: tutorial

--- a/articles/quickstart/native/ios-swift-facebook-login/index.yml
+++ b/articles/quickstart/native/ios-swift-facebook-login/index.yml
@@ -1,4 +1,8 @@
 title: iOS Swift - Facebook Login
+# TODO remove 'image' and 'logo_name' once new QS page is live. Then only use 'logo'.
+image: /media/platforms/ios.png
+logo_name: ios
+logo: apple
 alias:
   - iOS
   - Swift
@@ -10,8 +14,6 @@ author:
   name: Rita Zerrizuela
   email: rita.zerrizuela@auth0.com
   community: false
-logo_name: ios
-image: /media/platforms/ios.png
 topics:
   - quickstart
 contentType: tutorial

--- a/articles/quickstart/native/ios-swift-siwa/index.yml
+++ b/articles/quickstart/native/ios-swift-siwa/index.yml
@@ -1,4 +1,7 @@
 title: iOS Swift - Sign In With Apple
+# TODO remove 'image' once new QS page is live. Then only use 'logo'.
+image: /media/platforms/ios.png
+logo: apple
 alias:
   - ios
   - swift
@@ -10,7 +13,6 @@ author:
   name: Martin Walsh
   email: martin.walsh@auth0.com
   community: false
-image: /media/platforms/ios.png
 topics:
   - quickstart
 contentType: tutorial

--- a/articles/quickstart/native/ios-swift/index.yml
+++ b/articles/quickstart/native/ios-swift/index.yml
@@ -1,4 +1,7 @@
 title: iOS Swift
+# TODO remove 'image' once new QS page is live. Then only use 'logo'.
+image: /media/platforms/ios.png
+logo: apple
 alias:
   - ios
   - swift
@@ -10,7 +13,6 @@ author:
   name: Martin Walsh
   email: martin.walsh@auth0.com
   community: false
-image: /media/platforms/ios.png
 topics:
   - quickstart
 contentType: tutorial

--- a/articles/quickstart/native/react-native/index.yml
+++ b/articles/quickstart/native/react-native/index.yml
@@ -1,4 +1,7 @@
 title: React Native
+# TODO remove 'image' once new QS page is live. Then only use 'logo'.
+image: /media/platforms/react.png
+logo: react
 alias:
   - reactnative
   - react native
@@ -13,7 +16,6 @@ language:
 framework:
   - React Native
 hybrid: true
-image: /media/platforms/react.png
 topics:
   - quickstart
 contentType: tutorial

--- a/articles/quickstart/native/windows-uwp-csharp/index.yml
+++ b/articles/quickstart/native/windows-uwp-csharp/index.yml
@@ -1,4 +1,7 @@
 title: Windows Universal App C#
+# TODO remove 'image' once new QS page is live. Then only use 'logo'.
+image: /media/platforms/windows-8.png
+logo: windows
 author:
   name: Damien Guard
   email: damien.guard@auth0.com
@@ -9,7 +12,6 @@ alias:
   - windows
 language:
   - C#
-image: /media/platforms/windows-8.png
 topics:
   - quickstart
 contentType: tutorial

--- a/articles/quickstart/native/wpf-winforms/index.yml
+++ b/articles/quickstart/native/wpf-winforms/index.yml
@@ -1,4 +1,7 @@
 title: WPF / Winforms
+# TODO remove 'image' once new QS page is live. Then only use 'logo'.
+image: /media/platforms/asp.png
+logo: windows
 author:
   name: Damien Guard
   email: damien.guard@auth0.com
@@ -10,7 +13,6 @@ language:
 framework:
   - WPF
   - WinForms
-image: /media/platforms/asp.png
 topics:
   - quickstart
 contentType: tutorial

--- a/articles/quickstart/native/xamarin/index.yml
+++ b/articles/quickstart/native/xamarin/index.yml
@@ -1,4 +1,7 @@
 title: Xamarin
+# TODO remove 'image' once new QS page is live. Then only use 'logo'.
+image: /media/platforms/xamarin.png
+logo: xamarin
 author:
   name: Damien Guard
   email: damien.guard@auth0.com
@@ -8,7 +11,6 @@ language:
 framework:
   - Xamarin
 hybrid: false
-image: /media/platforms/xamarin.png
 topics:
   - quickstart
 contentType: tutorial

--- a/articles/quickstart/spa/angular/index.yml
+++ b/articles/quickstart/spa/angular/index.yml
@@ -1,5 +1,7 @@
 title: Angular
+# TODO remove 'image' once new QS page is live. Then only use 'logo'.
 image: /media/platforms/angular.png
+logo: angular
 author:
   name: Steve Hobbs 
   email: steve.hobbs@auth0.com

--- a/articles/quickstart/spa/react/index.yml
+++ b/articles/quickstart/spa/react/index.yml
@@ -1,4 +1,7 @@
 title: React
+# TODO remove 'image' once new QS page is live. Then only use 'logo'.
+image: /media/platforms/react.png
+logo: react
 alias:
   - react
   - reactjs
@@ -10,7 +13,6 @@ author:
   community: false
 framework:
   - React
-image: /media/platforms/react.png
 topics:
   - quickstart
 contentType: tutorial

--- a/articles/quickstart/spa/vanillajs/index.yml
+++ b/articles/quickstart/spa/vanillajs/index.yml
@@ -1,7 +1,9 @@
 title: JavaScript
+# TODO remove 'image' once new QS page is live. Then only use 'logo'.
+image: /media/platforms/html5.png
+logo: javascript
 language:
   - JavaScript
-image: /media/platforms/html5.png
 author:
   name: Steve Hobbs
   email: steve.hobbs@auth0.com

--- a/articles/quickstart/spa/vuejs/index.yml
+++ b/articles/quickstart/spa/vuejs/index.yml
@@ -1,4 +1,7 @@
 title: Vue
+# TODO remove 'image' once new QS page is live. Then only use 'logo'.
+image: /media/platforms/vue.png
+logo: vuejs
 language:
   - Javascript
 author:
@@ -7,7 +10,6 @@ author:
   community: false
 framework:
   - Vue.js
-image: /media/platforms/vue.png
 topics:
   - quickstart
 contentType: tutorial

--- a/articles/quickstart/webapp/apache/index.yml
+++ b/articles/quickstart/webapp/apache/index.yml
@@ -1,7 +1,9 @@
 title: Apache
+# TODO remove 'image' once new QS page is live. Then only use 'logo'.
+image: /media/platforms/apache.jpg
+logo: apache
 author:
   community: true
-image: /media/platforms/apache.jpg
 topics:
   - quickstart
 snippets:

--- a/articles/quickstart/webapp/aspnet-core-2/index.yml
+++ b/articles/quickstart/webapp/aspnet-core-2/index.yml
@@ -1,5 +1,7 @@
 title: ASP.NET Core v2.1
+# TODO remove 'image' once new QS page is live. Then only use 'logo'.
 image: /media/platforms/asp.png
+logo: dotnet
 author:
   name: Damien Guard
   email: damien.guard@auth0.com

--- a/articles/quickstart/webapp/aspnet-core-beta/index.yml
+++ b/articles/quickstart/webapp/aspnet-core-beta/index.yml
@@ -1,5 +1,7 @@
 title: ASP.NET Core MVC (Beta)
+# TODO remove 'image' once new QS page is live. Then only use 'logo'.
 image: /media/platforms/asp.png
+logo: dotnet
 author:
   name: Frederik Prijck
   email: frederik.prijck@auth0.com

--- a/articles/quickstart/webapp/aspnet-core/index.yml
+++ b/articles/quickstart/webapp/aspnet-core/index.yml
@@ -1,5 +1,7 @@
 title: ASP.NET Core
+# TODO remove 'image' once new QS page is live. Then only use 'logo'.
 image: /media/platforms/asp.png
+logo: dotnet
 author:
   name: Damien Guard
   email: damien.guard@auth0.com

--- a/articles/quickstart/webapp/aspnet-owin/index.yml
+++ b/articles/quickstart/webapp/aspnet-owin/index.yml
@@ -1,5 +1,7 @@
 title: ASP.NET (OWIN)
+# TODO remove 'image' once new QS page is live. Then only use 'logo'.
 image: /media/platforms/asp.png
+logo: dotnet
 author:
   name: Damien Guard
   email: damien.guard@auth0.com

--- a/articles/quickstart/webapp/django/index.yml
+++ b/articles/quickstart/webapp/django/index.yml
@@ -1,5 +1,7 @@
 title: Django
+# TODO remove 'image' once new QS page is live. Then only use 'logo'.
 image: /media/platforms/python.png
+logo: python
 topics:
   - quickstart
 contentType: tutorial

--- a/articles/quickstart/webapp/express/index.yml
+++ b/articles/quickstart/webapp/express/index.yml
@@ -1,5 +1,7 @@
 title: Express
+# TODO remove 'image' once new QS page is live. Then only use 'logo'.
 image: /media/platforms/node.png
+logo: javascript
 author:
   name: David Patrick
   email: david.patrick@auth0.com

--- a/articles/quickstart/webapp/golang/index.yml
+++ b/articles/quickstart/webapp/golang/index.yml
@@ -1,5 +1,7 @@
 title: Go
+# TODO remove 'image' once new QS page is live. Then only use 'logo'.
 image: /media/platforms/golang.png
+logo: golang
 topics:
   - quickstart
 contentType: tutorial

--- a/articles/quickstart/webapp/java-ee/index.yml
+++ b/articles/quickstart/webapp/java-ee/index.yml
@@ -1,5 +1,8 @@
 title: Java EE
+# TODO remove 'image' and 'logo_name' once new QS page is live. Then only use 'logo'.
 logo_name: java
+image: /media/platforms/java.png
+logo: java
 author:
   name: Jim Anderson
   email: jim.anderson@auth0.com
@@ -11,7 +14,6 @@ languages:
   - Java
 framework:
   - Java EE
-image: /media/platforms/java.png
 topics:
   - quickstart
 contentType: tutorial

--- a/articles/quickstart/webapp/java-spring-boot/index.yml
+++ b/articles/quickstart/webapp/java-spring-boot/index.yml
@@ -1,6 +1,8 @@
 title: Java Spring Boot
+# TODO remove 'image' and 'logo_name' once new QS page is live. Then only use 'logo'.
 image: /media/platforms/spring.png
 logo_name: spring
+logo: spring
 author:
   name: Jim Anderson
   email: jim.anderson@auth0.com

--- a/articles/quickstart/webapp/java/index.yml
+++ b/articles/quickstart/webapp/java/index.yml
@@ -1,5 +1,7 @@
 title: Java
+# TODO remove 'image' once new QS page is live. Then only use 'logo'.
 image: /media/platforms/java.png
+logo: java
 topics:
   - quickstart
 contentType: tutorial

--- a/articles/quickstart/webapp/laravel/index.yml
+++ b/articles/quickstart/webapp/laravel/index.yml
@@ -1,5 +1,7 @@
 title: PHP (Laravel)
+# TODO remove 'image' once new QS page is live. Then only use 'logo'.
 image: /media/platforms/php.png
+logo: php
 languages:
   - PHP
 topics:

--- a/articles/quickstart/webapp/nextjs/index.yml
+++ b/articles/quickstart/webapp/nextjs/index.yml
@@ -1,4 +1,7 @@
 title: Next.js
+# TODO remove 'image' once new QS page is live. Then only use 'logo'.
+image: /media/platforms/nginx-plus.png
+logo: nextjs
 alias:
   - next
   - nextjs
@@ -11,7 +14,7 @@ author:
   name: Rita Zerrizuela
   email: rita.zerrizuela@auth0.com
   community: false
-image: /media/platforms/node.png
+
 topics:
   - quickstart
 contentType: tutorial

--- a/articles/quickstart/webapp/nginx-plus/index.yml
+++ b/articles/quickstart/webapp/nginx-plus/index.yml
@@ -1,9 +1,11 @@
 title: NGINX Plus
+# TODO remove 'image' once new QS page is live. Then only use 'logo'.
+image: /media/platforms/nginx-plus.png
+logo: nginx
 author:
   name: Amin Abbaspour
   email: amin.abbaspour@auth0.com
   community: false
-image: /media/platforms/nginx-plus.png
 topics:
   - quickstart
 snippets:

--- a/articles/quickstart/webapp/nodejs/index.yml
+++ b/articles/quickstart/webapp/nodejs/index.yml
@@ -1,5 +1,7 @@
 title: Node.js
+# TODO remove 'image' once new QS page is live. Then only use 'logo'.
 image: /media/platforms/node.png
+logo: nodejs
 author:
   name: Josh Cunningham
   email: josh.cunningham@auth0.com

--- a/articles/quickstart/webapp/php/index.yml
+++ b/articles/quickstart/webapp/php/index.yml
@@ -1,4 +1,7 @@
 title: PHP
+# TODO remove 'image' once new QS page is live. Then only use 'logo'.
+image: /media/platforms/php.png
+logo: php
 seo_alias: php
 alias:
   - php
@@ -9,7 +12,6 @@ author:
   email: evan.sims@auth0.com
   community: false
 thirdParty: false
-image: /media/platforms/php.png
 topics:
   - quickstart
 contentType: tutorial

--- a/articles/quickstart/webapp/python/index.yml
+++ b/articles/quickstart/webapp/python/index.yml
@@ -1,5 +1,7 @@
 title: Python
+# TODO remove 'image' once new QS page is live. Then only use 'logo'.
 image: /media/platforms/python.png
+logo: python
 author:
   name: Luciano Balmaceda
   email: luciano.balmaceda@auth0.com

--- a/articles/quickstart/webapp/rails/index.yml
+++ b/articles/quickstart/webapp/rails/index.yml
@@ -1,5 +1,7 @@
 title: Ruby On Rails
+# TODO remove 'image' once new QS page is live. Then only use 'logo'.
 image: /media/platforms/rails.png
+logo: rails
 author:
   name: David Patrick
   email: david.patrick@auth0.com


### PR DESCRIPTION
This change updates all quickstart articles to include a new `logo` attribute, which will be used to display the quickstart logos in the new quickstart listing page. The value will map to an image in `auth0-docs/public/img/platforms`, similar to how the libraries page maps the SDK logos. As the TODO comments indicate, once the new quickstarts page is live, we should remove references to the `image` and `logo_name` attributes, which will simplify the authoring experience.

Other PRs to follow:
* PR to `auth0-docs` to use the new logo attribute in the Quickstarts listing page, as well as to update the libraries page to use the quickstarts logo (they are the same).
* PR to this repo to remove the `logo` attribute from the sdk entries in quickstarts.