### PR TITLE
Update note about `app` directory

### DIFF
--- a/articles/quickstart/webapp/nextjs/01-login.md
+++ b/articles/quickstart/webapp/nextjs/01-login.md
@@ -73,7 +73,7 @@ This creates the following routes:
 On the frontend side, the SDK uses React Context to manage the authentication state of your users. To make that state available to all your pages, you need to override the [App component](https://nextjs.org/docs/advanced-features/custom-app) and wrap its inner component with a `UserProvider`. 
 
 :::note
-The `app` directory introduced with Next.js 13 is currently in beta, and Vercel [does not recommend](https://nextjs.org/blog/next-13#new-app-directory-beta) using it in production. As such, this SDK does not support it yet.
+Support for the new `app` directory is coming. Check out the [beta release](https://github.com/auth0/nextjs-auth0/issues/1235).
 :::
 
 Create the file `pages/_app.js` as follows:

--- a/articles/quickstart/webapp/nextjs/interactive.md
+++ b/articles/quickstart/webapp/nextjs/interactive.md
@@ -69,7 +69,7 @@ Then, import in that file the `handleAuth` method from the SDK, and export the r
 On the frontend side, the SDK uses React Context to manage the authentication state of your users. To make that state available to all your pages, you need to override the [App component](https://nextjs.org/docs/advanced-features/custom-app) and wrap its inner component with a `UserProvider` in the file `pages/_app.jsx`.
 
 :::note
-The `app` directory introduced with Next.js 13 is currently in beta, and Vercel [does not recommend](https://nextjs.org/blog/next-13#new-app-directory-beta) using it in production. As such, this SDK does not support it yet.
+Support for the new `app` directory is coming. Check out the [beta release](https://github.com/auth0/nextjs-auth0/issues/1235).
 :::
 
 The authentication state exposed by `UserProvider` can be accessed in any component using the `useUser()` hook.


### PR DESCRIPTION
### Changes

This PR updates the Next.js Quickstart (both interactive and non-interactive) to note that support for the new `app` directory is coming, pointing toward the [beta releases](https://github.com/auth0/nextjs-auth0/issues/1235) of nextjs-auth0.