### PR TITLE
Update redirects.js

### DIFF
--- a/config/redirects.js
+++ b/config/redirects.js
@@ -3364,8 +3364,9 @@ const redirects = [
       '/universal-login/prompt-common',
       '/universal-login/text-customization-prompts/common',
       '/brand-and-customize/text-customization-new-universal-login/prompt-common',
+      '/customize/universal-login-pages/customize-login-text-prompts/prompt-common',
     ],
-    to: '/customize/universal-login-pages/customize-login-text-prompts/prompt-common',
+    to: '/customize/universal-login-pages/customize-login-text-prompts',
   },
   {
     from: [
@@ -3373,8 +3374,9 @@ const redirects = [
       '/universal-login/text-customization-prompts/consent',
       '/login/universal-login/prompt-consent',
       '/brand-and-customize/text-customization-new-universal-login/prompt-consent',
+      '/customize/universal-login-pages/customize-login-text-prompts/prompt-consent',
     ],
-    to: '/customize/universal-login-pages/customize-login-text-prompts/prompt-consent',
+    to: '/customize/universal-login-pages/customize-login-text-prompts',
   },
   {
     from: [
@@ -3382,15 +3384,17 @@ const redirects = [
       '/universal-login/text-customization-prompts/device-flow',
       '/login/universal-login/prompt-device-flow',
       '/brand-and-customize/text-customization-new-universal-login/prompt-device-flow',
+      '/customize/universal-login-pages/customize-login-text-prompts/prompt-device-flow',
     ],
-    to: '/customize/universal-login-pages/customize-login-text-prompts/prompt-device-flow',
+    to: '/customize/universal-login-pages/customize-login-text-prompts'
   },
   {
     from: [
       '/universal-login/prompt-email-otp-challenge',
       '/brand-and-customize/text-customization-new-universal-login/prompt-email-otp-challenge',
+      '/customize/universal-login-pages/customize-login-text-prompts/prompt-email-otp-challenge',
     ],
-    to: '/customize/universal-login-pages/customize-login-text-prompts/prompt-email-otp-challenge',
+    to: '/customize/universal-login-pages/customize-login-text-prompts',
   },
   {
     from: [
@@ -3398,15 +3402,17 @@ const redirects = [
       '/universal-login/text-customization-prompts/email-verification',
       '/login/universal-login/prompt-email-verification',
       '/brand-and-customize/text-customization-new-universal-login/prompt-email-verification',
+      '/customize/universal-login-pages/customize-login-text-prompts/prompt-email-verification',
     ],
-    to: '/customize/universal-login-pages/customize-login-text-prompts/prompt-email-verification',
+    to: '/customize/universal-login-pages/customize-login-text-prompts',
   },
   {
     from: [
       '/univeral-login/prompt-accept-invitation',
       '/brand-and-customize/text-customization-new-universal-login/prompt-accept-invitation',
+      '/customize/universal-login-pages/customize-login-text-prompts/prompt-accept-invitation',
     ],
-    to: '/customize/universal-login-pages/customize-login-text-prompts/prompt-accept-invitation',
+    to: '/customize/universal-login-pages/customize-login-text-prompts',
   },
   {
     from: [
@@ -3414,135 +3420,153 @@ const redirects = [
       '/universal-login/prompt-login',
       '/universal-login/text-customization-prompts/login',
       '/brand-and-customize/text-customization-new-universal-login/prompt-login',
+      '/customize/universal-login-pages/customize-login-text-prompts/prompt-login',
     ],
-    to: '/customize/universal-login-pages/customize-login-text-prompts/prompt-login',
+    to: '/customize/universal-login-pages/customize-login-text-prompts',
   },
   {
     from: [
       '/universal-login/prompt-login-email-verification',
       '/brand-and-customize/text-customization-new-universal-login/prompt-login-email-verification',
+      '/customize/universal-login-pages/customize-login-text-prompts/prompt-login-email-verification',
     ],
-    to: '/customize/universal-login-pages/customize-login-text-prompts/prompt-login-email-verification',
+    to: '/customize/universal-login-pages/customize-login-text-prompts',
   },
   {
     from: [
       '/universal-login/prompt-login-id',
       '/brand-and-customize/text-customization-new-universal-login/prompt-login-id',
+      '/customize/universal-login-pages/customize-login-text-prompts/prompt-login-id',
     ],
-    to: '/customize/universal-login-pages/customize-login-text-prompts/prompt-login-id',
+    to: '/customize/universal-login-pages/customize-login-text-prompts',
   },
   {
     from: [
       '/universal-login/prompt-login-password',
       '/brand-and-customize/text-customization-new-universal-login/prompt-login-password',
+      '/customize/universal-login-pages/customize-login-text-prompts/prompt-login-password',
     ],
-    to: '/customize/universal-login-pages/customize-login-text-prompts/prompt-login-password',
+    to: '/customize/universal-login-pages/customize-login-text-prompts',
   },
   {
     from: [
       '/universal-login/prompt-mfa',
       '/universal-login/text-customization-prompts/mfa',
       '/brand-and-customize/text-customization-new-universal-login/prompt-mfa',
+      '/customize/universal-login-pages/customize-login-text-prompts/prompt-mfa',
     ],
-    to: '/customize/universal-login-pages/customize-login-text-prompts/prompt-mfa',
+    to: '/customize/universal-login-pages/customize-login-text-prompts',
   },
   {
     from: [
       '/universal-login/prompt-mfa-email',
       '/universal-login/text-customization-prompts/mfa-email',
       '/brand-and-customize/text-customization-new-universal-login/prompt-mfa-email',
+      '/customize/universal-login-pages/customize-login-text-prompts/prompt-mfa-email',
     ],
-    to: '/customize/universal-login-pages/customize-login-text-prompts/prompt-mfa-email',
+    to: '/customize/universal-login-pages/customize-login-text-prompts',
   },
   {
     from: [
       '/universal-login/prompt-mfa-otp',
       '/universal-login/text-customization-prompts/mfa-otp',
       '/brand-and-customize/text-customization-new-universal-login/prompt-mfa-otp',
+      '/customize/universal-login-pages/customize-login-text-prompts/prompt-mfa-otp',
     ],
-    to: '/customize/universal-login-pages/customize-login-text-prompts/prompt-mfa-otp',
+    to: '/customize/universal-login-pages/customize-login-text-prompts',
   },
   {
     from: [
       '/universal-login/prompt-mfa-phone',
       '/brand-and-customize/text-customization-new-universal-login/prompt-mfa-phone',
+      '/customize/universal-login-pages/customize-login-text-prompts/prompt-mfa-phone',
     ],
-    to: '/customize/universal-login-pages/customize-login-text-prompts/prompt-mfa-phone',
+    to: '/customize/universal-login-pages/customize-login-text-prompts',
   },
   {
     from: [
       '/universal-login/prompt-mfa-push',
       '/universal-login/text-customization-prompts/mfa-push',
       '/brand-and-customize/text-customization-new-universal-login/prompt-mfa-push',
+      '/customize/universal-login-pages/customize-login-text-prompts/prompt-mfa-push',
     ],
-    to: '/customize/universal-login-pages/customize-login-text-prompts/prompt-mfa-push',
+    to: '/customize/universal-login-pages/customize-login-text-prompts',
   },
   {
     from: [
       '/universal-login/prompt-mfa-recovery-code',
       '/universal-login/text-customization-prompts/mfa-recovery-code',
       '/brand-and-customize/text-customization-new-universal-login/prompt-mfa-recovery-code',
+      '/customize/universal-login-pages/customize-login-text-prompts/prompt-mfa-recovery-code',
     ],
-    to: '/customize/universal-login-pages/customize-login-text-prompts/prompt-mfa-recovery-code',
+    to: '/customize/universal-login-pages/customize-login-text-prompts',
   },
   {
     from: [
       '/universal-login/prompt-mfa-sms',
       '/universal-login/text-customization-prompts/mfa-sms',
       '/brand-and-customize/text-customization-new-universal-login/prompt-mfa-sms',
+      '/customize/universal-login-pages/customize-login-text-prompts/prompt-mfa-sms',
     ],
-    to: '/customize/universal-login-pages/customize-login-text-prompts/prompt-mfa-sms',
+    to: '/customize/universal-login-pages/customize-login-text-prompts',
   },
   {
     from: [
       '/universal-login/prompt-mfa-voice',
       '/brand-and-customize/text-customization-new-universal-login/prompt-mfa-voice',
+      '/customize/universal-login-pages/customize-login-text-prompts/prompt-mfa-voice',
     ],
-    to: '/customize/universal-login-pages/customize-login-text-prompts/prompt-mfa-voice',
+    to: '/customize/universal-login-pages/customize-login-text-prompts',
   },
   {
     from: [
       '/universal-login/prompt-mfa-webauthn',
       '/brand-and-customize/text-customization-new-universal-login/prompt-mfa-webauthn',
+      '/customize/universal-login-pages/customize-login-text-prompts/prompt-mfa-webauthn',
     ],
-    to: '/customize/universal-login-pages/customize-login-text-prompts/prompt-mfa-webauthn',
+    to: '/customize/universal-login-pages/customize-login-text-prompts',
   },
   {
     from: [
       '/universal-login/prompt-organization-selection',
       '/brand-and-customize/text-customization-new-universal-login/prompt-organization-selection',
+      '/customize/universal-login-pages/customize-login-text-prompts/prompt-organization-selection',
     ],
-    to: '/customize/universal-login-pages/customize-login-text-prompts/prompt-organization-selection',
+    to: '/customize/universal-login-pages/customize-login-text-prompts',
   },
   {
     from: [
       '/universal-login/prompt-reset-password',
       '/universal-login/text-customization-prompts/reset-password',
       '/brand-and-customize/text-customization-new-universal-login/prompt-reset-password',
+      '/customize/universal-login-pages/customize-login-text-prompts/prompt-reset-password',
     ],
-    to: '/customize/universal-login-pages/customize-login-text-prompts/prompt-reset-password',
+    to: '/customize/universal-login-pages/customize-login-text-prompts',
   },
   {
     from: [
       '/universal-login/prompt-signup',
       '/universal-login/text-customization-prompts/signup',
       '/brand-and-customize/text-customization-new-universal-login/prompt-signup',
+      '/customize/universal-login-pages/customize-login-text-prompts/prompt-signup',
     ],
-    to: '/customize/universal-login-pages/customize-login-text-prompts/prompt-signup',
+    to: '/customize/universal-login-pages/customize-login-text-prompts',
   },
   {
     from: [
       '/universal-login/prompt-signup-id',
       '/brand-and-customize/text-customization-new-universal-login/prompt-signup-id',
+      '/customize/universal-login-pages/customize-login-text-prompts/prompt-signup-id',
     ],
-    to: '/customize/universal-login-pages/customize-login-text-prompts/prompt-signup-id',
+    to: '/customize/universal-login-pages/customize-login-text-prompts',
   },
   {
     from: [
       '/universal-login/prompt-signup-password',
       '/brand-and-customize/text-customization-new-universal-login/prompt-signup-password',
+      '/customize/universal-login-pages/customize-login-text-prompts/prompt-signup-password',
     ],
-    to: '/customize/universal-login-pages/customize-login-text-prompts/prompt-signup-password',
+    to: '/customize/universal-login-pages/customize-login-text-prompts',
   },
   {
     from: [


### PR DESCRIPTION
Redirecting all login prompt individual pages to '/customize/universal-login-pages/customize-login-text-prompts', which have accordion with HTML files so we can remove individual pages from Docs and remove the Nav

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
