### PR TITLE
Replace clientId with client_id in VueJS QuickStart

### DIFF
--- a/articles/quickstart/spa/vuejs/02-calling-an-api.md
+++ b/articles/quickstart/spa/vuejs/02-calling-an-api.md
@@ -31,7 +31,7 @@ const app = createApp(App);
 app.use(
   createAuth0({
     domain: "${account.namespace}",
-    clientId: "${account.clientId}",
+    client_id: "${account.clientId}",
     redirect_uri: window.location.origin,
     audience: "${apiIdentifier}",
   })


### PR DESCRIPTION
Fixes a typo with the VueJS quickstart that was using `clientId` instead of `client_id`.