### PR TITLE
[SDK-3497] Non-interactive version of Flutter quickstart

### DIFF
--- a/articles/quickstart/native/flutter/01-login.md
+++ b/articles/quickstart/native/flutter/01-login.md
@@ -1,0 +1,218 @@
+---
+title: Add login to your Flutter app
+default: true
+description: This tutorial demonstrates how to add user login with Auth0 to an Android or iOS Flutter application using the Auth0 Flutter SDK
+budicon: 448
+topics:
+  - quickstarts
+  - native
+  - flutter
+  - dart
+  - ios
+  - android
+contentType: tutorial
+useCase: quickstart
+files:
+  - files/build
+  - files/main
+  - files/profile
+github:
+  path: sample
+---
+
+# Add login to your Flutter app
+
+Auth0 allows you to quickly add authentication and access user profile information in your application. This guide demonstrates how to integrate Auth0 with a Flutter application using the [Auth0 Flutter SDK](https://github.com/auth0/auth0-flutter).
+
+:::note
+The Flutter SDK currently only supports Flutter applications running on Android or iOS platforms.
+:::
+
+## Getting started
+
+This quickstart assumes you already have a [Flutter](https://flutter.dev/) application up and running. If not, check out the [Flutter "getting started" guides](https://docs.flutter.dev/get-started/install) to get started with a simple app.
+
+You should also be familiar with the [Flutter command line tool](https://docs.flutter.dev/reference/flutter-cli).
+
+<%= include('_configure_urls_interactive') %>
+
+## Install the Auth0 Flutter SDK
+
+Add the Auth0 Flutter SDK into the project:
+
+```shell
+flutter pub get auth0_flutter
+```
+
+## Configure Android
+
+If you are not developing for the Android platform, skip this step.
+
+The SDK requires manifest placeholders. Auth0 uses placeholders internally to define an `intent-filter`, which captures the authentication callback URL. You must set the Auth0 tenant domain and the callback URL scheme, as in the following example:
+
+```groovy
+apply plugin: 'com.android.application'
+
+android {
+    defaultConfig {
+        applicationId "com.auth0.samples"
+        minSdkVersion 21
+        targetSdkVersion 30
+        // ...
+
+        // ---> Add the next line
+        manifestPlaceholders += [auth0Domain: "@string/com_auth0_domain", auth0Scheme: "@string/com_auth0_scheme"]
+        // <---
+    }
+}
+```
+
+You do not need to declare a specific `intent-filter` for your activity because you defined the manifest placeholders with your Auth0 **Domain** and **Scheme** values. The library handles the redirection for you.
+
+The sample uses values from `strings.xml`:
+
+- `com_auth0_domain`: The domain of your Auth0 tenant. Generally, you find this in the Auth0 Dashboard under your Application's **Settings** in the Domain field. If you are using a custom domain, you should set this to the value of your custom domain instead.
+- `com_auth0_scheme`: The scheme to use. Can be a custom scheme, or `https` if you want to use [Android App Links](https://auth0.com/docs/applications/enable-android-app-links). You can read more about setting this value in the [Auth0.Android SDK README](https://github.com/auth0/Auth0.Android#a-note-about-app-deep-linking).
+
+Run **Sync Project with Gradle Files** inside Android Studio to apply your changes.
+
+## Configure iOS
+
+If you are not developing for the iOS platform, skip this step.
+
+You need to register your bundle identifier as a custom URL scheme so the callback and logout URLs can reach your app.
+
+In Xcode, go to the **Info** tab of your app target settings. In the **URL Types** section, select the **＋** button to add a new entry. Then enter `auth0` into the **Identifier** field and `$(PRODUCT_BUNDLE_IDENTIFIER)` into the **URL Schemes** field.
+
+<p><img src="/media/articles/native-platforms/ios-swift/url-scheme.png" alt="Custom URL Scheme"></p>
+
+:::note
+The minimum target platform supported by the SDK is **iOS 12**.
+:::
+
+## Add login to your app
+
+[Universal Login](https://auth0.com/docs/authenticate/login/auth0-universal-login) is the easiest way to set up authentication in your application. We recommend using it for the best experience, best security, and the fullest array of features.
+
+Integrate Auth0 Universal Login in your Flutter app by using the `Auth0` class. Redirect your users to the Auth0 Universal Login page using `webAuthentication().login()`. This is a `Future` and must be awaited for you to retrieve the user's tokens.
+
+See this example of a `ElevatedButton` widget that logs the user in when clicked:
+
+```dart
+ElevatedButton(
+  onPressed: () async {
+    final credentials =
+        await auth0.webAuthentication().login();
+
+    setState(() {
+      _credentials = credentials;
+    });
+  },
+  child: const Text("Log in"))
+```
+
+**Android**: if you are using a custom scheme, pass this scheme to the login method so that the SDK can route to the login page and back again correctly:
+
+```dart
+await auth0.webAuthentication().login(scheme: 'YOUR CUSTOM SCHEME');
+```
+
+When a user logs in, they are redirected back to your application. Then, you are able to access the ID and access tokens for this user.
+
+::::checkpoint
+:::checkpoint-default
+Add a button to your app that calls `webAuthentication().login()` and logs the user into your app. Verify that you are redirected to Auth0 for authentication and then back to your application.
+
+Verify that you can get access to the tokens on the result of calling `login`.
+:::
+
+:::checkpoint-failure
+If your application did not launch successfully:
+
+- Ensure you set the Allowed Callback URLs are correct
+- Verify you saved your changes after entering your URLs
+- Make sure the domain and client ID values are imported correctly
+- If using Android, ensure that the manifest placeholders have been set up correctly, otherwise the redirect back to your app may not work
+
+Still having issues? Check out our [documentation](https://auth0.com/docs) or visit our [community page](https://community.auth0.com) to get more help.
+:::
+
+## Add logout to your app
+
+To log users out, redirect them to the Auth0 logout endpoint to clear their login session by calling the Auth0 Flutter SDK `webAuthentication().logout()`. [Read more about logging out of Auth0](https://auth0.com/docs/authenticate/login/logout).
+
+See this example of an `ElevatedButton` widget that logs the user out of the app:
+
+```dart
+ElevatedButton(
+  onPressed: () async {
+    await auth0.webAuthentication().logout();
+
+    setState(() {
+      _credentials = null;
+    });
+  },
+  child: const Text("Log out"))
+```
+
+**Android**: if you are using a custom scheme, pass this scheme to the logout method so that the SDK can route back to your app correctly:
+
+```
+await auth0.webAuthentication().logout(scheme: 'YOUR CUSTOM SCHEME');
+```
+
+::::checkpoint
+:::checkpoint-default
+Add a button to your app that calls `webAuthentication().logout()` and logs the user out of your application. When you select it, verify that your Flutter app redirects you to the logout endpoint and back again. You should not be logged in to your application.
+:::
+
+:::checkpoint-failure
+If your application did not log out successfully:
+
+- Ensure the Allowed Logout URLs are set properly
+- Verify you saved your changes after entering your URLs
+
+Still having issues? Check out our [documentation](https://auth0.com/docs) or visit our [community page](https://community.auth0.com) to get more help.
+:::
+::::
+
+## Show user profile information
+
+The user profile automatically retrieves user profile properties for you when you call `webAuthentication().login()`. The returned object from the login step contains a `user` property with all the user profile properties, which populates by decoding the ID token.
+
+See this example of a `View` component that displays the user profile on the screen:
+
+```dart
+import 'package:auth0_flutter/auth0_flutter.dart';
+import 'package:flutter/material.dart';
+
+class ProfileView extends StatelessWidget {
+  const ProfileView({Key? key, required this.user}) : super(key: key);
+
+  final UserProfile user;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        if (user.name != null) Text(user.name!),
+        if (user.email != null) Text(user.email!)
+      ],
+    );
+  }
+}
+```
+
+::::checkpoint
+:::checkpoint-default
+Log in and inspect the `user` property on the result. Verify the current user's profile information, such as `email` or `name`.
+:::
+:::checkpoint-failure
+If your application did not return user profile information:
+
+- Verify the access token is valid
+
+Still having issues? Check out our [documentation](https://auth0.com/docs) or visit our [community page](https://community.auth0.com) to get more help.
+:::
+::::

--- a/articles/quickstart/native/flutter/_configure_urls_interactive.md
+++ b/articles/quickstart/native/flutter/_configure_urls_interactive.md
@@ -8,7 +8,9 @@ The URLs below make use of a `SCHEME` placeholder, and this value varies dependi
 
 ### Configure an application
 
-Use the interactive selector to create a new Auth0 application or select an existing application that represents the project you want to integrate with. Every application in Auth0 is assigned an alphanumeric, unique client ID that your application code will use to call Auth0 APIs through the SDK.
+Use the interactive selector to create a new "Native Application", or select an existing application that represents the project you want to integrate with. Every application in Auth0 is assigned an alphanumeric, unique client ID that your application code will use to call Auth0 APIs through the SDK.
+
+Ensure that the **Token Endpoint Authentication Method** setting has a value of "None".
 
 Any settings you configure using this quickstart will automatically update for your application in the <a href="${manage_url}/#/">Dashboard</a>, which is where you can manage your applications in the future.
 

--- a/articles/quickstart/native/flutter/files/build.md
+++ b/articles/quickstart/native/flutter/files/build.md
@@ -13,7 +13,7 @@ android {
         // ...
 
         // ---> Add the next line
-        manifestPlaceholders = [auth0Domain: "@string/com_auth0_domain", auth0Scheme: "@string/com_auth0_scheme"]
+        manifestPlaceholders += [auth0Domain: "@string/com_auth0_domain", auth0Scheme: "@string/com_auth0_scheme"]
         // <---
     }
 }

--- a/articles/quickstart/native/flutter/index.yml
+++ b/articles/quickstart/native/flutter/index.yml
@@ -20,8 +20,10 @@ topics:
 contentType: tutorial
 useCase: quickstart
 seo_alias: flutter
-default_article: interactive
+default_article: 01-login
 articles:
+  - 01-login
+hidden_articles:
   - interactive
 show_steps: true
 github:


### PR DESCRIPTION
<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->

This is a non-interactive version of the Flutter quickstart, needed to support viewing the quickstart when inside the manage dashboard.

This contains only very minor content changes and is mostly a copy of the interactive version with the code snippets moved inline. It also incorporates the following customer feedback:

- Explained that the developer should create a "Native Application" type and ensure to check the endpoint authentication method
- Added min iOS platform target