### PR TITLE
Update 01-authorization.md

### DIFF
--- a/articles/quickstart/backend/aspnet-core-webapi/01-authorization.md
+++ b/articles/quickstart/backend/aspnet-core-webapi/01-authorization.md
@@ -64,7 +64,13 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     options.Audience = builder.Configuration["Auth0:Audience"];
     options.TokenValidationParameters = new TokenValidationParameters
     {
-        NameClaimType = ClaimTypes.NameIdentifier
+        NameClaimType = ClaimTypes.NameIdentifier,
+        SignatureValidator = delegate (string token, TokenValidationParameters parameters)
+          {
+              var jwt = new JwtSecurityToken(token);
+
+              return jwt;
+          }
     };
 });
 ```


### PR DESCRIPTION
SignatureValidator needs to be defined in the suggested way in NET 7 to avoid the error: "Signature validation failed. Token does not have a kid...". No other way around to make the JWT to be accepted.

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
