### PR TITLE
Update Laravel SDK v7 install guidance

### DIFF
--- a/articles/quickstart/backend/laravel/01-authorization.md
+++ b/articles/quickstart/backend/laravel/01-authorization.md
@@ -37,7 +37,7 @@ Let's install the [Auth0's Laravel SDK](https://github.com/auth0/laravel-auth0) 
 From a shell opened to our project's root directory, let's use Composer to install the SDK in our application:
 
 ```sh
-composer require auth0/login:dev-main
+composer require auth0/login
 ```
 
 ## Configure the SDK

--- a/articles/quickstart/webapp/laravel/01-login.md
+++ b/articles/quickstart/webapp/laravel/01-login.md
@@ -37,7 +37,7 @@ Let's install the [Auth0's Laravel SDK](https://github.com/auth0/laravel-auth0) 
 From a shell opened to our project's root directory, let's use Composer to install the SDK in our application:
 
 ```sh
-composer require auth0/login:dev-main
+composer require auth0/login
 ```
 
 ## Configure the SDK


### PR DESCRIPTION
Overlooked from my release PR, we should remove the 'dev-main' versioning from the Composer install command now that we're in GA.