### PR TITLE
Add interactive quickstart for React Native

### DIFF
--- a/articles/quickstart/native/react-native/files/app.md
+++ b/articles/quickstart/native/react-native/files/app.md
@@ -1,0 +1,53 @@
+---
+name: app.js
+language: javascript
+---
+```javascript
+import React, { useState } from 'react';
+import { Alert, Button, Text, View } from 'react-native';
+import Auth0 from 'react-native-auth0';
+
+var credentials = require('./auth0-configuration');
+const auth0 = new Auth0(credentials);
+
+const App = () => {
+
+    let [accessToken, setAccessToken] = useState(null);
+
+    const onLogin = () => {
+        auth0.webAuth
+            .authorize({
+                scope: 'openid profile email'
+            })
+            .then(credentials => {
+                Alert.alert('AccessToken: ' + credentials.accessToken);
+                setAccessToken(credentials.accessToken);
+            })
+            .catch(error => console.log(error));
+    };
+
+    const onLogout = () => {
+        auth0.webAuth
+            .clearSession({})
+            .then(success => {
+                Alert.alert('Logged out!');
+                setAccessToken(null);
+            })
+            .catch(error => {
+                console.log('Log out cancelled');
+            });
+    };
+
+    let loggedIn = accessToken !== null;
+    return (
+        <View>
+            <Text> Auth0Sample - Login </Text>
+            <Text>You are{loggedIn ? ' ' : ' not '}logged in. </Text>
+            <Button onPress={loggedIn ? onLogout : onLogin}
+                title={loggedIn ? 'Log Out' : 'Log In'} />
+        </View >
+    );
+}
+
+export default App;
+```

--- a/articles/quickstart/native/react-native/index.yml
+++ b/articles/quickstart/native/react-native/index.yml
@@ -22,6 +22,8 @@ contentType: tutorial
 useCase: quickstart
 seo_alias: react-native
 default_article: 00-login
+hidden_articles:
+  - interactive
 articles:
   - 00-login
 show_steps: true

--- a/articles/quickstart/native/react-native/interactive.md
+++ b/articles/quickstart/native/react-native/interactive.md
@@ -17,14 +17,37 @@ topics:
 
 <!-- markdownlint-disable MD002 MD012 MD041 -->
 
+## Configure Auth0 {{{ data-action=configure }}}
+
+To use Auth0 services, you’ll need to have an application set up in the Auth0 Dashboard. The Auth0 application is where you will configure how you want authentication to work for the project you are developing.
 
 ### Configure an application
 
-Use the interactive selector to create a new Auth0 application or select an existing application that represents the project you want to integrate with. Every application in Auth0 is assigned an alphanumeric, unique Client ID that your application code will use to call Auth0 APIs through the SDK.
+Use the interactive selector to create a new Auth0 application or select an existing application that represents the project you want to integrate with. Every application in Auth0 is assigned an alphanumeric, unique client ID that your application code will use to call Auth0 APIs through the SDK.
 
-Any settings you configure using this quickstart will automatically update for your application in the <a href="${manage_url}/#/">Dashboard</a>, which is where you can manage your applications in the future.
+Any settings you configure using this quickstart will automatically update for your Application in the <a href="${manage_url}/#/">Dashboard</a>, which is where you can manage your Applications in the future.
 
 If you would rather explore a complete configuration, you can view a sample application instead.
