### PR TITLE
Rename Windows Universal App to UWP

### DIFF
--- a/articles/quickstart/native/windows-uwp-csharp/01-login.md
+++ b/articles/quickstart/native/windows-uwp-csharp/01-login.md
@@ -1,7 +1,7 @@
 ---
 title: Login
 default: true
-description: This tutorial demonstrates how to add user login to a Windows Universal C# application using Auth0.
+description: This tutorial demonstrates how to add user login to a UWP C# application using Auth0.
 budicon: 448
 topics:
   - quickstarts

--- a/articles/quickstart/native/windows-uwp-csharp/index.yml
+++ b/articles/quickstart/native/windows-uwp-csharp/index.yml
@@ -1,4 +1,4 @@
-title: Windows Universal App C#
+title: UWP C#
 # TODO remove 'image' once new QS page is live. Then only use 'logo'.
 image: /media/platforms/windows-8.png
 logo: windows

--- a/articles/quickstart/native/windows-uwp-csharp/index.yml
+++ b/articles/quickstart/native/windows-uwp-csharp/index.yml
@@ -1,4 +1,4 @@
-title: UWP C#
+title: UWP
 # TODO remove 'image' once new QS page is live. Then only use 'logo'.
 image: /media/platforms/windows-8.png
 logo: windows


### PR DESCRIPTION
This aligns with the Microsoft naming better and make sure it's obvious that this applies to UWP apps
