### PR TITLE
[SDK-2966] Remove next steps from interactive QS

### DIFF
--- a/articles/quickstart/spa/react/index.yml
+++ b/articles/quickstart/spa/react/index.yml
@@ -60,20 +60,6 @@ next_steps:
       - text: Learn about rules
         icon: 345
         href: "/rules"
-  - path: interactive
-    list:
-      - text: Configure other identity providers
-        icon: 345
-        href: "/identityproviders"
-      - text: Enable multifactor authentication
-        icon: 345
-        href: "/multifactor-authentication"
-      - text: Learn about attack protection
-        icon: 345
-        href: "/attack-protection"
-      - text: Learn about rules
-        icon: 345
-        href: "/rules"
 troubleshooting_steps:
 
     

--- a/articles/quickstart/spa/react/interactive.md
+++ b/articles/quickstart/spa/react/interactive.md
@@ -157,11 +157,10 @@ Verify that:
 
 :::
 
-<!-- TODO real failure scenario checks -->
 :::checkpoint-failure
 Sorry about that. Here's a couple things to double check:
-* TODO
-* TODO 
+* you added the `isLoading` check before accessing the `isAuthenticated` property
+* you added the `Profile` component to the `index.js` file 
 
 Still having issues? Check out our [documentation](https://auth0.com/docs) or visit our [community page](https://community.auth0.com) to get more help.
 


### PR DESCRIPTION
Updates the React interactive quickstart to use the Next Steps copy and links per SDK-2966. Also adds troubleshooting steps to the Profile component section.