### PR TITLE
Remove deprecated WebSecurityConfigurerAdapter method

### DIFF
--- a/articles/quickstart/backend/java-spring-security5/01-authorization.md
+++ b/articles/quickstart/backend/java-spring-security5/01-authorization.md
@@ -91,21 +91,23 @@ If you are using Maven, add the Spring dependencies to your `pom.xml` file:
 
 ### Configure the resource server
 
-To configure the application as a Resource Server and validate the JWTs, create a class that extends `WebSecurityConfigurerAdapter`, add the `@EnableWebSecurity` annotation, and override the `configure` method:
+To configure the application as a Resource Server and validate the JWTs, create a class that will provide an instance of `SecurityFilterChain`, and add the `@EnableWebSecurity` annotation:
 
 ```java
 // src/main/java/com/auth0/example/security/SecurityConfig.java
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.web.SecurityFilterChain;
 
 @EnableWebSecurity
-public class SecurityConfig extends WebSecurityConfigurerAdapter {
+public class SecurityConfig {
 
-    @Override
-    public void configure(HttpSecurity http) throws Exception {
-        http.oauth2ResourceServer().jwt();
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.oauth2Login();
+        return http.build();
     }
 }
 ```
@@ -147,9 +149,7 @@ Update the `SecurityConfig` class to configure a `JwtDecoder` bean that uses the
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
 import org.springframework.security.oauth2.core.OAuth2TokenValidator;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -159,7 +159,7 @@ import org.springframework.security.oauth2.jwt.JwtValidators;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 
 @EnableWebSecurity
