### PR TITLE
Laravel v7 Beta Documentation

### DIFF
--- a/articles/quickstart/backend/laravel-beta/01-authorization.md
+++ b/articles/quickstart/backend/laravel-beta/01-authorization.md
@@ -1,0 +1,194 @@
+---
+title: Authorization
+description: This tutorial demonstrates how to add authorization to a Laravel API.
+topics:
+    - quickstart
+    - backend
+    - laravel
+contentType: tutorial
+useCase: quickstart
+default: true
+github:
+   path: app
+---
+
+This quickstart covers building an API protected by an Auth0-issued Access Token. This type of API is typically consumed by:
+
+- Mobile, desktop, and other native applications using the [Native login flow](https://auth0.com/docs/get-started/authentication-and-authorization-flow/authorization-code-flow-with-proof-key-for-code-exchange-pkce)
+- CLIs, daemons, or services running on your backend using the [Client Credentials Flow](https://auth0.com/docs/get-started/authentication-and-authorization-flow/client-credentials-flow)
+
+Suppose this API is only consumed by a web application on the same domain (in the case of AJAX actions or lazy loading content for an authenticated user). In that case, the API protection should be handled by the application itself and the [login flow secured by Auth0](https://auth0.com/docs/get-started/authentication-and-authorization-flow/authorization-code-flow).
+
+<%= include('../_includes/_api_auth_preamble') %>
+
+<%= include('../../../_includes/_api_auth_intro') %>
+
+<%= include('../_includes/_api_create_new') %>
+
+## Create a Laravel Application
+
+If you already have a Laravel 9 application, you can skip to the next step!
+
+Let's begin by setting up a new project directory for Laravel. Open your terminal/shell and run the following command — replacing `FOLDER_NAME` with a folder name of your choice to create and install Laravel within.
+
+```sh
+composer create-project --prefer-dist laravel/laravel FOLDER_NAME dev-master
+```
+
+Navigate into this new project folder before continuing. You'll want to run any instructed terminal/shell commands from this new directory from now on. We'll refer to this your project root directory.
+
+## Install the Auth0 Laravel SDK
+
+For this project, we'll be using [Auth0's Laravel SDK](ttps://github.com/auth0/laravel-auth0) to protect our Laravel routes. The SDK offers middleware you can apply to your routes, checking for and verifying bearer tokens in the 'Authorization' header of an incoming HTTP request.
+
+From your project's root directory, use Composer to require the SDK in your application:
+
+```sh
+composer require auth0/login:dev-main
+```
+
+## Configure the SDK
+
+Next, we'll want to install the Auth0 Laravel SDK's configuration file. From your project's root directory, run the following command:
+
+```sh
+php artisan vendor:publish --tag=auth0-config
+```
+
+You'll find a new file in your application's `config` folder called `auth0.php`. Although it's available to you to edit by hand, we strongly recommend keeping your Auth0 configuration details in your `.env` file as a best practice instead.
+
+Open up the `.env` file in your favorite editor from your project's root directory. We'll need to provide the Laravel SDK with some essential details about our Auth0 integration:
+
+```sh
+# This tells the Laravel SDK about your use case to customize its behavior.
+# The 'api' strategy is used for backend API applications like we're building here.
+AUTH0_STRATEGY=api
+
+# The URL of your Auth0 tenant domain
+# You'll find this in your Auth0 Application's settings page.
+AUTH0_DOMAIN=${account.namespace}
+
+# Your Auth0 application's Client ID
+# You'll find this in your Auth0 Application's settings page.
+AUTH0_CLIENT_ID=${account.clientId}
+
+# Your Auth0 Custom API identifier/audience.
+# You'll find this in your Custom API's settings page.
+AUTH0_AUDIENCE=${apiIdentifier}
+```
+
+## Configure Laravel
+
+Next, we need to tell Laravel to use the guards and middleware provided by the Auth0 Laravel SDK in your application. Laravel defines these relationships inside the `config\auth.php` file. Let's open that file and begin wiring the SDK:
+
+First, locate the `defaults` section. We'll set the default `guard` to `auth0`, like this:
+
+```php
+'defaults' => [
+    'guard' => 'auth0',
+    'passwords' => 'users',
+],
+```
+
+Next, locate the `guards` section, and we'll define Auth0 there:
+```php
+'guards' => [
+    // 📝 Any additional guards you use should stay here, too.
+
+    'auth0' => [
+        'driver' => 'auth0',
+        'provider' => 'auth0',
+    ],
+],
+```
+
+Finally, locate the `providers` section, and add Auth0 there as well:
+```php
+'providers' => [
+    // 📝 Any additional providers you use should stay here, too.
+
+    'auth0' => [
+        'driver' => 'auth0',
+        'repository' => \Auth0\Laravel\Auth\User\Repository::class
+    ],
+],
+```
+
+## Add Middleware
+
+Finally, we need to apply the Auth0 Laravel SDK middleware to protect our routes. Let's define three routes to demonstrate them. Open up your `routes/web.php` file and replace the contents with the following:
+
+```php
+// 📂 routes/web.php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+
+Route::get('/', function () {
+    if (Auth::check()) {
+        return response()->json([
+            'authorized' => true,
+            'user' => json_decode(json_encode((array) Auth::user(), JSON_THROW_ON_ERROR), true),
+        ], 200, [], JSON_PRETTY_PRINT);
+    }
+
+    return response()->json([
+        'authorized' => false,
+        'user' => null,
+    ], 200, [], JSON_PRETTY_PRINT);
+})->middleware(['auth0.authorize.optional']);
+```
+
+This route demonstrates the `auth0.authorize.optional` middleware. This middleware will resolve an available bearer token when provided (allowing you to access the token's properties through the `Auth::user()` command) but won't block requests without a token either, allowing you to treat such requests as "guest" requests.
+
+Let's add another to that file:
+
+```php
+// 👆 Continued from above, in routes/web.php
+
+Route::get('/required', function () {
+    return response()->json([
+        'authorized' => true,
+        'user' => json_decode(json_encode((array) Auth::user(), JSON_THROW_ON_ERROR), true),
+    ], 200, [], JSON_PRETTY_PRINT);
+})->middleware(['auth0.authorize']);
+```
+
+The `auth0.authorize` middleware will resolve a bearer token as above, but this middleware will completely block any requests that don't pass a valid Access Token to your application.
+
+Finally, let's demonstrate that same middleware with scopes:
+
+```php
+// 👆 Continued from above, in routes/web.php
+
+Route::get('/scoped', function () {
+    return response()->json([
+        'authorized' => true,
+        'user' => json_decode(json_encode((array) Auth::user(), JSON_THROW_ON_ERROR), true),
+    ], 200, [], JSON_PRETTY_PRINT);
+})->middleware(['auth0.authorize:read:messages']);
+```
+
+In passing the `read:messages` argument to the same `auth0.authorize` middleware example as above, we further restrict access to only requests passing a valid Access Token with that scope.
+
+## Run your application
+
+You've installed Laravel, the SDK, configured your application, and set up some routes — all that's left is to run your new application!
+
+```sh
+php artisan serve --port=3000
+```
+
+You can now access your application from your web browser by visiting https://127.0.0.1:3000.
+
+We can test these new routes by manually generating an Access Token for the API. In the Auth0 Dashboard, go to the **Test** tab for the API you created and click the **COPY TOKEN** link.
+
+:::note
+If you see a button to **Create & Authorize Test Application**, you'll need to click that before the **COPY TOKEN** button appears. After creating the test Application, click the **Machine to Machine Applications** tab, scroll down to the Application that was created, click the down icon, remove the `read:messages` permissions allowed for that Application, and click **Update**. Now click the **Test** tab, then **COPY TOKEN** to proceed.
+:::
+
+- Try sending a `GET` request using to the public route `http://127.0.0.1:3000/` and you should receive back a successful response.
+- Try sending a `GET` request to the private route `http://127.0.0.1:3000/required` and you'll receive an error response.
+- Add an `Authorization` header set to `Bearer API_TOKEN_HERE` using the Access Token you generated above, and send the `GET` request to the private route again and you should receive a successful response.
+- Try sending a `GET` request to the scoped route `http://127.0.0.1:3000/scoped` using Access Tokens with and without the `read:messages` permission to see how the route is protected under those circumstances.

--- a/articles/quickstart/backend/laravel-beta/01-authorization.md
+++ b/articles/quickstart/backend/laravel-beta/01-authorization.md
@@ -116,16 +116,13 @@ Finally, locate the `providers` section, and add Auth0 there as well:
 
 ## Add Middleware
 
-Finally, we need to apply the Auth0 Laravel SDK middleware to protect our routes. Let's define three routes to demonstrate them. Open up your `routes/web.php` file and replace the contents with the following:
+Finally, we need to apply the Auth0 Laravel SDK middleware to protect our routes. Let's define three routes to demonstrate them. Open up your `routes/web.php` file and add the following to that file:
 
 ```php
 // 📂 routes/web.php
+// 👆 Keep anything already present in the file, just add the following ...
 
-declare(strict_types=1);
-
-use Illuminate\Support\Facades\Route;
-
-Route::get('/', function () {
+Route::get('/public', function () {
     if (Auth::check()) {
         return response()->json([
             'authorized' => true,
@@ -147,7 +144,7 @@ Let's add another to that file:
 ```php
 // 👆 Continued from above, in routes/web.php
 
-Route::get('/required', function () {
+Route::get('/private', function () {
     return response()->json([
         'authorized' => true,
         'user' => json_decode(json_encode((array) Auth::user(), JSON_THROW_ON_ERROR), true),
@@ -162,7 +159,7 @@ Finally, let's demonstrate that same middleware with scopes:
 ```php
 // 👆 Continued from above, in routes/web.php
 
-Route::get('/scoped', function () {
+Route::get('/private-scoped', function () {
     return response()->json([
         'authorized' => true,
         'user' => json_decode(json_encode((array) Auth::user(), JSON_THROW_ON_ERROR), true),
@@ -177,7 +174,7 @@ In passing the `read:messages` argument to the same `auth0.authorize` middleware
 You've installed Laravel, the SDK, configured your application, and set up some routes — all that's left is to run your new application!
 
 ```sh
-php artisan serve --port=3000
+php artisan serve --port=3010
 ```
 
 You can now access your application from your web browser by visiting https://127.0.0.1:3000.

--- a/articles/quickstart/backend/laravel-beta/02-using.md
+++ b/articles/quickstart/backend/laravel-beta/02-using.md
@@ -1,0 +1,12 @@
+---
+title: Using your API
+description: This tutorial will show you how to use your API.
+topics:
+    - quickstart
+    - backend
+    - laravel
+contentType: tutorial
+useCase: quickstart
+---
+
+<%= include('../_includes/_api_using') %>

--- a/articles/quickstart/backend/laravel-beta/03-troubleshooting.md
+++ b/articles/quickstart/backend/laravel-beta/03-troubleshooting.md
@@ -1,0 +1,12 @@
+---
+title: Troubleshooting
+description: This document will help you troubleshoot your configuration if you get unexpected responses from your API.
+topics:
+    - quickstart
+    - backend
+    - laravel
+contentType: tutorial
+useCase: quickstart
+---
+
+<%= include('../_includes/_api_troubleshooting') %>

--- a/articles/quickstart/backend/laravel-beta/download.md
+++ b/articles/quickstart/backend/laravel-beta/download.md
@@ -3,5 +3,5 @@ To run it from the command line:
 ```bash
 composer install
 php artisan key:generate
-php artisan serve --port=3000
+php artisan serve --port=3010
 ```

--- a/articles/quickstart/backend/laravel-beta/download.md
+++ b/articles/quickstart/backend/laravel-beta/download.md
@@ -1,0 +1,7 @@
+To run it from the command line:
+
+```bash
+composer install
+php artisan key:generate
+php artisan serve --port=3000
+```

--- a/articles/quickstart/backend/laravel-beta/index.yml
+++ b/articles/quickstart/backend/laravel-beta/index.yml
@@ -1,8 +1,8 @@
-title: Laravel API
+title: Laravel
 # TODO remove 'image' once new QS page is live. Then only use 'logo'.
 image: /media/platforms/php.png
 logo: laravel
-thirdParty: false
+beta: true
 alias:
   - laravel
 languages:
@@ -10,8 +10,8 @@ languages:
 framework:
   - Laravel
 author:
-  name: Josh Cunningham
-  email: josh.cunningham@auth0.com
+  name: Evan Sims
+  email: evan.sims@auth0.com
   community: false
 topics:
   - quickstart
@@ -22,19 +22,20 @@ articles:
   - 02-using
   - 03-troubleshooting
 default_article: 01-authorization
+seo_alias: laravel
 show_steps: true
 github:
   org: auth0-samples
   repo: auth0-laravel-api-samples
-  branch: main
+  branch: beta
 sdk:
   name: laravel-auth0
   url: https://github.com/auth0/laravel-auth0
   logo: laravel
 requirements:
-  - Composer 1.5 and up
-  - PHP 7.3 and up
-  - Laravel 8.0 and up
+  - Composer 2.0+
+  - PHP 8.0+
+  - Laravel 9.0+
 next_steps:
   - path: 01-authorization
     list:

--- a/articles/quickstart/backend/laravel-beta/index.yml
+++ b/articles/quickstart/backend/laravel-beta/index.yml
@@ -1,4 +1,4 @@
-title: Laravel
+title: Laravel API
 # TODO remove 'image' once new QS page is live. Then only use 'logo'.
 image: /media/platforms/php.png
 logo: laravel
@@ -39,15 +39,15 @@ requirements:
 next_steps:
   - path: 01-authorization
     list:
-    - text: Configure other identity providers
-      icon: 345
-      href: "/identityproviders"
-    - text: Enable multifactor authentication
-      icon: 345
-      href: "/multifactor-authentication"
-    - text: Learn about attack protection
-      icon: 345
-      href: "/attack-protection"
-    - text: Learn about rules
-      icon: 345
-      href: "/rules"
+      - text: Configure other identity providers
+        icon: 345
+        href: '/identityproviders'
+      - text: Enable multifactor authentication
+        icon: 345
+        href: '/multifactor-authentication'
+      - text: Learn about attack protection
+        icon: 345
+        href: '/attack-protection'
+      - text: Learn about rules
+        icon: 345
+        href: '/rules'

--- a/articles/quickstart/backend/laravel/01-authorization.md
+++ b/articles/quickstart/backend/laravel/01-authorization.md
@@ -11,6 +11,10 @@ contentType: tutorial
 useCase: quickstart
 ---
 
+::: panel New Beta Release Available!
+<span class="badge badge-warning">Beta</span> &nbsp; **[The new Auth0 Laravel SDK is now available in beta.](https://github.com/auth0/laravel-auth0)** Updated to support new PHP language features, new Laravel features, and offer an exciting new API — we think the new SDK elevates the developer experience. We'd love for you to [give the new beta release a try](https://github.com/auth0/laravel-auth0). Be sure to visit our [new webapp quickstart](/quickstart/webapp/laravel-beta) and [backend api](/quickstart/backend/laravel-beta) quickstarts, and drop by the [the Auth0 Community](https://community.auth0.com/) to let us know your thoughts!
+:::
+
 This quickstart covers building an API protected by an Auth0-issued access token. This type of API is typically consumed by:
 
 - Mobile, desktop, and other native applications using the [Native login flow](https://auth0.com/docs/flows/concepts/auth-code-pkce)
@@ -279,7 +283,7 @@ class CheckScope
                         if ($s === $scope)
                             $hasScope = true;
                     }
-                } 
+                }
                 if(!$hasScope) {
                     return response()->json(["message" => "Insufficient scope"], 403);
                 }

--- a/articles/quickstart/webapp/laravel-beta/01-login.md
+++ b/articles/quickstart/webapp/laravel-beta/01-login.md
@@ -1,443 +1,212 @@
 ---
 title: Login
-description: This tutorial demonstrates how to add user login to a Laravel application.
+description: This guide demonstrates how to integrate Auth0 with a Laravel application using the Auth0 Laravel SDK.
 topics:
-  - quickstarts
-  - webapp
-  - login
-  - laravel
-github:
-    path: app
+    - quickstart
+    - backend
+    - laravel
 contentType: tutorial
 useCase: quickstart
 default: true
+github:
+   path: app
 ---
-
-<!-- markdownlint-disable MD002 -->
 
 <%= include('../_includes/_getting_started', { library: 'Laravel', callback: 'http://localhost:3000/auth0/callback' }) %>
 
 <%= include('../../../_includes/_logout_url', { returnTo: 'http://localhost:3000' }) %>
 
-## Install and Configure Laravel 8
-
-If you are installing Auth0 to an existing app, you can skip this section. Otherwise, walk through the Laravel guides below to get started with a sample project.
-
-1. **[Installation](https://laravel.com/docs/8.x#installation)**
-    * Use any of the install methods listed to start a new project
-    * PHP can be served any way that works for your development process (we use Homebrew-installed Apache and PHP)
-    * Walk through the "Configuration" section completely
-2. **[Configuration](https://laravel.com/docs/8.x#configuration)**
-    * Create a .env file, used later for critical and sensitive Auth0 connection values
-    * Make sure `APP_DEBUG` is set to `true`
-
-By the end of those 2 sections, you should have a Laravel application up and running locally or on a test server.
-
-## Integrate Auth0 in your application
-
-### Install the Auth0 plugin and its dependencies
-
-To install this plugin run `composer require auth0/login`
+## Create a Laravel Application
 
 ::: note
-**[Composer](https://getcomposer.org/)** is a tool for dependency management in PHP. It allows you to declare the dependent libraries your project needs and it will install them in your project for you. See Composer's [getting started](https://getcomposer.org/doc/00-intro.md) doc for information on how to use it.
+If you already have a Laravel 9 application prepared, you can skip this step.
 :::
 
-This will install:
+Let's begin by setting up a new Laravel application. Let's open a shell and run the following command — replacing `DIRECTORY_NAME` with a directory name of preference to create and install Laravel within. The directory cannot already exist.
 
-* The [Auth0 PHP SDK](https://github.com/auth0/auth0-PHP) in `vendor\auth0\auth0-php`
-* The [Auth0 Laravel plugin](https://github.com/auth0/laravel-auth0) in `vendor\auth0\login`
-
-### Enable Auth0 Login in Laravel
-
-First, we need to add the Auth0 Services to the list of Providers in `config/app.php`:
-
-```php
-// config/app.php
-// ...
-'providers' => [
-    // ...
-    Auth0\Login\LoginServiceProvider::class,
-],
+```sh
+composer create-project --prefer-dist laravel/laravel DIRECTORY_NAME dev-master
 ```
 
-If you want to use an `Auth0` facade, add an alias in the same file (not required, [more information on facades here](http://laravel.com/docs/8.x/facades)):
+We'll refer to this new directory as our project's root directory. As we work through this tutorial, we'll run any instructed shell commands from within that directory.
 
-```php
-// config/app.php
-// ...
-'aliases' => [
-    // ...
-    'Auth0' => Auth0\Login\Facade\Auth0::class,
-],
+## Install the SDK
+
+Let's install the [Auth0's Laravel SDK](https://github.com/auth0/laravel-auth0) to protect our new Laravel application's routes. The SDK offers a range of middleware types and router controllers that will help us integrate authentication and protect our application's routes.
+
+From a shell opened to our project's root directory, let's use Composer to install the SDK in our application:
+
+```sh
+composer require auth0/login:dev-main
 ```
 
-Finally, you will need to bind a class that provides the app's User model each time a user is logged in or a JWT is decoded. You can use the `Auth0UserRepository` provided by this package or build your own (see the "Custom User Handling" section below).
+## Configure the SDK
 
-Replace the contents of your `app/Providers/AppServiceProvider` file with the following:
+Next, let's create the SDK's configuration file. Again from a shell opened to our projects root directory, let's use Laravel's the `vendor:publish` command to import the configuration file into our application:
 
-```php
-// app/Providers/AppServiceProvider.php
-
-<?php
-
-namespace App\Providers;
-
-use Illuminate\Support\ServiceProvider;
-
-class AppServiceProvider extends ServiceProvider
-{
-    public function register()
-    {
-        $this->app->bind(
-            \Auth0\Login\Contract\Auth0UserRepository::class,
-            \Auth0\Login\Repository\Auth0UserRepository::class
-        );
-    }
-
-    public function boot() {}
-}
-
+```sh
+php artisan vendor:publish --tag=auth0-config
 ```
 
-### Configure It
+Now we can begin configuring our Auth0 integration by adding options to the `.env` file in our project's root directory. Let's open that `.env` file and add some essential details for our project:
 
-To configure the plugin, you must publish the plugin configuration and complete the file `config/laravel-auth0.php` using information from your Auth0 account and details of your implementation.
-
-Publish the default configuration file with the following command:
-
-```bash
-php artisan vendor:publish
-```
-
-Select the option for `Auth0\Login\LoginServiceProvider` and look for `Publishing complete.` This creates the file `config/laravel-auth0.php` with the following settings:
-
-* `domain` - Your Auth0 tenant domain, found in your Application settings (required)
-* `client_id` - Your Auth0 Client ID, found in your Application settings (required)
-* `client_secret` - Your Auth0 Client Secret, found in your Application settings (required)
-* `redirect_uri` - The callback URI for your Laravel application to handle the login response from Auth0; by default this is `APP_URL/auth0/callback` (required)
-* `persist_user` - Should the user information persist in a PHP session? Default is `true`
-* `persist_access_token` - Should the Access Token persist in a PHP session? Default is `false`
-* `persist_id_token` - Should the ID Token persist in a PHP session? Default is `false`
-* `authorized_issuers` - An array of authorized token issuers; this should include your tenant domain as a URL
-* `api_identifier` - The optional Identifier for an API meant for individual users. This is created during the [Laravel API quickstart](quickstart/backend/laravel), if needed.
-* `secret_base64_encoded` - Is the Client Secret Base64 encoded? Look below the Client Secret field in the Auth0 dashboard to see how to set this; default is `false`
-* `supported_algs` - An array of JWT decoding algorithms supported by your application; the default is `[ 'RS256' ]` and the array should typically only have a single value.
-* `guzzle_options` - Specify additional [request options for Guzzle](http://docs.guzzlephp.org/en/stable/request-options.html)
-
-To keep sensitive data out of version control and allow for different testing and production instances, we recommend using the `.env` file Laravel uses to load other environment-specific variables:
-
-```ini
-// .env
-// ...
+```sh
+# The URL of your Auth0 tenant domain
+# You'll find this in your Auth0 Application's settings page.
 AUTH0_DOMAIN=${account.namespace}
+
+# Your Auth0 application's Client ID
+# You'll find this in your Auth0 Application's settings page.
 AUTH0_CLIENT_ID=${account.clientId}
-AUTH0_CLIENT_SECRET=YOUR_CLIENT_SECRET
+
+# Your Auth0 application's Client ID
+# You'll find this in your Auth0 Application's settings page.
+AUTH0_CLIENT_SECRET=${account.clientSecret}
+
+# Your Auth0 Custom API identifier/audience.
+# You'll find this in your Custom API's settings page.
+AUTH0_AUDIENCE=${apiIdentifier}
+
+# Authentication callback URI, as defined in your Auth0 Application settings.
+# (You must configure this in your AUth0 Application's settings page as well!)
+AUTH0_REDIRECT_URI=http://localhost:3000/auth0/callback
 ```
 
-In `laravel-auth0.php`, the global helper `env()` is used to retrieve these values and load them in your Laravel app.
+## Configure the application
 
-### Set Up Routes
+Now let's connect our Laravel application with the SDK so we can begin working with our Auth0 integration. For this, we'll be making changes to our `config\auth.php` file. This file contains a lot of settings, but we only need to make a few small changes.
 
-The plugin works with the [Laravel authentication system](https://laravel.com/docs/8.x/authentication) by creating a callback route to handle the authentication data from the Auth0 server.
-
-First, we'll add our route and controller to `routes/web.php`. The route used here must match the `redirect_uri` configuration option set previously:
+To start, let's find the `defaults` section. We'll set the default `guard` to `auth0`, like this:
 
 ```php
-// routes/web.php
+// 📂 config/auth.php
 
-<?php
-
-use Illuminate\Support\Facades\Route;
-use Auth0\Login\Auth0Controller;
-use App\Http\Controllers\Auth\Auth0IndexController;
-
-Route::view('/', 'welcome');
-
-Route::get('/auth0/callback', [Auth0Controller::class, 'callback'])->name('auth0-callback');
+'defaults' => [
+    'guard' => 'auth0',
+    // 📝 Leave any other settings in this section alone.
+],
 ```
 
-If you load this callback URL now, you should be immediately redirected back to the homepage rather than getting a 404 error. This tells us that the route is set up and being handled.
-
-Now we need to add this URL to the **Allowed Callback URLs** field in the Application settings screen for the Application used with this app. This should be your Laravel app's `APP_URL` followed by `/auth0/callback`. If you downloaded a sample from this quickstart, you may have already configured this above.
-
-Lastly, we need to set up how users log in and out of our app. This is handled by redirecting users to Auth0 for the former and clearing out session data for the latter. Let's start by creating a generic route handling controller. In the console:
-
-```bash
-php artisan make:controller Auth/Auth0IndexController
-```
-
-This creates a controller file to handle the routes used to log in and out. Let's create a function for each of these in the controller we just made:
-
+Next, find the `guards` section, and add `auth0` there:
 ```php
-// app/Http/Controllers/Auth/Auth0IndexController.php
+// 👆 Continued from above, in config/auth.php
 
-<?php
+'guards' => [
+    // 📝 Any additional guards you use should stay here, too.
 
-namespace App\Http\Controllers\Auth;
-
-use App;
-use Auth;
-use Redirect;
-use App\Http\Controllers\Controller;
-
-class Auth0IndexController extends Controller
-{
-    public function login()
-    {
-        if (Auth::check()) {
-            return redirect()->intended('/');
-        }
-
-        return App::make('auth0')->login(
-            null,
-            null,
-            ['scope' => 'openid name email email_verified'],
-            'code'
-        );
-    }
-
-    public function logout()
-    {
-        Auth::logout();
-
-        $logoutUrl = sprintf(
-            'https://%s/v2/logout?client_id=%s&returnTo=%s',
-            config('laravel-auth0.domain'),
-            config('laravel-auth0.client_id'),
-            config('app.url')
-        );
-
-        return Redirect::intended($logoutUrl);
-    }
-
-    public function profile()
-    {
-        if (!Auth::check()) {
-            return redirect()->route('login');
-        }
-
-        return view('profile')->with(
-            'user',
-            print_r(Auth::user()->getUserInfo(), true)
-        );
-    }
-}
-```
-
-Now, add the routes tied to the correct handler method along with names we can use and `auth` middleware where needed:
-
-```php
-// routes/web.php
-// ...
-Route::get('/login', [Auth0IndexController::class, 'login'])->name('login');
-Route::get('/logout', [Auth0IndexController::class, 'logout'])->name('logout');
-Route::get('/profile', [Auth0IndexController::class, 'profile'])->name('profile');
-```
-
-### Integrate with Laravel authentication system
-
-The [Laravel authentication system](https://laravel.com/docs/8.x/authentication) needs a *User Object* given by a *User Provider*. With these two abstractions, the user entity can have any structure you like and can be stored anywhere. You configure the *User Provider* indirectly, by selecting a user provider in `config/auth.php`. The default provider is Eloquent, which persists the User model in a database using the ORM.
-
-The plugin comes with an authentication driver called `auth0` which defines a user structure that wraps the [Normalized User Profile](/users/normalized) defined by Auth0. This driver does not actually persist the User, it just stores it in session for future calls. This works fine for basic testing or if you don't really need to persist the user. For persistence in the database, see the "Custom User Handling" section below.
-
-At any point you can call `Auth::check()` to see if there is a user logged in and `Auth::user()` to get the wrapper with the user information.
-
-Configure the User driver in `config/auth.php` to use `auth0` like this:
-
-```php
-// config/auth.php
-// ...
-'providers' => [
-    'users' => [
-        'driver' => 'auth0'
+    'auth0' => [
+        'driver' => 'auth0',
+        'provider' => 'auth0',
     ],
 ],
 ```
 
-## Add Login and Logout Links
+Finally, find the `providers` section, and add `auth0` there as well:
+```php
+// 👆 Continued from above, in config/auth.php
 
-To test all this out, let's add links to our site to access these routes. If you're using the default project, open up `resources/views/welcome.blade.php` and look for the `@if (Route::has('login'))` block. Change that block to the following:
+'providers' => [
+    // 📝 Any additional providers you use should stay here, too.
 
-```blade
-@if (Route::has('login'))
-    <div class="hidden fixed top-0 right-0 px-6 py-4 sm:block">
-        @auth
-            <a href="{{ route('logout') }}" class="text-sm text-gray-700 underline">Sign out</a>
-        @else
-            <a href="{{ route('login') }}" class="text-sm text-gray-700 underline">Sign in / Register</a>
-        @endauth
-    </div>
-@endif
+    'auth0' => [
+        'driver' => 'auth0',
+        'repository' => \Auth0\Laravel\Auth\User\Repository::class
+    ],
+],
 ```
 
-Load the homepage of your app and you should see a **Login** link at the top right. If you click on that, you should be redirected to an Auth0 login page for your application. If this does not happen then you should see one of two things:
+## Authentication routes
 
-1. A Laravel debug screen (is `APP_DEBUG` is set to `true`) which, along with the steps above, should help diagnose the issues
-2. An Auth0 error page with more information under the "Technical Details" heading (click **See details for this error**)
-
-Once you're able to successfully log in, you will be redirected to your homepage with a **Logout** link at the top right. This tells us that the login process was successful and the Auth0 user provider is functioning properly. Click **Logout** and you should be back where you started.
-
-At this point you should have a fully-functioning authentication process using Auth0!
-
-## Optional: Custom User Handling
-
-What if you need to customize how users are handled beyond what Auth0 provides? You may want to, for example, store the user profile in a database. These kind of customizations can be done by extending the `Auth0UserRepository` class with your own custom class.
-
-::: note
-The database information below is an example and is based on a new, default Laravel project. Your database connection information will be different and the table, column names may need to be adjusted, and migrations should be reviewed.
-:::
-
-Let's walk through how to add user database persistence using this a custom Repository class called `CustomUserRepository`. You'll need to have a database configured and a `users` table created. If you're starting with the default project, update your MySQL information in your `.env` file:
-
-```ini
-DB_CONNECTION=mysql
-DB_HOST=127.0.0.1
-DB_PORT=3306
-DB_DATABASE=laravel
-DB_USERNAME=db_user
-DB_PASSWORD=db_password
-```
-
-In the `database/migrations` folder for the default Laravel project there will be two files, one for creating a users table and one for creating a password reset table. We can delete the password reset one since that's handled by Auth0 but we want to change the users one to remove unnecessary columns and add a new one.
-
-Edit the migration file with a name similar to `create_users_table` and change the `CreateUsersTable::up()` method to remove the `password` field and add one for `sub` (the Auth0 user ID):
+To make setting up authentication a cinch, the SDK includes some plug-and-play router controllers we can setup some routes with. Let's edit our `routes/web.php` file to add those now:
 
 ```php
-// database/migrations/x_x_x_create_users_table.php
+// 📂 routes/web.php
+// 👆 Keep anything already present in the file, just add the following ...
 
-<?php
-
-use Illuminate\Database\Migrations\Migration;
-use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\Schema;
-
-class CreateUsersTable extends Migration
-{
-    public function up()
-    {
-        Schema::create('users', function (Blueprint $table) {
-            $table->id();
-            $table->string('name');
-            $table->string('email')->unique();
-            $table->string('sub')->unique();
-            $table->string('password');
-            $table->rememberToken();
-            $table->timestamps();
-        });
-    }
-
-    public function down()
-    {
-        Schema::dropIfExists('users');
-    }
-}
-
+Route::get('/login', \Auth0\Laravel\Http\Controller\Stateful\Login::class)->name('login');
+Route::get('/logout', \Auth0\Laravel\Http\Controller\Stateful\Logout::class)->name('logout');
+Route::get('/auth0/callback', \Auth0\Laravel\Http\Controller\Stateful\Callback::class)->name('auth0.callback');
 ```
 
-Save this file and run the artisan command to create this table:
+- We'll direct our end users to the `/login` route when they want to login, where they'll use Auth0's Universal Login Page to authenticate with our app.
+- The `/logout` route will redirect them to Auth0's logout endpoint and sign them out of our application.
+- The `/auth0/callback` route handles some important final authentication matters for us after the user logs in, and sets up the user's local session with our application.
 
-```bash
-php artisan migrate
-```
+## Protecting routes
 
-After running this migration, the `sub` field must also be added as field in `$fillable` in the User model. Failing to do so will cause SQL insert errors when the `upsertUser()` function tries to add a new User record. The `sub` field won't be included in the query and the query will attemt to insert a NULL value for `sub`.
+Now we can setup our routes using the SDK's middleware to automatically protect parts of our application. For this type of application there are two types of middleware available — so let's create a few routes to demonstrate them!
+
+We'll need to again edit our `routes/web.php` file, and add the following routes to that file:
 
 ```php
-// app/Models/User.php
+// 📂 routes/web.php
+// 👆 Keep anything already present in the file, just add the following ...
 
-<?php
+Route::get('/', function () {
+    if (Auth::check()) {
+        return view('auth0.user');
+    }
 
-namespace App\Models;
-
-use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Foundation\Auth\User as Authenticatable;
-use Illuminate\Notifications\Notifiable;
-
-class User extends Authenticatable
-{
-    use HasFactory, Notifiable;
-
-    protected $fillable = [
-        'name',
-        'email',
-        'sub'
-    ];
-
-    protected $hidden = [
-        'remember_token'
-    ];
-}
+    return view('auth0/guest');
+})->middleware(['auth0.authenticate.optional']);
 ```
 
-Next, make a `CustomUserRepository.php` class we can modify:
+This route demonstrates the `auth0.authenticate.optional` middleware. This middleware will resolve an available user session (allowing you to access the user's profile through the `Auth::user()` method) but won't block requests without a session, allowing you to treat those as "guest" requests.
 
-```bash
-# From the Laravel root
-mkdir app/Repositories;
-touch app/Repositories/CustomUserRepository.php
-```
-
-We're going to implement a method called `upsertUser()` to retrieve or add users to the database. We'll also re-implement the `getUserByDecodedJWT()` and `getUserByUserInfo()` methods to use `upsertUser()` when getting users:
+Let's add another to that file:
 
 ```php
-// app/Repositories/CustomUserRepository.php
+// 👆 Continued from above, in routes/web.php
 
-<?php
-
-namespace App\Repositories;
-
-use App\Models\User;
-
-use Auth0\Login\Auth0User;
-use Auth0\Login\Auth0JWTUser;
-use Auth0\Login\Repository\Auth0UserRepository;
-use Illuminate\Contracts\Auth\Authenticatable;
-
-class CustomUserRepository extends Auth0UserRepository
-{
-    protected function upsertUser( $profile ) {
-        return User::firstOrCreate(['sub' => $profile['sub']], [
-            'email' => $profile['email'] ?? '',
-            'name' => $profile['name'] ?? '',
-        ]);
-    }
-
-    public function getUserByDecodedJWT(array $decodedJwt) : Authenticatable
-    {
-        $user = $this->upsertUser( $decodedJwt );
-        return new Auth0JWTUser( $user->getAttributes() );
-    }
-
-    public function getUserByUserInfo(array $userinfo) : Authenticatable
-    {
-        $user = $this->upsertUser( $userinfo['profile'] );
-        return new Auth0User( $user->getAttributes(), $userinfo['accessToken'] );
-    }
-}
+// Require an authenticated session to access this route.
+Route::get('/required', function () {
+    return view('auth0.user');
+})->middleware(['auth0.authenticate']);
 ```
 
-::: note
-If you get an error message stating "Can't initialize a new session while there is one active session already" while testing changes to the Repository file, clear all cookies for the testing site and try again. This can happen when a session is set but an error occurs after or the process does not complete.
-:::
+This middleware will reject requests from end users that aren't authenticated, limiting that route to requests from users with accounts.
 
-Finally, we'll change the binding in the `AppServiceProvider` to point to this new custom Repository class:
+## Adding views
+
+Last but not least, let's create a couple small Blade views that we defined in those routes; nothing fancy here, just for demonstration purposes.
+
+Let's create our `resources/views/auth0/guest.blade.php` file:
 
 ```php
-// app/Providers/AppServiceProvider.php
-// ...
+// 📂 resources/views/auth0/guest.blade.php
 
-class AppServiceProvider extends ServiceProvider
-{
-    public function register()
-    {
-        $this->app->bind(
-            \Auth0\Login\Contract\Auth0UserRepository::class,
-            \App\Repositories\CustomUserRepository::class
-        );
-    }
-
-    // ...
+<!DOCTYPE html>
+<html>
+    <body>
+        <p>You're a guest. <a href="{{ route('login') }}">Log in</a></p>
+    </body>
+</html>
 ```
 
-Logging in for the first time should create a new entry in the database with the Auth0 `sub` ID and email address used. Subsequent logins should simply access that same user and not create any new records.
+And finally, let's create our `resources/views/auth0/user.blade.php` file:
+
+```php
+// 📂 resources/views/auth0/user.blade.php
+
+<!DOCTYPE html>
+<html>
+    <body>
+        <p>Welcome! You are authenticated. <a href="{{ route('logout') }}">Log out</a></p>
+        <div>
+            <pre><?php print_r(Auth::user()) ?></pre>
+        </div>
+    </body>
+</html>
+```
+
+In a real world application you'll probably want to do something a bit more elaborate, but this will serve our needs here!
+
+## Run the application
+
+We've installed Laravel and the SDK, configured our application, and set up some routes — all that's left is for us to try out our new application:
+
+```sh
+php artisan serve --port=3000
+```
+
+We're all set our new application is live and waiting for us. Give it a try by loading [http://localhost:3000](http://localhost:3000) in your web browser.

--- a/articles/quickstart/webapp/laravel-beta/01-login.md
+++ b/articles/quickstart/webapp/laravel-beta/01-login.md
@@ -1,0 +1,443 @@
+---
+title: Login
+description: This tutorial demonstrates how to add user login to a Laravel application.
+topics:
+  - quickstarts
+  - webapp
+  - login
+  - laravel
+github:
+    path: app
+contentType: tutorial
+useCase: quickstart
+default: true
+---
+
+<!-- markdownlint-disable MD002 -->
+
+<%= include('../_includes/_getting_started', { library: 'Laravel', callback: 'http://localhost:3000/auth0/callback' }) %>
+
+<%= include('../../../_includes/_logout_url', { returnTo: 'http://localhost:3000' }) %>
+
+## Install and Configure Laravel 8
+
+If you are installing Auth0 to an existing app, you can skip this section. Otherwise, walk through the Laravel guides below to get started with a sample project.
+
+1. **[Installation](https://laravel.com/docs/8.x#installation)**
+    * Use any of the install methods listed to start a new project
+    * PHP can be served any way that works for your development process (we use Homebrew-installed Apache and PHP)
+    * Walk through the "Configuration" section completely
+2. **[Configuration](https://laravel.com/docs/8.x#configuration)**
+    * Create a .env file, used later for critical and sensitive Auth0 connection values
+    * Make sure `APP_DEBUG` is set to `true`
+
+By the end of those 2 sections, you should have a Laravel application up and running locally or on a test server.
+
+## Integrate Auth0 in your application
+
+### Install the Auth0 plugin and its dependencies
+
+To install this plugin run `composer require auth0/login`
+
+::: note
+**[Composer](https://getcomposer.org/)** is a tool for dependency management in PHP. It allows you to declare the dependent libraries your project needs and it will install them in your project for you. See Composer's [getting started](https://getcomposer.org/doc/00-intro.md) doc for information on how to use it.
+:::
+
+This will install:
+
+* The [Auth0 PHP SDK](https://github.com/auth0/auth0-PHP) in `vendor\auth0\auth0-php`
+* The [Auth0 Laravel plugin](https://github.com/auth0/laravel-auth0) in `vendor\auth0\login`
+
+### Enable Auth0 Login in Laravel
+
+First, we need to add the Auth0 Services to the list of Providers in `config/app.php`:
+
+```php
+// config/app.php
+// ...
+'providers' => [
+    // ...
+    Auth0\Login\LoginServiceProvider::class,
+],
+```
+
+If you want to use an `Auth0` facade, add an alias in the same file (not required, [more information on facades here](http://laravel.com/docs/8.x/facades)):
+
+```php
+// config/app.php
+// ...
+'aliases' => [
+    // ...
+    'Auth0' => Auth0\Login\Facade\Auth0::class,
+],
+```
+
+Finally, you will need to bind a class that provides the app's User model each time a user is logged in or a JWT is decoded. You can use the `Auth0UserRepository` provided by this package or build your own (see the "Custom User Handling" section below).
+
+Replace the contents of your `app/Providers/AppServiceProvider` file with the following:
+
+```php
+// app/Providers/AppServiceProvider.php
+
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+class AppServiceProvider extends ServiceProvider
+{
+    public function register()
+    {
+        $this->app->bind(
+            \Auth0\Login\Contract\Auth0UserRepository::class,
+            \Auth0\Login\Repository\Auth0UserRepository::class
+        );
+    }
+
+    public function boot() {}
+}
+
+```
+
+### Configure It
+
+To configure the plugin, you must publish the plugin configuration and complete the file `config/laravel-auth0.php` using information from your Auth0 account and details of your implementation.
+
+Publish the default configuration file with the following command:
+
+```bash
+php artisan vendor:publish
+```
+
+Select the option for `Auth0\Login\LoginServiceProvider` and look for `Publishing complete.` This creates the file `config/laravel-auth0.php` with the following settings:
+
+* `domain` - Your Auth0 tenant domain, found in your Application settings (required)
+* `client_id` - Your Auth0 Client ID, found in your Application settings (required)
+* `client_secret` - Your Auth0 Client Secret, found in your Application settings (required)
+* `redirect_uri` - The callback URI for your Laravel application to handle the login response from Auth0; by default this is `APP_URL/auth0/callback` (required)
+* `persist_user` - Should the user information persist in a PHP session? Default is `true`
+* `persist_access_token` - Should the Access Token persist in a PHP session? Default is `false`
+* `persist_id_token` - Should the ID Token persist in a PHP session? Default is `false`
+* `authorized_issuers` - An array of authorized token issuers; this should include your tenant domain as a URL
+* `api_identifier` - The optional Identifier for an API meant for individual users. This is created during the [Laravel API quickstart](quickstart/backend/laravel), if needed.
+* `secret_base64_encoded` - Is the Client Secret Base64 encoded? Look below the Client Secret field in the Auth0 dashboard to see how to set this; default is `false`
+* `supported_algs` - An array of JWT decoding algorithms supported by your application; the default is `[ 'RS256' ]` and the array should typically only have a single value.
+* `guzzle_options` - Specify additional [request options for Guzzle](http://docs.guzzlephp.org/en/stable/request-options.html)
+
+To keep sensitive data out of version control and allow for different testing and production instances, we recommend using the `.env` file Laravel uses to load other environment-specific variables:
+
+```ini
+// .env
+// ...
+AUTH0_DOMAIN=${account.namespace}
+AUTH0_CLIENT_ID=${account.clientId}
+AUTH0_CLIENT_SECRET=YOUR_CLIENT_SECRET
+```
+
+In `laravel-auth0.php`, the global helper `env()` is used to retrieve these values and load them in your Laravel app.
+
+### Set Up Routes
+
+The plugin works with the [Laravel authentication system](https://laravel.com/docs/8.x/authentication) by creating a callback route to handle the authentication data from the Auth0 server.
+
+First, we'll add our route and controller to `routes/web.php`. The route used here must match the `redirect_uri` configuration option set previously:
+
+```php
+// routes/web.php
+
+<?php
+
+use Illuminate\Support\Facades\Route;
+use Auth0\Login\Auth0Controller;
+use App\Http\Controllers\Auth\Auth0IndexController;
+
+Route::view('/', 'welcome');
+
+Route::get('/auth0/callback', [Auth0Controller::class, 'callback'])->name('auth0-callback');
+```
+
+If you load this callback URL now, you should be immediately redirected back to the homepage rather than getting a 404 error. This tells us that the route is set up and being handled.
+
+Now we need to add this URL to the **Allowed Callback URLs** field in the Application settings screen for the Application used with this app. This should be your Laravel app's `APP_URL` followed by `/auth0/callback`. If you downloaded a sample from this quickstart, you may have already configured this above.
+
+Lastly, we need to set up how users log in and out of our app. This is handled by redirecting users to Auth0 for the former and clearing out session data for the latter. Let's start by creating a generic route handling controller. In the console:
+
+```bash
+php artisan make:controller Auth/Auth0IndexController
+```
+
+This creates a controller file to handle the routes used to log in and out. Let's create a function for each of these in the controller we just made:
+
+```php
+// app/Http/Controllers/Auth/Auth0IndexController.php
+
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App;
+use Auth;
+use Redirect;
+use App\Http\Controllers\Controller;
+
+class Auth0IndexController extends Controller
+{
+    public function login()
+    {
+        if (Auth::check()) {
+            return redirect()->intended('/');
+        }
+
+        return App::make('auth0')->login(
+            null,
+            null,
+            ['scope' => 'openid name email email_verified'],
+            'code'
+        );
+    }
+
+    public function logout()
+    {
+        Auth::logout();
+
+        $logoutUrl = sprintf(
+            'https://%s/v2/logout?client_id=%s&returnTo=%s',
+            config('laravel-auth0.domain'),
+            config('laravel-auth0.client_id'),
+            config('app.url')
+        );
+
+        return Redirect::intended($logoutUrl);
+    }
+
+    public function profile()
+    {
+        if (!Auth::check()) {
+            return redirect()->route('login');
+        }
+
+        return view('profile')->with(
+            'user',
+            print_r(Auth::user()->getUserInfo(), true)
+        );
+    }
+}
+```
+
+Now, add the routes tied to the correct handler method along with names we can use and `auth` middleware where needed:
+
+```php
+// routes/web.php
+// ...
+Route::get('/login', [Auth0IndexController::class, 'login'])->name('login');
+Route::get('/logout', [Auth0IndexController::class, 'logout'])->name('logout');
+Route::get('/profile', [Auth0IndexController::class, 'profile'])->name('profile');
+```
+
+### Integrate with Laravel authentication system
+
+The [Laravel authentication system](https://laravel.com/docs/8.x/authentication) needs a *User Object* given by a *User Provider*. With these two abstractions, the user entity can have any structure you like and can be stored anywhere. You configure the *User Provider* indirectly, by selecting a user provider in `config/auth.php`. The default provider is Eloquent, which persists the User model in a database using the ORM.
+
+The plugin comes with an authentication driver called `auth0` which defines a user structure that wraps the [Normalized User Profile](/users/normalized) defined by Auth0. This driver does not actually persist the User, it just stores it in session for future calls. This works fine for basic testing or if you don't really need to persist the user. For persistence in the database, see the "Custom User Handling" section below.
+
+At any point you can call `Auth::check()` to see if there is a user logged in and `Auth::user()` to get the wrapper with the user information.
+
+Configure the User driver in `config/auth.php` to use `auth0` like this:
+
+```php
+// config/auth.php
+// ...
+'providers' => [
+    'users' => [
+        'driver' => 'auth0'
+    ],
+],
+```
+
+## Add Login and Logout Links
+
+To test all this out, let's add links to our site to access these routes. If you're using the default project, open up `resources/views/welcome.blade.php` and look for the `@if (Route::has('login'))` block. Change that block to the following:
+
+```blade
+@if (Route::has('login'))
+    <div class="hidden fixed top-0 right-0 px-6 py-4 sm:block">
+        @auth
+            <a href="{{ route('logout') }}" class="text-sm text-gray-700 underline">Sign out</a>
+        @else
+            <a href="{{ route('login') }}" class="text-sm text-gray-700 underline">Sign in / Register</a>
+        @endauth
+    </div>
+@endif
+```
+
+Load the homepage of your app and you should see a **Login** link at the top right. If you click on that, you should be redirected to an Auth0 login page for your application. If this does not happen then you should see one of two things:
+
+1. A Laravel debug screen (is `APP_DEBUG` is set to `true`) which, along with the steps above, should help diagnose the issues
+2. An Auth0 error page with more information under the "Technical Details" heading (click **See details for this error**)
+
+Once you're able to successfully log in, you will be redirected to your homepage with a **Logout** link at the top right. This tells us that the login process was successful and the Auth0 user provider is functioning properly. Click **Logout** and you should be back where you started.
+
+At this point you should have a fully-functioning authentication process using Auth0!
+
+## Optional: Custom User Handling
+
+What if you need to customize how users are handled beyond what Auth0 provides? You may want to, for example, store the user profile in a database. These kind of customizations can be done by extending the `Auth0UserRepository` class with your own custom class.
+
+::: note
+The database information below is an example and is based on a new, default Laravel project. Your database connection information will be different and the table, column names may need to be adjusted, and migrations should be reviewed.
+:::
+
+Let's walk through how to add user database persistence using this a custom Repository class called `CustomUserRepository`. You'll need to have a database configured and a `users` table created. If you're starting with the default project, update your MySQL information in your `.env` file:
+
+```ini
+DB_CONNECTION=mysql
+DB_HOST=127.0.0.1
+DB_PORT=3306
+DB_DATABASE=laravel
+DB_USERNAME=db_user
+DB_PASSWORD=db_password
+```
+
+In the `database/migrations` folder for the default Laravel project there will be two files, one for creating a users table and one for creating a password reset table. We can delete the password reset one since that's handled by Auth0 but we want to change the users one to remove unnecessary columns and add a new one.
+
+Edit the migration file with a name similar to `create_users_table` and change the `CreateUsersTable::up()` method to remove the `password` field and add one for `sub` (the Auth0 user ID):
+
+```php
+// database/migrations/x_x_x_create_users_table.php
+
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateUsersTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('sub')->unique();
+            $table->string('password');
+            $table->rememberToken();
+            $table->timestamps();
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('users');
+    }
+}
+
+```
+
+Save this file and run the artisan command to create this table:
+
+```bash
+php artisan migrate
+```
+
+After running this migration, the `sub` field must also be added as field in `$fillable` in the User model. Failing to do so will cause SQL insert errors when the `upsertUser()` function tries to add a new User record. The `sub` field won't be included in the query and the query will attemt to insert a NULL value for `sub`.
+
+```php
+// app/Models/User.php
+
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Notifications\Notifiable;
+
+class User extends Authenticatable
+{
+    use HasFactory, Notifiable;
+
+    protected $fillable = [
+        'name',
+        'email',
+        'sub'
+    ];
+
+    protected $hidden = [
+        'remember_token'
+    ];
+}
+```
+
+Next, make a `CustomUserRepository.php` class we can modify:
+
+```bash
+# From the Laravel root
+mkdir app/Repositories;
+touch app/Repositories/CustomUserRepository.php
+```
+
+We're going to implement a method called `upsertUser()` to retrieve or add users to the database. We'll also re-implement the `getUserByDecodedJWT()` and `getUserByUserInfo()` methods to use `upsertUser()` when getting users:
+
+```php
+// app/Repositories/CustomUserRepository.php
+
+<?php
+
+namespace App\Repositories;
+
+use App\Models\User;
+
+use Auth0\Login\Auth0User;
+use Auth0\Login\Auth0JWTUser;
+use Auth0\Login\Repository\Auth0UserRepository;
+use Illuminate\Contracts\Auth\Authenticatable;
+
+class CustomUserRepository extends Auth0UserRepository
+{
+    protected function upsertUser( $profile ) {
+        return User::firstOrCreate(['sub' => $profile['sub']], [
+            'email' => $profile['email'] ?? '',
+            'name' => $profile['name'] ?? '',
+        ]);
+    }
+
+    public function getUserByDecodedJWT(array $decodedJwt) : Authenticatable
+    {
+        $user = $this->upsertUser( $decodedJwt );
+        return new Auth0JWTUser( $user->getAttributes() );
+    }
+
+    public function getUserByUserInfo(array $userinfo) : Authenticatable
+    {
+        $user = $this->upsertUser( $userinfo['profile'] );
+        return new Auth0User( $user->getAttributes(), $userinfo['accessToken'] );
+    }
+}
+```
+
+::: note
+If you get an error message stating "Can't initialize a new session while there is one active session already" while testing changes to the Repository file, clear all cookies for the testing site and try again. This can happen when a session is set but an error occurs after or the process does not complete.
+:::
+
+Finally, we'll change the binding in the `AppServiceProvider` to point to this new custom Repository class:
+
+```php
+// app/Providers/AppServiceProvider.php
+// ...
+
+class AppServiceProvider extends ServiceProvider
+{
+    public function register()
+    {
+        $this->app->bind(
+            \Auth0\Login\Contract\Auth0UserRepository::class,
+            \App\Repositories\CustomUserRepository::class
+        );
+    }
+
+    // ...
+```
+
+Logging in for the first time should create a new entry in the database with the Auth0 `sub` ID and email address used. Subsequent logins should simply access that same user and not create any new records.

--- a/articles/quickstart/webapp/laravel-beta/download.md
+++ b/articles/quickstart/webapp/laravel-beta/download.md
@@ -1,0 +1,29 @@
+To run the sample follow these steps:
+
+1) Set the **Allowed Callback URLs** in the [Application Settings](${manage_url}/#/applications/${account.clientId}/settings) to:
+```text
+http://localhost:3000/auth0/callback
+```
+
+2) Set the **Allowed Logout URLs** in the [Application Settings](${manage_url}/#/applications/${account.clientId}/settings) to:
+```text
+http://localhost:3000
+```
+
+3) Make sure [PHP](http://php.net/downloads.php) and [Composer](https://getcomposer.org/download/) are installed and execute the following commands in the sample's directory:
+
+```bash
+composer install
+php artisan migrate
+php artisan key:generate
+php artisan serve --port=3000
+```
+
+You can also run it from a [Docker](https://www.docker.com) image with the following commands:
+
+```bash
+# In Linux / macOS
+sh exec.sh
+# In Windows' Powershell
+./exec.ps1
+```

--- a/articles/quickstart/webapp/laravel-beta/download.md
+++ b/articles/quickstart/webapp/laravel-beta/download.md
@@ -2,7 +2,7 @@ To run the sample follow these steps:
 
 1) Set the **Allowed Callback URLs** in the [Application Settings](${manage_url}/#/applications/${account.clientId}/settings) to:
 ```text
-http://localhost:3000/callback
+http://localhost:3000/auth0/callback
 ```
 
 2) Set the **Allowed Logout URLs** in the [Application Settings](${manage_url}/#/applications/${account.clientId}/settings) to:

--- a/articles/quickstart/webapp/laravel-beta/download.md
+++ b/articles/quickstart/webapp/laravel-beta/download.md
@@ -2,7 +2,7 @@ To run the sample follow these steps:
 
 1) Set the **Allowed Callback URLs** in the [Application Settings](${manage_url}/#/applications/${account.clientId}/settings) to:
 ```text
-http://localhost:3000/auth0/callback
+http://localhost:3000/callback
 ```
 
 2) Set the **Allowed Logout URLs** in the [Application Settings](${manage_url}/#/applications/${account.clientId}/settings) to:
@@ -17,13 +17,4 @@ composer install
 php artisan migrate
 php artisan key:generate
 php artisan serve --port=3000
-```
-
-You can also run it from a [Docker](https://www.docker.com) image with the following commands:
-
-```bash
-# In Linux / macOS
-sh exec.sh
-# In Windows' Powershell
-./exec.ps1
 ```

--- a/articles/quickstart/webapp/laravel-beta/index.yml
+++ b/articles/quickstart/webapp/laravel-beta/index.yml
@@ -1,8 +1,8 @@
-title: Laravel API
+title: Laravel
 # TODO remove 'image' once new QS page is live. Then only use 'logo'.
 image: /media/platforms/php.png
 logo: laravel
-thirdParty: false
+beta: true
 alias:
   - laravel
 languages:
@@ -10,33 +10,32 @@ languages:
 framework:
   - Laravel
 author:
-  name: Josh Cunningham
-  email: josh.cunningham@auth0.com
+  name: Evan Sims
+  email: evan.sims@auth0.com
   community: false
 topics:
   - quickstart
 contentType: tutorial
 useCase: quickstart
 articles:
-  - 01-authorization
-  - 02-using
-  - 03-troubleshooting
-default_article: 01-authorization
+  - 01-login
+default_article: 01-login
+seo_alias: laravel
 show_steps: true
 github:
   org: auth0-samples
-  repo: auth0-laravel-api-samples
-  branch: main
+  repo: auth0-laravel-php-web-app
+  branch: beta
 sdk:
   name: laravel-auth0
   url: https://github.com/auth0/laravel-auth0
   logo: laravel
 requirements:
-  - Composer 1.5 and up
-  - PHP 7.3 and up
-  - Laravel 8.0 and up
+  - Composer 2.0+
+  - PHP 8.0+
+  - Laravel 9.0+
 next_steps:
-  - path: 01-authorization
+  - path: 01-login
     list:
     - text: Configure other identity providers
       icon: 345

--- a/articles/quickstart/webapp/laravel/01-login.md
+++ b/articles/quickstart/webapp/laravel/01-login.md
@@ -14,7 +14,9 @@ github:
     path: 01-Login
 ---
 
-<!-- markdownlint-disable MD002 -->
+::: panel New Beta Release Available!
+<span class="badge badge-warning">Beta</span> &nbsp; **[The new Auth0 Laravel SDK is now available in beta.](https://github.com/auth0/laravel-auth0)** Updated to support new PHP language features, new Laravel features, and offer an exciting new API — we think the new SDK elevates the developer experience. We'd love for you to [give the new beta release a try](https://github.com/auth0/laravel-auth0). Be sure to visit our [new webapp quickstart](/quickstart/webapp/laravel-beta) and [backend api](/quickstart/backend/laravel-beta) quickstarts, and drop by the [the Auth0 Community](https://community.auth0.com/) to let us know your thoughts!
+:::
 
 <%= include('../_includes/_getting_started', { library: 'Laravel', callback: 'http://localhost:3000/auth0/callback' }) %>
 

--- a/articles/quickstart/webapp/laravel/index.yml
+++ b/articles/quickstart/webapp/laravel/index.yml
@@ -20,7 +20,7 @@ show_steps: true
 github:
   org: auth0-samples
   repo: auth0-laravel-php-web-app
-  branch: master
+  branch: main
 sdk:
   name: laravel-auth0
   url: https://github.com/auth0/laravel-auth0


### PR DESCRIPTION
This PR:
- Adds new Laravel quick start documentation for the upcoming Laravel v7 Beta — a backend API and regular web app quick start.
- Updates the GitHub repo branch names of these two quickstart samples to the new 'main' defaults (the branches will not be renamed until this PR is ready to merge.)

Associated repos:
- [Laravel v7](https://github.com/auth0/laravel-auth0)
- [Laravel v7 Regular Web App QS on GitHub, "beta" branch](https://github.com/auth0-samples/auth0-laravel-php-web-app/tree/beta)
- [Laravel v7 Backend API QS on GitHub, "beta" branch](https://github.com/auth0-samples/auth0-laravel-api-samples/tree/beta)