+
+### Configure Callback URLs
+
+A callback URL is a URL in your application that you would like Auth0 to redirect users to after they have authenticated. If not set, users will not be returned to your application after they log in.
+
+::: note
+If you are following along with our sample project, set this
+- for iOS - `{PRODUCT_BUNDLE_IDENTIFIER}://${account.namespace}/ios/{PRODUCT_BUNDLE_IDENTIFIER}/callback`
+- for Android - `{YOUR_APP_PACKAGE_NAME}://${account.namespace}/android/{YOUR_APP_PACKAGE_NAME}/callback`
+:::
+
+### Configure Logout URLs
+
+A logout URL is a URL in your application that you would like Auth0 to redirect users to after they have logged out. If not set, users will not be able to log out from your application and will receive an error.
+
+::: note
+If you are following along with our sample project, set this
+- for iOS - `{PRODUCT_BUNDLE_IDENTIFIER}://${account.namespace}/ios/{PRODUCT_BUNDLE_IDENTIFIER}/callback`
+- for Android - `{YOUR_APP_PACKAGE_NAME}://${account.namespace}/android/{YOUR_APP_PACKAGE_NAME}/callback`
+:::
 
 ## Install dependencies 
 

--- a/articles/quickstart/native/react-native/interactive.md
+++ b/articles/quickstart/native/react-native/interactive.md
@@ -83,11 +83,10 @@ cd ios
 pod install
 ```
 
-First, you must provide a way for your users to log in. We recommend useing the Auth0 hosted [login page](/hosted-pages/login).
-<div class="phone-mockup"><img src="/media/articles/native-platforms/ios-swift/login-ios.png" alt="Universal Login"></div>
-
 ## Integrate Auth0 in your application
 
+First, you must provide a way for your users to log in. We recommend useing the Auth0 hosted [login page](/hosted-pages/login).
+<div class="phone-mockup"><img src="/media/articles/native-platforms/ios-swift/login-ios.png" alt="Universal Login"></div>
 ### Configure Android
 
 Open your app's `build.gradle` file (typically at `android/app/build.gradle`) and add the following manifest placeholders. The value for `auth0Domain` should be populated from your Auth0 application settings [as configured above](#get-your-application-keys).

--- a/articles/quickstart/native/react-native/interactive.md
+++ b/articles/quickstart/native/react-native/interactive.md
@@ -7,13 +7,24 @@ files:
   - files/app
 github:
   path: 00-Login
+topics: 
+  - quickstarts 
+  - native 
+  - react-native
 ---
 
 # Add Login to your React Native App
 
 <!-- markdownlint-disable MD002 MD012 MD041 -->
 
-<%= include('../_includes/_getting_started', { library: 'React Native'}) %>
+
+### Configure an application
+
+Use the interactive selector to create a new Auth0 application or select an existing application that represents the project you want to integrate with. Every application in Auth0 is assigned an alphanumeric, unique client ID that your application code will use to call Auth0 APIs through the SDK.
+
+Any settings you configure using this quickstart will automatically update for your Application in the <a href="${manage_url}/#/">Dashboard</a>, which is where you can manage your Applications in the future.
+
+If you would rather explore a complete configuration, you can view a sample application instead.
 
 ## Install Dependencies 
 

--- a/articles/quickstart/native/react-native/interactive.md
+++ b/articles/quickstart/native/react-native/interactive.md
@@ -19,7 +19,7 @@ topics:
 
 ## Configure Auth0 {{{ data-action=configure }}}
 
-To use Auth0 services, you’ll need to have an application set up in the Auth0 Dashboard. The Auth0 application is where you will configure how you want authentication to work for the project you are developing.
+To use Auth0 services, you need to have an application set up in the Auth0 Dashboard. The Auth0 application is where you will configure authentication in your project.
 
 ### Configure an application
 
@@ -31,7 +31,7 @@ If you would rather explore a complete configuration, you can view a sample appl
 
 ### Configure Callback URLs
 
-A callback URL is a URL in your application that you would like Auth0 to redirect users to after they have authenticated. If not set, users will not be returned to your application after they log in.
+A callback URL is the application URL that Auth0 will direct your users to once they have authenticated. If you do not set this value, Auth0 will not return users to your application after they log in.
 
 ::: note
 If you are following along with our sample project, set this
@@ -41,7 +41,7 @@ If you are following along with our sample project, set this
 
 ### Configure Logout URLs
 
-A logout URL is a URL in your application that you would like Auth0 to redirect users to after they have logged out. If not set, users will not be able to log out from your application and will receive an error.
+A logout URL is the application URL Auth0 will redirect your users to once they log out. If you do not set this value, users will not be able to log out from your application and will receive an error.
 
 ::: note
 If you are following along with our sample project, set this
@@ -51,8 +51,7 @@ If you are following along with our sample project, set this
 
 ## Install dependencies 
 
-How to install the React Native Auth0 module.
-
+In this section, you will learn how to install the React Native Auth0 module.
 ::: note
 Please refer to the [official documentation](https://facebook.github.io/react-native/) for additional details on React Native.
 :::
@@ -75,7 +74,7 @@ npm install react-native-auth0 --save
 
 ### Additional iOS step: install the module Pod
 
-CocoaPods is the package management tool for iOS that the React Native framework uses to install itself into your project. For the iOS native module to work with your iOS app you must first install the library Pod. If you're familiar with older React Native SDK versions, this is similar to what was called _linking a native module_. The process is now simplified:
+[CocoaPods](https://cocoapods.org/) is the package management tool for iOS. The React Native framework uses CocoaPods to install itself into your project. For the iOS native module to work with your iOS app you must first install the library Pod. If you are familiar with older React Native SDK versions, this is similar to _linking a native module_. The process is now simplified:
 
 Change directory into the `ios` folder and run `pod install`.
 
@@ -84,8 +83,7 @@ cd ios
 pod install
 ```
 
