### PR TITLE
Enable refresh tokens on all ionic samples

### DIFF
--- a/articles/quickstart/native/ionic-angular/01-login.md
+++ b/articles/quickstart/native/ionic-angular/01-login.md
@@ -57,6 +57,8 @@ const redirect_uri = `<%= "${config.appId}" %>://${account.namespace}/capacitor/
     AuthModule.forRoot({
       domain: "${account.namespace}",
       clientId: "${account.clientId}",
+      useRefreshTokens: true,
+      useRefreshTokensFallback: false,
       authorizationParams: {
         redirect_uri,
       }
@@ -71,6 +73,8 @@ The `AuthModule.forRoot` function takes the following configuration:
 
 - `domain`: The "domain" value present under the "Settings" of the application you created in your Auth0 dashboard, or your custom domain if using Auth0's [Custom Domains feature](http://localhost:3000/docs/custom-domains)
 - `clientId`: The "client ID" value present under the "Settings" of the application you created in your Auth0 dashboard
+- `useRefreshTokens`: To use auth0-angular with Ionic on Android and iOS, it's required to enable refresh tokens.
+- `useRefreshTokensFallback`: To use auth0-angular with Ionic on Android and iOS, it's required to disable the iframe fallback.
 - `authorizationParams.redirect_uri`: The URL to where you'd like to redirect your users after they authenticate with Auth0.
 
 <%= include('../_includes/ionic/_note_storage') %>

--- a/articles/quickstart/native/ionic-angular/files/app-module.md
+++ b/articles/quickstart/native/ionic-angular/files/app-module.md
@@ -24,6 +24,8 @@ const redirect_uri = `<%= "${config.appId}" %>://${account.namespace}/capacitor/
     AuthModule.forRoot({
       domain: "${account.namespace}",
       clientId: "${account.clientId}",
+      useRefreshTokens: true,
+      useRefreshTokensFallback: false,
       authorizationParams: {
         redirect_uri
       }

--- a/articles/quickstart/native/ionic-angular/interactive.md
+++ b/articles/quickstart/native/ionic-angular/interactive.md
@@ -42,6 +42,8 @@ The `AuthModule.forRoot` function takes the following configuration:
 
 - `domain`: The `domain` value present under the **Settings** of the application you created in the Auth0 Dashboard, or your custom domain if you are using Auth0's [custom domains feature](http://localhost:3000/docs/custom-domains).
 - `clientId`: The Client ID value present under the **Settings** of the application you created in the Auth0 Dashboard.
+- `useRefreshTokens`: To use auth0-angular with Ionic on Android and iOS, it's required to enable refresh tokens.
+- `useRefreshTokensFallback`: To use auth0-angular with Ionic on Android and iOS, it's required to disable the iframe fallback.
 - `authorizationParams.redirect_uri`: The URL to redirect your users after they authenticate with Auth0.
 
 <%= include('../_includes/ionic/_note_storage') %>

--- a/articles/quickstart/native/ionic-react/01-login.md
+++ b/articles/quickstart/native/ionic-react/01-login.md
@@ -43,6 +43,8 @@ ReactDOM.render(
   <Auth0Provider
     domain="${account.namespace}"
     clientId="${account.clientId}"
+    useRefreshTokens={true}
+    useRefreshTokensFallback={false}
     authorizationParams={{
       redirect_uri="YOUR_PACKAGE_ID://${account.namespace}/capacitor/YOUR_PACKAGE_ID/callback"
     }}
@@ -57,6 +59,8 @@ The `Auth0Provider` component takes the following props:
 
 - `domain`: The "domain" value present under the "Settings" of the application you created in your Auth0 dashboard, or your custom domain if using Auth0's [Custom Domains feature](http://localhost:3000/docs/custom-domains)
 - `clientId`: The "client ID" value present under the "Settings" of the application you created in your Auth0 dashboard
+- `useRefreshTokens`: To use auth0-react with Ionic on Android and iOS, it's required to enable refresh tokens.
+- `useRefreshTokensFallback`: To use auth0-react with Ionic on Android and iOS, it's required to disable the iframe fallback.
 - `authorizationParams.redirect_uri`: The URL to where you'd like to redirect your users after they authenticate with Auth0.
 
 <%= include('../_includes/ionic/_note_storage') %>

--- a/articles/quickstart/native/ionic-react/files/index.md
+++ b/articles/quickstart/native/ionic-react/files/index.md
@@ -13,6 +13,8 @@ ReactDOM.render(
   <Auth0Provider
     domain="${account.namespace}"
     clientId="${account.clientId}"
+    useRefreshTokens={true}
+    useRefreshTokensFallback={false}
     authorizationParams={{
       redirect_uri: "YOUR_PACKAGE_ID://${account.namespace}/capacitor/YOUR_PACKAGE_ID/callback"
     }}

--- a/articles/quickstart/native/ionic-react/interactive.md
+++ b/articles/quickstart/native/ionic-react/interactive.md
@@ -42,6 +42,8 @@ The `Auth0Provider` component takes the following props:
 
 - `domain`: The `domain` value present under the **Settings** of the application you created in your Auth0 Dashboard, or your custom domain if using Auth0's [Custom Domains feature](http://localhost:3000/docs/custom-domains).
 - `clientId`: The Client ID value present under the **Settings** of the application you created in your Auth0 Dashboard.
+- `useRefreshTokens`: To use auth0-react with Ionic on Android and iOS, it's required to enable refresh tokens.
+- `useRefreshTokensFallback`: To use auth0-react with Ionic on Android and iOS, it's required to disable the iframe fallback.
 - `authorizationParams.redirect_uri`: The URL to where you'd like to redirect your users after they authenticate with Auth0.
 
 <%= include('../_includes/ionic/_note_storage') %>

--- a/articles/quickstart/native/ionic-vue/01-login.md
+++ b/articles/quickstart/native/ionic-vue/01-login.md
@@ -54,6 +54,8 @@ app.use(
   createAuth0({
     domain: "${account.namespace}",
     clientId: "${account.clientId}",
+    useRefreshTokens: true,
+    useRefreshTokensFallback: false,
     authorizationParams: {
       redirect_uri
     }
@@ -69,6 +71,8 @@ The `createAuth0` plugin takes the following props:
 
 - `domain`: The "domain" value present under the "Settings" of the application you created in your Auth0 dashboard, or your custom domain if using Auth0's [Custom Domains feature](http://localhost:3000/docs/custom-domains)
 - `clientId`: The "client ID" value present under the "Settings" of the application you created in your Auth0 dashboard
+- `useRefreshTokens`: To use auth0-vue with Ionic on Android and iOS, it's required to enable refresh tokens.
+- `useRefreshTokensFallback`: To use auth0-vue with Ionic on Android and iOS, it's required to disable the iframe fallback.
 - `authorizationParams.redirect_uri`: The URL to where you'd like to redirect your users after they authenticate with Auth0.
 
 <%= include('../_includes/ionic/_note_storage') %>

--- a/articles/quickstart/native/ionic-vue/files/main.md
+++ b/articles/quickstart/native/ionic-vue/files/main.md
@@ -24,6 +24,8 @@ app.use(
   createAuth0({
     domain: "${account.namespace}",
     clientId: "${account.clientId}",
+    useRefreshTokens: true,
+    useRefreshTokensFallback: false,
     authorizationParams: {
       redirect_uri
     }

--- a/articles/quickstart/native/ionic-vue/interactive.md
+++ b/articles/quickstart/native/ionic-vue/interactive.md
@@ -42,6 +42,8 @@ The `createAuth0` composable takes the following configuration:
 
 - `domain`: The `domain` value present under the **Settings** of the application you created in the Auth0 Dashboard, or your custom domain if you are using Auth0's [custom domains feature](http://localhost:3000/docs/custom-domains).
 - `clientId`: The Client ID value present under the **Settings** of the application you created in the Auth0 Dashboard.
+- `useRefreshTokens`: To use auth0-vue with Ionic on Android and iOS, it's required to enable refresh tokens.
+- `useRefreshTokensFallback`: To use auth0-vue with Ionic on Android and iOS, it's required to disable the iframe fallback.
 - `authorizationParams.redirect_uri`: The URL to redirect your users after they authenticate with Auth0.
 
 <%= include('../_includes/ionic/_note_storage') %>


### PR DESCRIPTION
Using iframes with ionic has two problems:

- the custom scheme does not match the window.origin
- the cookies arent shared between the capacitor browser (used for interactive login) and the in-app browser (used for silent auth).

Therefore our guidance should be to enable refresh tokens.