### PR TITLE
Update home route in golang webapp qs

### DIFF
--- a/articles/quickstart/webapp/golang/01-login.md
+++ b/articles/quickstart/webapp/golang/01-login.md
@@ -147,6 +147,7 @@ package router
 
 import (
 	"encoding/gob"
+	"net/http"
 
 	"github.com/gin-contrib/sessions"
 	"github.com/gin-contrib/sessions/cookie"
@@ -155,7 +156,6 @@ import (
 	"01-Login/platform/authenticator"
 	"01-Login/platform/middleware"
 	"01-Login/web/app/callback"
-	"01-Login/web/app/home"
 	"01-Login/web/app/login"
 	"01-Login/web/app/logout"
 	"01-Login/web/app/user"
@@ -175,7 +175,9 @@ func New(auth *authenticator.Authenticator) *gin.Engine {
 	router.Static("/public", "web/static")
 	router.LoadHTMLGlob("web/template/*")
 
-	router.GET("/", home.Handler)
+	router.GET("/", func(ctx *gin.Context) {
+		ctx.HTML(http.StatusOK, "home.html", nil)
+	})
 	router.GET("/login", login.Handler(auth))
 	router.GET("/callback", callback.Handler(auth))
 	router.GET("/user", user.Handler)


### PR DESCRIPTION
<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->

This fixes a small issue where home.go isn't references within the QS.