-The first step in adding authentication to your application is to provide a way for your users to log in. The fastest, most secure, and most feature-rich way to do this with Auth0 is to use the hosted [login page](/hosted-pages/login).
-
+First, you must provide a way for your users to log in. We recommend useing the Auth0 hosted [login page](/hosted-pages/login).
 <div class="phone-mockup"><img src="/media/articles/native-platforms/ios-swift/login-ios.png" alt="Universal Login"></div>
 
 ## Integrate Auth0 in your application
@@ -122,7 +120,7 @@ In the file `ios/<YOUR PROJECT>/AppDelegate.m` add the following:
 }
 ```
 
-Next you will need to add a URLScheme using your App's bundle identifier.
+Next, add a URLScheme using your App's bundle identifier.
 
 Inside the `ios` folder open the `Info.plist` and locate the value for `CFBundleIdentifier`
 
@@ -131,7 +129,7 @@ Inside the `ios` folder open the `Info.plist` and locate the value for `CFBundle
 <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 ```
 
-then below register a URL type entry using the value of `CFBundleIdentifier` as the value for the `CFBundleURLSchemes`
+Update the value for the `CFBundleURLSchemes` with the value `CFBundleIdentifier` to register a URL type entry.
 
 ```xml
 <key>CFBundleURLTypes</key>
@@ -153,7 +151,7 @@ then below register a URL type entry using the value of `CFBundleIdentifier` as 
 If your application was generated using the React Native CLI, the default value of `$(PRODUCT_BUNDLE_IDENTIFIER)` dynamically matches `org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)`. For the sample app, this value matches `com.auth0samples`.
 :::
 
-Take note of this value as you'll be using it to define the callback URLs below. If desired, you can change it using XCode in the following way:
+In a later step, you will use this value to define the callback URLs below. You can change it using XCode with the following steps:
 
 - Open the `ios/<YOUR PROJECT>.xcodeproj` file or run `xed ios` on a Terminal from the app root.
 - Open your project's or desired target's Build Settings tab and find the section that contains "Bundle Identifier".
