### PR TITLE
Typo fix for Python QS

### DIFF
--- a/articles/quickstart/webapp/python/01-login.md
+++ b/articles/quickstart/webapp/python/01-login.md
@@ -98,7 +98,7 @@ oauth = OAuth(app)
 oauth.register(
     "auth0",
     client_id=env.get("AUTH0_CLIENT_ID"),
-    client_id=env.get("AUTH0_CLIENT_SECRET"),
+    client_secret=env.get("AUTH0_CLIENT_SECRET"),
     client_kwargs={
         "scope": "openid profile email",
     },


### PR DESCRIPTION
Fixing typo: `client_id` should be `client_secret` in the Authlib config