### PR TITLE
Update Angular Calling an API to include redirect_uri

### DIFF
--- a/articles/quickstart/spa/angular/02-calling-an-api.md
+++ b/articles/quickstart/spa/angular/02-calling-an-api.md
@@ -78,6 +78,8 @@ AuthModule.forRoot({
   clientId: '${account.clientId}',
 
   authorizationParams: {
+    redirect_uri: window.location.origin,
+    
     // Request this audience at user authentication time
     audience: 'https://${account.namespace}/api/v2/',
 


### PR DESCRIPTION
The redirect_uri was missing from the calling an API example, while it's included in the login example. We should include it in calling an API as well, as it's required to specify it.
