### PR TITLE
[SDK-3544] React Native Auth0 vNext quickstart

### DIFF
--- a/articles/quickstart/native/react-native-vnext/00-login.md
+++ b/articles/quickstart/native/react-native-vnext/00-login.md
@@ -72,7 +72,7 @@ android {
 ```
 
 ::: note
-The `applicationId` value will be auto-replaced at runtime with the package name or ID of your application (e.g. `com.example.app`). You can change this value from the `build.gradle` file. You can also check it at the top of your `AndroidManifest.xml` file.
+At runtime, the `applicationId` value will automatically update with your application's package name or ID (e.g. `com.example.app`). You can change this value from the `build.gradle` file. You can also check it at the top of your `AndroidManifest.xml` file.
 :::
 
 ### Configure iOS

--- a/articles/quickstart/native/react-native-vnext/00-login.md
+++ b/articles/quickstart/native/react-native-vnext/00-login.md
@@ -166,13 +166,6 @@ Remember to replace `{YOUR_APP_PACKAGE_NAME}` with your actual application's pac
 
 ## Add login to your app
 
-[Universal login](/hosted-pages/login) is the easiest way to set up authentication in your application. We recommend using it for the best experience, best security and the fullest array of features.
-
-::: note
-You can also embed login functionality directly in your application. If you use this method, some features, such as single sign-on, will not be accessible.
-To learn how to embed functionality using a custom login form in your application, follow the [Custom Login Form Sample](https://github.com/auth0-samples/auth0-react-native-sample/tree/Embedded/01-Custom-Form). Make sure you read the [Browser-Based vs. Native Login Flows on Mobile Devices](/tutorials/browser-based-vs-native-experience-on-mobile) article to learn how to choose between the two types of login flows.
-:::
-
 First, import the `useAuth0` hook and the `Auth0Provider` component from the `react-native-auth0` package.
 
 ```js
@@ -241,7 +234,9 @@ Add a button that calls `clearSession` when clicked. Verify that you are logged 
 
 ## Show user profile information
 
-The `useAuth0` hook exposes a `user` object that contains information about the authenticated user. If a user has not been authenticated, this propertyu will be `null`.
+The `useAuth0` hook exposes a `user` object that contains information about the authenticated user. You can use this to access user profile information about the authenticated user that has been decoded from the [ID token](https://auth0.com/docs/secure/tokens/id-tokens).
+
+If a user has not been authenticated, this property will be `null`.
 
 ```js
 const Profile = () => {

--- a/articles/quickstart/native/react-native-vnext/00-login.md
+++ b/articles/quickstart/native/react-native-vnext/00-login.md
@@ -59,7 +59,7 @@ First, you must provide a way for your users to log in. We recommend useing the 
 
 ### Configure Android
 
-Open your app's `build.gradle` file (typically at `android/app/build.gradle`) and add the following manifest placeholders. The value for `auth0Domain` should be populated from your Auth0 application settings [as configured above](#get-your-application-keys).
+Open your app's `build.gradle` file (typically at `android/app/build.gradle`) and add the following manifest placeholders. The value for `auth0Domain` should contain your Auth0 application settings [as configured above](#get-your-application-keys).
 
 ```groovy
 android {

--- a/articles/quickstart/native/react-native-vnext/00-login.md
+++ b/articles/quickstart/native/react-native-vnext/00-login.md
@@ -89,7 +89,7 @@ In the file `ios/<YOUR PROJECT>/AppDelegate.m` add the following:
 }
 ```
 
-Next you will need to add a URLScheme using your App's bundle identifier.
+Next, add a URLScheme using your App's bundle identifier.
 
 Inside the `ios` folder open the `Info.plist` and locate the value for `CFBundleIdentifier`
 

--- a/articles/quickstart/native/react-native-vnext/00-login.md
+++ b/articles/quickstart/native/react-native-vnext/00-login.md
@@ -42,7 +42,7 @@ npm install react-native-auth0 --save
 
 ### Additional iOS step: install the module Pod
 
-CocoaPods is the package management tool for iOS that the React Native framework uses to install itself into your project. For the iOS native module to work with your iOS app you must first install the library Pod. If you're familiar with older React Native SDK versions, this is similar to what was called _linking a native module_. The process is now simplified:
+CocoaPods is the iOS package management tool the React Native framework uses to install itself into your project. For the iOS native module to work with your iOS app, first install the library Pod. If you're familiar with older React Native SDK versions, this is similar to the previous _linking a native module_. The process is now simplified:
 
 Change directory into the `ios` folder and run `pod install`.
 

--- a/articles/quickstart/native/react-native-vnext/00-login.md
+++ b/articles/quickstart/native/react-native-vnext/00-login.md
@@ -98,7 +98,7 @@ In the `ios` folder, open the `Info.plist` and locate the value for `CFBundleIde
 <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 ```
 
-then below register a URL type entry using the value of `CFBundleIdentifier` as the value for the `CFBundleURLSchemes`
+Below this value, register a URL type entry using the value of `CFBundleIdentifier` as the value for the `CFBundleURLSchemes`.
 
 ```xml
 <key>CFBundleURLTypes</key>

--- a/articles/quickstart/native/react-native-vnext/00-login.md
+++ b/articles/quickstart/native/react-native-vnext/00-login.md
@@ -51,7 +51,7 @@ cd ios
 pod install
 ```
 
-The first step in adding authentication to your application is to provide a way for your users to log in. The fastest, most secure, and most feature-rich way to do this with Auth0 is to use the hosted [login page](/hosted-pages/login).
+First, you must provide a way for your users to log in. We recommend useing the Auth0 hosted [login page](/hosted-pages/login).
 
 <div class="phone-mockup"><img src="/media/articles/native-platforms/ios-swift/login-ios.png" alt="Universal Login"></div>
 

--- a/articles/quickstart/native/react-native-vnext/00-login.md
+++ b/articles/quickstart/native/react-native-vnext/00-login.md
@@ -234,7 +234,7 @@ Add a button that calls `clearSession` when clicked. Verify that you are logged 
 
 ## Show user profile information
 
-The `useAuth0` hook exposes a `user` object that contains information about the authenticated user. You can use this to access user profile information about the authenticated user that has been decoded from the [ID token](https://auth0.com/docs/secure/tokens/id-tokens).
+The `useAuth0` hook exposes a `user` object that contains information about the authenticated user. You can use this to access decoded user profile information about the authenticated user from the [ID token](https://auth0.com/docs/secure/tokens/id-tokens).
 
 If a user has not been authenticated, this property will be `null`.
 

--- a/articles/quickstart/native/react-native-vnext/00-login.md
+++ b/articles/quickstart/native/react-native-vnext/00-login.md
@@ -166,7 +166,7 @@ Remember to replace `{YOUR_APP_PACKAGE_NAME}` with your actual application's pac
 
 ## Add login to your app
 
-First, import the `useAuth0` hook and the `Auth0Provider` component from the `react-native-auth0` package.
+Import the `useAuth0` hook and the `Auth0Provider` component from the `react-native-auth0` package.
 
 ```js
 import {useAuth0, Auth0Provider} from 'react-native-auth0';

--- a/articles/quickstart/native/react-native-vnext/00-login.md
+++ b/articles/quickstart/native/react-native-vnext/00-login.md
@@ -172,7 +172,7 @@ First, import the `useAuth0` hook and the `Auth0Provider` component from the `re
 import {useAuth0, Auth0Provider} from 'react-native-auth0';
 ```
 
-Next, wrap your application in the `Auth0Provider` component, providing your Auth0 domain and client ID values:
+Next, wrap your application in the `Auth0Provider` component, providing your Auth0 domain and Client ID values:
 
 ```js
 const App = () => {

--- a/articles/quickstart/native/react-native-vnext/00-login.md
+++ b/articles/quickstart/native/react-native-vnext/00-login.md
@@ -208,7 +208,7 @@ Add a button component that calls `authorize` when clicked. Verify that you are 
 
 ## Add logout to your app
 
-To log the user out, redirect them to the Auth0 log out endpoint by importing and calling the `clearSession` method from the `useAuth0` hook. This will remove their session from the authorization server.
+To log the user out, redirect them to the Auth0 log out endpoint by importing and calling the `clearSession` method from the `useAuth0` hook. This method removes their session from the authorization server.
 
 See this usage example of a button that logs the user out of the app when clicked:
 

--- a/articles/quickstart/native/react-native-vnext/00-login.md
+++ b/articles/quickstart/native/react-native-vnext/00-login.md
@@ -18,7 +18,7 @@ useCase: quickstart
 
 ## Install Dependencies
 
-How to install the React Native Auth0 module.
+In this section, you will install the React Native Auth0 module.
 
 ::: note
 Please refer to the [official documentation](https://facebook.github.io/react-native/) for additional details on React Native.

--- a/articles/quickstart/native/react-native-vnext/00-login.md
+++ b/articles/quickstart/native/react-native-vnext/00-login.md
@@ -120,7 +120,7 @@ Below this value, register a URL type entry using the value of `CFBundleIdentifi
 If your application was generated using the React Native CLI, the default value of `$(PRODUCT_BUNDLE_IDENTIFIER)` dynamically matches `org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)`. For the sample app, this value matches `com.auth0samples`.
 :::
 
-Take note of this value as you'll be using it to define the callback URLs below. If desired, you can change it using XCode in the following way:
+Note this value as you'll be using it to define the callback URLs below. If desired, you can change it using XCode in the following way:
 
 - Open the `ios/<YOUR PROJECT>.xcodeproj` file or run `xed ios` on a Terminal from the app root.
 - Open your project's or desired target's Build Settings tab and find the section that contains "Bundle Identifier".

--- a/articles/quickstart/native/react-native-vnext/00-login.md
+++ b/articles/quickstart/native/react-native-vnext/00-login.md
@@ -91,7 +91,7 @@ In the file `ios/<YOUR PROJECT>/AppDelegate.m` add the following:
 
 Next, add a URLScheme using your App's bundle identifier.
 
-Inside the `ios` folder open the `Info.plist` and locate the value for `CFBundleIdentifier`
+In the `ios` folder, open the `Info.plist` and locate the value for `CFBundleIdentifier`
 
 ```xml
 <key>CFBundleIdentifier</key>

--- a/articles/quickstart/native/react-native-vnext/00-login.md
+++ b/articles/quickstart/native/react-native-vnext/00-login.md
@@ -1,0 +1,261 @@
+---
+title: Login
+description: This tutorial demonstrates how to add user login to a React Native application using Auth0.
+budicon: 448
+topics:
+  - quickstarts
+  - native
+  - react-native
+github:
+  path: 00-Login-Hooks
+contentType: tutorial
+useCase: quickstart
+---
+
+<!-- markdownlint-disable MD002 MD012 MD041 -->
+
+<%= include('../_includes/_getting_started', { library: 'React Native'}) %>
+
+## Install Dependencies
+
+How to install the React Native Auth0 module.
+
+::: note
+Please refer to the [official documentation](https://facebook.github.io/react-native/) for additional details on React Native.
+:::
+
+### Yarn
+
+```bash
+yarn add react-native-auth0
+```
+
+::: note
+For further reference on yarn, check [their official documentation](https://yarnpkg.com/en/docs).
+:::
+
+### npm
+
+```bash
+npm install react-native-auth0 --save
+```
+
+### Additional iOS step: install the module Pod
+
+CocoaPods is the package management tool for iOS that the React Native framework uses to install itself into your project. For the iOS native module to work with your iOS app you must first install the library Pod. If you're familiar with older React Native SDK versions, this is similar to what was called _linking a native module_. The process is now simplified:
+
+Change directory into the `ios` folder and run `pod install`.
+
+```bash
+cd ios
+pod install
+```
+
+The first step in adding authentication to your application is to provide a way for your users to log in. The fastest, most secure, and most feature-rich way to do this with Auth0 is to use the hosted [login page](/hosted-pages/login).
+
+<div class="phone-mockup"><img src="/media/articles/native-platforms/ios-swift/login-ios.png" alt="Universal Login"></div>
+
+## Integrate Auth0 in Your Application
+
+### Configure Android
+
+Open your app's `build.gradle` file (typically at `android/app/build.gradle`) and add the following manifest placeholders. The value for `auth0Domain` should be populated from your Auth0 application settings [as configured above](#get-your-application-keys).
+
+```groovy
+android {
+    defaultConfig {
+        // Add the next line
+        manifestPlaceholders = [auth0Domain: "${account.namespace}", auth0Scheme: "<%= "${applicationId}" %>"]
+    }
+    ...
+}
+```
+
+::: note
+The `applicationId` value will be auto-replaced at runtime with the package name or ID of your application (e.g. `com.example.app`). You can change this value from the `build.gradle` file. You can also check it at the top of your `AndroidManifest.xml` file.
+:::
+
+### Configure iOS
+
+In the file `ios/<YOUR PROJECT>/AppDelegate.m` add the following:
+
+```objc
+#import <React/RCTLinkingManager.h>
+
+- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url
+            options:(NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options
+{
+  return [RCTLinkingManager application:app openURL:url options:options];
+}
+```
+
+Next you will need to add a URLScheme using your App's bundle identifier.
+
+Inside the `ios` folder open the `Info.plist` and locate the value for `CFBundleIdentifier`
+
+```xml
+<key>CFBundleIdentifier</key>
+<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+```
+
+then below register a URL type entry using the value of `CFBundleIdentifier` as the value for the `CFBundleURLSchemes`
+
+```xml
+<key>CFBundleURLTypes</key>
+<array>
+    <dict>
+        <key>CFBundleTypeRole</key>
+        <string>None</string>
+        <key>CFBundleURLName</key>
+        <string>auth0</string>
+        <key>CFBundleURLSchemes</key>
+        <array>
+            <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+        </array>
+    </dict>
+</array>
+```
+
+::: note
+If your application was generated using the React Native CLI, the default value of `$(PRODUCT_BUNDLE_IDENTIFIER)` dynamically matches `org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)`. For the sample app, this value matches `com.auth0samples`.
+:::
+
+Take note of this value as you'll be using it to define the callback URLs below. If desired, you can change it using XCode in the following way:
+
+- Open the `ios/<YOUR PROJECT>.xcodeproj` file or run `xed ios` on a Terminal from the app root.
+- Open your project's or desired target's Build Settings tab and find the section that contains "Bundle Identifier".
+- Replace the "Bundle Identifier" value with your desired application's bundle identifier name.
+
+For additional information please read [react native docs](https://facebook.github.io/react-native/docs/linking).
+
+<%= include('../../../_includes/_callback_url') %>
+
+#### iOS callback URL
+
+```text
+{PRODUCT_BUNDLE_IDENTIFIER}://${account.namespace}/ios/{PRODUCT_BUNDLE_IDENTIFIER}/callback
+```
+
+Remember to replace `{PRODUCT_BUNDLE_IDENTIFIER}` with your actual application's bundle identifier name.
+
+#### Android callback URL
+
+```text
+{YOUR_APP_PACKAGE_NAME}://${account.namespace}/android/{YOUR_APP_PACKAGE_NAME}/callback
+```
+
+Remember to replace `{YOUR_APP_PACKAGE_NAME}` with your actual application's package name.
+
+<%= include('../../../_includes/_logout_url') %>
+
+#### iOS logout URL
+
+```text
+{PRODUCT_BUNDLE_IDENTIFIER}://${account.namespace}/ios/{PRODUCT_BUNDLE_IDENTIFIER}/callback
+```
+
+Remember to replace `{PRODUCT_BUNDLE_IDENTIFIER}` with your actual application's bundle identifier name.
+
+#### Android logout URL
+
+```text
+{YOUR_APP_PACKAGE_NAME}://${account.namespace}/android/{YOUR_APP_PACKAGE_NAME}/callback
+```
+
+Remember to replace `{YOUR_APP_PACKAGE_NAME}` with your actual application's package name.
+
+## Add login to your app
+
+[Universal login](/hosted-pages/login) is the easiest way to set up authentication in your application. We recommend using it for the best experience, best security and the fullest array of features.
+
+::: note
+You can also embed login functionality directly in your application. If you use this method, some features, such as single sign-on, will not be accessible.
+To learn how to embed functionality using a custom login form in your application, follow the [Custom Login Form Sample](https://github.com/auth0-samples/auth0-react-native-sample/tree/Embedded/01-Custom-Form). Make sure you read the [Browser-Based vs. Native Login Flows on Mobile Devices](/tutorials/browser-based-vs-native-experience-on-mobile) article to learn how to choose between the two types of login flows.
+:::
+
+First, import the `useAuth0` hook and the `Auth0Provider` component from the `react-native-auth0` package.
+
+```js
+import {useAuth0, Auth0Provider} from 'react-native-auth0';
+```
+
+Next, wrap your application in the `Auth0Provider` component, providing your Auth0 domain and client ID values:
+
+```js
+const App = () => {
+  return (
+    <Auth0Provider domain={"${account.namespace}"} clientId={"${account.clientId}"}>
+      {/* your application */}
+    </Auth0Provider>
+  );
+};
+```
+
+Finally, present the hosted login screen using the `authorize` method from the `useAuth0` hook. See this usage example showing logging in on a button click:
+
+```js
+const LoginButton = () => {
+    const {authorize} = useAuth0();
+
+    const onPress = async () => {
+        try {
+            await authorize();
+        } catch (e) {
+            console.log(e);
+        }
+    };
+
+    return <Button onPress={onPress} title="Log in" />
+}
+```
+
+:::panel Checkpoint
+Add a button component that calls `authorize` when clicked. Verify that you are redirected to the login page and then back to your application.
+:::
+
+## Add logout to your app
+
+To log the user out, redirect them to the Auth0 log out endpoint by importing and calling the `clearSession` method from the `useAuth0` hook. This will remove their session from the authorization server.
+
+See this usage example of a button that logs the user out of the app when clicked:
+
+```js
+const LogoutButton = () => {
+    const {clearSession} = useAuth0();
+
+    const onPress = async () => {
+        try {
+            await clearSession();
+        } catch (e) {
+            console.log(e);
+        }
+    };
+
+    return <Button onPress={onPress} title="Log out" />
+}
+```
+
+:::panel Checkpoint
+Add a button that calls `clearSession` when clicked. Verify that you are logged out of the application when clicked.
+:::
+
+## Show user profile information
+
+The `useAuth0` hook exposes a `user` object that contains information about the authenticated user. If a user has not been authenticated, this propertyu will be `null`.
+
+```js
+const Profile = () => {
+    const {user} = useAuth0();
+
+    return (
+        <>
+            {user && <Text>Logged in as {user.name}</Text>}
+            {!user && <Text>Not logged in</Text>}
+        </>
+    )
+}
+```
+
+:::panel Checkpoint
+Add a component to your app that uses the `user` prop to display information about the user on the screen.
+:::

--- a/articles/quickstart/native/react-native-vnext/download.md
+++ b/articles/quickstart/native/react-native-vnext/download.md
@@ -1,0 +1,24 @@
+To run the sample follow these steps:
+
+1) Set the **Allowed Callback URLs** in the [Application Settings](${manage_url}/#/applications/${account.clientId}/settings) so it works for both Android and iOS apps:
+```text
+com.auth0samples://${account.namespace}/ios/com.auth0samples/callback,com.auth0samples://${account.namespace}/android/com.auth0samples/callback
+```
+
+2) Set the **Allowed Logout URLs** in the [Application Settings](${manage_url}/#/applications/${account.clientId}/settings) so it works for both Android and iOS apps:
+```text
+com.auth0samples://${account.namespace}/ios/com.auth0samples/callback,com.auth0samples://${account.namespace}/android/com.auth0samples/callback
+```
+
+3) Make sure [Node.JS LTS](https://nodejs.org/en/download/), [Yarn](https://yarnpkg.com/lang/en/docs/install/) and [CocoaPods](http://guides.cocoapods.org/using/getting-started.html) are installed. 
+
+4) Execute the following commands in the sample's directory:
+
+```bash
+yarn install # Install dependencies
+cd ios && pod install # Install the iOS module Pod
+yarn run ios # Run on iOS device
+yarn run android # Run on Android device
+```
+
+Read more about how to run react-native apps in their [official documentation](https://facebook.github.io/react-native/docs/running-on-device.html).

--- a/articles/quickstart/native/react-native-vnext/files/app.md
+++ b/articles/quickstart/native/react-native-vnext/files/app.md
@@ -2,52 +2,53 @@
 name: app.js
 language: javascript
 ---
-```javascript
-import React, { useState } from 'react';
-import { Alert, Button, Text, View } from 'react-native';
-import Auth0 from 'react-native-auth0';
 
-var credentials = require('./auth0-configuration');
-const auth0 = new Auth0(credentials);
+```javascript
+import React from 'react';
+import {Button, Text, View} from 'react-native';
+import {useAuth0, Auth0Provider} from 'react-native-auth0';
+
+const Home = () => {
+  const {authorize, clearSession, user} = useAuth0();
+
+  const onLogin = async () => {
+    try {
+      await authorize();
+    } catch (e) {
+      console.log(e);
+    }
+  };
+
+  const onLogout = async () => {
+    try {
+      await clearSession();
+    } catch (e) {
+      console.log('Log out cancelled');
+    }
+  };
+
+  const loggedIn = user !== undefined && user !== null;
+
+  return (
+    <View style={styles.container}>
+      {loggedIn && <Text>You are logged in as {user.name}</Text>}
+      {!loggedIn && <Text>You are not logged in</Text>}
+
+      <Button
+        onPress={loggedIn ? onLogout : onLogin}
+        title={loggedIn ? 'Log Out' : 'Log In'}
+      />
+    </View>
+  );
+};
 
 const App = () => {
-
-    let [accessToken, setAccessToken] = useState(null);
-
-    const onLogin = () => {
-        auth0.webAuth
-            .authorize({
-                scope: 'openid profile email'
-            })
-            .then(credentials => {
-                Alert.alert('AccessToken: ' + credentials.accessToken);
-                setAccessToken(credentials.accessToken);
-            })
-            .catch(error => console.log(error));
-    };
-
-    const onLogout = () => {
-        auth0.webAuth
-            .clearSession({})
-            .then(success => {
-                Alert.alert('Logged out!');
-                setAccessToken(null);
-            })
-            .catch(error => {
-                console.log('Log out cancelled');
-            });
-    };
-
-    let loggedIn = accessToken !== null;
-    return (
-        <View>
-            <Text> Auth0Sample - Login </Text>
-            <Text>You are{loggedIn ? ' ' : ' not '}logged in. </Text>
-            <Button onPress={loggedIn ? onLogout : onLogin}
-                title={loggedIn ? 'Log Out' : 'Log In'} />
-        </View >
-    );
-}
+  return (
+    <Auth0Provider domain={"${account.namespace}"} clientId={"${account.clientId}"}>
+      <Home />
+    </Auth0Provider>
+  );
+};
 
 export default App;
 ```

--- a/articles/quickstart/native/react-native-vnext/files/app.md
+++ b/articles/quickstart/native/react-native-vnext/files/app.md
@@ -13,7 +13,7 @@ const Home = () => {
 
   const onLogin = async () => {
     try {
-      await authorize();
+      await authorize({scope: 'openid profile email'});
     } catch (e) {
       console.log(e);
     }
@@ -49,6 +49,15 @@ const App = () => {
     </Auth0Provider>
   );
 };
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#F5FCFF',
+  }
+});
 
 export default App;
 ```

--- a/articles/quickstart/native/react-native-vnext/files/app.md
+++ b/articles/quickstart/native/react-native-vnext/files/app.md
@@ -1,0 +1,53 @@
+---
+name: app.js
+language: javascript
+---
+```javascript
+import React, { useState } from 'react';
+import { Alert, Button, Text, View } from 'react-native';
+import Auth0 from 'react-native-auth0';
+
+var credentials = require('./auth0-configuration');
+const auth0 = new Auth0(credentials);
+
+const App = () => {
+
+    let [accessToken, setAccessToken] = useState(null);
+
+    const onLogin = () => {
+        auth0.webAuth
+            .authorize({
+                scope: 'openid profile email'
+            })
+            .then(credentials => {
+                Alert.alert('AccessToken: ' + credentials.accessToken);
+                setAccessToken(credentials.accessToken);
+            })
+            .catch(error => console.log(error));
+    };
+
+    const onLogout = () => {
+        auth0.webAuth
+            .clearSession({})
+            .then(success => {
+                Alert.alert('Logged out!');
+                setAccessToken(null);
+            })
+            .catch(error => {
+                console.log('Log out cancelled');
+            });
+    };
+
+    let loggedIn = accessToken !== null;
+    return (
+        <View>
+            <Text> Auth0Sample - Login </Text>
+            <Text>You are{loggedIn ? ' ' : ' not '}logged in. </Text>
+            <Button onPress={loggedIn ? onLogout : onLogin}
+                title={loggedIn ? 'Log Out' : 'Log In'} />
+        </View >
+    );
+}
+
+export default App;
+```

--- a/articles/quickstart/native/react-native-vnext/index.yml
+++ b/articles/quickstart/native/react-native-vnext/index.yml
@@ -1,0 +1,55 @@
+title: React Native
+# TODO remove 'image' once new QS page is live. Then only use 'logo'.
+image: /media/platforms/react.png
+logo: react
+alias:
+  - reactnative
+  - react native
+  - react native ios
+  - react native android
+author:
+  name: Steve Hobbs
+  email: steve.hobbs@okta.com
+  community: false
+language:
+  - Javascript
+framework:
+  - React Native
+hybrid: true
+beta: true
+topics:
+  - quickstart
+contentType: tutorial
+useCase: quickstart
+seo_alias: react-native
+default_article: 00-login
+hidden_articles:
+  - interactive
+articles:
+  - 00-login
+show_steps: true
+github:
+  org: auth0-samples
+  repo: auth0-react-native-sample
+sdk:
+  name: react-native-auth0
+  url: https://github.com/auth0/react-native-auth0
+  logo: react
+requirements:
+  - React Native 0.62.2
+  - NodeJS 10.16
+next_steps:
+  - path: 00-login
+    list:
+      - text: Configure other identity providers
+        icon: 345
+        href: '/identityproviders'
+      - text: Enable multifactor authentication
+        icon: 345
+        href: '/multifactor-authentication'
+      - text: Learn about attack protection
+        icon: 345
+        href: '/attack-protection'
+      - text: Learn about rules
+        icon: 345
+        href: '/rules'

--- a/articles/quickstart/native/react-native-vnext/interactive.md
+++ b/articles/quickstart/native/react-native-vnext/interactive.md
@@ -1,0 +1,219 @@
+---
+title: Add Login to your React Native App
+description: This quickstart demonstrates how to add user login to an React Native application using Auth0.
+seo_alias: react-native
+interactive: true
+files:
+  - files/app
+github:
+  path: 00-Login
+topics: 
+  - quickstarts 
+  - native 
+  - react-native
+---
+
+# Add Login to your React Native App
+
+<!-- markdownlint-disable MD002 MD012 MD041 -->
+
+## Configure Auth0 {{{ data-action=configure }}}
+
+To use Auth0 services, you need to have an application set up in the Auth0 Dashboard. The Auth0 application is where you will configure authentication in your project.
+
+### Configure an application
+
+Use the interactive selector to create a new Auth0 application or select an existing application that represents the project you want to integrate with. Every application in Auth0 is assigned an alphanumeric, unique client ID that your application code will use to call Auth0 APIs through the SDK.
+
+Any settings you configure using this quickstart will automatically update for your Application in the <a href="${manage_url}/#/">Dashboard</a>, which is where you can manage your Applications in the future.
+
+If you would rather explore a complete configuration, you can view a sample application instead.
+
+### Configure Callback URLs
+
+A callback URL is the application URL that Auth0 will direct your users to once they have authenticated. If you do not set this value, Auth0 will not return users to your application after they log in.
+
+::: note
+If you are following along with our sample project, set this
+- for iOS - `{PRODUCT_BUNDLE_IDENTIFIER}://${account.namespace}/ios/{PRODUCT_BUNDLE_IDENTIFIER}/callback`
+- for Android - `{YOUR_APP_PACKAGE_NAME}://${account.namespace}/android/{YOUR_APP_PACKAGE_NAME}/callback`
+:::
+
+### Configure Logout URLs
+
+A logout URL is the application URL Auth0 will redirect your users to once they log out. If you do not set this value, users will not be able to log out from your application and will receive an error.
+
+::: note
+If you are following along with our sample project, set this
+- for iOS - `{PRODUCT_BUNDLE_IDENTIFIER}://${account.namespace}/ios/{PRODUCT_BUNDLE_IDENTIFIER}/callback`
+- for Android - `{YOUR_APP_PACKAGE_NAME}://${account.namespace}/android/{YOUR_APP_PACKAGE_NAME}/callback`
+:::
+
+## Install dependencies 
+
+In this section, you will learn how to install the React Native Auth0 module.
+::: note
+Please refer to the [official documentation](https://facebook.github.io/react-native/) for additional details on React Native.
+:::
+
+### Yarn
+
+```bash
+yarn add react-native-auth0
+```
+
+::: note
+For further reference on yarn, check [their official documentation](https://yarnpkg.com/en/docs).
+:::
+
+### npm
+
+```bash
+npm install react-native-auth0 --save
+```
+
+### Additional iOS step: install the module Pod
+
+[CocoaPods](https://cocoapods.org/) is the package management tool for iOS. The React Native framework uses CocoaPods to install itself into your project. For the iOS native module to work with your iOS app you must first install the library Pod. If you are familiar with older React Native SDK versions, this is similar to _linking a native module_. The process is now simplified:
+
+Change directory into the `ios` folder and run `pod install`.
+
+```bash
+cd ios
+pod install
+```
+
+## Integrate Auth0 in your application
+
+First, you must provide a way for your users to log in. We recommend useing the Auth0 hosted [login page](/hosted-pages/login).
+<div class="phone-mockup"><img src="/media/articles/native-platforms/ios-swift/login-ios.png" alt="Universal Login"></div>
+### Configure Android
+
+Open your app's `build.gradle` file (typically at `android/app/build.gradle`) and add the following manifest placeholders. The value for `auth0Domain` should be populated from your Auth0 application settings [as configured above](#get-your-application-keys).
+
+```groovy
+android {
+    defaultConfig {
+        // Add the next line
+        manifestPlaceholders = [auth0Domain: "${account.namespace}", auth0Scheme: "<%= "${applicationId}" %>"]
+    }
+    ...
+}
+```
+
+::: note
+The `applicationId` value will be auto-replaced at runtime with the package name or ID of your application (e.g. `com.example.app`). You can change this value from the `build.gradle` file. You can also check it at the top of your `AndroidManifest.xml` file.
+:::
+
+### Configure iOS
+
+In the file `ios/<YOUR PROJECT>/AppDelegate.m` add the following:
+
+```objc
+#import <React/RCTLinkingManager.h>
+
+- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url
+            options:(NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options
+{
+  return [RCTLinkingManager application:app openURL:url options:options];
+}
+```
+
+Next, add a URLScheme using your App's bundle identifier.
+
+Inside the `ios` folder open the `Info.plist` and locate the value for `CFBundleIdentifier`
+
+```xml
+<key>CFBundleIdentifier</key>
+<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+```
+
+Update the value for the `CFBundleURLSchemes` with the value `CFBundleIdentifier` to register a URL type entry.
+
+```xml
+<key>CFBundleURLTypes</key>
+<array>
+    <dict>
+        <key>CFBundleTypeRole</key>
+        <string>None</string>
+        <key>CFBundleURLName</key>
+        <string>auth0</string>
+        <key>CFBundleURLSchemes</key>
+        <array>
+            <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+        </array>
+    </dict>
+</array>
+```
+
+::: note
+If your application was generated using the React Native CLI, the default value of `$(PRODUCT_BUNDLE_IDENTIFIER)` dynamically matches `org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)`. For the sample app, this value matches `com.auth0samples`.
+:::
+
+In a later step, you will use this value to define the callback URLs below. You can change it using XCode with the following steps:
+
+- Open the `ios/<YOUR PROJECT>.xcodeproj` file or run `xed ios` on a Terminal from the app root.
+- Open your project's or desired target's Build Settings tab and find the section that contains "Bundle Identifier".
+- Replace the "Bundle Identifier" value with your desired application's bundle identifier name.
+
+For additional information please read [react native docs](https://facebook.github.io/react-native/docs/linking).
+
+
+<%= include('../../../_includes/_callback_url') %>
+
+#### iOS callback URL
+
+```text
+{PRODUCT_BUNDLE_IDENTIFIER}://${account.namespace}/ios/{PRODUCT_BUNDLE_IDENTIFIER}/callback
+```
+
+Remember to replace `{PRODUCT_BUNDLE_IDENTIFIER}` with your actual application's bundle identifier name.
+
+
+#### Android callback URL
+
+```text
+{YOUR_APP_PACKAGE_NAME}://${account.namespace}/android/{YOUR_APP_PACKAGE_NAME}/callback
+```
+
+Remember to replace `{YOUR_APP_PACKAGE_NAME}` with your actual application's package name.
+
+
+<%= include('../../../_includes/_logout_url') %>
+
+#### iOS logout URL
+
+```text
+{PRODUCT_BUNDLE_IDENTIFIER}://${account.namespace}/ios/{PRODUCT_BUNDLE_IDENTIFIER}/callback
+```
+
+Remember to replace `{PRODUCT_BUNDLE_IDENTIFIER}` with your actual application's bundle identifier name.
+
+#### Android logout URL
+
+```text
+{YOUR_APP_PACKAGE_NAME}://${account.namespace}/android/{YOUR_APP_PACKAGE_NAME}/callback
+```
+
+Remember to replace `{YOUR_APP_PACKAGE_NAME}` with your actual application's package name.
+
+
+## Add authentication with Auth0 {{{ data-action=code data-code="app.js#12:22" }}}
+
+[Universal login](/hosted-pages/login) is the easiest way to set up authentication in your application. We recommend using it for the best experience, best security and the fullest array of features.
+
+::: note
+You can also embed login functionality directly in your application. If you use this method, some features, such as single sign-on, will not be accessible. 
+To learn how to embed functionality using a custom login form in your application, follow the [Custom Login Form Sample](https://github.com/auth0-samples/auth0-react-native-sample/tree/Embedded/01-Custom-Form). Make sure you read the [Browser-Based vs. Native Login Flows on Mobile Devices](/tutorials/browser-based-vs-native-experience-on-mobile) article to learn how to choose between the two types of login flows.
+:::
+
+Upon successful authentication, Auth0 returns the user's `credentials`, containing an `access_token`, an `id_token` and an `expires_in` value.
+
+::: note
+For more information on the `accessToken`, refer to our [access token documentation](/tokens/concepts/access-tokens).
+:::
+
+## Log the user out {{{ data-action=code data-code="app.js#24:34" }}}
+
+To log the user out, redirect them to the Auth0 log out endpoint by calling `clearSession`. This will remove their session from the authorization server. After this happens, remove the access token from the state. 
+

--- a/articles/quickstart/native/react-native-vnext/interactive.md
+++ b/articles/quickstart/native/react-native-vnext/interactive.md
@@ -104,7 +104,7 @@ android {
 ```
 
 ::: note
-At runtime, the `applicationId` value will automatically update with your application's package name or ID (e.g. `com.example.app`). You can change this value from the `build.gradle` file. You can also check it at the top of your `AndroidManifest.xml` file.```
+At runtime, the `applicationId` value will automatically update with your application's package name or ID (e.g. `com.example.app`). You can change this value from the `build.gradle` file. You can also check it at the top of your `AndroidManifest.xml` file.
 :::
 
 ### Configure iOS

--- a/articles/quickstart/native/react-native-vnext/interactive.md
+++ b/articles/quickstart/native/react-native-vnext/interactive.md
@@ -123,7 +123,7 @@ In the file `ios/<YOUR PROJECT>/AppDelegate.m` add the following:
 
 Next, add a URLScheme using your App's bundle identifier.
 
-Inside the `ios` folder open the `Info.plist` and locate the value for `CFBundleIdentifier`
+In the `ios` folder, open the `Info.plist` and locate the value for `CFBundleIdentifier`
 
 ```xml
 <key>CFBundleIdentifier</key>

--- a/articles/quickstart/native/react-native-vnext/interactive.md
+++ b/articles/quickstart/native/react-native-vnext/interactive.md
@@ -170,7 +170,7 @@ Import the `useAuth0` hook and `Auth0Provider` component from the `react-native-
 import {useAuth0, Auth0Provider} from 'react-native-auth0';
 ```
 
-For the SDK to function properly, you must wrap your application in the `Auth0Provider` component, and set the following properties:
+For the SDK to function correctly, wrap your application in the `Auth0Provider` component and set the following properties:
 
 - `domain`: The domain of your Auth0 tenant. Generally, you can find this in the Auth0 Dashboard under your Application's Settings in the Domain field. If you are using a [custom domain](https://auth0.com/docs/custom-domains), you should set this to the value of your custom domain instead.
 - `clientId`: The ID of the Auth0 Application you set up earlier in this quickstart. You can find this in the Auth0 Dashboard under your Application's Settings in the Client ID field.

--- a/articles/quickstart/native/react-native-vnext/interactive.md
+++ b/articles/quickstart/native/react-native-vnext/interactive.md
@@ -177,7 +177,7 @@ For the SDK to function properly, you must wrap your application in the `Auth0Pr
 
 ::::checkpoint
 :::checkpoint-default
-Your `Auth0Provider` component should now be properly configured. Run your application to verify that:
+You just configured the `Auth0Provider` component. Run your application to verify that:
 - the SDK is initializing correctly
 - your application is not throwing any errors related to Auth0
 :::

--- a/articles/quickstart/native/react-native-vnext/interactive.md
+++ b/articles/quickstart/native/react-native-vnext/interactive.md
@@ -27,7 +27,7 @@ Use the interactive selector to create a new Auth0 application or select an exis
 
 Any settings you configure using this quickstart will automatically update for your Application in the <a href="${manage_url}/#/">Dashboard</a>, which is where you can manage your Applications in the future.
 
-If you would rather explore a complete configuration, you can view a sample application instead.
+To explore a complete configuration, review the sample application in your Dashboard.
 
 ### Configure Callback URLs
 

--- a/articles/quickstart/native/react-native-vnext/interactive.md
+++ b/articles/quickstart/native/react-native-vnext/interactive.md
@@ -91,7 +91,7 @@ First, you must provide a way for your users to log in. We recommend useing the 
 
 ### Configure Android
 
-Open your app's `build.gradle` file (typically at `android/app/build.gradle`) and add the following manifest placeholders. The value for `auth0Domain` should be populated from your Auth0 application settings [as configured above](#get-your-application-keys).
+Open the `build.gradle` file in your application directory (typically at `android/app/build.gradle`) and add the following manifest placeholders. The value for `auth0Domain` should contain your Auth0 application settings [as configured above](#get-your-application-keys).
 
 ```groovy
 android {

--- a/articles/quickstart/native/react-native-vnext/interactive.md
+++ b/articles/quickstart/native/react-native-vnext/interactive.md
@@ -231,7 +231,7 @@ Still having issues? Check out our [documentation](https://auth0.com/docs) or vi
 
 ## Show user profile information {{{ data-action=code data-code="app.js#28:29" }}}
 
-The `useAuth0` hook exposes a `user` object that contains information about the authenticated user. You can use this to access user profile information about the authenticated user that has been decoded from the [ID token](https://auth0.com/docs/secure/tokens/id-tokens).
+The `useAuth0` hook exposes a `user` object that contains information about the authenticated user. You can use this to access decoded user profile information about the authenticated user from the [ID token](https://auth0.com/docs/secure/tokens/id-tokens).
 
 If a user has not been authenticated, this property will be `null`.
 

--- a/articles/quickstart/native/react-native-vnext/interactive.md
+++ b/articles/quickstart/native/react-native-vnext/interactive.md
@@ -191,7 +191,7 @@ Still having issues? Check out our [documentation](https://auth0.com/docs) or vi
 ::::
 ## Add login to your app {{{ data-action=code data-code="app.js#8:14" }}}
 
-Authenticate the user by calling the `authorize` method provided by the `useAuth0` hook. This redirects the user to the Auth0 [Universal Login](https://auth0.com/docs/authenticate/login/auth0-universal-login) page for authentication, then back to your app.
+Authenticate the user by calling the `authorize` method provided by the `useAuth0` hook. This method redirects the user to the Auth0 [Universal Login](https://auth0.com/docs/authenticate/login/auth0-universal-login) page for authentication, then back to your app.
 
 To confirm the user successfully logged in, check that the `user` property provided by the hook is not `null`.
 

--- a/articles/quickstart/native/react-native-vnext/interactive.md
+++ b/articles/quickstart/native/react-native-vnext/interactive.md
@@ -205,7 +205,7 @@ If your application did not launch successfully:
 - Ensure you set the Allowed Callback URLs are correct
 - Verify you saved your changes after entering your URLs
 - Make sure the domain and client ID values are imported correctly
-- If using Android, ensure that the manifest placeholders have been set up correctly, otherwise the redirect back to your app may not work
+- If using Android, ensure you set up the manifest placeholders correctly, otherwise the redirect back to your app may not work
 
 Still having issues? Check out our [documentation](https://auth0.com/docs) or visit our [community page](https://community.auth0.com) to get more help.
 :::

--- a/articles/quickstart/native/react-native-vnext/interactive.md
+++ b/articles/quickstart/native/react-native-vnext/interactive.md
@@ -130,7 +130,7 @@ In the `ios` folder, open the `Info.plist` and locate the value for `CFBundleIde
 <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 ```
 
-Update the value for the `CFBundleURLSchemes` with the value `CFBundleIdentifier` to register a URL type entry.
+Below this value, register a URL type entry using the value of `CFBundleIdentifier` as the value for the `CFBundleURLSchemes`.
 
 ```xml
 <key>CFBundleURLTypes</key>

--- a/articles/quickstart/native/react-native-vnext/interactive.md
+++ b/articles/quickstart/native/react-native-vnext/interactive.md
@@ -88,6 +88,7 @@ pod install
 
 First, you must provide a way for your users to log in. We recommend useing the Auth0 hosted [login page](/hosted-pages/login).
 <div class="phone-mockup"><img src="/media/articles/native-platforms/ios-swift/login-ios.png" alt="Universal Login"></div>
+
 ### Configure Android
 
 Open your app's `build.gradle` file (typically at `android/app/build.gradle`) and add the following manifest placeholders. The value for `auth0Domain` should be populated from your Auth0 application settings [as configured above](#get-your-application-keys).

--- a/articles/quickstart/native/react-native-vnext/interactive.md
+++ b/articles/quickstart/native/react-native-vnext/interactive.md
@@ -104,7 +104,7 @@ android {
 ```
 
 ::: note
-The `applicationId` value will be auto-replaced at runtime with the package name or ID of your application (e.g. `com.example.app`). You can change this value from the `build.gradle` file. You can also check it at the top of your `AndroidManifest.xml` file.
+At runtime, the `applicationId` value will automatically update with your application's package name or ID (e.g. `com.example.app`). You can change this value from the `build.gradle` file. You can also check it at the top of your `AndroidManifest.xml` file.```
 :::
 
 ### Configure iOS

--- a/articles/quickstart/native/react-native-vnext/interactive.md
+++ b/articles/quickstart/native/react-native-vnext/interactive.md
@@ -19,7 +19,7 @@ topics:
 
 ## Configure Auth0 {{{ data-action=configure }}}
 
-To use Auth0 services, you need to have an application set up in the Auth0 Dashboard. The Auth0 application is where you will configure authentication in your project.
+To use Auth0 services, you must have an application set up in the Auth0 Dashboard. The Auth0 application is where you will configure authentication in your project.
 
 ### Configure an application
 

--- a/articles/quickstart/native/react-native-vnext/interactive.md
+++ b/articles/quickstart/native/react-native-vnext/interactive.md
@@ -193,7 +193,7 @@ Still having issues? Check out our [documentation](https://auth0.com/docs) or vi
 
 Authenticate the user by calling the `authorize` method provided by the `useAuth0` hook. This redirects the user to the Auth0 [Universal Login](https://auth0.com/docs/authenticate/login/auth0-universal-login) page for authentication, then back to your app.
 
-For confirmation that the user was logged in successfully, check that the `user` property provided by the hook is not `null`.
+To confirm the user successfully logged in, check that the `user` property provided by the hook is not `null`.
 
 ::::checkpoint
 :::checkpoint-default

--- a/articles/quickstart/native/react-native-vnext/interactive.md
+++ b/articles/quickstart/native/react-native-vnext/interactive.md
@@ -75,7 +75,7 @@ npm install react-native-auth0 --save
 
 ### Additional iOS step: install the module Pod
 
-[CocoaPods](https://cocoapods.org/) is the package management tool for iOS. The React Native framework uses CocoaPods to install itself into your project. For the iOS native module to work with your iOS app you must first install the library Pod. If you are familiar with older React Native SDK versions, this is similar to _linking a native module_. The process is now simplified:
+CocoaPods is the iOS package management tool the React Native framework uses to install itself into your project. For the iOS native module to work with your iOS app, first install the library Pod. If you're familiar with older React Native SDK versions, this is similar to the previous _linking a native module_. The process is now simplified:
 
 Change directory into the `ios` folder and run `pod install`.
 

--- a/articles/quickstart/native/react-native-vnext/interactive.md
+++ b/articles/quickstart/native/react-native-vnext/interactive.md
@@ -162,7 +162,7 @@ For additional information please read [react native docs](https://facebook.gith
 
 ## Configure the Auth0Provider component {{{ data-action=code data-code="app.js#41:43"}}}
 
-The `useAuth0` hook relies on a React Context to provide state management. This context is provided by the `Auth0Provider` component.
+The `useAuth0` hook relies on a React Context to provide state management. The `Auth0Provider` component provides this context.
 
 Import the `useAuth0` hook and `Auth0Provider` component from the `react-native-auth0` package:
 

--- a/articles/quickstart/native/react-native-vnext/interactive.md
+++ b/articles/quickstart/native/react-native-vnext/interactive.md
@@ -52,6 +52,7 @@ If you are following along with our sample project, set this
 ## Install dependencies 
 
 In this section, you will learn how to install the React Native Auth0 module.
+
 ::: note
 Please refer to the [official documentation](https://facebook.github.io/react-native/) for additional details on React Native.
 :::
@@ -158,62 +159,83 @@ In a later step, you will use this value to define the callback URLs below. You 
 
 For additional information please read [react native docs](https://facebook.github.io/react-native/docs/linking).
 
+## Configure the Auth0Provider component {{{ data-action=code data-code="app.js#41:43"}}}
 
-<%= include('../../../_includes/_callback_url') %>
+The `useAuth0` hook relies on a React Context to provide state management. This context is provided by the `Auth0Provider` component.
 
-#### iOS callback URL
+Import the `useAuth0` hook and `Auth0Provider` component from the `react-native-auth0` package:
 
-```text
-{PRODUCT_BUNDLE_IDENTIFIER}://${account.namespace}/ios/{PRODUCT_BUNDLE_IDENTIFIER}/callback
+```js
+import {useAuth0, Auth0Provider} from 'react-native-auth0';
 ```
 
-Remember to replace `{PRODUCT_BUNDLE_IDENTIFIER}` with your actual application's bundle identifier name.
+For the SDK to function properly, you must wrap your application in the `Auth0Provider` component, and set the following properties:
 
+- `domain`: The domain of your Auth0 tenant. Generally, you can find this in the Auth0 Dashboard under your Application's Settings in the Domain field. If you are using a [custom domain](https://auth0.com/docs/custom-domains), you should set this to the value of your custom domain instead.
+- `clientId`: The ID of the Auth0 Application you set up earlier in this quickstart. You can find this in the Auth0 Dashboard under your Application's Settings in the Client ID field.
 
-#### Android callback URL
-
-```text
-{YOUR_APP_PACKAGE_NAME}://${account.namespace}/android/{YOUR_APP_PACKAGE_NAME}/callback
-```
-
-Remember to replace `{YOUR_APP_PACKAGE_NAME}` with your actual application's package name.
-
-
-<%= include('../../../_includes/_logout_url') %>
-
-#### iOS logout URL
-
-```text
-{PRODUCT_BUNDLE_IDENTIFIER}://${account.namespace}/ios/{PRODUCT_BUNDLE_IDENTIFIER}/callback
-```
-
-Remember to replace `{PRODUCT_BUNDLE_IDENTIFIER}` with your actual application's bundle identifier name.
-
-#### Android logout URL
-
-```text
-{YOUR_APP_PACKAGE_NAME}://${account.namespace}/android/{YOUR_APP_PACKAGE_NAME}/callback
-```
-
-Remember to replace `{YOUR_APP_PACKAGE_NAME}` with your actual application's package name.
-
-
-## Add authentication with Auth0 {{{ data-action=code data-code="app.js#12:22" }}}
-
-[Universal login](/hosted-pages/login) is the easiest way to set up authentication in your application. We recommend using it for the best experience, best security and the fullest array of features.
-
-::: note
-You can also embed login functionality directly in your application. If you use this method, some features, such as single sign-on, will not be accessible. 
-To learn how to embed functionality using a custom login form in your application, follow the [Custom Login Form Sample](https://github.com/auth0-samples/auth0-react-native-sample/tree/Embedded/01-Custom-Form). Make sure you read the [Browser-Based vs. Native Login Flows on Mobile Devices](/tutorials/browser-based-vs-native-experience-on-mobile) article to learn how to choose between the two types of login flows.
+::::checkpoint
+:::checkpoint-default
+Your `Auth0Provider` component should now be properly configured. Run your application to verify that:
+- the SDK is initializing correctly
+- your application is not throwing any errors related to Auth0
 :::
-
-Upon successful authentication, Auth0 returns the user's `credentials`, containing an `access_token`, an `id_token` and an `expires_in` value.
-
-::: note
-For more information on the `accessToken`, refer to our [access token documentation](/tokens/concepts/access-tokens).
+:::checkpoint-failure
+If your application did not launch successfully:
+- make sure the correct application is selected
+- did you save after entering your URLs?
+- ensure your domain and client ID values are correct
+Still having issues? Check out our [documentation](https://auth0.com/docs) or visit our [community page](https://community.auth0.com) to get more help.
 :::
+::::
+## Add login to your app {{{ data-action=code data-code="app.js#8:14" }}}
 
-## Log the user out {{{ data-action=code data-code="app.js#24:34" }}}
+Authenticate the user by calling the `authorize` method provided by the `useAuth0` hook. This redirects the user to the Auth0 [Universal Login](https://auth0.com/docs/authenticate/login/auth0-universal-login) page for authentication, then back to your app.
 
-To log the user out, redirect them to the Auth0 log out endpoint by calling `clearSession`. This will remove their session from the authorization server. After this happens, remove the access token from the state. 
+For confirmation that the user was logged in successfully, check that the `user` property provided by the hook is not `null`.
 
+::::checkpoint
+:::checkpoint-default
+Add a button component that calls `authorize` when clicked. Verify that you are redirected to the login page and then back to your application.
+:::
+:::checkpoint-failure
+If your application did not launch successfully:
+
+- Ensure you set the Allowed Callback URLs are correct
+- Verify you saved your changes after entering your URLs
+- Make sure the domain and client ID values are imported correctly
+- If using Android, ensure that the manifest placeholders have been set up correctly, otherwise the redirect back to your app may not work
+
+Still having issues? Check out our [documentation](https://auth0.com/docs) or visit our [community page](https://community.auth0.com) to get more help.
+:::
+::::
+
+## Add logout to your app {{{ data-action=code data-code="app.js#16:22" }}}
+
+To log the user out, redirect them to the Auth0 log out endpoint by calling `clearSession`. This will remove their session from the authorization server and log the user out of the application.
+
+::::checkpoint
+:::checkpoint-default
+Add a button that calls `clearSession` and observe that you are redirected to the Auth0 logout endpoint and back again. You should no longer be logged in to your application.
+:::
+:::checkpoint-failure
+If your application did not log out successfully:
+
+- Ensure the Allowed Logout URLs are set properly
+- Verify you saved your changes after entering your URLs
+
+Still having issues? Check out our [documentation](https://auth0.com/docs) or visit our [community page](https://community.auth0.com) to get more help.
+:::
+::::
+
+## Show user profile information {{{ data-action=code data-code="app.js#28:29" }}}
+
+The `useAuth0` hook exposes a `user` object that contains information about the authenticated user. You can use this to access user profile information about the authenticated user that has been decoded from the [ID token](https://auth0.com/docs/secure/tokens/id-tokens).
+
+If a user has not been authenticated, this property will be `null`.
+
+::::checkpoint
+:::checkpoint-default
+Log in and inspect the `user` property on the result. Verify the current user's profile information, such as `email` or `name`.
+:::
+::::

--- a/articles/quickstart/native/react-native-vnext/interactive.md
+++ b/articles/quickstart/native/react-native-vnext/interactive.md
@@ -51,7 +51,7 @@ If you are following along with our sample project, set this
 
 ## Install dependencies 
 
-In this section, you will learn how to install the React Native Auth0 module.
+In this section, you will install the React Native Auth0 module.
 
 ::: note
 Please refer to the [official documentation](https://facebook.github.io/react-native/) for additional details on React Native.

--- a/articles/quickstart/native/react-native/interactive.md
+++ b/articles/quickstart/native/react-native/interactive.md
@@ -159,46 +159,6 @@ In a later step, you will use this value to define the callback URLs below. You 
 
 For additional information please read [react native docs](https://facebook.github.io/react-native/docs/linking).
 
-
-<%= include('../../../_includes/_callback_url') %>
-
-#### iOS callback URL
-
-```text
-{PRODUCT_BUNDLE_IDENTIFIER}://${account.namespace}/ios/{PRODUCT_BUNDLE_IDENTIFIER}/callback
-```
-
-Remember to replace `{PRODUCT_BUNDLE_IDENTIFIER}` with your actual application's bundle identifier name.
-
-
-#### Android callback URL
-
-```text
-{YOUR_APP_PACKAGE_NAME}://${account.namespace}/android/{YOUR_APP_PACKAGE_NAME}/callback
-```
-
-Remember to replace `{YOUR_APP_PACKAGE_NAME}` with your actual application's package name.
-
-
-<%= include('../../../_includes/_logout_url') %>
-
-#### iOS logout URL
-
-```text
-{PRODUCT_BUNDLE_IDENTIFIER}://${account.namespace}/ios/{PRODUCT_BUNDLE_IDENTIFIER}/callback
-```
-
-Remember to replace `{PRODUCT_BUNDLE_IDENTIFIER}` with your actual application's bundle identifier name.
-
-#### Android logout URL
-
-```text
-{YOUR_APP_PACKAGE_NAME}://${account.namespace}/android/{YOUR_APP_PACKAGE_NAME}/callback
-```
-
-Remember to replace `{YOUR_APP_PACKAGE_NAME}` with your actual application's package name.
-
-
 ## Add authentication with Auth0 {{{ data-action=code data-code="app.js#12:22" }}}
 
 [Universal login](/hosted-pages/login) is the easiest way to set up authentication in your application. We recommend using it for the best experience, best security and the fullest array of features.

--- a/articles/quickstart/native/react-native/interactive.md
+++ b/articles/quickstart/native/react-native/interactive.md
@@ -87,6 +87,7 @@ pod install
 
 First, you must provide a way for your users to log in. We recommend useing the Auth0 hosted [login page](/hosted-pages/login).
 <div class="phone-mockup"><img src="/media/articles/native-platforms/ios-swift/login-ios.png" alt="Universal Login"></div>
+
 ### Configure Android
 
 Open your app's `build.gradle` file (typically at `android/app/build.gradle`) and add the following manifest placeholders. The value for `auth0Domain` should be populated from your Auth0 application settings [as configured above](#get-your-application-keys).


### PR DESCRIPTION
This PR adds:

- an updated quickstart for our vNext improvements for React Native Auth0, that shows our new Hooks API
- both interactive and non-interactive versions
- quickstart is currently marked as `beta` and will override the current quickstart when our SDK improvements go live

![image](https://user-images.githubusercontent.com/766403/186477920-f977d382-a844-4ca7-9d97-10bb8839a201.png)
