### PR TITLE
[GNE-1564] fix: formatting issue in download instructions for some quickstarts

### DIFF
--- a/articles/quickstart/native/ionic-angular/download.md
+++ b/articles/quickstart/native/ionic-angular/download.md
@@ -30,7 +30,6 @@ npm run build
 
 # to test it in iOS
 npx cap run ios
-
 # to test it in Android
 npx cap run android
 ```

--- a/articles/quickstart/native/ionic-react/download.md
+++ b/articles/quickstart/native/ionic-react/download.md
@@ -30,7 +30,6 @@ npm run build
 
 # to test it in iOS
 npx cap run ios
-
 # to test it in Android
 npx cap run android
 ```

--- a/articles/quickstart/spa/angular/download.md
+++ b/articles/quickstart/spa/angular/download.md
@@ -24,7 +24,6 @@ You can also run it from a [Docker](https://www.docker.com) image with the follo
 ```bash
 # In Linux / macOS
 sh exec.sh
-
 # In Windows' Powershell
 ./exec.ps1
 ```

--- a/articles/quickstart/spa/react/download.md
+++ b/articles/quickstart/spa/react/download.md
@@ -23,7 +23,6 @@ You can also run it from a [Docker](https://www.docker.com) image with the follo
 ```bash
 # In Linux / macOS
 sh exec.sh
-
 # In Windows' Powershell
 ./exec.ps1
 ```

--- a/articles/quickstart/spa/vanillajs/download.md
+++ b/articles/quickstart/spa/vanillajs/download.md
@@ -23,7 +23,6 @@ You can also run it from a [Docker](https://www.docker.com) image with the follo
 ```bash
 # In Linux / macOS
 sh exec.sh
-
 # In Windows' Powershell
 ./exec.ps1
 ```

--- a/articles/quickstart/webapp/nextjs/download.md
+++ b/articles/quickstart/webapp/nextjs/download.md
@@ -22,7 +22,6 @@ You can also run it from a [Docker](https://www.docker.com) image with the follo
 ```bash
 # In Linux / macOS
 sh exec.sh
-
 # In Windows' Powershell
 ./exec.ps1
 ```


### PR DESCRIPTION
This PR fixes a formatting issue in the download instructions markdown
Reference: https://auth0team.atlassian.net/browse/GNE-1564

Here is the previous PR which was approved but because of forking was failing integration tests: https://github.com/auth0/docs/pull/10168