### PR TITLE
Correct spring oauth server maven dependency

### DIFF
--- a/articles/quickstart/backend/java-spring-security5/01-authorization.md
+++ b/articles/quickstart/backend/java-spring-security5/01-authorization.md
@@ -83,7 +83,7 @@ If you are using Maven, add the Spring dependencies to your `pom.xml` file:
         <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
     <dependency>
-        <groupId>org.springframework.security</groupId>
+        <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
     </dependency>
 </dependencies>


### PR DESCRIPTION
Spring boot oauth2 resource server dependency was pointed wrong in the maven code snippet. This has been fixed in this PR