### PR TITLE
Update `AppDelegate` extension in RN Quickstarts

### DIFF
--- a/articles/quickstart/native/react-native/00-login.md
+++ b/articles/quickstart/native/react-native/00-login.md
@@ -92,7 +92,7 @@ In the file `ios/<YOUR PROJECT>/AppDelegate.mm` add the following:
 ```
 
 ::: note
-This file will be `ios/<YOUR PROJECT>/AppDelegate.m` in applications using the [old architecture](https://reactnative.dev/docs/next/new-architecture-app-intro#ios---use-objective-c-mm-extension).
+This file will be `ios/<YOUR PROJECT>/AppDelegate.m` on applications using the [old architecture](https://reactnative.dev/docs/next/new-architecture-app-intro#ios---use-objective-c-mm-extension).
 :::
 
 Next, add a URLScheme using your App's bundle identifier.

--- a/articles/quickstart/native/react-native/00-login.md
+++ b/articles/quickstart/native/react-native/00-login.md
@@ -79,7 +79,7 @@ At runtime, the `applicationId` value will automatically update with your applic
 
 ### Configure iOS
 
-In the file `ios/<YOUR PROJECT>/AppDelegate.m` add the following:
+In the file `ios/<YOUR PROJECT>/AppDelegate.mm` add the following:
 
 ```objc
 #import <React/RCTLinkingManager.h>
@@ -90,6 +90,10 @@ In the file `ios/<YOUR PROJECT>/AppDelegate.m` add the following:
   return [RCTLinkingManager application:app openURL:url options:options];
 }
 ```
+
+::: note
+This file will be `ios/<YOUR PROJECT>/AppDelegate.m` in applications using the [old architecture](https://reactnative.dev/docs/next/new-architecture-app-intro#ios---use-objective-c-mm-extension).
+:::
 
 Next, add a URLScheme using your App's bundle identifier.
 

--- a/articles/quickstart/native/react-native/interactive.md
+++ b/articles/quickstart/native/react-native/interactive.md
@@ -124,7 +124,7 @@ In the file `ios/<YOUR PROJECT>/AppDelegate.mm` add the following:
 ```
 
 ::: note
-This file will be `ios/<YOUR PROJECT>/AppDelegate.m` in applications using the [old architecture](https://reactnative.dev/docs/next/new-architecture-app-intro#ios---use-objective-c-mm-extension).
+This file will be `ios/<YOUR PROJECT>/AppDelegate.m` on applications using the [old architecture](https://reactnative.dev/docs/next/new-architecture-app-intro#ios---use-objective-c-mm-extension).
 :::
 
 Next, add a URLScheme using your App's bundle identifier.

--- a/articles/quickstart/native/react-native/interactive.md
+++ b/articles/quickstart/native/react-native/interactive.md
@@ -111,7 +111,7 @@ At runtime, the `applicationId` value will automatically update with your applic
 
 ### Configure iOS
 
-In the file `ios/<YOUR PROJECT>/AppDelegate.m` add the following:
+In the file `ios/<YOUR PROJECT>/AppDelegate.mm` add the following:
 
 ```objc
 #import <React/RCTLinkingManager.h>
@@ -122,6 +122,10 @@ In the file `ios/<YOUR PROJECT>/AppDelegate.m` add the following:
   return [RCTLinkingManager application:app openURL:url options:options];
 }
 ```
+
+::: note
+This file will be `ios/<YOUR PROJECT>/AppDelegate.m` in applications using the [old architecture](https://reactnative.dev/docs/next/new-architecture-app-intro#ios---use-objective-c-mm-extension).
+:::
 
 Next, add a URLScheme using your App's bundle identifier.
 


### PR DESCRIPTION
### Changes

The release [0.68.0](https://reactnative.dev/blog/2022/03/30/version-068) of React Native introduced the new architecture, which uses Turbo Native modules that can be written using Objective-C or C++. To support both, the AppDelegate file is now an [Objective-C++ file](https://reactnative.dev/docs/next/new-architecture-app-intro#ios---use-objective-c-mm-extension), with the `.mm` extension.

<img width="825" alt="Screen Shot 2022-10-31 at 23 38 12" src="https://user-images.githubusercontent.com/5055789/199146609-0a6899d9-0bad-4a01-985c-bb809c7f5779.png">

This PR updates the React Native QS to use the `AppDelegate.mm` file name, and adds a note for older applications.