### PR TITLE
Ensure vue-beta quickstart uses the actual account settings

### DIFF
--- a/articles/quickstart/spa/vuejs-beta/02-calling-an-api.md
+++ b/articles/quickstart/spa/vuejs-beta/02-calling-an-api.md
@@ -30,10 +30,10 @@ const app = createApp(App);
 
 app.use(
   createAuth0({
-    domain: '<AUTH0_DOMAIN>',
-    client_id: '<AUTH0_CLIENT_ID>',
-    redirect_uri: '<MY_CALLBACK_URL>',
-    audience: '<AUTH0_AUDIENCE>'
+    domain: "${account.namespace}",
+    clientId: "${account.clientId}",
+    redirect_uri: window.location.origin,
+    audience: "${apiIdentifier}",
   })
 );
 

--- a/articles/quickstart/spa/vuejs-beta/_includes/_centralized_login.md
+++ b/articles/quickstart/spa/vuejs-beta/_includes/_centralized_login.md
@@ -19,9 +19,9 @@ const app = createApp(App);
 
 app.use(
   createAuth0({
-    domain: '<AUTH0_DOMAIN>',
-    client_id: '<AUTH0_CLIENT_ID>',
-    redirect_uri: '<MY_CALLBACK_URL>'
+    domain: "${account.namespace}",
+    clientId: "${account.clientId}",
+    redirect_uri: window.location.origin
   })
 );
 


### PR DESCRIPTION
The Vue Beta quickstart wasnt using the values from the logged-in account to show the domain, clientId and audience.
This also changes the redirect URI to ensure it can just be copied out.