### PR TITLE
Add Auth0-Vue v2 beta Quickstart

### DIFF
--- a/articles/quickstart/spa/vuejs-beta/01-login.md
+++ b/articles/quickstart/spa/vuejs-beta/01-login.md
@@ -1,0 +1,26 @@
+---
+title: Login
+description: This quickstart demonstrates how to add user login to a Vue.JS application using Auth0.
+budicon: 448
+topics:
+  - quickstarts
+  - spa
+  - vuejs
+  - login
+github:
+  path: 01-Login
+sample_download_required_data:
+  - client
+contentType: tutorial
+useCase: quickstart
+---
+
+<!-- markdownlint-disable MD034 MD041 -->
+
+::: warning
+This quickstart is designed for using [Auth0 Vue](https://github.com/auth0/auth0-vue) with Vue 3 applications. If you are using Vue 2, please check out the [Vue 2 Tutorial with Auth0 SPA SDK](https://github.com/auth0/auth0-vue/blob/main/tutorial/vue2-login.md) instead.
+:::
+
+<%= include('../_includes/_getting_started', { library: 'Vue.js', callback: 'http://localhost:3000', returnTo: 'http://localhost:3000', webOriginUrl: 'http://localhost:3000', showLogoutInfo: true, showWebOriginInfo: true, new_js_sdk: true, show_install_info: false }) %>
+
+<%= include('_includes/_centralized_login') %>

--- a/articles/quickstart/spa/vuejs-beta/02-calling-an-api.md
+++ b/articles/quickstart/spa/vuejs-beta/02-calling-an-api.md
@@ -1,0 +1,109 @@
+---
+title: Calling an API
+description: This quickstart demonstrates how to make calls to an external API from a Vue.JS application using Auth0.
+budicon: 448
+topics:
+  - quickstarts
+  - spa
+  - vuejs
+  - apis
+github:
+  path: 02-Calling-an-API
+sample_download_required_data:
+  - client
+  - api
+contentType: tutorial
+useCase: quickstart
+---
+
+<!-- markdownlint-disable MD002 MD041 -->
+
+<%= include('../_includes/_calling_api_create_api') %>
+
+## Configuring the plugin
+To call an API, configure the plugin by setting the `audience` to the **API Identifier** of the API you want to call:
+
+```ts
+import { createAuth0 } from '@auth0/auth0-vue';
+
+const app = createApp(App);
+
+app.use(
+  createAuth0({
+    domain: "${account.namespace}",
+    clientId: "${account.clientId}",
+    authorizationParams: {
+      redirect_uri: window.location.origin,
+      audience: "${apiIdentifier}",
+    }
+  })
+);
+
+app.mount('#app');
+```
+
+## Retrieving an Access Token
+With the plugin configured using an `audience`, Auth0 will return an Access Token that can be sent to your API.
+You can retrieve an Access Token by using the `getAccessTokenSilently` function thats exposed by our SDK.
+
+```html
+<script>
+  import { useAuth0 } from '@auth0/auth0-vue';
+
+  export default {
+    setup() {
+      const { getAccessTokenSilently } = useAuth0();
+
+      return {
+        doSomethingWithToken: async () => {
+          const token = await getAccessTokenSilently();
+        }
+      };
+    }
+  };
+</script>
+```
+
+### Using the Options API
+
+If you are using the Options API, you can use the same `getAccessTokenSilently` method from the global `$auth0` property through the `this` accessor.
+
+```html
+<script>
+  export default {
+    methods: {
+      async doSomethingWithToken() {
+        const token = await this.$auth0.getAccessTokenSilently();
+      }
+    }
+  };
+</script>
+```
+
+## Calling an API
+To call an API, include the token in the `Authorization` header of your request.
+There are many ways to make HTTP calls with Vue. Here is an example using the `fetch` API with Vue's Composition API:
+
+```html
+<script>
+  import { useAuth0 } from '@auth0/auth0-vue';
+
+  export default {
+    setup() {
+      const { getAccessTokenSilently } = useAuth0();
+
+      return {
+        doSomethingWithToken: async () => {
+          const token = await getAccessTokenSilently();
+          const response = await fetch('https://api.example.com/posts', {
+            headers: {
+              Authorization: 'Bearer ' + token
+            }
+          });
+          const data = await response.json();
+        }
+      };
+    }
+  };
+</script>
+```

--- a/articles/quickstart/spa/vuejs-beta/_includes/_centralized_login.md
+++ b/articles/quickstart/spa/vuejs-beta/_includes/_centralized_login.md
@@ -100,7 +100,7 @@ Use the `logout` function that is exposed on the return value of `useAuth0`, whi
 
       return {
         logout: () => {
-          logout({ authorizationParams: { returnTo: window.location.origin } });
+          logout({ logoutParams: { returnTo: window.location.origin } });
         }
       };
     }
