### PR TITLE
Update 02-calling-an-api.md

### DIFF
--- a/articles/quickstart/spa/angular/02-calling-an-api.md
+++ b/articles/quickstart/spa/angular/02-calling-an-api.md
@@ -150,7 +150,7 @@ export class UserMetadataComponent implements OnInit {
           encodeURI(`https://${account.namespace}/api/v2/users/<%= "${user.sub}" %>`)
         )
       ),
-      map((user) => user['user_metadata']),
+      map((user) => user['email']),
       tap((meta) => (this.metadata = meta))
     )
     .subscribe();


### PR DESCRIPTION
user_metadata field didn't exist. I just changed it to email which was one of the fields returned.

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
