### PR TITLE
Docs 3196 fix create hooks

### DIFF
--- a/config/redirects.js
+++ b/config/redirects.js
@@ -4878,7 +4878,6 @@ const redirects = [
       '/hooks/guides/create-hooks-using-dashboard',
       '/auth0-hooks/cli/create-delete',
       '/hooks/create-hooks',
-      '/customize/hooks/create-hooks',
     ],
     to: '/customize/hooks/create-hooks',
   },

--- a/config/redirects.js
+++ b/config/redirects.js
@@ -4878,6 +4878,7 @@ const redirects = [
       '/hooks/guides/create-hooks-using-dashboard',
       '/auth0-hooks/cli/create-delete',
       '/hooks/create-hooks',
+      '/create-hooks',
     ],
     to: '/customize/hooks/create-hooks',
   },

--- a/config/redirects.js
+++ b/config/redirects.js
@@ -4880,7 +4880,7 @@ const redirects = [
       '/hooks/create-hooks',
       '/customize/hooks/create-hooks',
     ],
-    to: '/customize/hooks',
+    to: '/customize/hooks/create-hooks',
   },
   {
     from: [


### PR DESCRIPTION
Error in archiving Create Hooks. This doc needs to be reinstated on the site with warnings to only use Hooks for testing purposes.
<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
