### PR TITLE
[SDK-3821] React beta quickstart

### DIFF
--- a/articles/quickstart/_includes/_auth0-react-install.md
+++ b/articles/quickstart/_includes/_auth0-react-install.md
@@ -12,5 +12,6 @@ npm install @auth0/auth0-react
 ```bash
 npm install @auth0/auth0-react@beta
 ```
+<% } %>
 
 The SDK exposes methods and variables that help you integrate Auth0 with your React application idiomatically using [React Hooks](https://reactjs.org/docs/hooks-overview.html) or [Higher-Order Components](https://reactjs.org/docs/higher-order-components.html).

--- a/articles/quickstart/_includes/_auth0-react-install.md
+++ b/articles/quickstart/_includes/_auth0-react-install.md
@@ -4,8 +4,13 @@
 
 Run the following command within your project directory to install the Auth0 React SDK:
 
+<% if (typeof v2 === 'undefined' || v2 === false) { %>
 ```bash
 npm install @auth0/auth0-react
+```
+<% } else { %>
+```bash
+npm install @auth0/auth0-react@beta
 ```
 
 The SDK exposes methods and variables that help you integrate Auth0 with your React application idiomatically using [React Hooks](https://reactjs.org/docs/hooks-overview.html) or [Higher-Order Components](https://reactjs.org/docs/higher-order-components.html).

--- a/articles/quickstart/spa/react-beta/01-login.md
+++ b/articles/quickstart/spa/react-beta/01-login.md
@@ -78,7 +78,7 @@ export default LoginButton;
 :::panel Checkpoint
 Add the `LoginButton` component to your application. When you click it, verify that your React application redirects you to the [Auth0 Universal Login](https://auth0.com/universal-login) page and that you can now log in or sign up using a username and password or a social provider.
 
-Once that's complete, verify that Auth0 redirects you to your application using the value of the `authorizationParams.redirectUri` that you used to configure the `Auth0Provider`.
+Once that's complete, verify that Auth0 redirects you to your application using the value of the `authorizationParams.redirect_uri` that you used to configure the `Auth0Provider`.
 :::
 
 ![Auth0 Universal Login](/media/quickstarts/universal-login.png)

--- a/articles/quickstart/spa/react-beta/01-login.md
+++ b/articles/quickstart/spa/react-beta/01-login.md
@@ -16,7 +16,7 @@ useCase: quickstart
 
 <%= include('../_includes/_getting_started', { library: 'React', callback: 'http://localhost:3000', returnTo: 'http://localhost:3000', webOriginUrl: 'http://localhost:3000', showLogoutInfo: true, showWebOriginInfo: true, new_js_sdk: true, show_install_info: false }) %>
 
-<%= include('../../_includes/_auth0-react-install.md') %>
+<%= include('../../_includes/_auth0-react-install.md', { v2: true }) %>
 
 ### Configure the `Auth0Provider` component
 

--- a/articles/quickstart/spa/react-beta/01-login.md
+++ b/articles/quickstart/spa/react-beta/01-login.md
@@ -1,0 +1,150 @@
+---
+title: Login
+description: "Auth0 allows you to add authentication to your React application quickly and to gain access to user profile information. This guide demonstrates how to integrate Auth0 with any new or existing React application using the Auth0 React SDK."
+budicon: 448
+topics:
+  - quickstarts
+  - spa
+  - react
+  - login
+github:
+  path: Sample-01
+contentType: tutorial
+useCase: quickstart
+---
+<!-- markdownlint-disable MD002 MD034 MD041 -->
+
+<%= include('../_includes/_getting_started', { library: 'React', callback: 'http://localhost:3000', returnTo: 'http://localhost:3000', webOriginUrl: 'http://localhost:3000', showLogoutInfo: true, showWebOriginInfo: true, new_js_sdk: true, show_install_info: false }) %>
+
+<%= include('../../_includes/_auth0-react-install.md') %>
+
+### Configure the `Auth0Provider` component
+
+Under the hood, the Auth0 React SDK uses [React Context](https://reactjs.org/docs/context.html) to manage the authentication state of your users. One way to integrate Auth0 with your React app is to wrap your root component with an `Auth0Provider` that you can import from the SDK.
+
+```javascript
+import React from "react";
+import ReactDOM from "react-dom";
+import App from "./App";
+import { Auth0Provider } from "@auth0/auth0-react";
+
+ReactDOM.render(
+  <Auth0Provider
+    domain="${account.namespace}"
+    clientId="${account.clientId}"
+    authorizationParams={{
+      redirect_uri: window.location.origin
+    }}
+  >
+    <App />
+  </Auth0Provider>,
+  document.getElementById("root")
+);
+```
+
+The `Auth0Provider` component takes the following props:
+
+- `domain` and `clientId`: The values of these properties correspond to the "Domain" and "Client ID" values present under the "Settings" of the single-page application that you registered with Auth0.
+
+<%= include('../_includes/_auth_note_custom_domains') %>
+
+- `authorizationParams.redirectUri`: The URL to where you'd like to redirect your users after they authenticate with Auth0.
+
+`Auth0Provider` stores the authentication state of your users and the state of the SDK &mdash; whether Auth0 is ready to use or not. It also exposes helper methods to log in and log out your users, which you can access using the `useAuth0()` hook.
+
+:::panel Checkpoint
+Now that you have configured `Auth0Provider`, run your application to verify that the SDK is initializing correctly, and your application is not throwing any errors related to Auth0.
+:::
+
+## Add Login to Your Application
+
+The Auth0 React SDK gives you tools to quickly implement user authentication in your React application, such as creating a [login](https://auth0.com/docs/login) button using the `loginWithRedirect()` method from the `useAuth0()` hook. Executing `loginWithRedirect()` redirects your users to the Auth0 Universal Login Page, where Auth0 can authenticate them. Upon successful authentication, Auth0 will redirect your users back to your application.
+
+```javascript
+import React from "react";
+import { useAuth0 } from "@auth0/auth0-react";
+
+const LoginButton = () => {
+  const { loginWithRedirect } = useAuth0();
+
+  return <button onClick={() => loginWithRedirect()}>Log In</button>;
+};
+
+export default LoginButton;
+```
+
+<%= include('../../_includes/_auth0-react-classes-info.md') %>
+
+:::panel Checkpoint
+Add the `LoginButton` component to your application. When you click it, verify that your React application redirects you to the [Auth0 Universal Login](https://auth0.com/universal-login) page and that you can now log in or sign up using a username and password or a social provider.
+
+Once that's complete, verify that Auth0 redirects you to your application using the value of the `authorizationParams.redirectUri` that you used to configure the `Auth0Provider`.
+:::
+
+![Auth0 Universal Login](/media/quickstarts/universal-login.png)
+
+<%= include('../_includes/_auth_note_dev_keys') %>
+
+## Add Logout to Your Application
+
+Now that you can log in to your React application, you need [a way to log out](https://auth0.com/docs/logout/guides/logout-auth0). You can create a logout button using the `logout()` method from the `useAuth0()` hook. Executing `logout()` redirects your users to your [Auth0 logout endpoint](https://auth0.com/docs/api/authentication?javascript#logout) (`https://YOUR_DOMAIN/v2/logout`) and then immediately redirects them to your application.
+
+```javascript
+import React from "react";
+import { useAuth0 } from "@auth0/auth0-react";
+
+const LogoutButton = () => {
+  const { logout } = useAuth0();
+
+  return (
+    <button onClick={() => logout({ logoutParams: { returnTo: window.location.origin } })}>
+      Log Out
+    </button>
+  );
+};
+
+export default LogoutButton;
+```
+
+:::panel Checkpoint
+Add the `LogoutButton` component to your application. When you click it, verify that your React application redirects you the address you specified as one of the "Allowed Logout URLs" in the "Settings" and that you are no longer logged in to your application.
+:::
+
+## Show User Profile Information
+
+The Auth0 React SDK helps you retrieve the [profile information](https://auth0.com/docs/users/concepts/overview-user-profile) associated with logged-in users quickly in whatever component you need, such as their name or profile picture, to personalize the user interface. The profile information is available through the `user` property exposed by the `useAuth0()` hook. Take this `Profile` component as an example of how to use it:
+
+```javascript
+import React from "react";
+import { useAuth0 } from "@auth0/auth0-react";
+
+const Profile = () => {
+  const { user, isAuthenticated, isLoading } = useAuth0();
+
+  if (isLoading) {
+    return <div>Loading ...</div>;
+  }
+
+  return (
+    isAuthenticated && (
+      <div>
+        <img src={user.picture} alt={user.name} />
+        <h2>{user.name}</h2>
+        <p>{user.email}</p>
+      </div>
+    )
+  );
+};
+
+export default Profile;
+```
+
+The `user` property contains sensitive information and artifacts related to the user's identity. As such, its availability depends on the user's authentication status. To prevent any render errors, use the `isAuthenticated` property from `useAuth0()` to check if Auth0 has authenticated the user before React renders any component that consumes the `user` property. Ensure that the SDK has completed loading before accessing the `isAuthenticated` property, by checking that `isLoading` is `false`.
+
+:::panel Checkpoint
+Verify that you can display the `user.name` or [any other `user` property](https://auth0.com/docs/users/references/user-profile-structure#user-profile-attributes) within a component correctly after you have logged in.
+:::                                              
+
+:::note
+For a deep dive into implementing user authentication in React, visit the [Complete Guide to React User Authentication with Auth0](https://auth0.com/blog/complete-guide-to-react-user-authentication/). This guide provides you with additional details, such as creating a signup button, protecting routes using different strategies, and using class components. 
+:::

--- a/articles/quickstart/spa/react-beta/02-calling-an-api.md
+++ b/articles/quickstart/spa/react-beta/02-calling-an-api.md
@@ -27,7 +27,7 @@ If you followed the [previous section where you added user log in to React](/qui
 
 The `Auth0Provider` setup is similar to the one discussed in the [Configure the `Auth0Provider` component](/quickstart/spa/auth0-react#configure-the-auth0provider-component) section: you wrap your root component with `Auth0Provider` to which you pass the `domain` and `clientId` props. The values of these two props come from the ["Settings" values](https://auth0.com/docs/quickstart/spa/react#configure-auth0) of the single-page application you've registered with Auth0.
 
-However, your React application needs to pass an access token when it calls a target API to access private resources. You can [request an access token](https://auth0.com/docs/tokens/guides/get-access-tokens) in a format that the API can verify by passing the `audience` and `scope` props to `Auth0Provider` as follows:
+However, your React application needs to pass an access token when it calls a target API to access private resources. You can [request an access token](https://auth0.com/docs/tokens/guides/get-access-tokens) in a format that the API can verify by passing the `audience` and `scope` props to `Auth0Provider`'s `authorizationParams` as follows:
 
 ```javascript
 import React from "react";
@@ -69,7 +69,7 @@ In the case of the Auth0 Management API, the `read:current_user` and `update:cur
 
 ## Get an Access Token 
 
-Once you configure `Auth0Provider`, you can easily get the access token using the [`getAccessTokenSilently()`](https://auth0.github.io/auth0-react/interfaces/auth0_context.auth0contextinterface.html#getaccesstokensilently) method from the [`useAuth0()`](https://auth0.github.io/auth0-react/modules/use_auth0.html) custom React Hook wherever you need it. 
+Once you configure `Auth0Provider`, you can get the access token using the [`getAccessTokenSilently()`](https://auth0.github.io/auth0-react/interfaces/auth0_context.auth0contextinterface.html#getaccesstokensilently) method from the [`useAuth0()`](https://auth0.github.io/auth0-react/modules/use_auth0.html) custom React Hook wherever you need it.
 
 Take this `Profile` component as an example:
 

--- a/articles/quickstart/spa/react-beta/02-calling-an-api.md
+++ b/articles/quickstart/spa/react-beta/02-calling-an-api.md
@@ -55,13 +55,13 @@ ReactDOM.render(
 As Auth0 can only issue tokens for custom scopes that exist on your API, ensure that you define the scopes used above when [setting up an API](https://auth0.com/docs/getting-started/set-up-api) with Auth0.
 :::
 
-Auth0 uses the value of the `audience` prop to determine which resource server (API) the user is authorizing your React application to access. 
+Auth0 uses the value of the `authorizationParams.audience` prop to determine which resource server (API) the user is authorizing your React application to access. 
 
 :::note
 In the case of the Auth0 Management API, the audience is `https://${account.namespace}/api/v2/`. In the case of your APIs, you create an _Identifier_ value that serves as the _Audience_ value whenever you [set up an API](https://auth0.com/docs/getting-started/set-up-api) with Auth0.
 :::
 
-The actions that your React application can perform on the API depend on the [scopes](https://auth0.com/docs/scopes/current) that your access token contains, which you define as the value of `scope`. Your React application will request authorization from the user to access the requested scopes, and the user will approve or deny the request.
+The actions that your React application can perform on the API depend on the [scopes](https://auth0.com/docs/scopes/current) that your access token contains, which you define as the value of `authorizationParams.scope`. Your React application will request authorization from the user to access the requested scopes, and the user will approve or deny the request.
 
 :::note
 In the case of the Auth0 Management API, the `read:current_user` and `update:current_user_metadata` scopes let you get an access token that can retrieve user details and update the user's information. In the case of your APIs, you'll define custom [API scopes](https://auth0.com/docs/scopes/current/api-scopes) to implement access control, and you'll identify them in the calls that your client applications make to that API.

--- a/articles/quickstart/spa/react-beta/02-calling-an-api.md
+++ b/articles/quickstart/spa/react-beta/02-calling-an-api.md
@@ -1,0 +1,165 @@
+---
+title: Call an API
+description: This tutorial demonstrates how to make API calls to the Auth0 Management API.
+budicon: 448
+topics:
+  - quickstarts
+  - spa
+  - react
+  - login
+github:
+  path: Sample-01
+contentType: tutorial
+sample_download_required_data:
+  - client
+  - api
+useCase: quickstart
+---
+<!-- markdownlint-disable MD002 MD034 MD041 -->
+
+<%= include('../_includes/_calling_api_preamble_api2") %>
+
+:::note
+If you followed the [previous section where you added user log in to React](/quickstart/spa/auth0-react#add-login-to-your-application), make sure that you log out of your application as you'll need a new access token to call APIs.
+:::
+
+## Set Up the Auth0 Service
+
+The `Auth0Provider` setup is similar to the one discussed in the [Configure the `Auth0Provider` component](/quickstart/spa/auth0-react#configure-the-auth0provider-component) section: you wrap your root component with `Auth0Provider` to which you pass the `domain` and `clientId` props. The values of these two props come from the ["Settings" values](https://auth0.com/docs/quickstart/spa/react#configure-auth0) of the single-page application you've registered with Auth0.
+
+However, your React application needs to pass an access token when it calls a target API to access private resources. You can [request an access token](https://auth0.com/docs/tokens/guides/get-access-tokens) in a format that the API can verify by passing the `audience` and `scope` props to `Auth0Provider` as follows:
+
+```javascript
+import React from "react";
+import ReactDOM from "react-dom";
+import App from "./App";
+import { Auth0Provider } from "@auth0/auth0-react";
+
+ReactDOM.render(
+  <Auth0Provider
+    domain="${account.namespace}"
+    clientId="${account.clientId}"
+    authorizationParams={{
+      redirectUri: window.location.origin,
+      audience: "https://${account.namespace}/api/v2/",
+      scope: "read:current_user update:current_user_metadata"
+    }}
+  >
+    <App />
+  </Auth0Provider>,
+  document.getElementById("root")
+);
+```
+
+:::note
+As Auth0 can only issue tokens for custom scopes that exist on your API, ensure that you define the scopes used above when [setting up an API](https://auth0.com/docs/getting-started/set-up-api) with Auth0.
+:::
+
+Auth0 uses the value of the `audience` prop to determine which resource server (API) the user is authorizing your React application to access. 
+
+:::note
+In the case of the Auth0 Management API, the audience is `https://${account.namespace}/api/v2/`. In the case of your APIs, you create an _Identifier_ value that serves as the _Audience_ value whenever you [set up an API](https://auth0.com/docs/getting-started/set-up-api) with Auth0.
+:::
+
+The actions that your React application can perform on the API depend on the [scopes](https://auth0.com/docs/scopes/current) that your access token contains, which you define as the value of `scope`. Your React application will request authorization from the user to access the requested scopes, and the user will approve or deny the request.
+
+:::note
+In the case of the Auth0 Management API, the `read:current_user` and `update:current_user_metadata` scopes let you get an access token that can retrieve user details and update the user's information. In the case of your APIs, you'll define custom [API scopes](https://auth0.com/docs/scopes/current/api-scopes) to implement access control, and you'll identify them in the calls that your client applications make to that API.
+:::
+
+## Get an Access Token 
+
+Once you configure `Auth0Provider`, you can easily get the access token using the [`getAccessTokenSilently()`](https://auth0.github.io/auth0-react/interfaces/auth0_context.auth0contextinterface.html#getaccesstokensilently) method from the [`useAuth0()`](https://auth0.github.io/auth0-react/modules/use_auth0.html) custom React Hook wherever you need it. 
+
+Take this `Profile` component as an example:
+
+```javascript
+import React, { useEffect, useState } from "react";
+import { useAuth0 } from "@auth0/auth0-react";
+
+const Profile = () => {
+  const { user, isAuthenticated, getAccessTokenSilently } = useAuth0();
+  const [userMetadata, setUserMetadata] = useState(null);
+
+  return (
+    isAuthenticated && (
+      <div>
+        <img src={user.picture} alt={user.name} />
+        <h2>{user.name}</h2>
+        <p>{user.email}</p>
+        <h3>User Metadata</h3>
+        {userMetadata ? (
+          <pre>{JSON.stringify(userMetadata, null, 2)}</pre>
+        ) : (
+          "No user metadata defined"
+        )}
+      </div>
+    )
+  );
+};
+
+export default Profile;
+```
+
+As it is, `userMetadata` is always `null` in the `Profile` component. Add the following `useEffect()` hook to the component to fetch the user metadata from an API:
+
+```javascript
+useEffect(() => {
+  const getUserMetadata = async () => {
+    const domain = "${account.namespace}";
+
+    try {
+      const accessToken = await getAccessTokenSilently({
+        authorizationParams: {
+          audience: `https://<%= "${domain}" %>/api/v2/`,
+          scope: "read:current_user",
+        },
+      });
+
+      const userDetailsByIdUrl = `https://<%= "${domain}" %>/api/v2/users/<%= "${user.sub}" %>`;
+
+      const metadataResponse = await fetch(userDetailsByIdUrl, {
+        headers: {
+          Authorization: `Bearer <%= "${accessToken}" %>`,
+        },
+      });
+
+      const { user_metadata } = await metadataResponse.json();
+
+      setUserMetadata(user_metadata);
+    } catch (e) {
+      console.log(e.message);
+    }
+  };
+
+  getUserMetadata();
+}, [getAccessTokenSilently, user?.sub]);
+```
+
+You use a React Effect Hook to call an asynchronous `getUserMetadata()` function. The function first calls `getAccessTokenSilently()`, which returns a Promise that resolves to an access token that you can use to make a call to a protected API.
+
+You pass an object with the `authorizationParams.audience` and `authorizationParams.scope` properties as the argument of `getAccessTokenSilently()` to ensure that the access token you get is for the intended API and has the required permissions to access the desired endpoint.
+ 
+:::note
+In the case of the Auth0 Management API, one of the scopes that the [`/api/v2/users/{id}` endpoint](https://auth0.com/docs/api/management/v2#!/Users/get_users_by_id) requires is `read:current_user`.
+:::
+ 
+You can then include the access token in the authorization header of the API call that you make. The API will take care of validating the access token and processing the request.
+
+Upon success, you extract the `user_metadata` property from the API response and use `setUserMetadata()` to make React aware of it.
+
+For a more detailed example, see how to [create a `useApi` hook](https://github.com/auth0/auth0-react/blob/master/EXAMPLES.md#create-a-useapi-hook-for-accessing-protected-apis-with-an-access-token) for accessing protected APIs with an access token.
+
+:::panel Checkpoint
+Your application will show "No user metadata defined" if you have not set any `user_metadata` for the logged-in user. To further test out this integration, head to the [Users section of the Auth0 dashboard](https://manage.auth0.com/#/users) and click on the user who is logged in. Update the `user_metadata` section with a value like `{ "theme": "dark" }` and click "Save". Refresh your React application and verify that it reflects the new `user_metadata`. 
+:::
+
+:::note
+The `getAccessTokenSilently()` method can renew the access and ID token for you using [refresh tokens](https://auth0.com/docs/tokens/concepts/refresh-tokens). To [get a refresh token](https://auth0.com/docs/tokens/guides/get-refresh-tokens) when a user logs in, pass `useRefreshTokens={true}` as a prop to `Auth0Provider`. 
+:::
+
+As a final reminder, consult the [Auth0 API quickstarts](https://auth0.com/docs/quickstart/backend) to learn how to integrate Auth0 with your backend platform.
+
+:::note
+For a deep dive into making secure calls to an API from React, visit the [Complete Guide to React User Authentication with Auth0](https://auth0.com/blog/complete-guide-to-react-user-authentication/#Calling-an-API). This guide provides you with additional details, such setting up a sample Express API server and getting test access tokens from the Auth0 Dashboard. 
+:::

--- a/articles/quickstart/spa/react-beta/download.md
+++ b/articles/quickstart/spa/react-beta/download.md
@@ -1,0 +1,28 @@
+<!-- markdownlint-disable MD031 MD041 -->
+
+To run the sample follow these steps:
+
+1) Set the **Allowed Callback URLs** in the [Application Settings](${manage_url}/#/applications/${account.clientId}/settings) to
+```text
+http://localhost:3000
+```
+2) Set **Allowed Web Origins** in the [Application Settings](${manage_url}/#/applications/${account.clientId}/settings) to
+```text
+http://localhost:3000
+```
+3) Set **Allowed Logout URLs** in the [Application Settings](${manage_url}/#/applications/${account.clientId}/settings) to
+```text
+http://localhost:3000
+```
+4) Make sure [Node.JS LTS](https://nodejs.org/en/download/) is installed and execute the following commands in the sample's directory:
+```bash
+npm install && npm start
+```
+You can also run it from a [Docker](https://www.docker.com) image with the following commands:
+
+```bash
+# In Linux / macOS
+sh exec.sh
+# In Windows' Powershell
+./exec.ps1
+```

--- a/articles/quickstart/spa/react-beta/files/app.md
+++ b/articles/quickstart/spa/react-beta/files/app.md
@@ -1,0 +1,29 @@
+---
+name: app.js
+language: javascript
+---
+
+```javascript
+import { useAuth0 } from "@auth0/auth0-react";
+import React from "react";
+
+const Profile = () => {
+  const { user, isAuthenticated, isLoading } = useAuth0();
+
+  if (isLoading) {
+    return <div>Loading ...</div>;
+  }
+
+  return (
+    isAuthenticated && (
+      <div>
+        <img src={user.picture} alt={user.name} />
+        <h2>{user.name}</h2>
+        <p>{user.email}</p>
+      </div>
+    )
+  );
+};
+
+export default Profile;
+```

--- a/articles/quickstart/spa/react-beta/files/index.md
+++ b/articles/quickstart/spa/react-beta/files/index.md
@@ -1,0 +1,26 @@
+---
+name: index.js
+language: javascript
+---
+
+```javascript
+import { Auth0Provider } from "@auth0/auth0-react";
+import React from "react";
+import ReactDOM from "react-dom";
+
+import App from "./App";
+
+ReactDOM.render(
+  <Auth0Provider
+    domain="${account.namespace}"
+    clientId="${account.clientId}"
+    authorizationParams={{
+      redirect_uri: window.location.origin
+    }}
+    
+  >
+    <App />
+  </Auth0Provider>,
+  document.getElementById("root")
+);
+```

--- a/articles/quickstart/spa/react-beta/files/login.md
+++ b/articles/quickstart/spa/react-beta/files/login.md
@@ -1,0 +1,17 @@
+---
+name: login.js
+language: javascript
+---
+
+```javascript
+import { useAuth0 } from "@auth0/auth0-react";
+import React from "react";
+
+const LoginButton = () => {
+  const { loginWithRedirect } = useAuth0();
+
+  return <button onClick={() => loginWithRedirect()}>Log In</button>;
+};
+
+export default LoginButton;
+```

--- a/articles/quickstart/spa/react-beta/files/logout.md
+++ b/articles/quickstart/spa/react-beta/files/logout.md
@@ -1,0 +1,21 @@
+---
+name: logout.js
+language: javascript
+---
+
+```javascript
+import { useAuth0 } from "@auth0/auth0-react";
+import React from "react";
+
+const LogoutButton = () => {
+  const { logout } = useAuth0();
+
+  return (
+    <button onClick={() => logout({ logoutParams: { returnTo: window.location.origin } })}>
+      Log Out
+    </button>
+  );
+};
+
+export default LogoutButton;
+```

--- a/articles/quickstart/spa/react-beta/files/profile.md
+++ b/articles/quickstart/spa/react-beta/files/profile.md
@@ -1,0 +1,29 @@
+---
+name: profile.js
+language: javascript
+---
+
+```javascript
+import { useAuth0 } from "@auth0/auth0-react";
+import React from "react";
+
+const Profile = () => {
+  const { user, isAuthenticated, isLoading } = useAuth0();
+
+  if (isLoading) {
+    return <div>Loading ...</div>;
+  }
+
+  return (
+    isAuthenticated && (
+      <div>
+        <img src={user.picture} alt={user.name} />
+        <h2>{user.name}</h2>
+        <p>{user.email}</p>
+      </div>
+    )
+  );
+};
+
+export default Profile;
+```

--- a/articles/quickstart/spa/react-beta/index.yml
+++ b/articles/quickstart/spa/react-beta/index.yml
@@ -38,7 +38,7 @@ show_steps: true
 github:
   org: auth0-samples
   repo: auth0-react-samples
-  branch: master
+  branch: beta
 requirements:
   - React 16.8
 next_steps:

--- a/articles/quickstart/spa/react-beta/index.yml
+++ b/articles/quickstart/spa/react-beta/index.yml
@@ -1,0 +1,66 @@
+title: React
+beta: true
+# TODO remove 'image' once new QS page is live. Then only use 'logo'.
+image: /media/platforms/react.png
+logo: react
+alias:
+  - react
+  - reactjs
+language:
+  - Javascript
+author:
+  name: Dan Arias
+  email: dan.arias@auth0.com
+  community: false
+framework:
+  - React
+topics:
+  - quickstart
+contentType: tutorial
+useCase: quickstart
+show_releases: true
+sdk:
+  name: auth0-react
+  url: https://www.github.com/auth0/auth0-react/
+  logo: react
+snippets:
+  dependencies: application-platforms/react/dependencies
+  setup: application-platforms/react/setup
+  use: application-platforms/react/use
+seo_alias: react
+default_article: "01-login"
+articles:
+  - "01-login"
+  - "02-calling-an-api"
+hidden_articles:
+  - "interactive"
+show_steps: true
+github:
+  org: auth0-samples
+  repo: auth0-react-samples
+  branch: master
+requirements:
+  - React 16.8
+next_steps:
+  - path: 01-login
+    list:
+      - text: "Part 2: Calling an API using an access token"
+        icon: 345
+        href: "/quickstart/spa/react/02-calling-an-api"
+  - path: 02-calling-an-api
+    list:
+      - text: Configure other identity providers
+        icon: 345
+        href: "/identityproviders"
+      - text: Enable multifactor authentication
+        icon: 345
+        href: "/multifactor-authentication"
+      - text: Learn about attack protection
+        icon: 345
+        href: "/attack-protection"
+      - text: Learn about rules
+        icon: 345
+        href: "/rules"
+troubleshooting_steps:
+
+    

--- a/articles/quickstart/spa/react-beta/interactive.md
+++ b/articles/quickstart/spa/react-beta/interactive.md
@@ -1,0 +1,155 @@
+---
+title: Add Login to your React App
+description: "Auth0 allows you to add authentication to your React application quickly and to gain access to user profile information. This guide demonstrates how to integrate Auth0 with any new or existing React application using the Auth0 React SDK."
+interactive: true
+files:
+  - files/index
+  - files/login
+  - files/logout
+  - files/profile
+github:
+  path: Sample-01
+---
+
+# Add Login to your React App
+
+Auth0 allows you to add authentication to almost any application type quickly. This guide demonstrates how to integrate Auth0, add authentication, and display user profile information in any React application using the Auth0 React SDK.
+
+To use this quickstart, you’ll need to:
+- Sign up for a free Auth0 account or log in to Auth0.
+- Have a working React project that you want to integrate with. Alternatively, you can view or download a sample application after logging in.
+
+<%= include('../../_includes/_configure_auth0_interactive', { 
+  callback: 'http://localhost:3000',
+  returnTo: 'http://localhost:3000',
+  webOriginUrl: 'http://localhost:3000',
+  showWebOriginInfo: true
+}) %>
+
+## Install the Auth0 React SDK {{{ data-action=code data-code="index.js#13:22" }}}
+
+Auth0 provides a [React SDK](https://github.com/auth0/auth0-react) (auth0-react.js) to simplify the process of implementing Auth0 authentication and authorization in React apps.
+
+Install the Auth0 React SDK by running the following commands in your terminal:
+
+```bash
+cd <your-project-directory>
+npm install @auth0/auth0-react
+```
+
+### Configure the Auth0Provider component
+
+For the SDK to function properly, you must set the following properties in the Auth0Provider component:
+
+- `domain`: The domain of your Auth0 tenant. Generally, you can find this in the Auth0 Dashboard under your Application's Settings in the Domain field. If you are using a [custom domain](https://auth0.com/docs/custom-domains), you should set this to the value of your custom domain instead.
+- `clientId`: The ID of the Auth0 Application you set up earlier in this quickstart. You can find this in the Auth0 Dashboard under your Application's Settings in the Client ID field.
+- `authorizationParams.redirectUri`: The URL in your application that you would like Auth0 to redirect users to after they have authenticated. This corresponds to the callback URL you set up earlier in this quickstart. You can also find this value in the Auth0 Dashboard under your Application's Settings in the Callback URLs field. Make sure what you enter in your code matches what you set up earlier or your users will see an error.
+
+::::checkpoint
+
+:::checkpoint-default
+
+Your Auth0Provider component should now be properly configured. Run your application to verify that:
+- the SDK is initializing correctly
+- your application is not throwing any errors related to Auth0
+
+:::
+
+:::checkpoint-failure
+Sorry about that. Here's a couple things to double check:
+* make sure the correct application is selected
+* did you save after entering your URLs?
+* make sure the domain and client ID imported correctly
+
+Still having issues? Check out our [documentation](https://auth0.com/docs) or visit our [community page](https://community.auth0.com) to get more help.
+
+:::
+::::
+
+## Add Login to Your Application {{{ data-action=code data-code="login.js#4:7" }}}
+
+Now that you have configured your Auth0 Application and the Auth0 React SDK, you need to set up login for your project. To do this, you will use the SDK’s loginWithRedirect() method to create a login button that redirects users to the Auth0 Universal Login page. After a user successfully authenticates, they will be redirected to the callback URL you set up earlier in this quickstart.
+
+<%= include('../../_includes/_auth0-react-classes-info.md') %>
+
+Create a new file in your application called `login.js` for the login button component, and copy in the code from the interactive panel to the right, which contains the logic needed for login. Then, update your `index.js` file to include the new login button.
+
+::::checkpoint
+
+:::checkpoint-default
+
+You should now be able to log in or sign up using a username and password.
+
+Click the login button and verify that:
+* your React Application redirects you to the Auth0 Universal Login page
+* you can log in or sign up
+* Auth0 redirects you to your application using the value of the `authorizationParams.redirectUri` you used to configure the `Auth0Provider`
+
+:::
+
+:::checkpoint-failure
+Sorry about that. Here's a couple things to double check:
+* you configured the correct `authorizationParams.redirectUri`
+* you added the Login button to the `index.js` file
+
+Still having issues? Check out our [documentation](https://auth0.com/docs) or visit our [community page](https://community.auth0.com) to get more help.
+
+:::
+::::
+
+## Add Logout to your Application {{{ data-action=code data-code="logout.js#10:18" }}}
+
+Users who log in to your project will also need a way to log out. Create a logout button using the SDK’s logout() method. When users log out, they will be redirected to your [Auth0 logout](https://auth0.com/docs/api/authentication?javascript#logout) endpoint, which will then immediately redirect them to the logout URL you set up earlier in this quickstart.
+
+Create a new file in your application called `logout.js` for the logout button component, and copy in the code from the interactive panel, which contains the logic needed for logout. Then, update your `index.js` file to include the logout button.
+
+::::checkpoint
+
+:::checkpoint-default
+
+Run your application and click the logout button, verify that:
+* your React application redirects you to the address you specified as one of the Allowed Logout URLs in your Application Settings
+* you are no longer logged in to your application
+
+:::
+
+:::checkpoint-failure
+Sorry about that. Here's a couple things to double check:
+* you configured the correct Logout URL
+* you added the Logout button to the `index.js` file 
+
+Still having issues? Check out our [documentation](https://auth0.com/docs) or visit our [community page](https://community.auth0.com) to get more help.
+
+:::
+
+::::
+
+## Show User Profile Information {{{ data-action=code data-code="profile.js#11:26" }}}
+
+Now that your users can log in and log out, you will likely want to be able to retrieve the [profile information](https://auth0.com/docs/users/concepts/overview-user-profile) associated with authenticated users. For example, you may want to be able to display a logged-in user’s name or profile picture in your project.
+
+The Auth0 React SDK provides user information through the `user` property. Review the `profile.js` code in the interactive panel to see an example of how to use it.
+
+Because the `user` property contains sensitive information related to the user's identity, its availability depends on the user's authentication status. To prevent render errors, you should always:
+- use the `isAuthenticated` property to determine whether Auth0 has authenticated the user before React renders any component that consumes the `user` property.
+- ensure that the SDK has finished loading by checking that `isLoading` is false before accessing the `isAuthenticated` property.
+
+::::checkpoint
+
+:::checkpoint-default
+
+Verify that:
+* you can display the `user.name` or any other user property within a component correctly after you have logged in
+
+:::
+
+:::checkpoint-failure
+Sorry about that. Here's a couple things to double check:
+* you added the `isLoading` check before accessing the `isAuthenticated` property
+* you added the `Profile` component to the `index.js` file 
+
+Still having issues? Check out our [documentation](https://auth0.com/docs) or visit our [community page](https://community.auth0.com) to get more help.
+
+:::
+
+::::

--- a/articles/quickstart/spa/react-beta/interactive.md
+++ b/articles/quickstart/spa/react-beta/interactive.md
@@ -34,7 +34,7 @@ Install the Auth0 React SDK by running the following commands in your terminal:
 
 ```bash
 cd <your-project-directory>
-npm install @auth0/auth0-react
+npm install @auth0/auth0-react@beta
 ```
 
 ### Configure the Auth0Provider component

--- a/articles/quickstart/spa/react-beta/interactive.md
+++ b/articles/quickstart/spa/react-beta/interactive.md
@@ -43,7 +43,7 @@ For the SDK to function properly, you must set the following properties in the A
 
 - `domain`: The domain of your Auth0 tenant. Generally, you can find this in the Auth0 Dashboard under your Application's Settings in the Domain field. If you are using a [custom domain](https://auth0.com/docs/custom-domains), you should set this to the value of your custom domain instead.
 - `clientId`: The ID of the Auth0 Application you set up earlier in this quickstart. You can find this in the Auth0 Dashboard under your Application's Settings in the Client ID field.
-- `authorizationParams.redirectUri`: The URL in your application that you would like Auth0 to redirect users to after they have authenticated. This corresponds to the callback URL you set up earlier in this quickstart. You can also find this value in the Auth0 Dashboard under your Application's Settings in the Callback URLs field. Make sure what you enter in your code matches what you set up earlier or your users will see an error.
+- `authorizationParams.redirect_uri`: The URL in your application that you would like Auth0 to redirect users to after they have authenticated. This corresponds to the callback URL you set up earlier in this quickstart. You can also find this value in the Auth0 Dashboard under your Application's Settings in the Callback URLs field. Make sure what you enter in your code matches what you set up earlier or your users will see an error.
 
 ::::checkpoint
 
@@ -83,13 +83,13 @@ You should now be able to log in or sign up using a username and password.
 Click the login button and verify that:
 * your React Application redirects you to the Auth0 Universal Login page
 * you can log in or sign up
-* Auth0 redirects you to your application using the value of the `authorizationParams.redirectUri` you used to configure the `Auth0Provider`
+* Auth0 redirects you to your application using the value of the `authorizationParams.redirect_uri` you used to configure the `Auth0Provider`
 
 :::
 
 :::checkpoint-failure
 Sorry about that. Here's a couple things to double check:
-* you configured the correct `authorizationParams.redirectUri`
+* you configured the correct `authorizationParams.redirect_uri`
 * you added the Login button to the `index.js` file
 
 Still having issues? Check out our [documentation](https://auth0.com/docs) or visit our [community page](https://community.auth0.com) to get more help.


### PR DESCRIPTION
Adding the beta QS for auth0-react for the upcoming v2 beta, most code changes were just `authorizationParams`/`logutParams` changes

There's no references to `localOnly` in this QS like in the Vue QS, not sure if it's worth adding a similar note?