### PR TITLE
Mention support for .NET 6.0 in ASP.NET Core Web App quickstart

### DIFF
--- a/articles/quickstart/webapp/aspnet-core/index.yml
+++ b/articles/quickstart/webapp/aspnet-core/index.yml
@@ -33,5 +33,6 @@ github:
 requirements:
   - .NET Core 3.1
   - .NET 5.0
+  - .NET 6.0
 sample_download_required_data:
   - client


### PR DESCRIPTION
The quickstart works with .NET6 as well. Previously it would cause some warning, but now it should work without warnings.