### PR TITLE
Update refresh-tokens.md

### DIFF
--- a/articles/flows/guides/device-auth/includes/refresh-tokens.md
+++ b/articles/flows/guides/device-auth/includes/refresh-tokens.md
@@ -52,6 +52,10 @@ To refresh your token, make a `POST` request to the `/oauth/token` endpoint in t
 | `refresh_token` | The Refresh Token to use. |
 | `scope`         | (Optional) A space-delimited list of requested scope permissions. If not sent, the original scopes will be used; otherwise you can request a reduced set of scopes. Note that this must be URL encoded. |
 
+::: warning
+You should only include a `client_secret` parameter if working with a confidential client. To learn more on Confidential and Public applications, see [Confidental and Public Applications](https://auth0.com/docs/get-started/applications/confidential-and-public-applications).
+:::
+
 ### Refresh Token Response
 
 If all goes well, you'll receive an `HTTP 200` response with a payload containing a new `access_token`, `id_token` (optionally), token lifetime in seconds (`expires_in`), granted `scope` values, and `token_type`:


### PR DESCRIPTION
This was pointed out to me in this community post: https://community.auth0.com/t/device-flow-refresh-token-is-client-secret-really-required/93066

The primary use use-case for device flow uses a native application (the app type created previously in the doc/tutorial) where a client secret is not required - Adding the warning to make it clear that this parameter should only be included if using a confidential client.

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
