### PR TITLE
Guidance to use custom scheme for Expo

### DIFF
--- a/articles/quickstart/native/react-native-expo/00-login.md
+++ b/articles/quickstart/native/react-native-expo/00-login.md
@@ -112,7 +112,7 @@ These values are found in the Expo config file at `app.json` or `app.config.js`.
 
 <%= include('../../../_includes/_callback_url') %>
 
-#### Callback URL and logout URL
+#### iOS callback URL
 
 ```text
 {YOUR_CUSTOM_SCHEME}://${account.namespace}/ios/{IOS_BUNDLE_IDENTIFIER}/callback

--- a/articles/quickstart/native/react-native-expo/00-login.md
+++ b/articles/quickstart/native/react-native-expo/00-login.md
@@ -66,13 +66,18 @@ Add the `react-native-auth0` plugin to the [Expo config](https://docs.expo.dev/w
       [
         "react-native-auth0",
         {
-          "domain": "${account.namespace}"
+          "domain": "${account.namespace}",
+          "customScheme": "YOUR_CUSTOM_SCHEME"
         }
       ]
     ]
   }
 }
 ```
+
+::: note
+The custom scheme should be a unique, all lowercase value with no special characters.
+:::
 
 ### Generate native source code
 
@@ -96,10 +101,10 @@ These values are found in the Expo config file at `app.json` or `app.config.js`.
 {
     ...
     "android": {
-      "package": "com.auth0samples"
+      "package": "YOUR_ANDROID_PACKAGE_NAME_IS_FOUND_HERE"
     },
     "ios": {
-      "bundleIdentifier": "com.auth0samples"
+      "bundleIdentifier": "YOUR_IOS_BUNDLE_IDENTIFIER_IS_FOUND_HERE"
     }
   }
 }
@@ -107,10 +112,10 @@ These values are found in the Expo config file at `app.json` or `app.config.js`.
 
 <%= include('../../../_includes/_callback_url') %>
 
-#### iOS callback URL
+#### Callback URL and logout URL
 
 ```text
-{IOS_BUNDLE_IDENTIFIER}://${account.namespace}/ios/{IOS_BUNDLE_IDENTIFIER}/callback
+{YOUR_CUSTOM_SCHEME}://${account.namespace}/ios/{IOS_BUNDLE_IDENTIFIER}/callback
 ```
 
 Remember to replace `{IOS_BUNDLE_IDENTIFIER}` with your actual application's bundle identifier name.
@@ -118,7 +123,7 @@ Remember to replace `{IOS_BUNDLE_IDENTIFIER}` with your actual application's bun
 #### Android callback URL
 
 ```text
-{ANDROID_PACKAGE}://${account.namespace}/android/{ANDROID_PACKAGE}/callback
+{YOUR_CUSTOM_SCHEME}://${account.namespace}/android/{ANDROID_PACKAGE}/callback
 ```
 
 Remember to replace `{ANDROID_PACKAGE}` with your actual application's package name.
@@ -128,7 +133,7 @@ Remember to replace `{ANDROID_PACKAGE}` with your actual application's package n
 #### iOS logout URL
 
 ```text
-{IOS_BUNDLE_IDENTIFIER}://${account.namespace}/ios/{IOS_BUNDLE_IDENTIFIER}/callback
+{YOUR_CUSTOM_SCHEME}://${account.namespace}/ios/{IOS_BUNDLE_IDENTIFIER}/callback
 ```
 
 Remember to replace `{IOS_BUNDLE_IDENTIFIER}` with your actual application's bundle identifier name.
@@ -136,7 +141,7 @@ Remember to replace `{IOS_BUNDLE_IDENTIFIER}` with your actual application's bun
 #### Android logout URL
 
 ```text
-{ANDROID_PACKAGE}://${account.namespace}/android/{ANDROID_PACKAGE}/callback
+{YOUR_CUSTOM_SCHEME}://${account.namespace}/android/{ANDROID_PACKAGE}/callback
 ```
 
 Remember to replace `{ANDROID_PACKAGE}` with your actual application's package name.
