### PR TITLE
fix: Typo in Laravel's `vendor:publish` command during install

### DIFF
--- a/articles/quickstart/backend/laravel/01-authorization.md
+++ b/articles/quickstart/backend/laravel/01-authorization.md
@@ -45,7 +45,7 @@ composer require auth0/login
 Next, let's create the SDK's configuration file. Again from a shell opened to our projects root directory, let's use Laravel's the `vendor:publish` command to import the configuration file into our application:
 
 ```sh
-php artisan vendor:publish --tag=auth0-config
+php artisan vendor:publish --tag auth0-config
 ```
 
 Now we can begin configuring our Auth0 integration by adding options to the `.env` file in our project's root directory. Let's open that `.env` file and add some essential details for our project:

--- a/articles/quickstart/backend/laravel/interactive.md
+++ b/articles/quickstart/backend/laravel/interactive.md
@@ -63,7 +63,7 @@ composer require auth0/login
 Create the SDK's configuration file from the project's root directory. Use Laravel's the `vendor:publish` command to import the configuration file into the application:
 
 ```sh
-php artisan vendor:publish --tag=auth0-config
+php artisan vendor:publish --tag auth0-config
 ```
 
 Now, configure your Auth0 integration by adding options to the `.env` file in the project's root directory. Open the `.env` file to add essential details for your project.

--- a/articles/quickstart/webapp/laravel/01-login.md
+++ b/articles/quickstart/webapp/laravel/01-login.md
@@ -45,7 +45,7 @@ composer require auth0/login
 Next, let's create the SDK's configuration file. Again from a shell opened to our projects root directory, let's use Laravel's the `vendor:publish` command to import the configuration file into our application:
 
 ```sh
-php artisan vendor:publish --tag=auth0-config
+php artisan vendor:publish --tag auth0-config
 ```
 
 Now we can begin configuring our Auth0 integration by adding options to the `.env` file in our project's root directory. Let's open that `.env` file and add some essential details for our project:

--- a/articles/quickstart/webapp/laravel/interactive.md
+++ b/articles/quickstart/webapp/laravel/interactive.md
@@ -57,7 +57,7 @@ composer require auth0/login
 Create the SDK's configuration file from the project's root directory. Use Laravel's the `vendor:publish` command to import the configuration file into the application:
 
 ```sh
-php artisan vendor:publish --tag=auth0-config
+php artisan vendor:publish --tag auth0-config
 ```
 
 Now, configure your Auth0 integration by adding options to the `.env` file in the project's root directory. Open the `.env` file and add some essential details for your project.


### PR DESCRIPTION
This PR fixes a typo in the installation guidance for the Laravel quickstarts' `vendor:publish` command, which generates a templated Auth0 configuration file for end users.