### PR TITLE
Update Flutter quickstart for GA

### DIFF
--- a/articles/quickstart/native/flutter/index.yml
+++ b/articles/quickstart/native/flutter/index.yml
@@ -18,7 +18,6 @@ sdk:
   url: https://www.github.com/auth0/auth0-flutter/
   logo: flutter
 hybrid: true
-beta: true
 topics:
   - quickstart
 contentType: tutorial

--- a/articles/quickstart/native/flutter/interactive.md
+++ b/articles/quickstart/native/flutter/interactive.md
@@ -79,7 +79,7 @@ Integrate Auth0 Universal Login in your Flutter app by using the `Auth0` class. 
 **Android**: if you are using a custom scheme, pass this scheme to the login method so that the SDK can route to the login page and back again correctly:
 
 ```dart
-await auth0.webAuthentication().login(scheme: 'YOUR CUSTOM SCHEME');
+await auth0.webAuthentication(scheme: 'YOUR CUSTOM SCHEME').login();
 ```
 
 When a user logs in, they are redirected back to your application. Then, you are able to access the ID and access tokens for this user.
@@ -110,7 +110,7 @@ To log users out, redirect them to the Auth0 logout endpoint to clear their logi
 **Android**: if you are using a custom scheme, pass this scheme to the logout method so that the SDK can route back to your app correctly:
 
 ```
-await auth0.webAuthentication().logout(scheme: 'YOUR CUSTOM SCHEME');
+await auth0.webAuthentication(scheme: 'YOUR CUSTOM SCHEME').logout();
 ```
 
 ::::checkpoint


### PR DESCRIPTION
This removes the beta mark on the Flutter QuickStart to ensure it shows up in the UI, as the Flutter SDK is about to go GA.