### PR TITLE
Update redirects.js

### DIFF
--- a/config/redirects.js
+++ b/config/redirects.js
@@ -3816,20 +3816,6 @@ const redirects = [
 
   {
     from: [
-      '/cms/joomla/configuration',
-      '/cms/integrate-with-joomla',
-    ],
-    to: '/customize/integrations/cms/integrate-with-joomla',
-  },
-  {
-    from: [
-      '/cms/joomla/installation',
-      '/cms/joomla-installation',
-    ],
-    to: '/customize/integrations/cms/joomla-installation',
-  },
-  {
-    from: [
       '/cms/wordpress',
       '/cms/wordpress/jwt-authentication',
       '/cms/wordpress-plugin',


### PR DESCRIPTION
Joomla SDK deprecated and advised by SDKs to remove docs. Removing redirect and will Archive docs

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
