### PR TITLE
Web api minimal hosting model doc migration

### DIFF
--- a/articles/quickstart/backend/aspnet-core-webapi/01-authorization.md
+++ b/articles/quickstart/backend/aspnet-core-webapi/01-authorization.md
@@ -55,7 +55,7 @@ In your application, register the authentication services:
 
 ```csharp
 // Program.cs
-
+var builder = WebApplication.CreateBuilder(args);
 var domain = $"https://{builder.Configuration["Auth0:Domain"]}/";
 builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
 .AddJwtBearer(options =>

--- a/articles/quickstart/backend/aspnet-core-webapi/01-authorization.md
+++ b/articles/quickstart/backend/aspnet-core-webapi/01-authorization.md
@@ -69,7 +69,7 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
 });
 ```
 
-To add the authentication and authorization middleware to the middleware pipeline, call  the `UseAuthentication` and `UseAuthorization` methods under your Program.cs `var app = builder.Build();` method:
+To add the authentication and authorization middleware to the middleware pipeline, add a call to the `UseAuthentication` and `UseAuthorization` methods in your Program.cs file:
 
 ```csharp
 // Program.cs

--- a/articles/quickstart/backend/aspnet-core-webapi/01-authorization.md
+++ b/articles/quickstart/backend/aspnet-core-webapi/01-authorization.md
@@ -73,6 +73,7 @@ To add the authentication and authorization middleware to the middleware pipelin
 
 ```csharp
 // Program.cs
+var app = builder.Build();
 
 app.UseAuthentication();
 app.UseAuthorization();

--- a/articles/quickstart/backend/aspnet-core-webapi/01-authorization.md
+++ b/articles/quickstart/backend/aspnet-core-webapi/01-authorization.md
@@ -127,7 +127,7 @@ public class HasScopeHandler : AuthorizationHandler<HasScopeRequirement>
 }
 ```
 
-Under your Program's `var builder = WebApplication.CreateBuilder(args);` method, call the `AddAuthorization` method. To add policies for the scopes, call `AddPolicy` for each scope. Also ensure that you register the `HasScopeHandler` as a singleton:
+In your Program.cs file, add a call to the `AddAuthorization` method. To add policies for the scopes, call `AddPolicy` for each scope. Also ensure that you register the `HasScopeHandler` as a singleton:
 
 ```csharp
 // Program.cs

--- a/articles/quickstart/backend/aspnet-core-webapi/01-authorization.md
+++ b/articles/quickstart/backend/aspnet-core-webapi/01-authorization.md
@@ -72,7 +72,7 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
 To add the authentication and authorization middleware to the middleware pipeline, call  the `UseAuthentication` and `UseAuthorization` methods under your Program.cs `var app = builder.Build();` method:
 
 ```csharp
-// Startup.cs
+// Program.cs
 
 app.UseAuthentication();
 app.UseAuthorization();

--- a/articles/quickstart/backend/aspnet-core-webapi/01-authorization.md
+++ b/articles/quickstart/backend/aspnet-core-webapi/01-authorization.md
@@ -127,24 +127,18 @@ public class HasScopeHandler : AuthorizationHandler<HasScopeRequirement>
 }
 ```
 
-In your Startup's `ConfigureServices` method, add a call to the `AddAuthorization` method. To add policies for the scopes, call `AddPolicy` for each scope. Also ensure that you register the `HasScopeHandler` as a singleton:
+Under your Program's `var builder = WebApplication.CreateBuilder(args);` method, call the `AddAuthorization` method. To add policies for the scopes, call `AddPolicy` for each scope. Also ensure that you register the `HasScopeHandler` as a singleton:
 
 ```csharp
-// Startup.cs
+// Program.cs
 
-public void ConfigureServices(IServiceCollection services)
+builder.Services.AddAuthorization(options =>
 {
-    //...
+    options.AddPolicy("read:messages", policy => policy.Requirements.Add(new 
+    HasScopeRequirement("read:messages", domain)));
+});
 
-    services.AddAuthorization(options =>
-    {
-        options.AddPolicy("read:messages", policy => policy.Requirements.Add(new HasScopeRequirement("read:messages", domain)));
-    });
-
-    services.AddSingleton<IAuthorizationHandler, HasScopeHandler>();
-
-    //...
-}
+builder.Services.AddSingleton<IAuthorizationHandler, HasScopeHandler>();
 ```
 
 ## Protect API Endpoints

