### PR TITLE
Update author for vue quickstart

### DIFF
--- a/articles/quickstart/native/ionic-vue/index.yml
+++ b/articles/quickstart/native/ionic-vue/index.yml
@@ -4,9 +4,9 @@ image: /media/platforms/ionic.jpeg
 logo_name: ionic
 logo: ionic
 author:
-  name: Jonathan 'ArcticGizmo' Howell
-  email: jon.howell314@gmail.com
-  community: true
+  name: Steve Hobbs
+  email: steve.hobbs@auth0.com
+  community: false
 alias:
   - ionic
   - vue


### PR DESCRIPTION
Move the author to the original author of the Ionic quickstarts to ensure we send the correct message that we maintain this, and not the community.