### PR TITLE
Ensure the Ionic quickstarts reference the correct SDK

### DIFF
--- a/articles/quickstart/native/ionic-angular/interactive.md
+++ b/articles/quickstart/native/ionic-angular/interactive.md
@@ -24,7 +24,7 @@ files:
 
 # Add login to your Ionic Angular with Capacitor app
 
-Auth0 allows you to quickly add authentication and access user profile information in your application. This guide demonstrates how to integrate Auth0 with an Ionic (Angular) & Capacitor application using the [Auth0 SPA SDK](https://github.com/auth0/auth0-spa-js).
+Auth0 allows you to quickly add authentication and access user profile information in your application. This guide demonstrates how to integrate Auth0 with an Ionic (Angular) & Capacitor application using the [Auth0 Angular SDK](https://github.com/auth0/auth0-angular).
 
 <%= include('../_includes/ionic/_article_intro') %>
 

--- a/articles/quickstart/native/ionic-react/interactive.md
+++ b/articles/quickstart/native/ionic-react/interactive.md
@@ -24,7 +24,7 @@ files:
 
 # Add login to your Ionic React with Capacitor app
 
-Auth0 allows you to quickly add authentication and gain access to user profile information in your application. This guide demonstrates how to integrate Auth0 with an Ionic (React) & Capacitor application using the [Auth0 SPA SDK](https://github.com/auth0/auth0-spa-js).
+Auth0 allows you to quickly add authentication and gain access to user profile information in your application. This guide demonstrates how to integrate Auth0 with an Ionic (React) & Capacitor application using the [Auth0 React SDK](https://github.com/auth0/auth0-react).
 
 <%= include('../_includes/ionic/_article_intro') %>
 

--- a/articles/quickstart/native/ionic-vue/interactive.md
+++ b/articles/quickstart/native/ionic-vue/interactive.md
@@ -24,7 +24,7 @@ files:
 
 # Add login to your Ionic Vue with Capacitor app
 
-Auth0 allows you to quickly add authentication and gain access to user profile information in your application. This guide demonstrates how to integrate Auth0 with an Ionic (Vue) & Capacitor application using the [Auth0 SPA SDK](https://github.com/auth0/auth0-spa-js).
+Auth0 allows you to quickly add authentication and gain access to user profile information in your application. This guide demonstrates how to integrate Auth0 with an Ionic (Vue) & Capacitor application using the [Auth0 Vue SDK](https://github.com/auth0/auth0-vue).
 
 <%= include('../_includes/ionic/_article_intro') %>
 


### PR DESCRIPTION
All 3 quickstarts mention they use the SPA-JS SDK, while they each use their own framework specific SDK.
