### PR TITLE
SDK-2879 Add BETA QS for GO backend API

### DIFF
--- a/articles/quickstart/backend/golang-beta/01-authorization.md
+++ b/articles/quickstart/backend/golang-beta/01-authorization.md
@@ -6,16 +6,10 @@ topics:
     - backend
     - golang
 github:
-  path: 01-Authorization-RS256
+  path: 01-Authorization-RS256-BETA
 contentType: tutorial
 useCase: quickstart
 ---
-
-::: panel New Beta Release Available!
-<span class="badge badge-warning">Beta</span> &nbsp; **[Our next-generation Auth0-Go-JWT-Middleware SDK is now available in beta.](https://github.com/auth0/go-jwt-middleware)** 
-Updated to offer an exciting new API — we think the new SDK elevates the developer experience. We'd love for you to [give the new beta release a try](https://github.com/auth0/go-jwt-middleware).
-Be sure to visit our [new backend api quickstart](/quickstart/backend/golang-beta), and drop by the [the Auth0 Community](https://community.auth0.com/) to let us know your thoughts!
-:::
 
 <%= include('../../../_includes/_api_auth_intro') %>
 
@@ -32,15 +26,14 @@ Add a `go.mod` file to list all the dependencies to be used.
 ```text
 // go.mod
 
-module 01-Authorization-RS256
+module 01-Authorization-RS256-BETA
 
 go 1.16
 
 require (
-	github.com/auth0/go-jwt-middleware v1.0.1-0.20210719135851-6401fcf7191b
+	github.com/auth0/go-jwt-middleware/v2 v2.0.0-beta
 	github.com/gin-contrib/cors v1.3.1
 	github.com/gin-gonic/gin v1.7.4
-	github.com/golang-jwt/jwt v3.2.1+incompatible
 	github.com/joho/godotenv v1.4.0
 )
 ```
@@ -84,68 +77,58 @@ package middleware
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
+	"time"
 
-	"github.com/auth0/go-jwt-middleware"
-	"github.com/auth0/go-jwt-middleware/validate/jwt-go"
+	"github.com/auth0/go-jwt-middleware/v2"
+	"github.com/auth0/go-jwt-middleware/v2/jwks"
+	"github.com/auth0/go-jwt-middleware/v2/validator"
 	"github.com/gin-gonic/gin"
-	"github.com/golang-jwt/jwt"
 )
 
-const signatureAlgorithm = "RS256"
-
-// Ensure our CustomClaims implement the jwtgo.CustomClaims interface.
-var _ jwtgo.CustomClaims = &CustomClaims{}
-
-// CustomClaims holds our custom claims for the *jwt.Token.
+// CustomClaims contains custom data we want from the token.
 type CustomClaims struct {
 	Scope string `json:"scope"`
-	jwt.StandardClaims
 }
 
-// Validate our *CustomClaims.
-func (c CustomClaims) Validate(_ context.Context) error {
-	expectedAudience := os.Getenv("AUTH0_AUDIENCE")
-	if c.Audience != expectedAudience {
-		return fmt.Errorf("token claims validation failed: unexpected audience %q", c.Audience)
-	}
-
-	expectedIssuer := "https://" + os.Getenv("AUTH0_DOMAIN") + "/"
-	if c.Issuer != expectedIssuer {
-		return fmt.Errorf("token claims validation failed: unexpected issuer %q", c.Issuer)
-	}
-
+// Validate does nothing for this example, but we need
+// it to satisfy validator.CustomClaims interface.
+func (c CustomClaims) Validate(ctx context.Context) error {
 	return nil
 }
 
 // EnsureValidToken is a gin.HandlerFunc middleware that will check the validity of our JWT.
 func EnsureValidToken() gin.HandlerFunc {
-	keyFunc := func(token *jwt.Token) (interface{}, error) {
-		certificate, err := getPEMCertificate(token)
-		if err != nil {
-			return token, err
-		}
-
-		return jwt.ParseRSAPublicKeyFromPEM([]byte(certificate))
+	issuerURL, err := url.Parse("https://" + os.Getenv("AUTH0_DOMAIN") + "/")
+	if err != nil {
+		log.Fatalf("Failed to parse the issuer url: %v", err)
 	}
 
-	customClaims := func() jwtgo.CustomClaims {
-		return &CustomClaims{}
-	}
+	provider := jwks.NewCachingProvider(issuerURL, 5*time.Minute)
 
-	validator, err := jwtgo.New(
-		keyFunc,
-		signatureAlgorithm,
-		jwtgo.WithCustomClaims(customClaims),
+	jwtValidator, err := validator.New(
+		provider.KeyFunc,
+		validator.RS256,
+		issuerURL.String(),
+		[]string{os.Getenv("AUTH0_AUDIENCE")},
+		validator.WithCustomClaims(&CustomClaims{}),
+		validator.WithAllowedClockSkew(time.Minute),
 	)
 	if err != nil {
 		log.Fatalf("Failed to set up the jwt validator")
 	}
 
-	m := jwtmiddleware.New(validator.ValidateToken)
+	errorHandler := func(w http.ResponseWriter, r *http.Request, err error) {
+		log.Printf("Encountered error while validating JWT: %v", err)
+	}
+
+	middleware := jwtmiddleware.New(
+		jwtValidator.ValidateToken,
+		jwtmiddleware.WithErrorHandler(errorHandler),
+	)
 
 	return func(ctx *gin.Context) {
 		var encounteredError = true
@@ -155,7 +138,7 @@ func EnsureValidToken() gin.HandlerFunc {
 			ctx.Next()
 		}
 
-		m.CheckJWT(handler).ServeHTTP(ctx.Writer, ctx.Request)
+		middleware.CheckJWT(handler).ServeHTTP(ctx.Writer, ctx.Request)
 
 		if encounteredError {
 			ctx.AbortWithStatusJSON(
@@ -169,54 +152,6 @@ func EnsureValidToken() gin.HandlerFunc {
 
 <%= include('../_includes/_api_jwks_description') %>
 
-Create the function to get the remote JWKS for your Auth0 account and return the certificate with the public key in PEM
-format.
-
-```go
-// 👆 We're continuing from the steps above. Append this to your middleware/jwt.go file.
-
-type (
-	jwks struct {
-		Keys []jsonWebKeys `json:"keys"`
-	}
-
-	jsonWebKeys struct {
-		Kty string   `json:"kty"`
-		Kid string   `json:"kid"`
-		Use string   `json:"use"`
-		N   string   `json:"n"`
-		E   string   `json:"e"`
-		X5c []string `json:"x5c"`
-	}
-)
-
-func getPEMCertificate(token *jwt.Token) (string, error) {
-	response, err := http.Get("https://" + os.Getenv("AUTH0_DOMAIN") + "/.well-known/jwks.json")
-	if err != nil {
-		return "", err
-	}
-	defer response.Body.Close()
-
-	var jwks jwks
-	if err = json.NewDecoder(response.Body).Decode(&jwks); err != nil {
-		return "", err
-	}
-
-	var cert string
-	for _, key := range jwks.Keys {
-		if token.Header["kid"] == key.Kid {
-			cert = "-----BEGIN CERTIFICATE-----\n" + key.X5c[0] + "\n-----END CERTIFICATE-----"
-			break
-		}
-	}
-
-	if cert == "" {
-		return cert, errors.New("unable to find appropriate key")
-	}
-
-	return cert, nil
-}
-```
 
 ## Protect API Endpoints
 
@@ -235,7 +170,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/joho/godotenv"
 
-	"01-Authorization-RS256/middleware"
+	"01-Authorization-RS256-BETA/middleware"
 )
 
 func main() {
@@ -317,8 +252,9 @@ func main() {
         "/api/private-scoped",
         middleware.EnsureValidToken(),
         func(ctx *gin.Context) {
-            claims := ctx.Request.Context().Value(jwtmiddleware.ContextKey{}).(*middleware.CustomClaims)
+            token := ctx.Request.Context().Value(jwtmiddleware.ContextKey{}).(*validator.ValidatedClaims)
             
+            claims := token.CustomClaims.(*middleware.CustomClaims)
             if !claims.HasScope("read:messages") {
                 response := map[string]string{"message": "Insufficient scope."}
                 ctx.JSON(http.StatusForbidden, response)

--- a/articles/quickstart/backend/golang-beta/02-using.md
+++ b/articles/quickstart/backend/golang-beta/02-using.md
@@ -1,0 +1,13 @@
+---
+title: Using your API
+description: This tutorial will show you how to use your API.
+budicon: 500
+topics:
+    - quickstart
+    - backend
+    - golang
+contentType: tutorial
+useCase: quickstart
+---
+
+<%= include('../_includes/_api_using') %>

--- a/articles/quickstart/backend/golang-beta/03-troubleshooting.md
+++ b/articles/quickstart/backend/golang-beta/03-troubleshooting.md
@@ -1,0 +1,10 @@
+---
+title: Troubleshooting
+name: Shows how to troubleshoot the JWT validator configuration
+description: This document will help you troubleshoot your configuration if you get unexpected responses from your API.
+budicon: 500
+contentType: tutorial
+useCase: quickstart
+---
+
+<%= include('../_includes/_api_troubleshooting') %> 

--- a/articles/quickstart/backend/golang-beta/download.md
+++ b/articles/quickstart/backend/golang-beta/download.md
@@ -1,0 +1,15 @@
+To run it from the command line:
+
+```bash
+go mod vendor
+go run main.go
+```
+
+The sample includes a [Docker](https://www.docker.com) image ready to run with the following command:
+
+```bash
+# In Linux / macOS
+sh exec.sh
+# In Windows' Powershell
+./exec.ps1
+```

--- a/articles/quickstart/backend/golang-beta/index.yml
+++ b/articles/quickstart/backend/golang-beta/index.yml
@@ -1,0 +1,48 @@
+title: Go API
+beta: true
+# TODO remove 'image' once new QS page is live. Then only use 'logo'.
+image: /media/platforms/golang.png
+logo: golang
+thirdParty: false
+alias:
+  - go
+  - golang
+languages:
+  - Go
+author:
+  name: Sergiu Ghitea
+  email: sergiu.ghitea@auth0.com
+  community: false
+topics:
+  - quickstart
+contentType: tutorial
+useCase: quickstart
+snippets:
+  dependencies: server-apis/golang/dependencies
+  setup: server-apis/golang/setup
+  use: server-apis/golang/use
+articles:
+  - 01-authorization
+  - 02-using
+  - 03-troubleshooting
+show_steps: true
+github:
+  org: auth0-samples
+  repo: auth0-golang-api-samples
+requirements:
+  - Go 1.15+
+next_steps:
+  - path: 01-authorization
+    list:
+    - text: Configure other identity providers
+      icon: 345
+      href: "/identityproviders"
+    - text: Enable multifactor authentication
+      icon: 345
+      href: "/multifactor-authentication"
+    - text: Learn about attack protection
+      icon: 345
+      href: "/attack-protection"
+    - text: Learn about rules
+      icon: 345
+      href: "/rules"


### PR DESCRIPTION
<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->

Add beta QS for go Backend API.
