### PR TITLE
Update Spring Boot versions in Quickstarts

### DIFF
--- a/articles/quickstart/backend/java-spring-security5/01-authorization.md
+++ b/articles/quickstart/backend/java-spring-security5/01-authorization.md
@@ -55,7 +55,7 @@ If you are using Gradle, you can add the required dependencies using the [Spring
 // build.gradle
 
 plugins {
-    id 'org.springframework.boot' version '2.5.5'
+    id 'org.springframework.boot' version '2.5.12'
     id 'io.spring.dependency-management' version '1.0.9.RELEASE'
 }
 
@@ -73,7 +73,7 @@ If you are using Maven, add the Spring dependencies to your `pom.xml` file:
 <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.5.5</version>
+    <version>2.5.12</version>
     <relativePath/>
 </parent>
 

--- a/articles/quickstart/webapp/java-spring-boot/01-login.md
+++ b/articles/quickstart/webapp/java-spring-boot/01-login.md
@@ -36,7 +36,7 @@ If you're using Gradle, you can include these dependencies as shown below.
 ```groovy
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.3.0.RELEASE'
+    id 'org.springframework.boot' version '2.5.12'
     id 'io.spring.dependency-management' version '1.0.9.RELEASE'
 }
 
@@ -52,7 +52,7 @@ If you are using Maven:
 <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.3.0.RELEASE</version>
+    <version>2.5.12</version>
     <relativePath/>
 </parent>
 


### PR DESCRIPTION
Accompanies https://github.com/auth0-samples/auth0-spring-boot-login-samples/pull/6 and https://github.com/auth0-samples/auth0-spring-security5-api-sample/pull/15 to update the Spring Boot version in our Quickstarts and samples to address [CVE-2022-22965](https://tanzu.vmware.com/security/cve-2022-22965).