### PR TITLE
Update custom URL scheme instructions in the Swift QS

### DIFF
--- a/articles/quickstart/native/ios-swift/01-login.md
+++ b/articles/quickstart/native/ios-swift/01-login.md
@@ -53,7 +53,7 @@ Make sure that the [application type](https://auth0.com/docs/configure/applicati
 
 Back in Xcode, go to the **Info** tab of your application target settings. In the **URL Types** section, click the **＋** button to add a new entry. There, enter `auth0` into the **Identifier** field and `$(PRODUCT_BUNDLE_IDENTIFIER)` into the **URL Schemes** field.
 
-This registers your Bundle Identifer as a custom scheme, so the callback and logout URLs can reach your application.
+This registers your Bundle Identifer as a custom URL scheme, so the callback and logout URLs can reach your application.
 
 ## Install the SDK
 

--- a/articles/quickstart/native/ios-swift/01-login.md
+++ b/articles/quickstart/native/ios-swift/01-login.md
@@ -53,6 +53,8 @@ Make sure that the [application type](https://auth0.com/docs/configure/applicati
 
 Back in Xcode, go to the **Info** tab of your application target settings. In the **URL Types** section, click the **＋** button to add a new entry. There, enter `auth0` into the **Identifier** field and `$(PRODUCT_BUNDLE_IDENTIFIER)` into the **URL Schemes** field.
 
+This registers your Bundle Identifer as a custom scheme, so the callback and logout URLs can reach your application.
+
 ## Install the SDK
 
 Add the [Auth0.swift](https://github.com/auth0/Auth0.swift) SDK into your project. The library will make requests to the Auth0 Authentication and Management APIs.


### PR DESCRIPTION
### Changes

This PR updates the custom URL scheme instructions in the Swift Quickstart, clarifying that step and connecting it with the one before.