### PR TITLE
Updating webhook request watching tools

### DIFF
--- a/articles/extensions/_troubleshoot-webhooks.md
+++ b/articles/extensions/_troubleshoot-webhooks.md
@@ -6,7 +6,7 @@ However, there are certainly alternatives to the inefficient process we detailed
 
 1. Check the [Logs](/logs) section of the [Dashboard](${manage_url}/#/logs) for helpful messages.
 
-1. Analyze the requests your webhook is making using a tool like [Hookbin](https://hookbin.com/) or [Mockbin](http://mockbin.org/).
+1. Analyze the requests your webhook is making using a tool like [Mockbin](http://mockbin.org/), [Beeceptor](https://beeceptor.com/), or (self-hosted) [RequestBin](https://github.com/Runscope/requestbin).
 
 1. Mock requests using cURL or [Postman](https://www.getpostman.com/)
 


### PR DESCRIPTION
Updating the troubleshooting webhooks to remove hookbin as it's been deprecated

Via [css-tricks](https://css-tricks.com/hookbin-capture-inspect-http-requests/)
![Screenshot 2023-03-09 at 10 26 29 AM](https://user-images.githubusercontent.com/872224/224087979-26513ebb-3148-44e5-a7a2-6dc0a79a46d3.png)