-public class SecurityConfig extends WebSecurityConfigurerAdapter {
+public class SecurityConfig {
 
     @Value("<%= "${auth0.audience}" %>")
     private String audience;
@@ -187,26 +187,28 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
 <%= include('../_includes/_api_endpoints') %>
 
-The example below shows how to secure API methods using the `HttpSecurity` object provided in the `configure()` method of the `SecurityConfig` class. Route matchers are used to restrict access based on the level of authorization required:
+The example below shows how to secure API methods using the `HttpSecurity` object provided in the `filterChain()` method of the `SecurityConfig` class. Route matchers are used to restrict access based on the level of authorization required:
 
 ```java
 // src/main/java/com/auth0/example/security/SecurityConfig.java
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.web.SecurityFilterChain;
 
 @EnableWebSecurity
-public class SecurityConfig extends WebSecurityConfigurerAdapter {
+public class SecurityConfig {
 
-    @Override
-    public void configure(HttpSecurity http) throws Exception {
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http.authorizeRequests()
                 .mvcMatchers("/api/public").permitAll()
                 .mvcMatchers("/api/private").authenticated()
                 .mvcMatchers("/api/private-scoped").hasAuthority("SCOPE_read:messages")
                 .and().cors()
                 .and().oauth2ResourceServer().jwt();
+        return http.build();
     }
 }
 ```

--- a/articles/quickstart/backend/java-spring-security5/files/security-config.md
+++ b/articles/quickstart/backend/java-spring-security5/files/security-config.md
@@ -7,17 +7,16 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
 import org.springframework.security.oauth2.core.OAuth2TokenValidator;
-import org.springframework.security.oauth2.jwt.Jwt;
-import org.springframework.security.oauth2.jwt.JwtDecoder;
-import org.springframework.security.oauth2.jwt.JwtDecoders;
-import org.springframework.security.oauth2.jwt.JwtValidators;
-import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.oauth2.jwt.*;
+import org.springframework.security.web.SecurityFilterChain;
 
+/**
+ * Configures our application with Spring Security to restrict access to our API endpoints.
+ */
 @EnableWebSecurity
-public class SecurityConfig extends WebSecurityConfigurerAdapter {
+public class SecurityConfig {
 
    @Value("<%= "${auth0.audience}" %>")
    private String audience;
@@ -25,32 +24,38 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
    @Value("<%= "${spring.security.oauth2.resourceserver.jwt.issuer-uri}" %>")
    private String issuer;
 
-    @Override
-    public void configure(HttpSecurity http) throws Exception {
-     /*
-     This is where we configure the security required for our endpoints and setup our app to serve as
-     an OAuth2 Resource Server, using JWT validation.
-     */
-     http.authorizeRequests()
-            .mvcMatchers("/api/public").permitAll()
-            .mvcMatchers("/api/private").authenticated()
-            .mvcMatchers("/api/private-scoped").hasAuthority("SCOPE_read:messages")
-            .and().cors()
-            .and().oauth2ResourceServer().jwt();
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        /*
+        This is where we configure the security required for our endpoints and setup our app to serve as
+        an OAuth2 Resource Server, using JWT validation.
+        */
+        http.authorizeRequests()
+                .mvcMatchers("/api/public").permitAll()
+                .mvcMatchers("/api/private").authenticated()
+                .mvcMatchers("/api/private-scoped").hasAuthority("SCOPE_read:messages")
+                .and().cors()
+                .and().oauth2ResourceServer().jwt();
+        return http.build();
     }
 
-   @Bean
-   JwtDecoder jwtDecoder() {
-     NimbusJwtDecoder jwtDecoder = (NimbusJwtDecoder)
-           JwtDecoders.fromOidcIssuerLocation(issuer);
+    @Bean
+    JwtDecoder jwtDecoder() {
+        /*
+        By default, Spring Security does not validate the "aud" claim of the token, to ensure that this token is
+        indeed intended for our app. Adding our own validator is easy to do:
+        */
 
-     OAuth2TokenValidator<Jwt> audienceValidator = new AudienceValidator(audience);
-     OAuth2TokenValidator<Jwt> withIssuer = JwtValidators.createDefaultWithIssuer(issuer);
-     OAuth2TokenValidator<Jwt> withAudience = new DelegatingOAuth2TokenValidator<>(withIssuer, audienceValidator);
+        NimbusJwtDecoder jwtDecoder = (NimbusJwtDecoder)
+                JwtDecoders.fromOidcIssuerLocation(issuer);
 
-     jwtDecoder.setJwtValidator(withAudience);
+        OAuth2TokenValidator<Jwt> audienceValidator = new AudienceValidator(audience);
+        OAuth2TokenValidator<Jwt> withIssuer = JwtValidators.createDefaultWithIssuer(issuer);
+        OAuth2TokenValidator<Jwt> withAudience = new DelegatingOAuth2TokenValidator<>(withIssuer, audienceValidator);
 
-     return jwtDecoder;
-   }
+        jwtDecoder.setJwtValidator(withAudience);
+
+        return jwtDecoder;
+    }
 }
 ```

--- a/articles/quickstart/backend/java-spring-security5/interactive.md
+++ b/articles/quickstart/backend/java-spring-security5/interactive.md
@@ -91,13 +91,13 @@ To validate the JWT, you also need to validate that the JWT is intended for your
 
 ## Configure the resource server {{{ data-action=code data-code="SecurityConfig.java" }}}
 
-To configure the application as a Resource Server and validate the JWTs, create a class that extends `WebSecurityConfigurerAdapter`, add the `@EnableWebSecurity` annotation, and override the `configure` method
+To configure the application as a Resource Server and validate the JWTs, create a class that will provide an instance of `SecurityFilterChain`, and add the `@EnableWebSecurity` annotation:
 
 ### Protect API endpoints
 
 <%= include('../_includes/_api_endpoints') %>
 
-The example below shows how to secure API methods using the `HttpSecurity` object provided in the `configure()` method of the `SecurityConfig` class. Route matchers restrict access based on the level of authorization required:
+The example below shows how to secure API methods using the `HttpSecurity` object provided in the `filterChain()` method of the `SecurityConfig` class. Route matchers restrict access based on the level of authorization required:
 
 ::: note
 By default, Spring Security creates a `GrantedAuthority` for each scope in the `scope` claim of the JWT. This scope enables using the `hasAuthority("SCOPE_read:messages")` method to restrict access to a valid JWT that contains the `read:messages` scope.

--- a/articles/quickstart/webapp/java-spring-boot/01-login.md
+++ b/articles/quickstart/webapp/java-spring-boot/01-login.md
@@ -112,21 +112,23 @@ spring:
 
 ## Add Login to Your Application
 
-To enable users to login with Auth0, you will need to extend the [WebSecurityConfigurerAdapter](https://docs.spring.io/spring-security/site/docs/current/api/org/springframework/security/config/annotation/web/configuration/WebSecurityConfigurerAdapter.html) class and override the `configure(HttpSecurity http)` method.
+To enable user login with Auth0, create a class that will provide an instance of [SecurityFilterChain](https://docs.spring.io/spring-security/site/docs/current/api/org/springframework/security/web/SecurityFilterChain.html), and add the `@EnableWebSecurity` annotation.
 
 ```java
 package com.auth0.example;
 
-import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Bean;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
 
-@Configuration
-public class SecurityConfig extends WebSecurityConfigurerAdapter {
+@EnableWebSecurity
+public class SecurityConfig {
 
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
-        http.oauth2Login();
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http.oauth2Login()
+                .and().build();
     }
 }
 ```
@@ -280,18 +282,19 @@ public class LogoutHandler extends SecurityContextLogoutHandler {
 }
 ```
 
-Next, you need to update your implementation of `WebSecurityConfigurerAdapter` to register your logout handler and specify the request path that should trigger logout (`/logout` in the example below).
+Next, you need to update your implementation of `SecurityFilterChain` to register your logout handler and specify the request path that should trigger logout (`/logout` in the example below).
 
 ```java
 package com.auth0.example;
 
-import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Bean;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
-@Configuration
-public class SecurityConfig extends WebSecurityConfigurerAdapter {
+@EnableWebSecurity
+public class SecurityConfig {
 
     private final LogoutHandler logoutHandler;
 
@@ -299,13 +302,14 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         this.logoutHandler = logoutHandler;
     }
 
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
-       http
-          .oauth2Login()
-          .and().logout()
-          .logoutRequestMatcher(new AntPathRequestMatcher("/logout"))
-          .addLogoutHandler(logoutHandler);
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+                .oauth2Login()
+                .and().logout()
+                .logoutRequestMatcher(new AntPathRequestMatcher("/logout"))
+                .addLogoutHandler(logoutHandler)
+                .and().build();
     }
 }
 ```

--- a/articles/quickstart/webapp/java-spring-boot/files/security-config-logout.md
+++ b/articles/quickstart/webapp/java-spring-boot/files/security-config-logout.md
@@ -5,12 +5,14 @@ language: java
 ```java
 package com.auth0.example;
 
-import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Bean;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
-@Configuration
-public class SecurityConfig extends WebSecurityConfigurerAdapter {
+@EnableWebSecurity
+public class SecurityConfig {
 
     private final LogoutHandler logoutHandler;
 
@@ -18,13 +20,14 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         this.logoutHandler = logoutHandler;
     }
 
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
-        http
-          .oauth2Login()
-          .and().logout()
-          .logoutRequestMatcher(new AntPathRequestMatcher("/logout"))
-          .addLogoutHandler(logoutHandler);
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+                .oauth2Login()
+                .and().logout()
+                .logoutRequestMatcher(new AntPathRequestMatcher("/logout"))
+                .addLogoutHandler(logoutHandler)
+                .and().build();
     }
 }
 ```

--- a/articles/quickstart/webapp/java-spring-boot/files/security-config.md
+++ b/articles/quickstart/webapp/java-spring-boot/files/security-config.md
@@ -5,16 +5,18 @@ language: java
 ```java
 package com.auth0.example;
 
-import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Bean;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
 
-@Configuration
-public class SecurityConfig extends WebSecurityConfigurerAdapter {
+@EnableWebSecurity
+public class SecurityConfig {
 
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
-        http.oauth2Login();
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http.oauth2Login()
+                .and().build();
     }
 }
 ```

--- a/articles/quickstart/webapp/java-spring-boot/interactive.md
+++ b/articles/quickstart/webapp/java-spring-boot/interactive.md
@@ -97,7 +97,7 @@ If you need more property mappings, [review the Spring documentation](https://do
 
 ## Add login to your application {{{ data-action=code data-code="SecurityConfig.java" }}}
 
-To enable user login with Auth0, extend the [WebSecurityConfigurerAdapter](https://docs.spring.io/spring-security/site/docs/current/api/org/springframework/security/config/annotation/web/configuration/WebSecurityConfigurerAdapter.html) class and override the `configure(HttpSecurity http)` method.
+To enable user login with Auth0, create a class that will provide an instance of [SecurityFilterChain](https://docs.spring.io/spring-security/site/docs/current/api/org/springframework/security/web/SecurityFilterChain.html), and add the `@EnableWebSecurity` annotation.
 
 Later in this quickstart, you will overwrite this file with `SecurityConfigWithLogout.java` to provide extra configurations to support the logout feature.
 
@@ -153,7 +153,7 @@ Now that users can log into your application, they need [a way to log out](https
 
 ## Update your security configuration {{{ data-action=code data-code="SecurityConfigWithLogout.java" }}}
 
-Next, update your implementation of `WebSecurityConfigurerAdapter` to register your logout handler and specify the request path that should trigger logout (`/logout` in the example below).
+Next, update your implementation of `SecurityFilterChain` to register your logout handler and specify the request path that should trigger logout (`/logout` in the example below).
 
 You can remove the `SecurityConfig.java` and replace it with `SecurityConfigWithLogout.java` or update the contents from the one file to another.
 


### PR DESCRIPTION
WebSecurityConfigurerAdapter has been deprecated and we have received many requests on this. To use the later feature of SecurityFilterChain we have updated the docs and the samples as well. 

This updates Spring Web and Spring API quickstart
https://github.com/auth0-samples/auth0-spring-security5-api-sample/pull/19
https://github.com/auth0-samples/auth0-spring-boot-login-samples/pull/12