### PR TITLE
Update the Swift Quickstarts

### DIFF
--- a/articles/quickstart/native/ios-swift/01-login.md
+++ b/articles/quickstart/native/ios-swift/01-login.md
@@ -25,7 +25,7 @@ The callback and logout URLs are the URLs that Auth0 invokes to redirect back to
 
 If the callback and logout URLs are not set, users will be unable to log in and out of the application and will get an error.
 
-Go to the settings page of your [Auth0 application](${manage_url}/#/applications/${account.clientId}/settings) and add the corresponding URL to **Allowed Callback URLs** and **Allowed Logout URLs**, according to the platform of your application. If you are using a [Custom Domain](/customize/custom-domains), use the value of your Custom Domain instead of the Auth0 Domain from the settings page.
+Go to the settings page of your [Auth0 application](${manage_url}/#/applications/${account.clientId}/settings) and add the corresponding URL to **Allowed Callback URLs** and **Allowed Logout URLs**, according to the platform of your application. If you are using a [custom domain](/customize/custom-domains), use the value of your custom domain instead of the Auth0 domain from the settings page.
 
 #### iOS
 
@@ -39,14 +39,14 @@ YOUR_BUNDLE_IDENTIFIER://${account.namespace}/ios/YOUR_BUNDLE_IDENTIFIER/callbac
 YOUR_BUNDLE_IDENTIFIER://${account.namespace}/macos/YOUR_BUNDLE_IDENTIFIER/callback
 ```
 
-E.g. if your iOS bundle identifier was `com.company.myapp` and your Auth0 Domain was `company.us.auth0.com`, then this value would be:
+For example, if your iOS bundle identifier was `com.example.MyApp` and your Auth0 domain was `example.us.auth0.com`, then this value would be:
 
 ```text
-com.company.myapp://company.us.auth0.com/ios/com.company.myapp/callback
+com.example.MyApp://example.us.auth0.com/ios/com.example.MyApp/callback
 ```
 
 ::: warning
-Make sure that the [application type](/get-started/applications) of the Auth0 application is **Native**. If you don’t have a Native Auth0 application already, [create one](/get-started/auth0-overview/create-applications/native-apps) before continuing.
+Make sure that the [application type](/get-started/applications) of the Auth0 application is **Native**, and that the **Token Endpoint Authentication Method** setting is set to `None`. If you don’t have a Native Auth0 application already, [create one](/get-started/auth0-overview/create-applications/native-apps) before continuing.
 :::
 
 ### Configure a Custom URL Scheme
@@ -109,7 +109,7 @@ For further reference on Carthage, check their [official documentation](https://
 
 ## Configure the SDK
 
-The Auth0.swift SDK needs the **Client ID** and **Domain** of the Auth0 application to communicate with Auth0. You can find these details in the [settings page](${manage_url}/#/applications/${account.clientId}/settings) of your Auth0 application. If you are using a [Custom Domain](/customize/custom-domains), use the value of your Custom Domain instead of the value from the settings page.
+The Auth0.swift SDK needs the **Client ID** and **domain** of the Auth0 application to communicate with Auth0. You can find these details in the [settings page](${manage_url}/#/applications/${account.clientId}/settings) of your Auth0 application. If you are using a [custom domain](/customize/custom-domains), use the value of your custom domain instead of the value from the settings page.
 
 <% if(typeof hideDashboardScreenshot === 'undefined' || hideDashboardScreenshot !== true) { %>
 ![App Dashboard](/media/articles/dashboard/client_settings.png)
@@ -138,7 +138,7 @@ You can also configure the SDK programmatically. Check the [README](https://gith
 :::
 
 ::: panel Checkpoint
-Now that you have configured Auth0.swift with the Client ID and Domain, run your application to verify that it is not producing any errors related to the SDK.
+Now that you have configured Auth0.swift with the Client ID and domain, run your application to verify that it is not producing any errors related to the SDK.
 :::
 
 ## Login
@@ -199,7 +199,7 @@ Verify that pressing the **Logout** button shows an alert box asking for consent
 
 ## Access User Profile Information
 
-The `Credentials` instance you obtained after logging in includes an [ID Token](/secure/tokens/id-tokens). The ID Token contains the profile information associated with the logged-in user, such as their name or profile picture. You can use these details to personalize the user interface of your application.
+The `Credentials` instance you obtained after logging in includes an [ID Token](/secure/tokens/id-tokens). The ID Token contains the profile information associated with the logged-in user, such as their email and profile picture. You can use these details to personalize the user interface of your application.
 
 The Auth0.swift SDK includes a [utility](https://github.com/auth0/JWTDecode.swift) for decoding [JWTs](https://jwt.io/) like the ID Token. Start by importing the `JWTDecode` module in the file where you want to access the user profile information.
 
@@ -218,11 +218,11 @@ print("Picture URL: \(picture)")
 ```
 
 ::: note
-You can retrieve the latest user information with the `userInfo(withAccessToken:)` method. Check the [README](https://github.com/auth0/Auth0.swift/blob/master/EXAMPLES.md#retrieve-user-information) to learn more.
+You can retrieve the latest user information with the `userInfo(withAccessToken:)` method. Check the [EXAMPLES](https://github.com/auth0/Auth0.swift/blob/master/EXAMPLES.md#retrieve-user-information) to learn more.
 :::
 
 ::: panel Checkpoint
-Verify that you can access the `name`, `picture`, or any other [claim](/secure/tokens/id-tokens/id-token-structure) after you have logged in.
+Verify that you can access the `email`, `picture`, or any other [claim](/secure/tokens/id-tokens/id-token-structure) after you have logged in.
 :::
 
 ## What's Next?

--- a/articles/quickstart/native/ios-swift/download.md
+++ b/articles/quickstart/native/ios-swift/download.md
@@ -2,7 +2,7 @@
 
 To run the sample application, first open `SwiftSample.xcodeproj` in Xcode and go to the settings of the application target you want to run. There are two application targets available: **SwiftSample (iOS)** and **SwiftSample (macOS)**. Change the bundle identifier from the default `com.auth0.samples.SwiftSample` to another value of your choosing.
 
-Then, go to the settings page of your [Auth0 application](${manage_url}/#/applications/${account.clientId}/settings) and add the corresponding URL to **Allowed Callback URLs** and **Allowed Logout URLs**. If you are using a [Custom Domain](https://auth0.com/docs/brand-and-customize/custom-domains), use the value of your Custom Domain instead of the Auth0 Domain from the settings page.
+Then, go to the settings page of your [Auth0 application](${manage_url}/#/applications/${account.clientId}/settings) and add the corresponding URL to **Allowed Callback URLs** and **Allowed Logout URLs**. If you are using a [custom domain](https://auth0.com/docs/customize/custom-domains), use the value of your custom domain instead of the Auth0 Domain from the settings page.
 
 For **SwiftSample (iOS)**:
 

--- a/articles/quickstart/native/ios-swift/interactive.md
+++ b/articles/quickstart/native/ios-swift/interactive.md
@@ -35,7 +35,7 @@ To use Auth0 services, you need an application set up in the Auth0 Dashboard. Th
 
 ### Configure an Auth0 application
 
-Use the interactive selector to create a new Auth0 application or select an existing application of the iOS or macOS app you want to integrate. Auth0 assigns every application an alphanumeric, unique Client ID that your app uses to call Auth0 APIs through the SDK.
+Use the interactive selector to create a new Auth0 application or select an existing **Native** Auth0 application. Auth0 assigns every application an alphanumeric, unique Client ID that your app uses to call Auth0 APIs through the SDK.
 
 Any settings you configure using this quickstart automatically update your Auth0 application in the <a href="${manage_url}/#/">Dashboard</a>, which is where you can manage your applications in the future.
 
@@ -59,10 +59,10 @@ YOUR_BUNDLE_IDENTIFIER://${account.namespace}/ios/YOUR_BUNDLE_IDENTIFIER/callbac
 YOUR_BUNDLE_IDENTIFIER://${account.namespace}/macos/YOUR_BUNDLE_IDENTIFIER/callback
 ```
 
-For example, if your iOS bundle identifier was `com.company.myapp` and your Auth0 tenant's domain was `company.us.auth0.com`, then this value would be:
+For example, if your iOS bundle identifier was `com.example.MyApp` and your Auth0 domain was `example.us.auth0.com`, then this value would be:
 
 ```text
-com.company.myapp://company.us.auth0.com/ios/com.company.myapp/callback
+com.example.MyApp://example.us.auth0.com/ios/com.example.MyApp/callback
 ```
 
 ## Configure your app
@@ -128,7 +128,7 @@ The Auth0.swift SDK needs your Auth0 **domain** and **Client ID**. You can find 
 - **domain**: The domain of your Auth0 tenant. If you are using a [custom domain](/customize/custom-domains), you should set this to the value of your custom domain instead.
 - **Client ID**: The alphanumeric, unique ID of the Auth0 application you set up earlier in this quickstart.
 
-Create a `plist` file named `Auth0.plist` in your app bundle containing the Auth0 Domain and Client ID values. 
+Create a `plist` file named `Auth0.plist` in your app bundle containing the Auth0 domain and Client ID values. 
 
 ::: note
 You can also configure the SDK programmatically. Check the [README](https://github.com/auth0/Auth0.swift#configure-client-id-and-domain-programmatically) to learn more.
@@ -143,7 +143,7 @@ You configured the Auth0.swift SDK. Run your app to verify that it is not produc
 If your application produces errors related to the SDK:
 - Make sure you selected the correct Auth0 application
 - Verify you saved your URL updates
-- Ensure you set the Auth0 Domain and Client ID correctly
+- Ensure you set the Auth0 domain and Client ID correctly
 
 Still having issues? Check out our [documentation](https://github.com/auth0/Auth0.swift#documentation) or visit our [community page](https://community.auth0.com) to get more help.
 :::
@@ -171,7 +171,7 @@ Press the **Login** button and verify that:
 :::checkpoint-failure
 If login fails or produces errors:
 - Verify you entered the correct callback URL
-- Ensure you set the Auth0 Domain and Client ID correctly
+- Ensure you set the Auth0 domain and Client ID correctly
 
 Still having issues? Check out our [documentation](https://github.com/auth0/Auth0.swift#documentation) or visit our [community page](https://community.auth0.com) to get more help.
 :::
@@ -192,7 +192,7 @@ Press the **Logout** button and verify that:
 :::checkpoint-failure
 If logout fails or produces errors:
 - Verify you entered the correct callback URL
-- Ensure you set the Auth0 Domain and Client ID correctly
+- Ensure you set the Auth0 domain and Client ID correctly
 
 Still having issues? Check out our [documentation](https://github.com/auth0/Auth0.swift#documentation) or visit our [community page](https://community.auth0.com) to get more help.
 :::
@@ -200,12 +200,12 @@ Still having issues? Check out our [documentation](https://github.com/auth0/Auth
 
 ## Access user profile information {{{ data-action=code data-code="User.swift#11:14" }}}
 
-The `Credentials` instance you obtained after logging in includes an [ID token](/secure/tokens/id-tokens). The ID token contains the profile information associated with the logged-in user, such as their name or profile picture. You can use these details to personalize the user interface of your app.
+The `Credentials` instance you obtained after logging in includes an [ID token](/secure/tokens/id-tokens). The ID token contains the profile information associated with the logged-in user, such as their email and profile picture. You can use these details to personalize the user interface of your app.
 
 The Auth0.swift SDK includes a [utility](https://github.com/auth0/JWTDecode.swift) for decoding [JWTs](https://jwt.io/) like the ID token. Start by importing the `JWTDecode` module in the file where you want to access the user profile information. Then, use the `decode(jwt:)` method to decode the ID token and access the claims it contains.
 
 ::: note
-You can retrieve the latest user information with the `userInfo(withAccessToken:)` method. Check the [README](https://github.com/auth0/Auth0.swift/blob/master/EXAMPLES.md#retrieve-user-information) to learn more.
+You can retrieve the latest user information with the `userInfo(withAccessToken:)` method. Check the [EXAMPLES](https://github.com/auth0/Auth0.swift/blob/master/EXAMPLES.md#retrieve-user-information) to learn more.
 :::
 
 ::::checkpoint
@@ -215,9 +215,9 @@ Verify that you can access the `email`, `picture`, or any other [claim](/secure/
 
 :::checkpoint-failure
 If you cannot access the user information:
-- Verify you imported the `JWTDecode` module when you invoke `decode(jwt:)` method
+- Verify you imported the `JWTDecode` module where you invoke the `decode(jwt:)` method
 - Make sure you spelled your claims correctly
 
-Still having issues? Check out our [documentation](https://github.com/auth0/Auth0.swift#documentation) or visit our [community page](https://community.auth0.com) to get more help.
+Still having issues? Check out our [documentation](https://github.com/auth0/Auth0.swift#documentation) or visit our [community forums](https://community.auth0.com) to get more help.
 :::
 ::::


### PR DESCRIPTION
### Changes

This PR updates the Swift Quickstarts (interactive and non-interactive) to use appropriate casing on certain terms –as specified in the docs guidelines– and addresses a few other inconsistencies between both Quickstarts.