@@ -210,7 +208,7 @@ You can also embed login functionality directly in your application. If you use 
 To learn how to embed functionality using a custom login form in your application, follow the [Custom Login Form Sample](https://github.com/auth0-samples/auth0-react-native-sample/tree/Embedded/01-Custom-Form). Make sure you read the [Browser-Based vs. Native Login Flows on Mobile Devices](/tutorials/browser-based-vs-native-experience-on-mobile) article to learn how to choose between the two types of login flows.
 :::
 
-Upon successful authentication the user's `credentials` will be returned, containing an `access_token`, an `id_token` and an `expires_in` value.
+Upon successful authentication, Auth0 returns the user's `credentials`, containing an `access_token`, an `id_token` and an `expires_in` value.
 
 ::: note
 For more information on the `accessToken`, refer to our [access token documentation](/tokens/concepts/access-tokens).

--- a/articles/quickstart/native/react-native/interactive.md
+++ b/articles/quickstart/native/react-native/interactive.md
@@ -190,7 +190,7 @@ To learn how to embed functionality using a custom login form in your applicatio
 Upon successful authentication the user's `credentials` will be returned, containing an `access_token`, an `id_token` and an `expires_in` value.
 
 ::: note
-For more information on the `accessToken`, refer to [Access Token](/tokens/concepts/access-tokens).
+For more information on the `accessToken`, refer to our [access token documentation](/tokens/concepts/access-tokens).
 :::
 
 ## Log the user out {{{ data-action=code data-code="app.js#24:34" }}}

--- a/articles/quickstart/native/react-native/interactive.md
+++ b/articles/quickstart/native/react-native/interactive.md
@@ -54,7 +54,7 @@ The first step in adding authentication to your application is to provide a way 
 
 <div class="phone-mockup"><img src="/media/articles/native-platforms/ios-swift/login-ios.png" alt="Universal Login"></div>
 
-## Integrate Auth0 in Your Application
+## Integrate Auth0 in your application
 
 ### Configure Android
 

--- a/articles/quickstart/native/react-native/interactive.md
+++ b/articles/quickstart/native/react-native/interactive.md
@@ -20,7 +20,7 @@ topics:
 
 ### Configure an application
 
-Use the interactive selector to create a new Auth0 application or select an existing application that represents the project you want to integrate with. Every application in Auth0 is assigned an alphanumeric, unique client ID that your application code will use to call Auth0 APIs through the SDK.
+Use the interactive selector to create a new Auth0 application or select an existing application that represents the project you want to integrate with. Every application in Auth0 is assigned an alphanumeric, unique Client ID that your application code will use to call Auth0 APIs through the SDK.
 
 Any settings you configure using this quickstart will automatically update for your Application in the <a href="${manage_url}/#/">Dashboard</a>, which is where you can manage your Applications in the future.
 

--- a/articles/quickstart/native/react-native/interactive.md
+++ b/articles/quickstart/native/react-native/interactive.md
@@ -195,5 +195,5 @@ For more information on the `accessToken`, refer to [Access Token](/tokens/conce
 
 ## Log the user out {{{ data-action=code data-code="app.js#24:34" }}}
 
-To log the user out, redirect them to the Auth0 log out endpoint by calling `clearSession`. This will remove their session from the authorization server. After this happens, remove the Access Token from the state. 
+To log the user out, redirect them to the Auth0 log out endpoint by calling `clearSession`. This will remove their session from the authorization server. After this happens, remove the access token from the state. 
 

--- a/articles/quickstart/native/react-native/interactive.md
+++ b/articles/quickstart/native/react-native/interactive.md
@@ -1,0 +1,188 @@
+---
+title: Add Login to your React Native App
+description: This quickstart demonstrates how to add user login to an React Native application using Auth0.
+seo_alias: react-native
+interactive: true
+files:
+  - files/app
+github:
+  path: 00-Login
+---
+
+# Add Login to your React Native App
+
+<!-- markdownlint-disable MD002 MD012 MD041 -->
+
+<%= include('../_includes/_getting_started', { library: 'React Native'}) %>
+
+## Install Dependencies 
+
+How to install the React Native Auth0 module.
+
+::: note
+Please refer to the [official documentation](https://facebook.github.io/react-native/) for additional details on React Native.
+:::
+
+### Yarn
+
+```bash
+yarn add react-native-auth0
+```
+
+::: note
+For further reference on yarn, check [their official documentation](https://yarnpkg.com/en/docs).
+:::
+
+### npm
+
+```bash
+npm install react-native-auth0 --save
+```
+
+### Additional iOS step: install the module Pod
+
+CocoaPods is the package management tool for iOS that the React Native framework uses to install itself into your project. For the iOS native module to work with your iOS app you must first install the library Pod. If you're familiar with older React Native SDK versions, this is similar to what was called _linking a native module_. The process is now simplified:
+
+Change directory into the `ios` folder and run `pod install`.
+
+```bash
+cd ios
+pod install
+```
+
+The first step in adding authentication to your application is to provide a way for your users to log in. The fastest, most secure, and most feature-rich way to do this with Auth0 is to use the hosted [login page](/hosted-pages/login).
+
+<div class="phone-mockup"><img src="/media/articles/native-platforms/ios-swift/login-ios.png" alt="Universal Login"></div>
+
+## Integrate Auth0 in Your Application
+
+### Configure Android
+
+Open your app's `build.gradle` file (typically at `android/app/build.gradle`) and add the following manifest placeholders. The value for `auth0Domain` should be populated from your Auth0 application settings [as configured above](#get-your-application-keys).
+
+```groovy
+android {
+    defaultConfig {
+        // Add the next line
+        manifestPlaceholders = [auth0Domain: "${account.namespace}", auth0Scheme: "<%= "${applicationId}" %>"]
+    }
+    ...
+}
+```
+
+::: note
+The `applicationId` value will be auto-replaced at runtime with the package name or ID of your application (e.g. `com.example.app`). You can change this value from the `build.gradle` file. You can also check it at the top of your `AndroidManifest.xml` file.
+:::
+
+### Configure iOS
+
+In the file `ios/<YOUR PROJECT>/AppDelegate.m` add the following:
+
+```objc
+#import <React/RCTLinkingManager.h>
+
+- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url
+            options:(NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options
+{
+  return [RCTLinkingManager application:app openURL:url options:options];
+}
+```
+
+Next you will need to add a URLScheme using your App's bundle identifier.
+
+Inside the `ios` folder open the `Info.plist` and locate the value for `CFBundleIdentifier`
+
+```xml
+<key>CFBundleIdentifier</key>
+<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+```
+
+then below register a URL type entry using the value of `CFBundleIdentifier` as the value for the `CFBundleURLSchemes`
+
+```xml
+<key>CFBundleURLTypes</key>
+<array>
+    <dict>
+        <key>CFBundleTypeRole</key>
+        <string>None</string>
+        <key>CFBundleURLName</key>
+        <string>auth0</string>
+        <key>CFBundleURLSchemes</key>
+        <array>
+            <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+        </array>
+    </dict>
+</array>
+```
+
+::: note
+If your application was generated using the React Native CLI, the default value of `$(PRODUCT_BUNDLE_IDENTIFIER)` dynamically matches `org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)`. For the sample app, this value matches `com.auth0samples`.
+:::
+
+Take note of this value as you'll be using it to define the callback URLs below. If desired, you can change it using XCode in the following way:
+
+- Open the `ios/<YOUR PROJECT>.xcodeproj` file or run `xed ios` on a Terminal from the app root.
+- Open your project's or desired target's Build Settings tab and find the section that contains "Bundle Identifier".
+- Replace the "Bundle Identifier" value with your desired application's bundle identifier name.
+
+For additional information please read [react native docs](https://facebook.github.io/react-native/docs/linking).
+
+
+<%= include('../../../_includes/_callback_url') %>
+
+#### iOS callback URL
+
+```text
+{PRODUCT_BUNDLE_IDENTIFIER}://${account.namespace}/ios/{PRODUCT_BUNDLE_IDENTIFIER}/callback
+```
+
+Remember to replace `{PRODUCT_BUNDLE_IDENTIFIER}` with your actual application's bundle identifier name.
+
+
+#### Android callback URL
+
+```text
+{YOUR_APP_PACKAGE_NAME}://${account.namespace}/android/{YOUR_APP_PACKAGE_NAME}/callback
+```
+
+Remember to replace `{YOUR_APP_PACKAGE_NAME}` with your actual application's package name.
+
+
+<%= include('../../../_includes/_logout_url') %>
+
+#### iOS logout URL
+
+```text
+{PRODUCT_BUNDLE_IDENTIFIER}://${account.namespace}/ios/{PRODUCT_BUNDLE_IDENTIFIER}/callback
+```
+
+Remember to replace `{PRODUCT_BUNDLE_IDENTIFIER}` with your actual application's bundle identifier name.
+
+#### Android logout URL
+
+```text
+{YOUR_APP_PACKAGE_NAME}://${account.namespace}/android/{YOUR_APP_PACKAGE_NAME}/callback
+```
+
+Remember to replace `{YOUR_APP_PACKAGE_NAME}` with your actual application's package name.
+
+
+## Add authentication with Auth0 {{{ data-action=code data-code="app.js#12:22" }}}
+
+[Universal login](/hosted-pages/login) is the easiest way to set up authentication in your application. We recommend using it for the best experience, best security and the fullest array of features.
+
+::: note
+You can also embed login functionality directly in your application. If you use this method, some features, such as single sign-on, will not be accessible. 
+To learn how to embed functionality using a custom login form in your application, follow the [Custom Login Form Sample](https://github.com/auth0-samples/auth0-react-native-sample/tree/Embedded/01-Custom-Form). Make sure you read the [Browser-Based vs. Native Login Flows on Mobile Devices](/tutorials/browser-based-vs-native-experience-on-mobile) article to learn how to choose between the two types of login flows.
+:::
+
+Upon successful authentication the user's `credentials` will be returned, containing an `access_token`, an `id_token` and an `expires_in` value.
+
+::: note
+For more information on the `accessToken`, refer to [Access Token](/tokens/concepts/access-tokens).
+:::
+
+## Log the user out {{{ data-action=code data-code="app.js#24:34" }}}
+
+To log the user out, redirect them to the Auth0 log out endpoint by calling `clearSession`. This will remove their session from the authorization server. After this happens, remove the Access Token from the state. 
+

--- a/articles/quickstart/native/react-native/interactive.md
+++ b/articles/quickstart/native/react-native/interactive.md
@@ -26,7 +26,7 @@ Any settings you configure using this quickstart will automatically update for y
 
 If you would rather explore a complete configuration, you can view a sample application instead.
 
-## Install Dependencies 
+## Install dependencies 
 
 How to install the React Native Auth0 module.
 

--- a/articles/quickstart/native/react-native/interactive.md
+++ b/articles/quickstart/native/react-native/interactive.md
@@ -22,7 +22,7 @@ topics:
 
 Use the interactive selector to create a new Auth0 application or select an existing application that represents the project you want to integrate with. Every application in Auth0 is assigned an alphanumeric, unique Client ID that your application code will use to call Auth0 APIs through the SDK.
 
-Any settings you configure using this quickstart will automatically update for your Application in the <a href="${manage_url}/#/">Dashboard</a>, which is where you can manage your Applications in the future.
+Any settings you configure using this quickstart will automatically update for your application in the <a href="${manage_url}/#/">Dashboard</a>, which is where you can manage your applications in the future.
 
 If you would rather explore a complete configuration, you can view a sample application instead.
 


### PR DESCRIPTION
We have migrated the React Native Quickstart to the interactive version. Added screenshots of the content and code.

![image](https://user-images.githubusercontent.com/15910425/167856393-ac32e471-c4ea-45ac-85e9-e45a2592e83d.png)

![image](https://user-images.githubusercontent.com/15910425/167856467-b45226bd-0717-4238-b53f-ad517738a42b.png)
