### PR TITLE
add express setup steps to node qs

### DIFF
--- a/articles/quickstart/backend/nodejs/files/server.md
+++ b/articles/quickstart/backend/nodejs/files/server.md
@@ -38,4 +38,8 @@ app.get('/api/private-scoped', checkJwt, checkScopes, function(req, res) {
     message: 'Hello from a private endpoint! You need to be authenticated and have a scope of read:messages to see this.'
   });
 });
+
+app.listen(3000, function() {
+  console.log('Listening on http://localhost:3000');
+});
 ```

--- a/articles/quickstart/webapp/express/files/server.md
+++ b/articles/quickstart/webapp/express/files/server.md
@@ -6,7 +6,9 @@ language: javascript
 <!-- markdownlint-disable MD041 -->
 
 ```javascript
+const express = require('express');
 const { auth, requiresAuth } = require('express-openid-connect');
+const app = express();
 
 const config = {
   authRequired: false,
@@ -31,5 +33,9 @@ app.get('/', (req, res) => {
 // The /profile route will show the user profile as JSON
 app.get('/profile', requiresAuth(), (req, res) => {
   res.send(JSON.stringify(req.oidc.user, null, 2));
+});
+
+app.listen(3000, function() {
+  console.log('Listening on http://localhost:3000');
 });
 ```


### PR DESCRIPTION
Add `app = express()` and `app.listen` steps to node QSs