### PR TITLE
Update 01-login.md

### DIFF
--- a/articles/quickstart/webapp/php/01-login.md
+++ b/articles/quickstart/webapp/php/01-login.md
@@ -148,7 +148,7 @@ $name = $session->user['name'] ?? $session->user['nickname'] ?? $session->user['
 
 ## Logging in
 
-Now let's create our /login route, which will use the Auth0 PHP SDK's `login()` method to setup the user session and return a customized URL to Auth0's Universal Login Page for this user to login.
+Now let's create our /login route, which will use the Auth0 PHP SDK's `login()` method to set up the user session and return a customized URL to Auth0's Universal Login Page for this user to login.
 
 ```PHP
 // 👆 We're continuing from the steps above. Append this to your index.php file.
@@ -157,7 +157,7 @@ Route::add('/login', function() use ($auth0) {
     // It's a good idea to reset user sessions each time they go to login to avoid "invalid state" errors, should they hit network issues or other problems that interrupt a previous login process:
     $auth0->clear();
 
-    // Finally, setup the local application session, and redirect the user to the Auth0 Universal Login Page to authenticate.
+    // Finally, set up the local application session, and redirect the user to the Auth0 Universal Login Page to authenticate.
     header("Location: " . $auth0->login(ROUTE_URL_CALLBACK));
     exit;
 });


### PR DESCRIPTION
Typo fix. As a verb, 'set up' is an open compound (two unhyphenated words).

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
