### PR TITLE
fix: Laravel QS' Composer `create-project` command points to obsolete branch

### DIFF
--- a/articles/quickstart/backend/laravel/01-authorization.md
+++ b/articles/quickstart/backend/laravel/01-authorization.md
@@ -25,7 +25,7 @@ If you already have a Laravel 9 application prepared, you can skip this step.
 Let's begin by setting up a new Laravel application. Let's open a shell and run the following command — replacing `DIRECTORY_NAME` with a directory name of preference to create and install Laravel within. The directory cannot already exist.
 
 ```sh
-composer create-project --prefer-dist laravel/laravel DIRECTORY_NAME dev-master
+composer create-project --prefer-dist laravel/laravel DIRECTORY_NAME
 ```
 
 We'll refer to this new directory as our project's root directory. As we work through this tutorial, we'll run any instructed shell commands from within that directory.

--- a/articles/quickstart/backend/laravel/interactive.md
+++ b/articles/quickstart/backend/laravel/interactive.md
@@ -41,7 +41,7 @@ If you already have a Laravel 9 application prepared, you can skip this step.
 Begin by setting up a new Laravel application. Open a shell and run the command below. Replace `DIRECTORY_NAME` with a preferred directory name to create and install in Laravel. The directory cannot already exist.
 
 ```sh
-composer create-project --prefer-dist laravel/laravel DIRECTORY_NAME dev-master
+composer create-project --prefer-dist laravel/laravel DIRECTORY_NAME
 ```
 
 This new directory is the project's root directory. As you work through this tutorial, run any instructed shell commands from within that directory.
@@ -78,7 +78,7 @@ Now, connect your Laravel application with the SDK so you can work with your Aut
 
 ## Configure routes {{{ data-action=code data-code="routes/web.php" }}}
 
-Use the SDK's middleware to automatically protect routes that use bearer tokens. For this type of application, there are different types of middleware available: 
+Use the SDK's middleware to automatically protect routes that use bearer tokens. For this type of application, there are different types of middleware available:
 
 - `auth0.authenticate.optional`: This middleware resolves an available bearer token when provided and allows you to access the token's properties through the `Auth::user()` command. Requests won't be blocked without a token, but treat tokenless requests as "guest" requests.
 - `auth0.authenticate`: This middleware rejects requests that do not contain a valid access token.

--- a/articles/quickstart/webapp/laravel/01-login.md
+++ b/articles/quickstart/webapp/laravel/01-login.md
@@ -25,7 +25,7 @@ If you already have a Laravel 9 application prepared, you can skip this step.
 Let's begin by setting up a new Laravel application. Let's open a shell and run the following command — replacing `DIRECTORY_NAME` with a directory name of preference to create and install Laravel within. The directory cannot already exist.
 
 ```sh
-composer create-project --prefer-dist laravel/laravel DIRECTORY_NAME dev-master
+composer create-project --prefer-dist laravel/laravel DIRECTORY_NAME
 ```
 
 We'll refer to this new directory as our project's root directory. As we work through this tutorial, we'll run any instructed shell commands from within that directory.

--- a/articles/quickstart/webapp/laravel/interactive.md
+++ b/articles/quickstart/webapp/laravel/interactive.md
@@ -35,7 +35,7 @@ If you already have a Laravel 9 application prepared, you can skip this step.
 Begin by setting up a new Laravel application. Open a shell and run the command below. Replace `DIRECTORY_NAME` with your preferred directory name to create and install in Laravel. The directory cannot already exist.
 
 ```sh
-composer create-project --prefer-dist laravel/laravel DIRECTORY_NAME dev-master
+composer create-project --prefer-dist laravel/laravel DIRECTORY_NAME
 ```
 
 This new directory is your project's root directory. As you work through this tutorial, run any instructed shell commands from within that directory.
@@ -72,7 +72,7 @@ Now connect your Laravel application with the SDK so you can work with your Auth
 
 ## Authentication routes {{{ data-action=code data-code="routes/web.php#1:3" }}}
 
-Set-up authentication routes with the SDK plug-and-play router controllers. 
+Set-up authentication routes with the SDK plug-and-play router controllers.
 
 Inside `routes/web.php`:
 
@@ -140,8 +140,8 @@ You're all set. Your new application is live and waiting for use. Give it a try 
 
 Now that you have configured your Laravel application to use Auth0, run your application to verify that:
 * When users navigate to the `/login` route, they redirect to Auth0.
-* Users redirect back to your application after sucessfully entering their credentials, indicating they are authenticated. 
-* Users not authenticated are prohibited from accessing the `/required` route. 
+* Users redirect back to your application after sucessfully entering their credentials, indicating they are authenticated.
+* Users not authenticated are prohibited from accessing the `/required` route.
 * When users navigate to the `/logout` route, they redirect to Auth0's logout endpoint and sign them out of our application.
 
 :::


### PR DESCRIPTION
This PR updates the Laravel Quickstarts to remove the `dev-master` branch specification in the Composer package manager `create-project` command, as that branch was made obsolete by Laravel 9's GA. It now defaults to the correct (latest GA) version available, as would be expected.