### PR TITLE
Remove extra character in XML snippet in beta Swift Quickstart

### DIFF
--- a/articles/quickstart/native/swift-beta/01-login.md
+++ b/articles/quickstart/native/swift-beta/01-login.md
@@ -115,7 +115,7 @@ Create a `plist` file named `Auth0.plist` in your application bundle with the fo
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "<http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
     <key>ClientId</key>


### PR DESCRIPTION
The Swift beta Quickstart includes an XML Plist snippet. While the Plist is parsed correctly in its current form (and works as expected), it contains an extra `<` in the Document Type definition URL. This PR removes that extra char, matching it with the version found in [the README](https://github.com/auth0/Auth0.swift/tree/beta#configure-client-id-and-domain-with-a-plist).