### PR TITLE
[SDK-3512] Add Flutter to docs library page

### DIFF
--- a/articles/quickstart/native/flutter/index.yml
+++ b/articles/quickstart/native/flutter/index.yml
@@ -13,6 +13,10 @@ language:
   - Dart
 framework:
   - Flutter
+sdk:
+  name: auth0-flutter
+  url: https://www.github.com/auth0/auth0-flutter/
+  logo: flutter
 hybrid: true
 beta: true
 topics:


### PR DESCRIPTION
<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->

This PR adds the `sdk` node to the Flutter quickstart metadata, meaning that this SDK will be picked up by the [libraries page]() and shown with all its links to GitHub and the quickstart itself.

**Note:** ~Should be merged at the time when the SDK goes GA.~ Can merge, as these don't show up in libraries for beta quickstarts, and the beta flag here is still intact.

![image](https://user-images.githubusercontent.com/766403/186403466-fbd16add-904b-433d-8b9f-eea10fcd3333.png)
