### PR TITLE
[SDK-3143] Share Configure Auth0 between interactive Quickstarts

### DIFF
--- a/articles/quickstart/_includes/_configure_auth0_interactive.md
+++ b/articles/quickstart/_includes/_configure_auth0_interactive.md
@@ -1,0 +1,39 @@
+## Configure Auth0 {{{ data-action=configure }}}
+
+To use Auth0 services, you’ll need to have an application set up in the Auth0 Dashboard. The Auth0 application is where you will configure how you want authentication to work for the project you are developing.
+
+### Configure an application
+
+Use the interactive selector to create a new Auth0 application or select an existing application that represents the project you want to integrate with. Every application in Auth0 is assigned an alphanumeric, unique client ID that your application code will use to call Auth0 APIs through the SDK.
+
+Any settings you configure using this quickstart will automatically update for your Application in the <a href="${manage_url}/#/">Dashboard</a>, which is where you can manage your Applications in the future.
+
+If you would rather explore a complete configuration, you can view a sample application instead.
+
+### Configure Callback URLs
+
+A callback URL is a URL in your application that you would like Auth0 to redirect users to after they have authenticated. If not set, users will not be returned to your application after they log in.
+
+::: note
+If you are following along with our sample project, set this to `${callback}`.
+:::
+
+### Configure Logout URLs
+
+A logout URL is a URL in your application that you would like Auth0 to redirect users to after they have logged out. If not set, users will not be able to log out from your application and will receive an error.
+
+::: note
+If you are following along with our sample project, set this to `${returnTo}`.
+:::
+
+<% if (typeof showWebOriginInfo !== 'undefined' && showWebOriginInfo === true) { %>
+
+### Configure Allowed Web Origins
+
+An Allowed Web Origin is a URL that you want to be allowed to access to your authentication flow. This must contain the URL of your project. If not properly set, your project will be unable to silently refresh authentication tokens, so your users will be logged out the next time they visit your application or refresh a page.
+
+::: note
+If you are following along with our sample project, set this to `${webOriginUrl}`.
+:::
+
+<% } %>

--- a/articles/quickstart/spa/react/interactive.md
+++ b/articles/quickstart/spa/react/interactive.md
@@ -19,41 +19,12 @@ To use this quickstart, you’ll need to:
 - Sign up for a free Auth0 account or log in to Auth0.
 - Have a working React project that you want to integrate with. Alternatively, you can view or download a sample application after logging in.
 
-## Configure Auth0 {{{ data-action=configure }}}
-
-To use Auth0 services, you’ll need to have an application set up in the Auth0 Dashboard. The Auth0 application is where you will configure how you want authentication to work for the project you are developing.
-
-### Configure an application
-
-Use the interactive selector to create a new Auth0 application or select an existing application that represents the project you want to integrate with. Every application in Auth0 is assigned an alphanumeric, unique client ID that your application code will use to call Auth0 APIs through the SDK.
-
-Any settings you configure using this quickstart will automatically update for your Application in the <a href="${manage_url}/#/">Dashboard</a>, which is where you can manage your Applications in the future.
-
-If you would rather explore a complete configuration, you can view a sample application instead.
-
-### Configure Callback URLs
-
-A callback URL is a URL in your application that you would like Auth0 to redirect users to after they have authenticated. If not set, users will not be returned to your application after they log in.
-
-::: note
-If you are following along with our sample project, set this to http://localhost:3000.
-:::
-
-### Configure Logout URLs
-
-A logout URL is a URL in your application that you would like Auth0 to redirect users to after they have logged out. If not set, users will not be able to log out from your application and will receive an error.
-
-::: note
-If you are following along with our sample project, set this to http://localhost:3000.
-:::
-
-### Configure Allowed Web Origins
-
-An Allowed Web Origin is a URL that you want to be allowed to access to your authentication flow. This must contain the URL of your project. If not properly set, your project will be unable to silently refresh authentication tokens, so your users will be logged out the next time they visit your application or refresh a page.
-
-::: note
-If you are following along with our sample project, set this to http://localhost:3000.
-:::
+<%= include('../../_includes/_configure_auth0_interactive', { 
+  callback: 'http://localhost:3000',
+  returnTo: 'http://localhost:3000',
+  webOriginUrl: 'http://localhost:3000',
+  showWebOriginInfo: true
+}) %>
 
 ## Install the Auth0 React SDK {{{ data-action=code data-code="index.js#13:22" }}}
 

--- a/articles/quickstart/webapp/aspnet-core/interactive.md
+++ b/articles/quickstart/webapp/aspnet-core/interactive.md
@@ -22,20 +22,10 @@ files:
 
 Auth0 allows you to quickly add authentication and gain access to user profile information in your application. This guide demonstrates how to integrate Auth0 with any new or existing ASP.NET MVC application using the Auth0.AspNetCore.Authentication SDK. 
 
-## Configure Auth0 {{{ data-action=configure }}}
-
-### Create a new application
-Create a new application or select an existing application to integrate with. You can also create and manage your applications in the Dashboard at Dashboard > Applications > Applications. 
-
-If you are logged in configuring your settings in the quickstart will automatically update your settings in the dashboard.
-
-### Configure Callback URLs
-
-A callback URL is a URL in your application where Auth0 redirects the user after they have authenticated. If not set, users won't have a place to be redirected to after logging in.
-
-### Configure Logout URLs
-
-A logout URL is a URL in your application that Auth0 can return to after the user has been logged out of the authorization server. This is specified in the returnTo query parameter. If this field is not set, users will be unable to log out from the application and will get an error.
+<%= include('../../_includes/_configure_auth0_interactive', { 
+  callback: 'http://localhost:3000/callback',
+  returnTo: 'http://localhost:3000'
+}) %>
 
 ## Install and Configure the SDK {{{ data-action=code data-code="Startup.cs#9:13" }}}
 


### PR DESCRIPTION
The Configure Auth0 part, which covers things such as Allowed Redirect URLs, Logout URLs, … is hardcoded in the React and [ASP.NET](http://asp.net/) quickstart.In order to avoid further duplication, this should be moved into an include and shared between both of the current quickstarts.