@@ -169,7 +174,7 @@ const LoginButton = () => {
 
     const onPress = async () => {
         try {
-            await authorize();
+            await authorize({scope: 'openid profile email'}, {customScheme: '{YOUR_CUSTOM_SCHEME}'});
         } catch (e) {
             console.log(e);
         }
@@ -195,7 +200,7 @@ const LogoutButton = () => {
 
     const onPress = async () => {
         try {
-            await clearSession();
+            await clearSession({customScheme: '{YOUR_CUSTOM_SCHEME}'});
         } catch (e) {
             console.log(e);
         }
@@ -217,12 +222,13 @@ If a user has not been authenticated, this property will be `null`.
 
 ```js
 const Profile = () => {
-    const {user} = useAuth0();
+    const {user, error} = useAuth0();
 
     return (
         <>
             {user && <Text>Logged in as {user.name}</Text>}
             {!user && <Text>Not logged in</Text>}
+            {error && <Text>{error.message}</Text>}
         </>
     )
 }

--- a/articles/quickstart/native/react-native-expo/files/app-json.md
+++ b/articles/quickstart/native/react-native-expo/files/app-json.md
@@ -16,7 +16,8 @@ language: json
       [
         "react-native-auth0",
         {
-          "domain": "${account.namespace}"
+          "domain": "${account.namespace}",
+          "customScheme": "auth0.com.auth0samples"
         }
       ]
     ],

--- a/articles/quickstart/native/react-native-expo/files/app.md
+++ b/articles/quickstart/native/react-native-expo/files/app.md
@@ -9,11 +9,11 @@ import {Button, Text, View} from 'react-native';
 import {useAuth0, Auth0Provider} from 'react-native-auth0';
 
 const Home = () => {
-  const {authorize, clearSession, user} = useAuth0();
+  const {authorize, clearSession, user, error} = useAuth0();
 
   const onLogin = async () => {
     try {
-      await authorize({scope: 'openid profile email'});
+      await authorize({scope: 'openid profile email'}, {customScheme: 'auth0.com.auth0samples'});
     } catch (e) {
       console.log(e);
     }
@@ -21,7 +21,7 @@ const Home = () => {
 
   const onLogout = async () => {
     try {
-      await clearSession();
+      await clearSession({customScheme: 'auth0.com.auth0samples'});
     } catch (e) {
       console.log('Log out cancelled');
     }
@@ -33,6 +33,7 @@ const Home = () => {
     <View style={styles.container}>
       {loggedIn && <Text>You are logged in as {user.name}</Text>}
       {!loggedIn && <Text>You are not logged in</Text>}
+      {error && <Text>{error.message}</Text>}
 
       <Button
         onPress={loggedIn ? onLogout : onLogin}

--- a/articles/quickstart/native/react-native-expo/interactive.md
+++ b/articles/quickstart/native/react-native-expo/interactive.md
@@ -42,8 +42,8 @@ A callback URL is the application URL that Auth0 will direct your users to once 
 
 ::: note
 If you are following along with our sample project, set this
-- for iOS - `{IOS_BUNDLE_IDENTIFIER}://${account.namespace}/ios/{IOS_BUNDLE_IDENTIFIER}/callback`
-- for Android - `{ANDROID_PACKAGE}://${account.namespace}/android/{ANDROID_PACKAGE}/callback`
+- for iOS - `auth0.com.auth0samples://${account.namespace}/ios/com.auth0samples/callback`
+- for Android - `auth0.com.auth0samples://${account.namespace}/android/com.auth0samples/callback`
 :::
 
 ### Configure Logout URLs
@@ -52,8 +52,8 @@ A logout URL is the application URL Auth0 will redirect your users to once they 
 
 ::: note
 If you are following along with our sample project, set this
-- for iOS - `{IOS_BUNDLE_IDENTIFIER}://${account.namespace}/ios/{IOS_BUNDLE_IDENTIFIER}/callback`
-- for Android - `{ANDROID_PACKAGE}://${account.namespace}/android/{ANDROID_PACKAGE}/callback`
+- for iOS - `auth0.com.auth0samples://${account.namespace}/ios/com.auth0samples/callback`
+- for Android - `auth0.com.auth0samples://${account.namespace}/android/com.auth0samples/callback`
 :::
 
 ## Install dependencies 


### PR DESCRIPTION
Updating Expo Quickstarts to use custom scheme mandatorily. This is to avoid Auth0 using same scheme as Expo to redirect after authentication.

The following PRs update the samples and README -
https://github.com/auth0/react-native-auth0/pull/610
https://github.com/auth0-samples/auth0-react-native-sample/pull/113
