### PR TITLE
Remove .html suffix on react-native docs link

### DIFF
--- a/articles/quickstart/native/react-native/00-login.md
+++ b/articles/quickstart/native/react-native/00-login.md
@@ -126,7 +126,7 @@ Take note of this value as you'll be using it to define the callback URLs below.
 - Open your project's or desired target's Build Settings tab and find the section that contains "Bundle Identifier".
 - Replace the "Bundle Identifier" value with your desired application's bundle identifier name.
 
-For additional information please read [react native docs](https://facebook.github.io/react-native/docs/linking.html).
+For additional information please read [react native docs](https://facebook.github.io/react-native/docs/linking).
 
 
 <%= include('../../../_includes/_callback_url') %>


### PR DESCRIPTION
For whatever reason the react native docs page doesn't properly resolve .html/ does not remove this suffix, and so this link 404s on react native docs. Removing the `.html` suffix fixes this problem

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
