### PR TITLE
Support for Rails 7

### DIFF
--- a/articles/quickstart/webapp/rails/01-login.md
+++ b/articles/quickstart/webapp/rails/01-login.md
@@ -111,7 +111,7 @@ To [prevent forged authentication requests](https://github.com/cookpad/omniauth-
 
 ```erb
   <!-- Place a login button anywhere on your application -->
-  ${"<%= button_to 'Login', '/auth/auth0', method: :post %>"}
+  ${"<%= button_to 'Login', '/auth/auth0', method: :post, data: { turbo: false } %>"}
 ```
 
 ## Add Logout to Your Application
@@ -128,7 +128,7 @@ class Auth0Controller < ApplicationController
   # ..Insert the code below
   def logout
     reset_session
-    redirect_to logout_url
+    redirect_to logout_url, allow_other_host: true
   end
 
   private
@@ -152,7 +152,7 @@ The user will now be able to logout of your application by visiting the `/auth/l
 
 ```erb
   <!-- Place a logout button anywhere on your application -->
-  ${"<%= button_to 'Logout', 'auth/logout', method: :get %>"}
+  ${"<%= button_to 'Logout', 'auth/logout', method: :get, data: { turbo: false } %>"}
 ```
 
 ## Show User Profile Information


### PR DESCRIPTION
I added `turbo: false` and `allow_other_host: true` for Rails 7.

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
