### PR TITLE
Laravel: Add note about authenticating the CLI as a user

### DIFF
--- a/articles/quickstart/backend/laravel/01-authorization.md
+++ b/articles/quickstart/backend/laravel/01-authorization.md
@@ -62,7 +62,7 @@ Run the following command from your project directory to download the [Auth0 CLI
 curl -sSfL https://raw.githubusercontent.com/auth0/auth0-cli/main/install.sh | sh -s -- -b .
 ```
 
-Then authenticate the CLI with your Auth0 account:
+Then authenticate the CLI with your Auth0 account, choosing "as a user" when prompted:
 
 ```shell
 ./auth0 login
@@ -184,7 +184,6 @@ Route::get('/me', function () {
 **You should cache user information in your application for brief periods.** This reduces the number of requests your application makes to Auth0, and improves performance. You should avoid storing user information in your application for long periods as this can lead to stale data. You should also avoid storing user information beyond the user's identifier in persistent databases.
 :::
 
-
 ## Run the Application
 
 You are now ready to start your Laravel application, so it can accept requests:
@@ -222,7 +221,7 @@ curl --request GET \
   --header 'Authorization: Bearer YOUR_ACCESS_TOKEN'
 ```
 
-Finally, try requesting the scope-protected route, which will only succeed if the access token has the  `read:messages` scope granted:
+Finally, try requesting the scope-protected route, which will only succeed if the access token has the `read:messages` scope granted:
 
 ```shell
 curl --request GET \

--- a/articles/quickstart/backend/laravel/interactive.md
+++ b/articles/quickstart/backend/laravel/interactive.md
@@ -68,7 +68,7 @@ Run the following command from your project directory to download the [Auth0 CLI
 curl -sSfL https://raw.githubusercontent.com/auth0/auth0-cli/main/install.sh | sh -s -- -b .
 ```
 
-Then authenticate the CLI with your Auth0 account:
+Then authenticate the CLI with your Auth0 account, choosing "as a user" when prompted:
 
 ```shell
 ./auth0 login
@@ -196,7 +196,6 @@ Route::get('/me', function () {
 **You should cache user information in your application for brief periods.** This reduces the number of requests your application makes to Auth0, and improves performance. You should avoid storing user information in your application for long periods as this can lead to stale data. You should also avoid storing user information beyond the user's identifier in persistent databases.
 :::
 
-
 ## Run the Application
 
 You are now ready to start your Laravel application, so it can accept requests:
@@ -234,7 +233,7 @@ curl --request GET \
   --header 'Authorization: Bearer YOUR_ACCESS_TOKEN'
 ```
 
-Finally, try requesting the scope-protected route, which will only succeed if the access token has the  `read:messages` scope granted:
+Finally, try requesting the scope-protected route, which will only succeed if the access token has the `read:messages` scope granted:
 
 ```shell
 curl --request GET \

--- a/articles/quickstart/webapp/laravel/01-login.md
+++ b/articles/quickstart/webapp/laravel/01-login.md
@@ -16,6 +16,7 @@ useCase: quickstart
 github:
   path: sample
 ---
+
 <!-- markdownlint-disable MD002 MD034 MD041 -->
 
 ## Laravel Installation
@@ -54,7 +55,7 @@ Run the following command from your project directory to download the [Auth0 CLI
 curl -sSfL https://raw.githubusercontent.com/auth0/auth0-cli/main/install.sh | sh -s -- -b .
 ```
 
-Then authenticate the CLI with your Auth0 account:
+Then authenticate the CLI with your Auth0 account, choosing "as a user" when prompted:
 
 ```shell
 ./auth0 login
@@ -191,6 +192,7 @@ php artisan serve
 ```
 
 ### Checkpoint
+
 Open your web browser and try accessing the following routes:
 
 - [http://localhost:8000](http://localhost:8000) to see the public route.

--- a/articles/quickstart/webapp/laravel/interactive.md
+++ b/articles/quickstart/webapp/laravel/interactive.md
@@ -61,7 +61,7 @@ Run the following command from your project directory to download the [Auth0 CLI
 curl -sSfL https://raw.githubusercontent.com/auth0/auth0-cli/main/install.sh | sh -s -- -b .
 ```
 
-Then authenticate the CLI with your Auth0 account:
+Then authenticate the CLI with your Auth0 account, choosing "as a user" when prompted:
 
 ```shell
 ./auth0 login


### PR DESCRIPTION
This PR adds a note to the Laravel quickstarts to authenticate the Auth0 CLI "as a user" when prompted. This PR is in response to developer feedback submitted to us, noting that clarity on this would be helpful.