### PR TITLE
Use the new JWTDecode claims subscript

### DIFF
--- a/articles/quickstart/native/ios-swift/files/User.md
+++ b/articles/quickstart/native/ios-swift/files/User.md
@@ -16,8 +16,8 @@ extension User {
     init?(from idToken: String) {
         guard let jwt = try? decode(jwt: idToken),
               let id = jwt.subject,
-              let email = jwt.claim(name: "email").string,
-              let picture = jwt.claim(name: "picture").string
+              let email = jwt["email"].string,
+              let picture = jwt["picture"].string
         else { return nil }
         self.id = id
         self.email = email


### PR DESCRIPTION
### Changes

This PR updates a code snippet in the Auth0.swift Quickstart to use the new claims subscript introduced in JWTDecode.swift [3.0.0](https://github.com/auth0/JWTDecode.swift/releases/tag/3.0.0).