### PR TITLE
Update redirects.js

### DIFF
--- a/config/redirects.js
+++ b/config/redirects.js
@@ -4465,8 +4465,12 @@ const redirects = [
     to: '/customize/extensions/authentication-api-debugger-extension',
   },
   {
-    from: ['/extensions/authentication-api-webhooks', '/extensions/auth0-authentication-api-webhooks'],
-    to: '/customize/extensions/auth0-authentication-api-webhooks',
+    from: [
+      '/extensions/authentication-api-webhooks', 
+      '/extensions/auth0-authentication-api-webhooks' , 
+      '/customize/extensions/auth0-authentication-api-webhooks',
+    ],
+    to: '/customize/extensions',
   },
   {
     from: ['/extensions/user-import-export', '/extensions/user-import-export-extension'],
@@ -4495,8 +4499,12 @@ const redirects = [
     to: 'https://marketplace.auth0.com/integrations/gitlab-pipeline',
   },
   {
-    from: ['/extensions/management-api-webhooks', '/extensions/auth0-management-api-webhooks'],
-    to: '/customize/extensions/auth0-management-api-webhooks',
+    from: [
+      '/extensions/management-api-webhooks', 
+      '/extensions/auth0-management-api-webhooks',
+      '/customize/extensions/auth0-management-api-webhooks',
+    ],
+    to: '/customize/extensions',
   },
   {
     from: ['/extensions/realtime-webtask-logs', '/extensions/real-time-webtask-logs'],

--- a/config/redirects.js
+++ b/config/redirects.js
@@ -4369,96 +4369,108 @@ const redirects = [
       '/logs/export-log-events-with-extensions',
       '/logs/log-export-extensions',
       '/extensions/log-export-extensions',
+      '/customize/extensions/export-log-events-with-extensions',
     ],
-    to: '/customize/extensions/export-log-events-with-extensions',
+    to: '/customize/log-streams/custom-log-streams',
   },
   {
     from: [
       '/extensions/export-logs-to-application-insights',
       '/extensions/application-insight',
       '/extensions/log-export-extensions/export-logs-to-application-insights',
+      '/customize/extensions/export-log-events-with-extensions/export-logs-to-application-insights',
     ],
-    to: '/customize/extensions/export-log-events-with-extensions/export-logs-to-application-insights',
+    to: '/customize/log-streams/custom-log-streams',
   },
   {
     from: [
       '/extensions/export-logs-to-cloudwatch',
       '/extensions/cloudwatch',
       '/extensions/log-export-extensions/export-logs-to-cloudwatch',
+      '/customize/extensions/export-log-events-with-extensions/export-logs-to-cloudwatch',
     ],
-    to: '/customize/extensions/export-log-events-with-extensions/export-logs-to-cloudwatch',
+    to: '/customize/log-streams/custom-log-streams',
   },
   {
     from: [
       '/extensions/export-logs-to-azure-blob-storage',
       '/extensions/azure-blob-storage',
       '/extensions/log-export-extensions/export-logs-to-azure-blob-storage',
+      '/customize/extensions/export-log-events-with-extensions/export-logs-to-azure-blob-storage',
     ],
-    to: '/customize/extensions/export-log-events-with-extensions/export-logs-to-azure-blob-storage',
+    to: '/customize/log-streams/custom-log-streams',
   },
   {
     from: [
       '/extensions/export-logs-to-logentries',
       '/extensions/logentries',
       '/extensions/log-export-extensions/export-logs-to-logentries',
+      '/customize/extensions/export-log-events-with-extensions/export-logs-to-logentries',
     ],
-    to: '/customize/extensions/export-log-events-with-extensions/export-logs-to-logentries',
+    to: '/customize/log-streams/custom-log-streams',
   },
   {
     from: [
       '/extensions/export-logs-to-loggly',
       '/extensions/loggly',
       '/extensions/log-export-extensions/export-logs-to-loggly',
+      '/customize/extensions/export-log-events-with-extensions/export-logs-to-loggly',
     ],
-    to: '/customize/extensions/export-log-events-with-extensions/export-logs-to-loggly',
+    to: '/customize/log-streams/custom-log-streams',
   },
   {
     from: [
       '/extensions/export-logs-to-logstash',
       '/extensions/logstash',
       '/extensions/log-export-extensions/export-logs-to-logstash',
+      '/customize/extensions/export-log-events-with-extensions/export-logs-to-logstash',
     ],
-    to: '/customize/extensions/export-log-events-with-extensions/export-logs-to-logstash',
+    to: '/customize/log-streams/custom-log-streams',
   },
   {
     from: [
       '/extensions/export-logs-to-mixpanel',
       '/extensions/mixpanel',
       '/extensions/log-export-extensions/export-logs-to-mixpanel',
+      '/customize/extensions/export-log-events-with-extensions/export-logs-to-mixpanel',
     ],
-    to: '/customize/extensions/export-log-events-with-extensions/export-logs-to-mixpanel',
+    to: '/customize/log-streams/custom-log-streams',
   },
   {
     from: [
       '/extensions/export-logs-to-papertrail',
       '/extensions/papertrail',
       '/extensions/log-export-extensions/export-logs-to-papertrail',
+      '/customize/extensions/export-log-events-with-extensions/export-logs-to-papertrail',
     ],
-    to: '/customize/extensions/export-log-events-with-extensions/export-logs-to-papertrail',
+    to: '/customize/log-streams/custom-log-streams',
   },
   {
     from: [
       '/extensions/export-logs-to-segment',
       '/extensions/segment',
       '/extensions/log-export-extensions/export-logs-to-segment',
+      '/customize/extensions/export-log-events-with-extensions/export-logs-to-segment',
     ],
-    to: '/customize/extensions/export-log-events-with-extensions/export-logs-to-segment',
+    to: '/customize/log-streams/custom-log-streams',
   },
   {
     from: [
       '/extensions/export-logs-to-splunk',
       '/extensions/splunk',
       '/extensions/log-export-extensions/export-logs-to-splunk',
+      '/customize/extensions/export-log-events-with-extensions/export-logs-to-splunk',
     ],
-    to: '/customize/extensions/export-log-events-with-extensions/export-logs-to-splunk',
+    to: '/customize/log-streams/custom-log-streams',
   },
   {
     from: [
       '/extensions/auth0-logs-to-sumo-logic',
       '/extensions/sumologic',
       '/extensions/log-export-extensions/auth0-logs-to-sumo-logic',
+      '/customize/extensions/export-log-events-with-extensions/auth0-logs-to-sumo-logic',
     ],
-    to: '/customize/extensions/export-log-events-with-extensions/auth0-logs-to-sumo-logic',
+    to: '/customize/log-streams/custom-log-streams',
   },
   {
     from: ['/extensions/authentication-api-debugger', '/extensions/authentication-api-debugger-extension'],


### PR DESCRIPTION
Starting redirects for Log Extension deprecation

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
