### PR TITLE
Guides 7 and 8

### DIFF
--- a/articles/libraries/auth0js/v9/migration-v7-v9.md
+++ b/articles/libraries/auth0js/v9/migration-v7-v9.md
@@ -2,7 +2,7 @@
 section: libraries
 title: Migrating from Auth0.js v7 to v9
 description: How to migrate from Auth0.js v7 to v9
-public: false
+public: true
 toc: true
 topics:
   - libraries

--- a/articles/libraries/auth0js/v9/migration-v8-v9.md
+++ b/articles/libraries/auth0js/v9/migration-v8-v9.md
@@ -2,7 +2,7 @@
 section: libraries
 title: Migrating to from Auth0.js v8 to v9
 description: How to migrate from Auth0.js v8 to v9
-public: false
+public: true
 toc: true
 topics:
   - libraries


### PR DESCRIPTION
Reinstate migration guides in /libraries

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