--- a/articles/quickstart/backend/aspnet-core-webapi/01-authorization.md
+++ b/articles/quickstart/backend/aspnet-core-webapi/01-authorization.md
@@ -54,45 +54,32 @@ In your application, register the authentication services:
 2. Make a call to the `AddJwtBearer` method to register the JWT Bearer authentication scheme. Configure your Auth0 domain as the authority, and your Auth0 API identifier as the audience. In some cases the access token will not have a `sub` claim which will lead to `User.Identity.Name` being `null`. If you want to map a different claim to `User.Identity.Name` then add it to `options.TokenValidationParameters` within the `AddAuthentication()` call.
 
 ```csharp
-// Startup.cs
+// Program.cs
 
-public void ConfigureServices(IServiceCollection services)
+var domain = $"https://{builder.Configuration["Auth0:Domain"]}/";
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+.AddJwtBearer(options =>
 {
-    // Some code omitted for brevity...
-
-    string domain = $"https://{Configuration["Auth0:Domain"]}/";
-    services
-        .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
-        .AddJwtBearer(options =>
-        {
-            options.Authority = domain;
-            options.Audience = Configuration["Auth0:Audience"];
-            // If the access token does not have a `sub` claim, `User.Identity.Name` will be `null`. Map it to a different claim by setting the NameClaimType below.
-            options.TokenValidationParameters = new TokenValidationParameters
-            {
-                NameClaimType = ClaimTypes.NameIdentifier
-            };
-        });
-}
+    options.Authority = domain;
+    options.Audience = builder.Configuration["Auth0:Audience"];
+    options.TokenValidationParameters = new TokenValidationParameters
+    {
+        NameClaimType = ClaimTypes.NameIdentifier
+    };
+});
 ```
 
-To add the authentication and authorization middleware to the middleware pipeline, add a call to the `UseAuthentication` and `UseAuthorization` methods in your Startup's `Configure` method:
+To add the authentication and authorization middleware to the middleware pipeline, call  the `UseAuthentication` and `UseAuthorization` methods under your Program.cs `var app = builder.Build();` method:
 
 ```csharp
 // Startup.cs
 
-public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+app.UseAuthentication();
+app.UseAuthorization();
+app.UseEndpoints(endpoints =>
 {
-    // Some code omitted for brevity...
-
-    app.UseAuthentication();
-    app.UseAuthorization();
-
-    app.UseEndpoints(endpoints =>
-    {
-        endpoints.MapControllers();
-    });
-}
+    endpoints.MapControllers();
+});
 ```
 
 ### Validate scopes

--- a/articles/quickstart/backend/aspnet-core-webapi/files/configure-middleware.md
+++ b/articles/quickstart/backend/aspnet-core-webapi/files/configure-middleware.md
@@ -1,5 +1,5 @@
 ---
-name: Startup.cs
+name: Program.cs
 language: csharp
 ---
 
@@ -15,7 +15,7 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     };
 });
 
-    services
+    builder.Services
       .AddAuthorization(options =>
       {
           options.AddPolicy(
@@ -26,20 +26,7 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
           );
       });
 
-    services.AddSingleton<IAuthorizationHandler, HasScopeHandler>();
-}
-
-builder.Services.AddAuthorization(options =>
-{
-    options.AddPolicy(
-        "read:messages",
-         policy => policy.Requirements.Add(
-            new HasScopeRequirement("read:messages", domain)
-        )
-    );
-});
-
-builder.Services.AddSingleton<IAuthorizationHandler, HasScopeHandler>();
+    builder.Services.AddSingleton<IAuthorizationHandler, HasScopeHandler>();
 
 app.UseAuthentication();
 app.UseAuthorization();

--- a/articles/quickstart/backend/aspnet-core-webapi/files/configure-middleware.md
+++ b/articles/quickstart/backend/aspnet-core-webapi/files/configure-middleware.md
@@ -4,6 +4,7 @@ language: csharp
 ---
 
 ```csharp
+var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
 .AddJwtBearer(options =>
 {
@@ -28,6 +29,7 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
 
     builder.Services.AddSingleton<IAuthorizationHandler, HasScopeHandler>();
 
+var app = builder.Build();
 app.UseAuthentication();
 app.UseAuthorization();
 ```

