### PR TITLE
[SDK-3068] Add Auth-Vue beta quickstart

### DIFF
--- a/articles/quickstart/spa/vuejs-beta/01-login.md
+++ b/articles/quickstart/spa/vuejs-beta/01-login.md
@@ -1,6 +1,6 @@
 ---
 title: Login
-description: This tutorial demonstrates how to add user login to a Vue.JS application using Auth0.
+description: This quickstart demonstrates how to add user login to a Vue.JS application using Auth0.
 budicon: 448
 topics:
   - quickstarts
@@ -18,7 +18,3 @@ useCase: quickstart
 <%= include('../_includes/_getting_started', { library: 'Vue.js', callback: 'http://localhost:3000', returnTo: 'http://localhost:3000', webOriginUrl: 'http://localhost:3000', showLogoutInfo: true, showWebOriginInfo: true, new_js_sdk: true, show_install_info: false }) %>
 
 <%= include('_includes/_centralized_login') %>
-
-:::note
-For a deep dive into implementing user authentication in Vue, visit the [Complete Guide to Vue User Authentication with Auth0](https://auth0.com/blog/complete-guide-to-vue-user-authentication/). This guide provides you with additional details, such as creating a signup button. 
-:::

--- a/articles/quickstart/spa/vuejs-beta/01-login.md
+++ b/articles/quickstart/spa/vuejs-beta/01-login.md
@@ -1,0 +1,24 @@
+---
+title: Login
+description: This tutorial demonstrates how to add user login to a Vue.JS application using Auth0.
+budicon: 448
+topics:
+  - quickstarts
+  - spa
+  - vuejs
+  - login
+github:
+  path: 01-Login
+contentType: tutorial
+useCase: quickstart
+---
+
+<!-- markdownlint-disable MD034 MD041 -->
+
+<%= include('../_includes/_getting_started', { library: 'Vue.js', callback: 'http://localhost:3000', returnTo: 'http://localhost:3000', webOriginUrl: 'http://localhost:3000', showLogoutInfo: true, showWebOriginInfo: true, new_js_sdk: true, show_install_info: false }) %>
+
+<%= include('_includes/_centralized_login') %>
+
+:::note
+For a deep dive into implementing user authentication in Vue, visit the [Complete Guide to Vue User Authentication with Auth0](https://auth0.com/blog/complete-guide-to-vue-user-authentication/). This guide provides you with additional details, such as creating a signup button. 
+:::

--- a/articles/quickstart/spa/vuejs-beta/01-login.md
+++ b/articles/quickstart/spa/vuejs-beta/01-login.md
@@ -9,6 +9,8 @@ topics:
   - login
 github:
   path: 01-Login
+sample_download_required_data:
+  - client
 contentType: tutorial
 useCase: quickstart
 ---

--- a/articles/quickstart/spa/vuejs-beta/02-calling-an-api.md
+++ b/articles/quickstart/spa/vuejs-beta/02-calling-an-api.md
@@ -64,7 +64,7 @@ You can retrieve an Access Token by using the `getAccessTokenSilently` function 
 
 ### Using the Options API
 
-In you are using the Options API, you can use the same `getAccessTokenSilently` method from the global `$auth0` property through your component's `this`.
+If you are using the Options API, you can use the same `getAccessTokenSilently` method from the global `$auth0` property through the `this` accessor.
 
 ```html
 <script>
@@ -79,8 +79,8 @@ In you are using the Options API, you can use the same `getAccessTokenSilently` 
 ```
 
 ## Calling an API
-Once you have an access token, you need to ensure that the token gets added to the `Authorization` header of your request.
-Depending on how you are implementing HTTP calls in your Vue application, the implementation will be slightly different. However, here is an example that uses `fetch` with Vue's Composition API:
+To call an API, include the token in the `Authorization` header of your request.
+There are many ways to make HTTP calls with Vue. Here is an example using the `fetch` API with Vue's Composition API:
 
 ```html
 <script>

--- a/articles/quickstart/spa/vuejs-beta/02-calling-an-api.md
+++ b/articles/quickstart/spa/vuejs-beta/02-calling-an-api.md
@@ -60,6 +60,8 @@ You will need to retrieve the Access Token by using the `getAccessTokenSilently`
 </script>
 ```
 
+### Using the Options API
+
 In you are using the Options API, you can use the same `getAccessTokenSilently` method from the global `$auth0` property through your component's `this`.
 
 ```html
@@ -74,6 +76,7 @@ In you are using the Options API, you can use the same `getAccessTokenSilently` 
 </script>
 ```
 
+## Calling an API
 Once you have an access token, you need to ensure that the token gets added to the `Authorization` header of your request.
 Depending on how you are implementing HTTP calls in your Vue application, the implementation will be slightly different. However, here is an example that uses `fetch` with Vue's Composition API:
 

--- a/articles/quickstart/spa/vuejs-beta/02-calling-an-api.md
+++ b/articles/quickstart/spa/vuejs-beta/02-calling-an-api.md
@@ -18,6 +18,8 @@ useCase: quickstart
 
 <!-- markdownlint-disable MD002 MD041 -->
 
+<%= include('../_includes/_calling_api_create_api') %>
+
 ## Configuring the plugin
 To call an API, configure the plugin by setting the `audience` to the **API Identifier** of the API you want to call:
 
@@ -40,7 +42,7 @@ app.mount('#app');
 
 ## Retrieving an Access Token
 With the plugin configured using an `audience`, Auth0 will return an Access Token that can be sent to your API.
-You will need to retrieve the Access Token by using the `getAccessTokenSilently` function and set it on the `Authorization` header of your request.
+You can retrieve an Access Token by using the `getAccessTokenSilently` function thats exposed by our SDK.
 
 ```html
 <script>

--- a/articles/quickstart/spa/vuejs-beta/02-calling-an-api.md
+++ b/articles/quickstart/spa/vuejs-beta/02-calling-an-api.md
@@ -1,7 +1,7 @@
 ---
 title: Calling an API
 description: This quickstart demonstrates how to make calls to an external API from a Vue.JS application using Auth0.
-budicon: 546
+budicon: 448
 topics:
   - quickstarts
   - spa
@@ -75,14 +75,28 @@ In you are using the Options API, you can use the same `getAccessTokenSilently` 
 ```
 
 Once you have an access token, you need to ensure that the token gets added to the `Authorization` header of your request.
-Depending on how you are implementing HTTP calls in your Vue application, the implementation will be slightly different. However, here is an example that uses `fetch`:
+Depending on how you are implementing HTTP calls in your Vue application, the implementation will be slightly different. However, here is an example that uses `fetch` with Vue's Composition API:
 
-```ts
-const token = await getAccessTokenSilently();
-const response = await fetch('https://api.example.com/posts', {
-  headers: {
-    Authorization: `Bearer ${token}`
-  }
-});
-const data = await response.json();
+```html
+<script>
+  import { useAuth0 } from '@auth0/auth0-vue';
+
+  export default {
+    setup() {
+      const { getAccessTokenSilently } = useAuth0();
+
+      return {
+        doSomethingWithToken: async () => {
+          const token = await getAccessTokenSilently();
+          const response = await fetch('https://api.example.com/posts', {
+            headers: {
+              Authorization: 'Bearer ' + token
+            }
+          });
+          const data = await response.json();
+        }
+      };
+    }
+  };
+</script>
 ```

--- a/articles/quickstart/spa/vuejs-beta/02-calling-an-api.md
+++ b/articles/quickstart/spa/vuejs-beta/02-calling-an-api.md
@@ -1,0 +1,88 @@
+---
+title: Calling an API
+description: This quickstart demonstrates how to make calls to an external API from a Vue.JS application using Auth0.
+budicon: 546
+topics:
+  - quickstarts
+  - spa
+  - vuejs
+  - apis
+github:
+  path: 02-Calling-an-API
+sample_download_required_data:
+  - client
+  - api
+contentType: tutorial
+useCase: quickstart
+---
+
+<!-- markdownlint-disable MD002 MD041 -->
+
+## Configuring the plugin
+To call an API, configure the plugin by setting the `audience` to the **API Identifier** of the API you want to call:
+
+```ts
+import { createAuth0 } from '@auth0/auth0-vue';
+
+const app = createApp(App);
+
+app.use(
+  createAuth0({
+    domain: '<AUTH0_DOMAIN>',
+    client_id: '<AUTH0_CLIENT_ID>',
+    redirect_uri: '<MY_CALLBACK_URL>',
+    audience: '<AUTH0_AUDIENCE>'
+  })
+);
+
+app.mount('#app');
+```
+
+## Retrieving an Access Token
+With the plugin configured using an `audience`, Auth0 will return an Access Token that can be sent to your API.
+You will need to retrieve the Access Token by using the `getAccessTokenSilently` function and set it on the `Authorization` header of your request.
+
+```html
+<script>
+  import { useAuth0 } from '@auth0/auth0-vue';
+
+  export default {
+    setup() {
+      const { getAccessTokenSilently } = useAuth0();
+
+      return {
+        doSomethingWithToken: async () => {
+          const token = await getAccessTokenSilently();
+        }
+      };
+    }
+  };
+</script>
+```
+
+In you are using the Options API, you can use the same `getAccessTokenSilently` method from the global `$auth0` property through your component's `this`.
+
+```html
+<script>
+  export default {
+    methods: {
+      async doSomethingWithToken() {
+        const token = await this.$auth0.getAccessTokenSilently();
+      }
+    }
+  };
+</script>
+```
+
+Once you have an access token, you need to ensure that the token gets added to the `Authorization` header of your request.
+Depending on how you are implementing HTTP calls in your Vue application, the implementation will be slightly different. However, here is an example that uses `fetch`:
+
+```ts
+const token = await getAccessTokenSilently();
+const response = await fetch('https://api.example.com/posts', {
+  headers: {
+    Authorization: `Bearer ${token}`
+  }
+});
+const data = await response.json();
+```

--- a/articles/quickstart/spa/vuejs-beta/_includes/_centralized_login.md
+++ b/articles/quickstart/spa/vuejs-beta/_includes/_centralized_login.md
@@ -1,0 +1,200 @@
+<!-- markdownlint-disable MD041 MD002 -->
+
+## Install the SDK
+
+You can install the [Auth0 Vue SDK](https://github.com/auth0/auth0-vue) using npm:
+
+```bash
+npm install @auth0/auth0-vue
+```
+
+## Registering the plugin
+
+In order to use the SDK in your Vue application, you will need to register its plugin with your Vue application by passing the return value of `createAuth0` to `app.use()`.
+
+```js
+import { createAuth0 } from '@auth0/auth0-vue';
+
+const app = createApp(App);
+
+app.use(
+  createAuth0({
+    domain: '<AUTH0_DOMAIN>',
+    client_id: '<AUTH0_CLIENT_ID>',
+    redirect_uri: '<MY_CALLBACK_URL>'
+  })
+);
+
+app.mount('#app');
+```
+
+Adding the plugin will register our SDK using both `provide` and `app.config.globalProperties`, allowing the SDK to be used with both the Composition API and Options API.
+
+## Log in to the App
+
+In order to add login to your application you can use the `loginWithRedirect` function that is exposed on the return value of `useAuth0`, which you can access in your component's `setup` function.
+
+```html
+<template>
+  <div>
+    <button @click="login">Log in</button>
+  </div>
+</template>
+<script>
+  import { useAuth0 } from '@auth0/auth0-vue';
+
+  export default {
+    setup() {
+      const { loginWithRedirect } = useAuth0();
+
+      return {
+        login: () => {
+          loginWithRedirect();
+        }
+      };
+    }
+  };
+</script>
+```
+
+Calling `loginWithRedirect` will redirect the user to Auth0, and redirect them back to the `redirect_uri` (provided when calling `createAuth0()`) after entering their credentials.
+
+### Using the Options API
+In case of the Options API, you can use the same `loginWithRedirect` method from the global `$auth0` property through your component's `this`.
+
+```html
+<template>
+  <div>
+    <button @click="login">Log in</button>
+  </div>
+</template>
+
+<script>
+  export default {
+    methods: {
+      login() {
+        this.$auth0.loginWithRedirect();
+      }
+    }
+  };
+</script>
+```
+
+## Display the User's Profile
+
+Once the user authenticates, the SDK extracts the user's profile information and stores it in memory. It can be accessed by using the reactive `user` property exposed by the return value of `useAuth0`, which you can access in your component's `setup` function.
+
+```html
+<template>
+  <div>
+    <h2>User Profile</h2>
+    <button @click="login">Log in</button>
+    <pre>
+        <code>{{ user }}</code>
+      </pre>
+  </div>
+</template>
+<script>
+  import { useAuth0 } from '@auth0/auth0-vue';
+
+  export default {
+    setup() {
+      const { loginWithRedirect, user } = useAuth0();
+
+      return {
+        login: () => {
+          loginWithRedirect();
+        },
+        user
+      };
+    }
+  };
+</script>
+```
+
+:::note
+Ensure the user is authenticated by implementing login in your application before accessing the user's profile.
+:::
+
+### Using the Options API
+In case of the Options API, you can use the same reactive `user` property from the global `$auth0` property through your component's `this`.
+
+```html
+<template>
+  <div>
+    <h2>User Profile</h2>
+    <button @click="login">Log in</button>
+    <pre>
+      <code>{{ user }}</code>
+    </pre>
+  </div>
+</template>
+
+<script>
+  export default {
+    data: function () {
+      return {
+        user: this.$auth0.user
+      };
+    },
+    methods: {
+      login() {
+        this.$auth0.loginWithRedirect();
+      }
+    }
+  };
+</script>
+```
+
+## Logout
+Adding logout to your application can be done by using the `logout` function that is exposed on the return value of `useAuth0`, which you can access in your component's `setup` function.
+
+```html
+<template>
+  <div>
+    <button @click="logout">Log out</button>
+  </div>
+</template>
+<script>
+  import { useAuth0 } from '@auth0/auth0-vue';
+
+  export default {
+    setup() {
+      const { logout } = useAuth0();
+
+      return {
+        logout: () => {
+          logout({ returnTo: window.location.origin });
+        }
+      };
+    }
+  };
+</script>
+```
+
+Calling `logout()` will redirect the user to Auth0 to ensure their session is ended with Auth0 as well. Once the user is logged out succesfuly, they will be redirected back to the specified `returnTo` parameter.
+
+:::note
+If you only want to log the user out of your application but not from Auth0, you can specifcy `localOnly: true` when calling `logout()`.
+:::
+
+### Using the Options API
+In case of the Options API, you can use the same `logout` method from the global `$auth0` property through your component's `this`.
+
+```html
+<template>
+  <div>
+    <button @click="logout">Log out</button>
+  </div>
+</template>
+
+<script>
+  export default {
+    methods: {
+      logout() {
+        this.$auth0.logout({ returnTo: window.location.origin });
+      }
+    }
+  };
+</script>
+```

--- a/articles/quickstart/spa/vuejs-beta/_includes/_centralized_login.md
+++ b/articles/quickstart/spa/vuejs-beta/_includes/_centralized_login.md
@@ -28,7 +28,7 @@ app.use(
 app.mount('#app');
 ```
 
-Adding the plugin will register our SDK using both `provide` and `app.config.globalProperties`, allowing the SDK to be used with both the [Composition API](https://v3.vuejs.org/guide/composition-api-introduction.html) and Options API.
+The plugin will register the SDK using both `provide` and `app.config.globalProperties`, allowing the SDK to be used with both the [Composition API](https://v3.vuejs.org/guide/composition-api-introduction.html) and [Options API](https://vuejs.org/guide/introduction.html#options-api).
 
 ## Add Login to Your Application
 

--- a/articles/quickstart/spa/vuejs-beta/_includes/_centralized_login.md
+++ b/articles/quickstart/spa/vuejs-beta/_includes/_centralized_login.md
@@ -5,7 +5,7 @@
 You can install the [Auth0 Vue SDK](https://github.com/auth0/auth0-vue) using npm:
 
 ```bash
-npm install @auth0/auth0-vue
+npm install @auth0/auth0-vue@beta
 ```
 
 ## Registering the plugin

--- a/articles/quickstart/spa/vuejs-beta/_includes/_centralized_login.md
+++ b/articles/quickstart/spa/vuejs-beta/_includes/_centralized_login.md
@@ -8,9 +8,9 @@ You can install the [Auth0 Vue SDK](https://github.com/auth0/auth0-vue) using np
 npm install @auth0/auth0-vue@beta
 ```
 
-## Registering the plugin
+### Register the plugin
 
-In order to use the SDK in your Vue application, you will need to register its plugin with your Vue application by passing the return value of `createAuth0` to `app.use()`.
+To use the SDK in your Vue application, register the plugin with your Vue application by passing the return value of `createAuth0` to `app.use()`.
 
 ```js
 import { createAuth0 } from '@auth0/auth0-vue';
@@ -28,11 +28,11 @@ app.use(
 app.mount('#app');
 ```
 
-Adding the plugin will register our SDK using both `provide` and `app.config.globalProperties`, allowing the SDK to be used with both the Composition API and Options API.
+Adding the plugin will register our SDK using both `provide` and `app.config.globalProperties`, allowing the SDK to be used with both the [Composition API](https://v3.vuejs.org/guide/composition-api-introduction.html) and Options API.
 
-## Log in to the App
+## Add Login to Your Application
 
-In order to add login to your application you can use the `loginWithRedirect` function that is exposed on the return value of `useAuth0`, which you can access in your component's `setup` function.
+To add login to your application, use the `loginWithRedirect` function that is exposed on the return value of `useAuth0`, which you can access in your component's `setup` function.
 
 ```html
 <template>
@@ -60,7 +60,7 @@ In order to add login to your application you can use the `loginWithRedirect` fu
 Calling `loginWithRedirect` will redirect the user to Auth0, and redirect them back to the `redirect_uri` (provided when calling `createAuth0()`) after entering their credentials.
 
 ### Using the Options API
-In case of the Options API, you can use the same `loginWithRedirect` method from the global `$auth0` property through your component's `this`.
+In you are using the Options API, you can use the same `loginWithRedirect` method from the global `$auth0` property through your component's `this`.
 
 ```html
 <template>
@@ -80,7 +80,60 @@ In case of the Options API, you can use the same `loginWithRedirect` method from
 </script>
 ```
 
-## Display the User's Profile
+## Add Logout to Your Application
+Use the `logout` function that is exposed on the return value of `useAuth0`, which you can access in your component's `setup` function, to log the user out of your application.
+
+```html
+<template>
+  <div>
+    <button @click="logout">Log out</button>
+  </div>
+</template>
+<script>
+  import { useAuth0 } from '@auth0/auth0-vue';
+
+  export default {
+    setup() {
+      const { logout } = useAuth0();
+
+      return {
+        logout: () => {
+          logout({ returnTo: window.location.origin });
+        }
+      };
+    }
+  };
+</script>
+```
+
+Calling `logout()` will redirect the user to Auth0 to ensure their session is ended with Auth0 as well. Once the user is logged out successfully, they will be redirected back to the specified `returnTo` parameter.
+
+:::note
+If you only want to log the user out of your application but not from Auth0, you can specifcy `localOnly: true` when calling `logout()`.
+:::
+
+### Using the Options API
+If you're using the Options API, you can use the same `logout` method from the global `$auth0` property through your component's `this`.
+
+```html
+<template>
+  <div>
+    <button @click="logout">Log out</button>
+  </div>
+</template>
+
+<script>
+  export default {
+    methods: {
+      logout() {
+        this.$auth0.logout({ returnTo: window.location.origin });
+      }
+    }
+  };
+</script>
+```
+
+## Show User Profile Information
 
 Once the user authenticates, the SDK extracts the user's profile information and stores it in memory. It can be accessed by using the reactive `user` property exposed by the return value of `useAuth0`, which you can access in your component's `setup` function.
 
@@ -118,7 +171,7 @@ Ensure the user is authenticated by implementing login in your application befor
 :::
 
 ### Using the Options API
-In case of the Options API, you can use the same reactive `user` property from the global `$auth0` property through your component's `this`.
+If you're using the Options API, you can use the same reactive `user` property from the global `$auth0` property through your component's `this`.
 
 ```html
 <template>
@@ -141,59 +194,6 @@ In case of the Options API, you can use the same reactive `user` property from t
     methods: {
       login() {
         this.$auth0.loginWithRedirect();
-      }
-    }
-  };
-</script>
-```
-
-## Logout
-Adding logout to your application can be done by using the `logout` function that is exposed on the return value of `useAuth0`, which you can access in your component's `setup` function.
-
-```html
-<template>
-  <div>
-    <button @click="logout">Log out</button>
-  </div>
-</template>
-<script>
-  import { useAuth0 } from '@auth0/auth0-vue';
-
-  export default {
-    setup() {
-      const { logout } = useAuth0();
-
-      return {
-        logout: () => {
-          logout({ returnTo: window.location.origin });
-        }
-      };
-    }
-  };
-</script>
-```
-
-Calling `logout()` will redirect the user to Auth0 to ensure their session is ended with Auth0 as well. Once the user is logged out succesfuly, they will be redirected back to the specified `returnTo` parameter.
-
-:::note
-If you only want to log the user out of your application but not from Auth0, you can specifcy `localOnly: true` when calling `logout()`.
-:::
-
-### Using the Options API
-In case of the Options API, you can use the same `logout` method from the global `$auth0` property through your component's `this`.
-
-```html
-<template>
-  <div>
-    <button @click="logout">Log out</button>
-  </div>
-</template>
-
-<script>
-  export default {
-    methods: {
-      logout() {
-        this.$auth0.logout({ returnTo: window.location.origin });
       }
     }
   };

--- a/articles/quickstart/spa/vuejs-beta/_includes/_centralized_login.md
+++ b/articles/quickstart/spa/vuejs-beta/_includes/_centralized_login.md
@@ -2,7 +2,7 @@
 
 ## Install the SDK
 
-You can install the [Auth0 Vue SDK](https://github.com/auth0/auth0-vue) using npm:
+Install the [Auth0 Vue SDK](https://github.com/auth0/auth0-vue) using npm:
 
 ```bash
 npm install @auth0/auth0-vue@beta
@@ -57,10 +57,10 @@ To add login to your application, use the `loginWithRedirect` function that is e
 </script>
 ```
 
-Calling `loginWithRedirect` will redirect the user to Auth0, and redirect them back to the `redirect_uri` (provided when calling `createAuth0()`) after entering their credentials.
+The `loginWithRedirect` function will redirect the user to Auth0, and redirect them back to the `redirect_uri` (provided when calling `createAuth0()`) after entering their credentials.
 
 ### Using the Options API
-In you are using the Options API, you can use the same `loginWithRedirect` method from the global `$auth0` property through your component's `this`.
+If you are using the Options API, you can use the same `loginWithRedirect` method from the global `$auth0` property through the `this` accessor.
 
 ```html
 <template>
@@ -106,14 +106,14 @@ Use the `logout` function that is exposed on the return value of `useAuth0`, whi
 </script>
 ```
 
-Calling `logout()` will redirect the user to Auth0 to ensure their session is ended with Auth0 as well. Once the user is logged out successfully, they will be redirected back to the specified `returnTo` parameter.
+The `logout()` function will redirect the user to Auth0 to ensure their session is ended with Auth0 as well. Once the user is logged out successfully, they will be redirected back to the specified `returnTo` parameter.
 
 :::note
-If you only want to log the user out of your application but not from Auth0, you can specifcy `localOnly: true` when calling `logout()`.
+To log the user out of your application but not from Auth0, use `logout({ localOnly: true })`.
 :::
 
 ### Using the Options API
-If you're using the Options API, you can use the same `logout` method from the global `$auth0` property through your component's `this`.
+If you're using the Options API, you can use the same `logout` method from the global `$auth0` property through the `this` accessor.
 
 ```html
 <template>
@@ -171,7 +171,7 @@ Ensure the user is authenticated by implementing login in your application befor
 :::
 
 ### Using the Options API
-If you're using the Options API, you can use the same reactive `user` property from the global `$auth0` property through your component's `this`.
+If you're using the Options API, you can use the same reactive `user` property from the global `$auth0` property through the `this` accessor.
 
 ```html
 <template>

--- a/articles/quickstart/spa/vuejs-beta/_includes/_centralized_login.md
+++ b/articles/quickstart/spa/vuejs-beta/_includes/_centralized_login.md
@@ -89,7 +89,7 @@ Once the user authenticates, the SDK extracts the user's profile information and
   <div>
     <h2>User Profile</h2>
     <button @click="login">Log in</button>
-    <pre>
+    <pre v-if="isAuthenticated">
         <code>{{ user }}</code>
       </pre>
   </div>
@@ -99,13 +99,14 @@ Once the user authenticates, the SDK extracts the user's profile information and
 
   export default {
     setup() {
-      const { loginWithRedirect, user } = useAuth0();
+      const { loginWithRedirect, user, isAuthenticated } = useAuth0();
 
       return {
         login: () => {
           loginWithRedirect();
         },
-        user
+        user,
+        isAuthenticated
       };
     }
   };

--- a/articles/quickstart/spa/vuejs-beta/download.md
+++ b/articles/quickstart/spa/vuejs-beta/download.md
@@ -1,0 +1,29 @@
+<!-- markdownlint-disable MD031 MD041 -->
+
+To run the sample follow these steps:
+
+1) Set the **Callback URL** in the [Application Settings](${manage_url}/#/applications/${account.clientId}/settings) to
+```text
+http://localhost:3000
+```
+2) Set **Allowed Web Origins** in the [Application Settings](${manage_url}/#/applications/${account.clientId}/settings) to
+```text
+http://localhost:3000
+```
+3) Set **Allowed Logout URLs** in the [Application Settings](${manage_url}/#/applications/${account.clientId}/settings) to 
+
+```text
+http://localhost:3000
+```
+4) Make sure [Node.JS LTS](https://nodejs.org/en/download/) is installed and execute the following commands in the sample's directory:
+```bash
+npm install && npm run serve
+```
+You can also run it from a [Docker](https://www.docker.com) image with the following commands:
+
+```bash
+# In Linux / macOS         
+sh exec.sh                 
+# In Windows' Powershell
+./exec.ps1
+```

--- a/articles/quickstart/spa/vuejs-beta/index.yml
+++ b/articles/quickstart/spa/vuejs-beta/index.yml
@@ -42,9 +42,9 @@ requirements:
 next_steps:
   - path: 01-login
     list:
-    - text: Retrieve an Access Token
+    - text: Calling an API
       icon: 345
-      href: "https://github.com/auth0/auth0-vue#retrieve-an-access-token"
+      href: "https://github.com/auth0/auth0-vue#calling-an-api"
     - text: Accessing ID Token Claims
       icon: 345
       href: "https://github.com/auth0/auth0-vue#accessing-id-token-claims"

--- a/articles/quickstart/spa/vuejs-beta/index.yml
+++ b/articles/quickstart/spa/vuejs-beta/index.yml
@@ -48,9 +48,9 @@ next_steps:
     - text: Accessing ID Token Claims
       icon: 345
       href: "https://github.com/auth0/auth0-vue#accessing-id-token-claims"
-    - text: Using a router
+    - text: Protect a Route
       icon: 345
-      href: "https://github.com/auth0/auth0-vue#retrieve-an-access-token"
+      href: "https://github.com/auth0/auth0-vue#aprotect-a-route"
     - text: Handling errors
       icon: 345
       href: "https://github.com/auth0/auth0-vue#error-handling"

--- a/articles/quickstart/spa/vuejs-beta/index.yml
+++ b/articles/quickstart/spa/vuejs-beta/index.yml
@@ -32,6 +32,7 @@ seo_alias: vuejs
 default_article: 01-login
 articles:
   - 01-login
+  - 02-calling-an-api
 show_steps: true
 github:
   org: auth0-samples
@@ -42,9 +43,11 @@ requirements:
 next_steps:
   - path: 01-login
     list:
-    - text: Calling an API
+    - text: "Part 2: Calling an API using an access token"
       icon: 345
-      href: "https://github.com/auth0/auth0-vue#calling-an-api"
+      href: "/quickstart/spa/vuejs-beta/02-calling-an-api"
+  - path: 02-calling-an-api
+    list:
     - text: Accessing ID Token Claims
       icon: 345
       href: "https://github.com/auth0/auth0-vue#accessing-id-token-claims"

--- a/articles/quickstart/spa/vuejs-beta/index.yml
+++ b/articles/quickstart/spa/vuejs-beta/index.yml
@@ -1,0 +1,56 @@
+title: Vue
+# TODO remove 'image' once new QS page is live. Then only use 'logo'.
+image: /media/platforms/vue.png
+logo: vuejs
+beta: true
+language:
+  - Javascript
+author:
+  name: Frederik Prijck
+  email: frederik.prijck@auth0.com
+  community: false
+framework:
+  - Vue.js
+topics:
+  - quickstart
+contentType: tutorial
+useCase: quickstart
+show_releases: true
+sdk:
+  name: auth0-spa-js
+  url: https://www.github.com/auth0/auth0-spa-js/
+  logo: vuejs
+snippets:
+  dependencies: application-platforms/vuejs/dependencies
+  setup: application-platforms/vuejs/setup
+  use: application-platforms/vuejs/use
+alias:
+  - vue
+  - vuejs
+  - vue.js
+seo_alias: vuejs
+default_article: 01-login
+articles:
+  - 01-login
+show_steps: true
+github:
+  org: auth0-samples
+  repo: auth0-vue-samples
+  branch: beta
+requirements:
+  - Vue 3+
+next_steps:
+  - path: 01-login
+    list:
+    - text: Retrieve an Access Token
+      icon: 345
+      href: "https://github.com/auth0/auth0-vue#retrieve-an-access-token"
+    - text: Accessing ID Token Claims
+      icon: 345
+      href: "https://github.com/auth0/auth0-vue#accessing-id-token-claims"
+    - text: Using a router
+      icon: 345
+      href: "https://github.com/auth0/auth0-vue#retrieve-an-access-token"
+    - text: Handling errors
+      icon: 345
+      href: "https://github.com/auth0/auth0-vue#error-handling"

--- a/articles/quickstart/spa/vuejs-beta/index.yml
+++ b/articles/quickstart/spa/vuejs-beta/index.yml
@@ -17,8 +17,8 @@ contentType: tutorial
 useCase: quickstart
 show_releases: true
 sdk:
-  name: auth0-spa-js
-  url: https://www.github.com/auth0/auth0-spa-js/
+  name: auth0-vue
+  url: https://www.github.com/auth0/auth0-vue
   logo: vuejs
 snippets:
   dependencies: application-platforms/vuejs/dependencies


### PR DESCRIPTION
Adds a new beta quickstart to demonstrate how to integrate Auth0 in a Vue Application using our brand new Auth0-Vue SDK.

It is based on the current Vue quickstart, which uses our Auth0-SPA-JS SDK. I did remove some bits and pieces to make it sound less like a tutorial and only focus on integrating login, logout and showing the user profile in your application (e.g. dropped the part on how to create a Vue application).