### PR TITLE
[SDK-3045] Add go backend quickstart to docs/libraries

### DIFF
--- a/articles/quickstart/backend/golang/index.yml
+++ b/articles/quickstart/backend/golang/index.yml
@@ -24,10 +24,15 @@ articles:
   - 01-authorization
   - 02-using
   - 03-troubleshooting
+default_article: 01-authorization
 show_steps: true
 github:
   org: auth0-samples
   repo: auth0-golang-api-samples
+sdk:
+  name: go-jwt-middleware
+  url: https://github.com/auth0/go-jwt-middleware
+  logo: golang
 requirements:
   - Go 1.15+
 next_steps:


### PR DESCRIPTION
<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->

In this PR we make sure we showcase the go backend quickstart as well on the docs/libraries page.