### PR TITLE
Update to use createRoot and render API to match new React usage

### DIFF
--- a/articles/quickstart/native/ionic-react/01-login.md
+++ b/articles/quickstart/native/ionic-react/01-login.md
@@ -35,23 +35,24 @@ Open `src/index.tsx` and wrap the `App` component in the `Auth0Provider` compone
 
 ```javascript
 import React from 'react';
-import ReactDOM from 'react-dom';
-import App from './App';
+import { createRoot } from 'react-dom/client';
 import { Auth0Provider } from '@auth0/auth0-react';
+import App from './App';
 
-ReactDOM.render(
+const root = createRoot(document.getElementById('root'));
+
+root.render(
   <Auth0Provider
     domain="${account.namespace}"
     clientId="${account.clientId}"
     useRefreshTokens={true}
     useRefreshTokensFallback={false}
     authorizationParams={{
-      redirect_uri="YOUR_PACKAGE_ID://${account.namespace}/capacitor/YOUR_PACKAGE_ID/callback"
+      redirect_uri: "YOUR_PACKAGE_ID://${account.namespace}/capacitor/YOUR_PACKAGE_ID/callback"
     }}
   >
     <App />
-  </Auth0Provider>,
-  document.getElementById('root')
+  </Auth0Provider>
 );
 ```
 

--- a/articles/quickstart/native/ionic-react/files/index.md
+++ b/articles/quickstart/native/ionic-react/files/index.md
@@ -5,11 +5,13 @@ language: javascript
 
 ```javascript
 import React from 'react';
-import ReactDOM from 'react-dom';
-import App from './App';
+import { createRoot } from 'react-dom/client';
 import { Auth0Provider } from '@auth0/auth0-react';
+import App from './App';
 
-ReactDOM.render(
+const root = createRoot(document.getElementById('root'));
+
+root.render(
   <Auth0Provider
     domain="${account.namespace}"
     clientId="${account.clientId}"
@@ -20,7 +22,6 @@ ReactDOM.render(
     }}
   >
     <App />
-  </Auth0Provider>,
-  document.getElementById('root')
+  </Auth0Provider>
 );
 ```

--- a/articles/quickstart/native/ionic-react/index.yml
+++ b/articles/quickstart/native/ionic-react/index.yml
@@ -38,6 +38,7 @@ requirements:
   - Node & Npm (LTS)
   - XCode 12+ (for iOS)
   - Android Studio 4+ (for Android)
+  - React 18
 next_steps:
   - path: 01-login
     list:

--- a/articles/quickstart/spa/react/01-login.md
+++ b/articles/quickstart/spa/react/01-login.md
@@ -27,13 +27,15 @@ Visit the [React Authentication By Example](https://developer.auth0.com/resource
 Under the hood, the Auth0 React SDK uses [React Context](https://reactjs.org/docs/context.html) to manage the authentication state of your users. One way to integrate Auth0 with your React app is to wrap your root component with an `Auth0Provider` that you can import from the SDK.
 
 ```javascript
-import React from "react";
-import ReactDOM from "react-dom";
-import App from "./App";
-import { Auth0Provider } from "@auth0/auth0-react";
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { Auth0Provider } from '@auth0/auth0-react';
+import App from './App';
 
-ReactDOM.render(
-  <Auth0Provider
+const root = createRoot(document.getElementById('root'));
+
+root.render(
+<Auth0Provider
     domain="${account.namespace}"
     clientId="${account.clientId}"
     authorizationParams={{
@@ -42,7 +44,6 @@ ReactDOM.render(
   >
     <App />
   </Auth0Provider>,
-  document.getElementById("root")
 );
 ```
 

--- a/articles/quickstart/spa/react/02-calling-an-api.md
+++ b/articles/quickstart/spa/react/02-calling-an-api.md
@@ -34,24 +34,25 @@ The `Auth0Provider` setup is similar to the one discussed in the [Configure the 
 However, your React application needs to pass an access token when it calls a target API to access private resources. You can [request an access token](https://auth0.com/docs/tokens/guides/get-access-tokens) in a format that the API can verify by passing the `audience` and `scope` props to `Auth0Provider` as follows:
 
 ```javascript
-import React from "react";
-import ReactDOM from "react-dom";
-import App from "./App";
-import { Auth0Provider } from "@auth0/auth0-react";
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { Auth0Provider } from '@auth0/auth0-react';
+import App from './App';
 
-ReactDOM.render(
+const root = createRoot(document.getElementById('root'));
+
+root.render(
   <Auth0Provider
     domain="${account.namespace}"
     clientId="${account.clientId}"
+    useRefreshTokens={true}
+    useRefreshTokensFallback={false}
     authorizationParams={{
-      redirect_uri: window.location.origin,
-      audience: "https://${account.namespace}/api/v2/",
-      scope: "read:current_user update:current_user_metadata"
+      redirect_uri="YOUR_PACKAGE_ID://${account.namespace}/capacitor/YOUR_PACKAGE_ID/callback"
     }}
   >
     <App />
-  </Auth0Provider>,
-  document.getElementById("root")
+  </Auth0Provider>
 );
 ```
 

--- a/articles/quickstart/spa/react/files/index.md
+++ b/articles/quickstart/spa/react/files/index.md
@@ -4,14 +4,15 @@ language: javascript
 ---
 
 ```javascript
-import { Auth0Provider } from "@auth0/auth0-react";
-import React from "react";
-import ReactDOM from "react-dom";
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { Auth0Provider } from '@auth0/auth0-react';
+import App from './App';
 
-import App from "./App";
+const root = createRoot(document.getElementById('root'));
 
-ReactDOM.render(
-  <Auth0Provider
+root.render(
+<Auth0Provider
     domain="${account.namespace}"
     clientId="${account.clientId}"
     authorizationParams={{
@@ -20,6 +21,5 @@ ReactDOM.render(
   >
     <App />
   </Auth0Provider>,
-  document.getElementById("root")
 );
 ```

--- a/articles/quickstart/spa/react/index.yml
+++ b/articles/quickstart/spa/react/index.yml
@@ -39,7 +39,7 @@ github:
   repo: auth0-react-samples
   branch: master
 requirements:
-  - React 16.8
+  - React 18
 next_steps:
   - path: 01-login
     list:


### PR DESCRIPTION
Updates all quickstarts that use React to use the newer `ReactDom.createRoot` and `root.render` APIs to fix the below warning log.

```
Warning: ReactDOM.render is no longer supported in React 18. Use createRoot instead. Until you switch to the new API, your app will behave as if it's running React 17. Learn more: https://reactjs.org/link/switch-to-createroot
```

~Marking as draft until the related sample PRs are up~

Ionic sample: https://github.com/auth0-samples/auth0-ionic-samples/pull/561
React sample: https://github.com/auth0-samples/auth0-react-samples/pull/334