### PR TITLE
Django backend quickstart updates

### DIFF
--- a/articles/quickstart/backend/django/01-authorization.md
+++ b/articles/quickstart/backend/django/01-authorization.md
@@ -29,7 +29,7 @@ django~=4.1
 djangorestframework~=3.13.1
 django-cors-headers~=3.1.1
 drf-jwt~=1.13.4
-pyjwt~=1.7.1
+pyjwt~=2.4
 requests~=2.22.0
 ```
 

--- a/articles/quickstart/backend/django/01-authorization.md
+++ b/articles/quickstart/backend/django/01-authorization.md
@@ -24,11 +24,11 @@ useCase: quickstart
  Add the following dependencies to your `requirements.txt` and run `pip install -r requirements.txt`.
 
 ```python
-cryptography~=2.8
-django~=2.2.7
-djangorestframework~=3.10.31
+cryptography~=2.9.2
+django~=4.1
+djangorestframework~=3.13.1
 django-cors-headers~=3.1.1
-drf-jwt~=1.13.3
+drf-jwt~=1.13.4
 pyjwt~=1.7.1
 requests~=2.22.0
 ```
@@ -172,6 +172,7 @@ from functools import wraps
 import jwt
 
 from django.http import JsonResponse
+from .utils import jwt_decode_token
 
 def get_token_auth_header(request):
     """Obtains the Access Token from the Authorization Header
@@ -191,7 +192,7 @@ def requires_scope(required_scope):
         @wraps(f)
         def decorated(*args, **kwargs):
             token = get_token_auth_header(args[0])
-            decoded = jwt.decode(token, verify=False)
+            decoded = jwt_decode_token(token, verify=False)
             if decoded.get("scope"):
                 token_scopes = decoded["scope"].split()
                 for token_scope in token_scopes:


### PR DESCRIPTION
<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
Hi - I tried to follow this quickstart and found a few issues
- I believe there is a typo in the suggested requirements.txt for the djangorestframework version.  I believe it should be 3.10.3 since 3.10.31 does not exist.  However rather than fixing this typo, see the next bullet for other dependency updates.  If you try to install the sample requirements.txt you get the error: `ERROR: Could not find a version that satisfies the requirement djangorestframework~=3.10.31 (from versions: 0.1, .... 3.9.1, 3.9.2, 3.9.3, 3.9.4, 3.10.0, 3.10.1, 3.10.2, 3.10.3, 3.11.0, 3.11.1, 3.11.2, 3.12.0, 3.12.1, 3.12.2, 3.12.3, 3.12.4, 3.13.0, 3.13.1)
ERROR: No matching distribution found for djangorestframework~=3.10.31`

- I would suggest updating all the dependencies.  Django 2.2.7 was released in November 4 2019 and django 4.1 is now the latest.  pyjwt is now on 2.4.  I have tested the quickstart with these dependency versions successfully.

- decoding the token in the model view needs to be handled by the decode function declared in the utils file.  I don't know if jwt.decode had a syntax change between versions but the example given doesn't make sense to me and produced errors of needing an algorithm specified and a public key.  The token is encrypted and needs to be decoded by a function that has knowledge of the algorithm and public key - which is what the function in the util file handles.

