### PR TITLE
Correct Callback URL

### DIFF
--- a/articles/quickstart/webapp/django/download.md
+++ b/articles/quickstart/webapp/django/download.md
@@ -3,7 +3,7 @@ To run the sample follow these steps:
 1) Set the **Allowed Callback URLs** in the [Application Settings](${manage_url}/#/applications/${account.clientId}/settings) to:
 
 ```text
-http://localhost:3000/complete/auth0
+http://localhost:3000/callback
 ```
 
 2) Set the **Allowed Logout URLs** in the [Application Settings](${manage_url}/#/applications/${account.clientId}/settings) to:


### PR DESCRIPTION
The app's callback URL is actually http://localhost:3000/callback

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
