### PR TITLE
Add redirects for Professional Services and MFA Provider Hook nav moves

### DIFF
--- a/config/redirects.js
+++ b/config/redirects.js
@@ -6672,8 +6672,9 @@ const redirects = [
       '/services/discover-and-design',
       '/services/maintain-and-improve',
       '/professional-services',
+      '/troubleshoot/professional-services',
     ],
-    to: '/troubleshoot/professional-services',
+    to: '/get-started/professional-services',
   },
   {
     from: [
@@ -6682,8 +6683,9 @@ const redirects = [
       '/professional-services/solution-design-services',
       '/services/solution-design',
       '/professional-services/discover-design',
+      '/troubleshoot/professional-services/discover-design',
     ],
-    to: '/troubleshoot/professional-services/discover-design',
+    to: '/get-started/professional-services/discover-design',
   },
   {
     from: [
@@ -6691,8 +6693,9 @@ const redirects = [
       '/services/custom-implementation',
       '/services/implement',
       '/professional-services/implement',
+      '/troubleshoot/professional-services/implement',
     ],
-    to: '/troubleshoot/professional-services/implement',
+    to: '/get-started/professional-services/implement',
   },
   {
     from: [
@@ -6703,12 +6706,17 @@ const redirects = [
       '/services/code-review',
       '/services/pair-programming',
       '/professional-services/maintain-improve',
+      '/troubleshoot/professional-services/maintain-improve',
     ],
-    to: '/troubleshoot/professional-services/maintain-improve',
+    to: '/get-started/professional-services/maintain-improve',
   },
   {
-    from: ['/services/packages', '/professional-services/packages'],
-    to: '/troubleshoot/professional-services/packages',
+    from: [
+      '/services/packages',
+      '/professional-services/packages',
+      '/troubleshoot/professional-services/packages',
+    ],
+    to: '/get-started/professional-services/packages',
   },
 
   /* Rules */

--- a/config/redirects.js
+++ b/config/redirects.js
@@ -6102,8 +6102,9 @@ const redirects = [
       '/mfa/send-phone-message-hook-amazon-sns',
       '/mfa/configure-amazon-sns-as-mfa-sms-provider',
       '/login/mfa/mfa-factors/configure-amazon-sns-as-mfa-sms-provider',
+      '/secure/multi-factor-authentication/multi-factor-authentication-factors/configure-amazon-sns-as-mfa-sms-provider',
     ],
-    to: '/secure/multi-factor-authentication/multi-factor-authentication-factors/configure-amazon-sns-as-mfa-sms-provider',
+    to: '/customize/hooks/extensibility-points/send-phone-message/configure-amazon-sns-as-mfa-sms-provider',
   },
   {
     from: [
@@ -6111,8 +6112,9 @@ const redirects = [
       '/mfa/send-phone-message-hook-esendex',
       '/mfa/configure-esendex-as-mfa-sms-provider',
       '/login/mfa/mfa-factors/configure-esendex-as-mfa-sms-provider',
+      '/secure/multi-factor-authentication/multi-factor-authentication-factors/configure-esendex-as-mfa-sms-provider',
     ],
-    to: '/secure/multi-factor-authentication/multi-factor-authentication-factors/configure-esendex-as-mfa-sms-provider',
+    to: '/customize/hooks/extensibility-points/send-phone-message/configure-esendex-as-mfa-sms-provider',
   },
   {
     from: [
@@ -6120,8 +6122,9 @@ const redirects = [
       '/mfa/send-phone-message-hook-infobip',
       '/mfa/configure-infobip-as-mfa-sms-provider',
       '/login/mfa/mfa-factors/configure-infobip-as-mfa-sms-provider',
+      '/secure/multi-factor-authentication/multi-factor-authentication-factors/configure-infobip-as-mfa-sms-provider',
     ],
-    to: '/secure/multi-factor-authentication/multi-factor-authentication-factors/configure-infobip-as-mfa-sms-provider',
+    to: '/customize/hooks/extensibility-points/send-phone-message/configure-infobip-as-mfa-sms-provider',
   },
   {
     from: [
@@ -6129,8 +6132,9 @@ const redirects = [
       '/mfa/send-phone-message-hook-mitto',
       '/mfa/configure-mitto-as-mfa-sms-provider',
       '/login/mfa/mfa-factors/configure-mitto-as-mfa-sms-provider',
+      '/secure/multi-factor-authentication/multi-factor-authentication-factors/configure-mitto-as-mfa-sms-provider',
     ],
-    to: '/secure/multi-factor-authentication/multi-factor-authentication-factors/configure-mitto-as-mfa-sms-provider',
+    to: '/customize/hooks/extensibility-points/send-phone-message/configure-mitto-as-mfa-sms-provider',
   },
   {
     from: [
@@ -6138,8 +6142,9 @@ const redirects = [
       '/mfa/send-phone-message-hook-telesign',
       '/mfa/configure-telesign-as-mfa-sms-provider',
       '/login/mfa/mfa-factors/configure-telesign-as-mfa-sms-provider',
+      '/secure/multi-factor-authentication/multi-factor-authentication-factors/configure-telesign-as-mfa-sms-provider',
     ],
-    to: '/secure/multi-factor-authentication/multi-factor-authentication-factors/configure-telesign-as-mfa-sms-provider',
+    to: '/customize/hooks/extensibility-points/send-phone-message/configure-telesign-as-mfa-sms-provider',
   },
   {
     from: [
@@ -6147,8 +6152,9 @@ const redirects = [
       '/mfa/send-phone-message-hook-twilio',
       '/mfa/configure-twilio-as-mfa-sms-provider',
       '/login/mfa/mfa-factors/configure-twilio-as-mfa-sms-provider',
+      '/secure/multi-factor-authentication/multi-factor-authentication-factors/configure-twilio-as-mfa-sms-provider',
     ],
-    to: '/secure/multi-factor-authentication/multi-factor-authentication-factors/configure-twilio-as-mfa-sms-provider',
+    to: '/customize/hooks/extensibility-points/send-phone-message/configure-twilio-as-mfa-sms-provider',
   },
   {
     from: [
@@ -6156,8 +6162,9 @@ const redirects = [
       '/mfa/send-phone-message-hook-vonage',
       '/mfa/configure-vonage-as-mfa-sms-provider',
       '/login/mfa/mfa-factors/configure-vonage-as-mfa-sms-provider',
+      '/secure/multi-factor-authentication/multi-factor-authentication-factors/configure-vonage-as-mfa-sms-provider',
     ],
-    to: '/secure/multi-factor-authentication/multi-factor-authentication-factors/configure-vonage-as-mfa-sms-provider',
+    to: '/customize/hooks/extensibility-points/send-phone-message/configure-vonage-as-mfa-sms-provider',
   },
   {
     from: [


### PR DESCRIPTION
- Moving Professional Services from Troubleshoot section of nav to Get Started section of nav.
- Moving MFA SMS Provider Hook Configs from MFA to Hooks section (in prep for later removal/to make room for replacement info pointing to Actions/Marketplace instead without losing the Hook content for people who may still need it).