### PR TITLE
Fix typo in Swift Quickstart snippet

### DIFF
--- a/articles/quickstart/native/swift-beta/01-login.md
+++ b/articles/quickstart/native/swift-beta/01-login.md
@@ -115,7 +115,7 @@ Create a `plist` file named `Auth0.plist` in your application bundle with the fo
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "<http://www.apple.com/DTDs/PropertyList-1.0.dtd">>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "<http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
     <key>ClientId</key>


### PR DESCRIPTION
This PR fixes a typo in an XML snippet in the beta Swift Quickstart.