### PR TITLE
Fix Flutter Web import path

### DIFF
--- a/articles/quickstart/spa/flutter/01-login.md
+++ b/articles/quickstart/spa/flutter/01-login.md
@@ -43,7 +43,7 @@ You should also be familiar with the [Flutter command line tool](https://docs.fl
 Integrate Auth0 Universal Login in your Flutter app by importing the SDK and instantiating the `Auth0` class using your Auth0 domain and Client ID values. See this example, which instantiates the class inside a widget state object:
 
 ```dart
-import 'package:auth0_flutter/auth0_flutter.dart';
+import 'package:auth0_flutter/auth0_flutter_web.dart';
 
 class MainView extends StatefulWidget {
   const MainView({Key? key}) : super(key: key);

--- a/articles/quickstart/spa/flutter/files/main.md
+++ b/articles/quickstart/spa/flutter/files/main.md
@@ -5,7 +5,7 @@ language: dart
 <!-- markdownlint-disable MD041 -->
 
 ```dart
-import 'package:auth0_flutter/auth0_flutter.dart';
+import 'package:auth0_flutter/auth0_flutter_web.dart';
 import 'package:flutter/material.dart';
 import 'profile_view.dart';
 


### PR DESCRIPTION
### Changes

This PR fixes an incorrect import path in the Flutter Web Quickstarts, both interactive and non-interactive.
