### PR TITLE
[SDK-3910] Flutter quickstart amendments

### DIFF
--- a/articles/quickstart/native/flutter/01-login.md
+++ b/articles/quickstart/native/flutter/01-login.md
@@ -34,7 +34,7 @@ This quickstart assumes you already have a [Flutter](https://flutter.dev/) appli
 
 You should also be familiar with the [Flutter command line tool](https://docs.flutter.dev/reference/flutter-cli).
 
-<%= include('\_configure_urls_interactive') %>
+<%= include('_configure_urls_interactive') %>
 
 ## Install the Auth0 Flutter SDK
 

--- a/articles/quickstart/native/flutter/01-login.md
+++ b/articles/quickstart/native/flutter/01-login.md
@@ -48,7 +48,9 @@ flutter pub add auth0_flutter
 
 If you are not developing for the Android platform, skip this step.
 
-The SDK requires manifest placeholders. Auth0 uses placeholders internally to define an `intent-filter`, which captures the authentication callback URL. You must set the Auth0 tenant domain and the callback URL scheme, as in the following example:
+The SDK requires manifest placeholders. Auth0 uses placeholders internally to define an `intent-filter`, which captures the authentication callback URL. You must set the Auth0 tenant domain and the callback URL scheme.
+
+Modify `app/build.gradle` to include manifest placeholders for `auth0Domain` and `auth0Scheme` inside the `defaultConfig` section:
 
 ```groovy
 apply plugin: 'com.android.application'
@@ -57,7 +59,7 @@ android {
     defaultConfig {
         applicationId "com.auth0.samples"
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion flutter.targetSdkVersion
         // ...
 
         // ---> Add the next line

--- a/articles/quickstart/native/flutter/01-login.md
+++ b/articles/quickstart/native/flutter/01-login.md
@@ -34,7 +34,7 @@ This quickstart assumes you already have a [Flutter](https://flutter.dev/) appli
 
 You should also be familiar with the [Flutter command line tool](https://docs.flutter.dev/reference/flutter-cli).
 
-<%= include('_configure_urls_interactive') %>
+<%= include('\_configure_urls_interactive') %>
 
 ## Install the Auth0 Flutter SDK
 
@@ -61,18 +61,18 @@ android {
         // ...
 
         // ---> Add the next line
-        manifestPlaceholders += [auth0Domain: "@string/com_auth0_domain", auth0Scheme: "@string/com_auth0_scheme"]
+        manifestPlaceholders += [auth0Domain: "${account.namespace}", auth0Scheme: "https"]
         // <---
     }
 }
 ```
 
+- `auth0Domain`: The domain of your Auth0 tenant. Generally, you find this in the Auth0 Dashboard under your Application's **Settings** in the Domain field. If you are using a custom domain, you should set this to the value of your custom domain instead.
+- `auth0Scheme`: The scheme to use. Can be a custom scheme, or `https` if you want to use [Android App Links](https://auth0.com/docs/applications/enable-android-app-links). You can read more about setting this value in the [Auth0.Android SDK README](https://github.com/auth0/Auth0.Android#a-note-about-app-deep-linking).
+
+:::note
 You do not need to declare a specific `intent-filter` for your activity because you defined the manifest placeholders with your Auth0 **Domain** and **Scheme** values. The library handles the redirection for you.
-
-The sample uses values from `strings.xml`:
-
-- `com_auth0_domain`: The domain of your Auth0 tenant. Generally, you find this in the Auth0 Dashboard under your Application's **Settings** in the Domain field. If you are using a custom domain, you should set this to the value of your custom domain instead.
-- `com_auth0_scheme`: The scheme to use. Can be a custom scheme, or `https` if you want to use [Android App Links](https://auth0.com/docs/applications/enable-android-app-links). You can read more about setting this value in the [Auth0.Android SDK README](https://github.com/auth0/Auth0.Android#a-note-about-app-deep-linking).
+:::
 
 Run **Sync Project with Gradle Files** inside Android Studio to apply your changes.
 

--- a/articles/quickstart/native/flutter/files/build.md
+++ b/articles/quickstart/native/flutter/files/build.md
@@ -1,5 +1,5 @@
 ---
-name: build.gradle
+name: app/build.gradle
 language: groovy
 ---
 
@@ -10,7 +10,7 @@ android {
     defaultConfig {
         applicationId "com.auth0.samples"
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion flutter.targetSdkVersion
         // ...
 
         // ---> Add the next line

--- a/articles/quickstart/native/flutter/files/build.md
+++ b/articles/quickstart/native/flutter/files/build.md
@@ -2,6 +2,7 @@
 name: build.gradle
 language: groovy
 ---
+
 ```groovy
 apply plugin: 'com.android.application'
 
@@ -13,7 +14,7 @@ android {
         // ...
 
         // ---> Add the next line
-        manifestPlaceholders += [auth0Domain: "@string/com_auth0_domain", auth0Scheme: "@string/com_auth0_scheme"]
+        manifestPlaceholders += [auth0Domain: "${account.namespace}", auth0Scheme: "https"]
         // <---
     }
 }

--- a/articles/quickstart/native/flutter/interactive.md
+++ b/articles/quickstart/native/flutter/interactive.md
@@ -35,7 +35,7 @@ This quickstart assumes you already have a [Flutter](https://flutter.dev/) appli
 
 You should also be familiar with the [Flutter command line tool](https://docs.flutter.dev/reference/flutter-cli).
 
-<%= include('_configure_urls_interactive') %>
+<%= include('\_configure_urls_interactive') %>
 
 ## Install the Auth0 Flutter SDK
 
@@ -51,12 +51,14 @@ If you are not developing for the Android platform, skip this step.
 
 The SDK requires manifest placeholders. Auth0 uses placeholders internally to define an `intent-filter`, which captures the authentication callback URL. You must set the Auth0 tenant domain and the callback URL scheme.
 
+[The sample](https://github.com/auth0-samples/auth0-flutter-samples/tree/main/sample/android) uses the following placeholders:
+
+- `auth0Domain`: The domain of your Auth0 tenant. Generally, you find this in the Auth0 Dashboard under your Application's **Settings** in the Domain field. If you are using a custom domain, you should set this to the value of your custom domain instead.
+- `auth0Scheme`: The scheme to use. Can be a custom scheme, or `https` if you want to use [Android App Links](https://auth0.com/docs/applications/enable-android-app-links). You can read more about setting this value in the [Auth0.Android SDK README](https://github.com/auth0/Auth0.Android#a-note-about-app-deep-linking).
+
+:::note
 You do not need to declare a specific `intent-filter` for your activity because you defined the manifest placeholders with your Auth0 **Domain** and **Scheme** values. The library handles the redirection for you.
-
-The sample uses values from `strings.xml`:
-
-- `com_auth0_domain`: The domain of your Auth0 tenant. Generally, you find this in the Auth0 Dashboard under your Application's **Settings** in the Domain field. If you are using a custom domain, you should set this to the value of your custom domain instead.
-- `com_auth0_scheme`: The scheme to use. Can be a custom scheme, or `https` if you want to use [Android App Links](https://auth0.com/docs/applications/enable-android-app-links). You can read more about setting this value in the [Auth0.Android SDK README](https://github.com/auth0/Auth0.Android#a-note-about-app-deep-linking).
+:::
 
 Run **Sync Project with Gradle Files** inside Android Studio to apply your changes.
 

--- a/articles/quickstart/native/flutter/interactive.md
+++ b/articles/quickstart/native/flutter/interactive.md
@@ -35,7 +35,7 @@ This quickstart assumes you already have a [Flutter](https://flutter.dev/) appli
 
 You should also be familiar with the [Flutter command line tool](https://docs.flutter.dev/reference/flutter-cli).
 
-<%= include('\_configure_urls_interactive') %>
+<%= include('_configure_urls_interactive') %>
 
 ## Install the Auth0 Flutter SDK
 

--- a/articles/quickstart/native/flutter/interactive.md
+++ b/articles/quickstart/native/flutter/interactive.md
@@ -45,7 +45,7 @@ Add the Auth0 Flutter SDK into the project:
 flutter pub add auth0_flutter
 ```
 
-## Configure Android {{{ data-action=code data-code="build.gradle#11" }}}
+## Configure Android {{{ data-action=code data-code="app/build.gradle#11" }}}
 
 If you are not developing for the Android platform, skip this step.
 


### PR DESCRIPTION
- fix: use inline values for domain and scheme instead of strings.xml
- fix: be explicit about which 'build.gradle' file to edit
