### PR TITLE
Fix Rails login normalized user profile

### DIFF
--- a/articles/quickstart/webapp/rails/01-login.md
+++ b/articles/quickstart/webapp/rails/01-login.md
@@ -196,7 +196,6 @@ Now that you have loaded the user from the session, you can use it to display in
 ```erb
 <!-- ./app/views/dashboard/show.html.erb -->
 <div>
-  <p>Normalized User Profile:${"<%= JSON.pretty_generate(@user[:info])%>"}</p>
-  <p>Full User Profile:${"<%= JSON.pretty_generate(@user[:extra][:raw_info])%>"}</p>
+  <p>Normalized User Profile:${"<%= JSON.pretty_generate(@user)%>"}</p>
 </div>
 ```


### PR DESCRIPTION
Given that `session[:userinfo]` already maps to raw info, we can no longer show the full user profile by calling `session[:userinfo][:extra][:raw_info]` as it leads to a `NoMethodError`. Now, we display the normalized information by using `@user` directly. This is in line with the changes in the sample repository https://github.com/auth0-samples/auth0-rubyonrails-sample/commit/c0da5862af2e548186ec00771e15e9de1aa75c4a#diff-6c10f94ab4d3763545c6c4868dcbdb21e18335b7dcbd7390bcf5a74c1ce350f7R9

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
