### PR TITLE
Update 01-login.md

### DIFF
--- a/articles/quickstart/webapp/rails/01-login.md
+++ b/articles/quickstart/webapp/rails/01-login.md
@@ -128,7 +128,7 @@ class Auth0Controller < ApplicationController
   # ..Insert the code below
   def logout
     reset_session
-    redirect_to logout_url
+    redirect_to logout_url # in Rails 7: redirect_to logout_url, allow_other_host: true
   end
 
   private


### PR DESCRIPTION
Rails 7 raises ActionController::Redirecting::UnsafeRedirectError when trying to redirect_to a host that doesn't match your app host

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