--- a/articles/quickstart/backend/aspnet-core-webapi/files/configure-middleware.md
+++ b/articles/quickstart/backend/aspnet-core-webapi/files/configure-middleware.md
@@ -39,7 +39,7 @@ builder.Services.AddAuthorization(options =>
     );
 });
 
-services.AddSingleton<IAuthorizationHandler, HasScopeHandler>();
+builder.Services.AddSingleton<IAuthorizationHandler, HasScopeHandler>();
 
 app.UseAuthentication();
 app.UseAuthorization();

--- a/articles/quickstart/backend/aspnet-core-webapi/files/configure-middleware.md
+++ b/articles/quickstart/backend/aspnet-core-webapi/files/configure-middleware.md
@@ -4,6 +4,7 @@ language: csharp
 ---
 
 ```csharp
+var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
 .AddJwtBearer(options =>
 {

--- a/articles/quickstart/backend/aspnet-core-webapi/index.yml
+++ b/articles/quickstart/backend/aspnet-core-webapi/index.yml
@@ -7,6 +7,7 @@ alias:
   - aspnet core webapi
   - asp.net core webapi 3.1
   - asp.net 5.0
+  - asp.net core webapi 6.0
 language:
   - C#
 framework:
@@ -36,6 +37,7 @@ github:
 requirements:
   - .NET Core 3.1
   - .NET 5.0
+  - .NET 6.0
 next_steps:
   - path: 01-authorization
     list:

--- a/articles/quickstart/backend/aspnet-core-webapi/interactive.md
+++ b/articles/quickstart/backend/aspnet-core-webapi/interactive.md
@@ -47,7 +47,7 @@ Install-Package Microsoft.AspNetCore.Authentication.JwtBearer
 
 ## Configure the middleware {{{ data-action=code data-code="Startup.cs" }}}
 
-Set up the authentication middleware by configuring it in your application's `Startup.cs` file:
+Set up the authentication middleware by configuring it in your application's `Program.cs` file:
 
 1. Register the authentication services by making a call to the `AddAuthentication` method. Configure `JwtBearerDefaults.AuthenticationScheme` as the default scheme.
  
@@ -57,14 +57,14 @@ Set up the authentication middleware by configuring it in your application's `St
 In some cases, the access token will not have a `sub` claim; in this case, the `User.Identity.Name` will be `null`. If you want to map a different claim to `User.Identity.Name`, add it to `options.TokenValidationParameters` within the `AddJwtBearer()` call.
 :::
 
-3. Add the authentication and authorization middleware to the middleware pipeline by adding calls to the `UseAuthentication` and `UseAuthorization` methods in the `Configure` method.
+3. Add the authentication and authorization middleware to the middleware pipeline by adding calls to the `UseAuthentication` and `UseAuthorization` methods under the `var app = builder.Build();` method.
 
 ## Validate scopes {{{ data-action=code data-code="HasScopeHandler.cs" }}}
 
 To ensure that an access token contains the correct scopes, use [Policy-Based Authorization](https://docs.microsoft.com/en-us/aspnet/core/security/authorization/policies) in the ASP.NET Core:
 
 1. Create a new authorization requirement called `HasScopeRequirement`, which will check whether the `scope` claim issued by your Auth0 tenant is present, and if so, will check that the claim contains the requested scope.
-2. In your `Startup.cs` file's `ConfigureServices` method, add a call to the `AddAuthorization` method.
+2. Under your `Program.cs` file's `var builder = WebApplication.CreateBuilder(args);` method, add a call to the `app.AddAuthorization` method.
 3. Add policies for scopes by calling `AddPolicy` for each scope.
 4. Register a singleton for the `HasScopeHandler` class.
 


### PR DESCRIPTION
<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
Hi as requested in [the #79 issue outside of this repo](https://github.com/auth0-samples/auth0-aspnetcore-mvc-samples/issues/79) I had edited the files for the Web API quickstart you mentioned. Here are the doc enhancements. 

FYI:
- All I did was swap in the markdown files for the Startup code for how to use the minimal hosting model logic in Program.cs. 
- I cannot submit this to Wordy unless I am reimbursed for submitting this to one of their editors. I imagine that's not even an issue. 

Hope it all looks good! We'll see.