### PR TITLE
[DXDOCS-224] feat: rename libraries section to sdks

### DIFF
--- a/config/sections.yml
+++ b/config/sections.yml
@@ -21,7 +21,7 @@
   folder: "api"
 
 - id: "libraries"
-  title: "Libraries"
+  title: "SDKs"
   url: "/libraries"
   folder: "libraries"
 


### PR DESCRIPTION
## ✏️ Changes

- Rename `Libraries` section to `SDKs` with the new branding


## 🔗 References

- [DXDOCS-224](https://auth0team.atlassian.net/browse/DXDOCS-224)