### PR TITLE
Next.js QS: Remove .env instructions from download modal

### DIFF
--- a/articles/quickstart/webapp/nextjs/download.md
+++ b/articles/quickstart/webapp/nextjs/download.md
@@ -12,16 +12,7 @@ http://localhost:3000/api/auth/callback
 http://localhost:3000
 ```
 
-3) Create a `.env.local` file under your root project directory with the following Auth0 configuration values:
-```bash
-AUTH0_SECRET='use [openssl rand -hex 32] to generate a 32 bytes value'
-AUTH0_BASE_URL='http://localhost:3000'
-AUTH0_ISSUER_BASE_URL='https://${account.namespace}'
-AUTH0_CLIENT_ID='${account.clientId}'
-AUTH0_CLIENT_SECRET='${account.clientSecret}'
-```
-
-4) Make sure [Node.JS LTS](https://nodejs.org/en/download/) is installed and execute the following commands in the root directory:
+3) Make sure [Node.JS LTS](https://nodejs.org/en/download/) is installed and execute the following commands in the root directory:
 ```bash
 npm install && npm run dev
 ```


### PR DESCRIPTION
This PR removes the instructions to create a `.env.local` file from the download modal instructions, as when the user is logged in the downloaded `.zip` will include a `.env.local` with the appropriate values.