### PR TITLE
Fix typos in PHP API quickstart

### DIFF
--- a/articles/quickstart/backend/php/01-authorization.md
+++ b/articles/quickstart/backend/php/01-authorization.md
@@ -116,7 +116,7 @@ if ($jwt !== null) {
 
     // Attempt to decode the token:
     try {
-        $token = $this->getSdk()->decode($jwt, null, null, null, null, null, null, \Auth0\SDK\Token::TYPE_TOKEN);
+        $token = $auth0->decode($jwt, null, null, null, null, null, null, \Auth0\SDK\Token::TYPE_TOKEN);
         define('ENDPOINT_AUTHORIZED', true);
     } catch (\Auth0\SDK\Exception\InvalidTokenException $exception) {
         // The token wasn't valid. Let's display the error message from the Auth0 SDK.
@@ -170,7 +170,7 @@ Next, we need to update our SdkConfiguration to tell the SDK to use it:
 // ✋ Insert this BEFORE the token handling we added in the step above, so the SDK uses the cache.
 
 $tokenCache = new \Symfony\Component\Cache\Adapter\FilesystemAdapter();
-$configuration->setTokenCache($tokenCache);
+$auth0->configuration()->setTokenCache($tokenCache);
 ```
 
 Our sample application will now cache our token-related network requests.


### PR DESCRIPTION
This PR resolves two typos in the PHP backend API quickstart that were overlooked when transferred from their source counterparts.