### PR TITLE
[SDK-2956] Add Github path info to interactive react quickstart

### DIFF
--- a/articles/quickstart/spa/react/interactive.md
+++ b/articles/quickstart/spa/react/interactive.md
@@ -7,6 +7,8 @@ files:
   - _files/login
   - _files/logout
   - _files/profile
+github:
+  path: Sample-01
 ---
 
 # Add Login to your React App


### PR DESCRIPTION
Adds the repo path info which will be used to show the view sample and download sample buttons. Related to https://github.com/auth0/auth0-docs/pull/2275