### PR TITLE
Use the new JWTDecode claims subscript in non-interactive QS

### DIFF
--- a/articles/quickstart/native/ios-swift/01-login.md
+++ b/articles/quickstart/native/ios-swift/01-login.md
@@ -211,8 +211,8 @@ Then, use the `decode(jwt:)` method to decode the ID Token and access the claims
 
 ```swift
 guard let jwt = try? decode(jwt: credentials.idToken),
-      let name = jwt.claim(name: "name").string,
-      let picture = jwt.claim(name: "picture").string else { return }
+      let name = jwt["name"].string,
+      let picture = jwt["picture"].string else { return }
 print("Name: \(name)")
 print("Picture URL: \(picture)")
 ```


### PR DESCRIPTION
### Changes

This PR updates a code snippet in the non-interactive Auth0.swift Quickstart to use the new claims subscript introduced in JWTDecode.swift [3.0.0](https://github.com/auth0/JWTDecode.swift/releases/tag/3.0.0).