### PR TITLE
[DXDOCS-153] fix: only run action for pr to master branch

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,6 +1,7 @@
 name: Integration Tests
 on:
-  pull_request: {}
+  pull_request:
+    branches: master
 
 concurrency: 
   group: pr-integration-tests-${{ github.event.pull_request.id }}


### PR DESCRIPTION
Only run integration tests action for PRs to master branch