@@ -128,7 +128,7 @@ If you're using the Options API, you can use the same `logout` method from the g
   export default {
     methods: {
       logout() {
-        this.$auth0.logout({ authorizationParams: { returnTo: window.location.origin } });
+        this.$auth0.logout({ logoutParams: { returnTo: window.location.origin } });
       }
     }
   };

--- a/articles/quickstart/spa/vuejs-beta/_includes/_centralized_login.md
+++ b/articles/quickstart/spa/vuejs-beta/_includes/_centralized_login.md
@@ -1,0 +1,203 @@
+<!-- markdownlint-disable MD041 MD002 -->
+
+## Install the SDK
+
+Install the [Auth0 Vue SDK](https://github.com/auth0/auth0-vue) using npm:
+
+```bash
+npm install @auth0/auth0-vue@beta
+```
+
+### Register the plugin
+
+To use the SDK in your Vue application, register the plugin with your Vue application by passing the return value of `createAuth0` to `app.use()`.
+
+```js
+import { createAuth0 } from '@auth0/auth0-vue';
+
+const app = createApp(App);
+
+app.use(
+  createAuth0({
+    domain: "${account.namespace}",
+    clientId: "${account.clientId}",
+    authorizationParams: {
+      redirect_uri: window.location.origin
+    }
+  })
+);
+
+app.mount('#app');
+```
+
+The plugin will register the SDK using both `provide` and `app.config.globalProperties`, allowing the SDK to be used with both the [Composition API](https://v3.vuejs.org/guide/composition-api-introduction.html) and [Options API](https://vuejs.org/guide/introduction.html#options-api).
+
+## Add Login to Your Application
+
+To add login to your application, use the `loginWithRedirect` function that is exposed on the return value of `useAuth0`, which you can access in your component's `setup` function.
+
+```html
+<template>
+  <div>
+    <button @click="login">Log in</button>
+  </div>
+</template>
+<script>
+  import { useAuth0 } from '@auth0/auth0-vue';
+
+  export default {
+    setup() {
+      const { loginWithRedirect } = useAuth0();
+
+      return {
+        login: () => {
+          loginWithRedirect();
+        }
+      };
+    }
+  };
+</script>
+```
+
+The `loginWithRedirect` function will redirect the user to Auth0, and redirect them back to the `redirect_uri` (provided when calling `createAuth0()`) after entering their credentials.
+
+#### Using the Options API
+If you are using the Options API, you can use the same `loginWithRedirect` method from the global `$auth0` property through the `this` accessor.
+
+```html
+<template>
+  <div>
+    <button @click="login">Log in</button>
+  </div>
+</template>
+
+<script>
+  export default {
+    methods: {
+      login() {
+        this.$auth0.loginWithRedirect();
+      }
+    }
+  };
+</script>
+```
+
+## Add Logout to Your Application
+Use the `logout` function that is exposed on the return value of `useAuth0`, which you can access in your component's `setup` function, to log the user out of your application.
+
+```html
+<template>
+  <div>
+    <button @click="logout">Log out</button>
+  </div>
+</template>
+<script>
+  import { useAuth0 } from '@auth0/auth0-vue';
+
+  export default {
+    setup() {
+      const { logout } = useAuth0();
+
+      return {
+        logout: () => {
+          logout({ authorizationParams: { returnTo: window.location.origin } });
+        }
+      };
+    }
+  };
+</script>
+```
+
+The `logout()` function will redirect the user to Auth0 to ensure their session is ended with Auth0 as well. Once the user is logged out successfully, they will be redirected back to the specified `returnTo` parameter.
+
+:::note
+To log the user out of your application but not from Auth0, use `logout({ localOnly: true })`.
+:::
+
+#### Using the Options API
+If you're using the Options API, you can use the same `logout` method from the global `$auth0` property through the `this` accessor.
+
+```html
+<template>
+  <div>
+    <button @click="logout">Log out</button>
+  </div>
+</template>
+
+<script>
+  export default {
+    methods: {
+      logout() {
+        this.$auth0.logout({ authorizationParams: { returnTo: window.location.origin } });
+      }
+    }
+  };
+</script>
+```
+
+## Show User Profile Information
+
+Once the user authenticates, the SDK extracts the user's profile information and stores it in memory. It can be accessed by using the reactive `user` property exposed by the return value of `useAuth0`, which you can access in your component's `setup` function.
+
+```html
+<template>
+  <div>
+    <h2>User Profile</h2>
+    <button @click="login">Log in</button>
+    <pre v-if="isAuthenticated">
+        <code>{{ user }}</code>
+      </pre>
+  </div>
+</template>
+<script>
+  import { useAuth0 } from '@auth0/auth0-vue';
+
+  export default {
+    setup() {
+      const { loginWithRedirect, user, isAuthenticated } = useAuth0();
+
+      return {
+        login: () => {
+          loginWithRedirect();
+        },
+        user,
+        isAuthenticated
+      };
+    }
+  };
+</script>
+```
+
+:::note
+Ensure the user is authenticated by implementing login in your application before accessing the user's profile.
+:::
+
+#### Using the Options API
+If you're using the Options API, you can use the same reactive `user` property from the global `$auth0` property through the `this` accessor.
+
+```html
+<template>
+  <div>
+    <h2>User Profile</h2>
+    <button @click="login">Log in</button>
+    <pre>
+      <code>{{ user }}</code>
+    </pre>
+  </div>
+</template>
+
+<script>
+  export default {
+    data: function () {
+      return {
+        user: this.$auth0.user
+      };
+    },
+    methods: {
+      login() {
+        this.$auth0.loginWithRedirect();
+      }
+    }
+  };
+</script>
+```

--- a/articles/quickstart/spa/vuejs-beta/download.md
+++ b/articles/quickstart/spa/vuejs-beta/download.md
@@ -1,0 +1,29 @@
+<!-- markdownlint-disable MD031 MD041 -->
+
+To run the sample follow these steps:
+
+1) Set the **Callback URL** in the [Application Settings](${manage_url}/#/applications/${account.clientId}/settings) to
+```text
+http://localhost:3000
+```
+2) Set **Allowed Web Origins** in the [Application Settings](${manage_url}/#/applications/${account.clientId}/settings) to
+```text
+http://localhost:3000
+```
+3) Set **Allowed Logout URLs** in the [Application Settings](${manage_url}/#/applications/${account.clientId}/settings) to 
+
+```text
+http://localhost:3000
+```
+4) Make sure [Node.JS LTS](https://nodejs.org/en/download/) is installed and execute the following commands in the sample's directory:
+```bash
+npm install && npm run serve
+```
+You can also run it from a [Docker](https://www.docker.com) image with the following commands:
+
+```bash
+# In Linux / macOS         
+sh exec.sh                 
+# In Windows' Powershell
+./exec.ps1
+```

--- a/articles/quickstart/spa/vuejs-beta/files/index.md
+++ b/articles/quickstart/spa/vuejs-beta/files/index.md
@@ -1,0 +1,22 @@
+---
+name: index.js
+language: javascript
+---
+
+```javascript
+import { createAuth0 } from '@auth0/auth0-vue';
+
+const app = createApp(App);
+
+app.use(
+  createAuth0({
+    domain: "${account.namespace}",
+    clientId: "${account.clientId}",
+    authorizationParams: {
+      redirect_uri: window.location.origin
+    }
+  })
+);
+
+app.mount('#app');
+```

--- a/articles/quickstart/spa/vuejs-beta/files/login.md
+++ b/articles/quickstart/spa/vuejs-beta/files/login.md
@@ -1,0 +1,37 @@
+---
+name: login.js
+language: html
+---
+
+```html
+<template>
+  <div>
+    <button @click="login">Log in</button>
+  </div>
+</template>
+<script>
+  // Composition API
+  import { useAuth0 } from '@auth0/auth0-vue';
+
+  export default {
+    setup() {
+      const auth0 = useAuth0();
+
+      return {
+        login() {
+          auth0.loginWithRedirect();
+        }
+      };
+    }
+  };
+
+  // Options API
+  export default {
+    methods: {
+      login() {
+        this.$auth0.loginWithRedirect();
+      }
+    }
+  };
+</script>
+```

--- a/articles/quickstart/spa/vuejs-beta/files/logout.md
+++ b/articles/quickstart/spa/vuejs-beta/files/logout.md
@@ -1,0 +1,45 @@
+---
+name: logout.js
+language: html
+---
+
+```html
+<template>
+  <div>
+    <button @click="logout">Log out</button>
+  </div>
+</template>
+<script>
+  // Composition API
+  import { useAuth0 } from '@auth0/auth0-vue';
+
+  export default {
+    setup() {
+      const auth0 = useAuth0();
+
+      return {
+        logout() {
+          auth0.logout({ 
+            authorizationParams: { 
+              returnTo: window.location.origin 
+            } 
+          });
+        }
+      };
+    }
+  };
+
+  // Options API
+  export default {
+    methods: {
+      logout() {
+        this.$auth0.logout({ 
+          authorizationParams: { 
+            returnTo: window.location.origin 
+          } 
+        });
+      }
+    }
+  };
+</script>
+```

--- a/articles/quickstart/spa/vuejs-beta/files/logout.md
+++ b/articles/quickstart/spa/vuejs-beta/files/logout.md
@@ -20,7 +20,7 @@ language: html
       return {
         logout() {
           auth0.logout({ 
-            authorizationParams: { 
+            logoutParams: { 
               returnTo: window.location.origin 
             } 
           });
@@ -34,7 +34,7 @@ language: html
     methods: {
       logout() {
         this.$auth0.logout({ 
-          authorizationParams: { 
+          logoutParams: { 
             returnTo: window.location.origin 
           } 
         });

--- a/articles/quickstart/spa/vuejs-beta/files/profile.md
+++ b/articles/quickstart/spa/vuejs-beta/files/profile.md
@@ -1,0 +1,50 @@
+---
+name: profile.js
+language: html
+---
+
+```html
+<template>
+  <div v-if="isLoading">Loading ...</div>
+  <div v-else>
+    <h2>User Profile</h2>
+    <button @click="login">Log in</button>
+    <pre v-if="isAuthenticated">
+        <code>{{ user }}</code>
+      </pre>
+  </div>
+</template>
+<script>
+  // Composition API
+  import { useAuth0 } from '@auth0/auth0-vue';
+
+  export default {
+    setup() {
+      const auth0 = useAuth0();
+
+      return {
+        login: () => auth0.loginWithRedirect(),
+        user: auth0.user,
+        isAuthenticated: auth0.isAuthenticated,
+        isLoading: auth0.isLoading,
+      };
+    }
+  };
+
+  // Options API
+  export default {
+    data() {
+      return {
+        user: this.$auth0.user,
+        isAuthenticated: this.$auth0.isAuthenticated,
+        isLoading: this.$auth0.isLoading,
+      };
+    },
+    methods: {
+      login() {
+        this.$auth0.loginWithRedirect();
+      }
+    }
+  };
+</script>
+```

--- a/articles/quickstart/spa/vuejs-beta/index.yml
+++ b/articles/quickstart/spa/vuejs-beta/index.yml
@@ -1,0 +1,61 @@
+title: Vue
+# TODO remove 'image' once new QS page is live. Then only use 'logo'.
+image: /media/platforms/vue.png
+logo: vuejs
+language:
+  - Javascript
+author:
+  name: Frederik Prijck
+  email: frederik.prijck@auth0.com
+  community: false
+framework:
+  - Vue.js
+topics:
+  - quickstart
+contentType: tutorial
+useCase: quickstart
+show_releases: true
+beta: true
+sdk:
+  name: auth0-vue
+  url: https://www.github.com/auth0/auth0-vue
+  logo: vuejs
+snippets:
+  dependencies: application-platforms/vuejs/dependencies
+  setup: application-platforms/vuejs/setup
+  use: application-platforms/vuejs/use
+alias:
+  - vue
+  - vuejs
+  - vue.js
+seo_alias: vuejs
+default_article: 01-login
+articles:
+  - 01-login
+  - 02-calling-an-api
+hidden_articles:
+  - interactive
+show_steps: true
+github:
+  org: auth0-samples
+  repo: auth0-vue-samples
+  branch: beta
+requirements:
+  - Vue 3+
+next_steps:
+  - path: 01-login
+    list:
+    - text: "Part 2: Calling an API using an access token"
+      icon: 345
+      href: "/quickstart/spa/vuejs/02-calling-an-api"
+  - path: 02-calling-an-api
+    list:
+    - text: Accessing ID Token Claims
+      icon: 345
+      href: "https://github.com/auth0/auth0-vue/blob/main/EXAMPLES.md#accessing-id-token-claims"
+    - text: Protect a Route
+      icon: 345
+      href: "https://github.com/auth0/auth0-vue/blob/main/EXAMPLES.md#protecting-a-route"
+    - text: Handling errors
+      icon: 345
+      href: "https://github.com/auth0/auth0-vue/blob/main/EXAMPLES.md#error-handling"

--- a/articles/quickstart/spa/vuejs-beta/interactive.md
+++ b/articles/quickstart/spa/vuejs-beta/interactive.md
@@ -1,0 +1,179 @@
+---
+title: Add Login to your Vue App
+description: "Auth0 allows you to add authentication to almost any application type quickly. This guide demonstrates how to integrate Auth0, add authentication, and display user profile information in any Vue application using the Auth0 Vue SDK."
+topics:
+  - quickstarts
+  - spa
+  - vuejs
+  - login
+github:
+  path: 01-Login
+sample_download_required_data:
+  - client
+contentType: tutorial
+useCase: quickstart
+interactive: true
+files:
+  - files/index
+  - files/login
+  - files/logout
+  - files/profile
+---
+
+# Add login to your Vue app
+
+Auth0 allows you to add authentication to almost any application type. This guide demonstrates how to integrate Auth0, add authentication, and display user profile information in any Vue application using the Auth0 Vue SDK.
+
+::: warning
+This quickstart is designed for using [Auth0 Vue](https://github.com/auth0/auth0-vue) with Vue 3 applications. If you are using Vue 2, please check out the [Vue 2 Tutorial with Auth0 SPA SDK](https://github.com/auth0/auth0-vue/blob/main/tutorial/vue2-login.md) instead.
+:::
+
+To use this quickstart, you will need:
+- A free Auth0 account or log in to Auth0.
+- A working Vue project that you want to integrate with OR you can download a sample application after logging in.
+<%= include('../../_includes/_configure_auth0_interactive', { 
+  callback: 'http://localhost:3000',
+  returnTo: 'http://localhost:3000',
+  webOriginUrl: 'http://localhost:3000',
+  showWebOriginInfo: true
+}) %>
+
+## Install the Auth0 Vue SDK {{{ data-action=code data-code="index.js" }}}
+
+Auth0 provides a [Vue SDK](https://github.com/auth0/auth0-vue) to simplify the process of implementing Auth0 authentication and authorization in Vue 3 apps.
+
+Install the Auth0 Vue SDK by running the following commands in your terminal:
+
+```bash
+cd <your-project-directory>
+npm install @auth0/auth0-vue@beta
+```
+
+### Register the plugin
+
+For the SDK to function, you must register the plugin with your Vue application using the following properties:
+
+- `domain`: The domain of your Auth0 tenant. This value is in the Auth0 Dashboard under your Application's Settings in the Domain field. If you are using a [custom domain](https://auth0.com/docs/custom-domains), set this to the value of your custom domain instead.
+- `clientId`: The ID of the Auth0 Application you set up earlier in this quickstart. Find this in the Auth0 Dashboard under your Application's Settings in the Client ID field.
+- `authorizationParams.redirect_uri`: The URL in your application that you would like Auth0 to redirect users to after they have authenticated. This corresponds to the callback URL you set up earlier in this quickstart. This value is in the Auth0 Dashboard under your Application's Settings in the Callback URLs field. Make sure what you enter in your code matches what you set up earlier or your users will see an error.
+
+The plugin will register the SDK using both `provide` and `app.config.globalProperties`. This enables both the [Composition API](https://vuejs.org/guide/introduction.html#composition-api) and [Options API](https://vuejs.org/guide/introduction.html#options-api).
+
+::::checkpoint
+
+:::checkpoint-default
+
+The plugin is now configured. Run your application to verify that:
+- the SDK is initializing correctly
+- your application is not throwing any errors related to Auth0
+
+:::
+
+:::checkpoint-failure
+If your application did not start successfully:
+* Verify you selected the correct application
+* Save your changes after entering your URLs
+* Verify the domain and Client ID imported correctly
+
+Still having issues? Check out our [documentation](https://auth0.com/docs) or visit our [community page](https://community.auth0.com) to get more help.
+
+:::
+::::
+
+## Add login to your application {{{ data-action=code data-code="login.js" }}}
+
+Next, you will set up login for your project. You will use the SDK’s `loginWithRedirect` function exposed on the return value of `useAuth0`, which you can access in your component's setup function. It will redirect users to the Auth0 Universal Login page. and, after a user authenticates, redirect then back to the callback URL you set up earlier in this quickstart.
+
+### Using the Options API
+If you are using the Options API, you can use the same `loginWithRedirect` method from the global `$auth0` property through the `this` accessor.
+
+
+::::checkpoint
+
+:::checkpoint-default
+
+You should now be able to log in using Auth0 Universal Login.
+
+Click the login button and verify that:
+* your Vue application redirects you to the Auth0 Universal Login page
+* you can log in or sign up
+* Auth0 redirects you to your application using the value of the `redirect_uri` you used to configure the plugin.
+
+:::
+
+:::checkpoint-failure
+If you were not able to log in using Auth0 Universal Login:
+* Verify you configured the correct `redirect_uri`
+* Verify the domain and Client ID are set correctly
+
+Still having issues? Check out our [documentation](https://auth0.com/docs) or visit our [community page](https://community.auth0.com) to get more help.
+
+:::
+::::
+
+## Add logout to your application {{{ data-action=code data-code="logout.js" }}}
+
+Users who log in to your project will also need a way to log out. When users log out, your application will redirect them to your [Auth0 logout](https://auth0.com/docs/api/authentication?javascript#logout) endpoint, which will then redirect them to the specified `authorizationParams.returnTo` parameter.
+
+Use the `logout` function exposed on the return value of `useAuth0`, which you can access in your component's `setup` function, to log the user out of your application.
+
+:::note
+To log the user out of your application but not from Auth0, use `logout({ openUrl: false })`.
+:::
+
+### Using the Options API
+With the Options API, you can use the same `logout` method from the global `$auth0` property through the `this` accessor.
+
+::::checkpoint
+
+:::checkpoint-default
+
+Run your application and click the logout button, verify that:
+* your Vue application redirects you to the `authorizationParams.returnTo` address
+* you are no longer logged in to your application
+
+:::
+
+:::checkpoint-failure
+If you are not able to logout:
+* Verify you specified a value for `authorizationParams.returnTo` when calling `logout`
+* Verify the Allowed Logout URLs in your Application Settings contains the `returnTo` value.
+
+Still having issues? Check out our [documentation](https://auth0.com/docs) or visit our [community page](https://community.auth0.com) to get more help.
+
+:::
+
+::::
+
+## Show user profile information {{{ data-action=code data-code="profile.js" }}}
+
+Next, you will configure how to retrieve the [profile information](https://auth0.com/docs/users/concepts/overview-user-profile) associated with authenticated users. For example, you may want to be able to display a logged-in user’s name or profile picture in your project.
+Once the user authenticates, the SDK extracts the user's profile information and stores it in memory. The application can access the user profile with the reactive `user` property. To access this property, review your component's `setup` function and find the `userAuth0` return value.
+
+The `user` property contains sensitive information related to the user's identity. It is only available based on the user's authentication status. To prevent render errors, you should always:
+- use the `isAuthenticated` property to determine whether Auth0 has authenticated the user before Vue renders any component that consumes the `user` property.
+
+- ensure that the SDK has finished loading by checking that `isLoading` is false before accessing the `isAuthenticated` property.
+
+### Using the Options API
+For the Options API, use the same reactive `user`, `isLoading`, and `isAuthenticated` properties from the global `$auth0` property through the `this` accessor.
+
+::::checkpoint
+
+:::checkpoint-default
+
+Verify that:
+* you can display the `user` or any of the user properties within a component correctly after you have logged in
+
+:::
+
+:::checkpoint-failure
+If you are having issues with the `user` properties:
+* Verify you added the `isLoading` check before accessing the `isAuthenticated` property
+* Verify you added the `isAuthenticated` check before accessing the `user` property
+
+Still having issues? Check out our [documentation](https://auth0.com/docs) or visit our [community page](https://community.auth0.com) to get more help.
+
+:::
+
+::::

--- a/articles/quickstart/spa/vuejs-beta/interactive.md
+++ b/articles/quickstart/spa/vuejs-beta/interactive.md
@@ -97,7 +97,7 @@ You should now be able to log in using Auth0 Universal Login.
 Click the login button and verify that:
 * your Vue application redirects you to the Auth0 Universal Login page
 * you can log in or sign up
-* Auth0 redirects you to your application using the value of the `redirect_uri` you used to configure the plugin.
+* Auth0 redirects you to your application using the value of the `authorizationParams.redirect_uri` you used to configure the plugin.
 
 :::
 
@@ -136,7 +136,7 @@ Run your application and click the logout button, verify that:
 
 :::checkpoint-failure
 If you are not able to logout:
-* Verify you specified a value for `authorizationParams.returnTo` when calling `logout`
+* Verify you specified a value for `logoutParams.returnTo` when calling `logout`
 * Verify the Allowed Logout URLs in your Application Settings contains the `returnTo` value.
 
 Still having issues? Check out our [documentation](https://auth0.com/docs) or visit our [community page](https://community.auth0.com) to get more help.

--- a/articles/quickstart/spa/vuejs-beta/interactive.md
+++ b/articles/quickstart/spa/vuejs-beta/interactive.md
@@ -129,7 +129,7 @@ With the Options API, you can use the same `logout` method from the global `$aut
 :::checkpoint-default
 
 Run your application and click the logout button, verify that:
-* your Vue application redirects you to the `authorizationParams.returnTo` address
+* your Vue application redirects you to the `logoutParams.returnTo` address
 * you are no longer logged in to your application
 
 :::


### PR DESCRIPTION
Adding the beta quickstart that goes with the soon-to-be-released v2 version of Auth0-Vue.

The only change code-wise is the placement of the returnTo parameter when calling logout, as well as mention of `openUrl` for local logout.