### PR TITLE
Add note about the new `app` dir in Next.js 13

### DIFF
--- a/articles/quickstart/webapp/nextjs/01-login.md
+++ b/articles/quickstart/webapp/nextjs/01-login.md
@@ -70,7 +70,13 @@ This creates the following routes:
 
 ### Add the `UserProvider` component
 
-On the frontend side, the SDK uses React Context to manage the authentication state of your users. To make that state available to all your pages, you need to override the [App component](https://nextjs.org/docs/advanced-features/custom-app) and wrap its inner component with a `UserProvider`. Create the file `pages/_app.js` as follows:
+On the frontend side, the SDK uses React Context to manage the authentication state of your users. To make that state available to all your pages, you need to override the [App component](https://nextjs.org/docs/advanced-features/custom-app) and wrap its inner component with a `UserProvider`. 
+
+:::note
+The `app` directory introduced with Next.js 13 is currently in beta, and Vercel [does not recommend](https://nextjs.org/blog/next-13#new-app-directory-beta) using it in production. As such, this SDK does not support it yet.
+:::
+
+Create the file `pages/_app.js` as follows:
 
 ```jsx
 // pages/_app.js

--- a/articles/quickstart/webapp/nextjs/interactive.md
+++ b/articles/quickstart/webapp/nextjs/interactive.md
@@ -68,6 +68,10 @@ Then, import in that file the `handleAuth` method from the SDK, and export the r
 
 On the frontend side, the SDK uses React Context to manage the authentication state of your users. To make that state available to all your pages, you need to override the [App component](https://nextjs.org/docs/advanced-features/custom-app) and wrap its inner component with a `UserProvider` in the file `pages/_app.jsx`.
 
+:::note
+The `app` directory introduced with Next.js 13 is currently in beta, and Vercel [does not recommend](https://nextjs.org/blog/next-13#new-app-directory-beta) using it in production. As such, this SDK does not support it yet.
+:::
+
 The authentication state exposed by `UserProvider` can be accessed in any component using the `useUser()` hook.
 
 ::::checkpoint


### PR DESCRIPTION
### Changes

This PR adds a note to the Next.js Quickstart about the `app` directory introduced with Next.js 13, which is currently in beta and not recommended for production use.