### PR TITLE
Added clause to clarify Lock Screen prompting

### DIFF
--- a/articles/libraries/auth0-android/save-and-refresh-tokens.md
+++ b/articles/libraries/auth0-android/save-and-refresh-tokens.md
@@ -111,7 +111,7 @@ private static final int RC_UNLOCK_AUTHENTICATION = 123;
 boolean available = manager.requireAuthentication(this, RC_UNLOCK_AUTHENTICATION, getString(R.string.unlock_authentication_title), getString(R.string.unlock_authentication_description));
 ```
 
-If the feature was enabled, the manager will prompt the user to authenticate using the configured Lock Screen. The result of this call will be obtained in the `onActivityResult` method of the activity passed before as first parameter. If the feature was not enabled, Lock Screen authentication will be skipped.
+If the feature was enabled, the manager will prompt the user to authenticate using the configured Lock Screen when the `getCredentials` method is called. The result of this call will be obtained in the `onActivityResult` method of the activity passed before as first parameter. If the feature was not enabled, Lock Screen authentication will be skipped.
 
 After checking that the received request code matches the one used in the configuration step, redirect the received parameters to the manager to finish the authentication. The credentials will be yield to the original callback.
 


### PR DESCRIPTION
Added clause on line 114 to clarify that getCredentials must be called after requireAuthentication to make the Lock Screen prompt the user for input.

Backlog ticket: https://auth0team.atlassian.net/browse/DOCS-3040

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
