### PR TITLE
Update PKCE-related messaging for Swift and Flutter mobile Quickstarts

### DIFF
--- a/articles/quickstart/native/flutter/_configure_urls_interactive.md
+++ b/articles/quickstart/native/flutter/_configure_urls_interactive.md
@@ -10,8 +10,6 @@ The URLs below make use of a `SCHEME` placeholder, and this value varies dependi
 
 Use the interactive selector to create a new "Native Application", or select an existing application that represents the project you want to integrate with. Every application in Auth0 is assigned an alphanumeric, unique client ID that your application code will use to call Auth0 APIs through the SDK.
 
-Ensure that the **Token Endpoint Authentication Method** setting has a value of "None".
-
 Any settings you configure using this quickstart will automatically update for your application in the <a href="${manage_url}/#/">Dashboard</a>, which is where you can manage your applications in the future.
 
 If you would rather explore a complete configuration, you can view a sample application instead.

--- a/articles/quickstart/native/ios-swift/01-login.md
+++ b/articles/quickstart/native/ios-swift/01-login.md
@@ -46,7 +46,7 @@ com.example.MyApp://example.us.auth0.com/ios/com.example.MyApp/callback
 ```
 
 ::: warning
-Make sure that the [application type](/get-started/applications) of the Auth0 application is **Native**, and that the **Token Endpoint Authentication Method** setting is set to `None`. If you don’t have a Native Auth0 application already, [create one](/get-started/auth0-overview/create-applications/native-apps) before continuing.
+Make sure that the [application type](/get-started/applications) of the Auth0 application is **Native**. If you don’t have a Native Auth0 application already, [create one](/get-started/auth0-overview/create-applications/native-apps) before continuing.
 :::
 
 ### Configure a Custom URL Scheme


### PR DESCRIPTION
### Changes

Recently there have been some changes in Manage, and now the **Token Endpoint Authentication Method** setting no longer shows up for mobile apps (because for this kind of app it must be `None`). Whereas for regular web apps it's been moved to another tab:

<img width="543" alt="Screenshot 2023-08-11 at 1 55 22 PM" src="https://github.com/auth0/Auth0.swift/assets/5055789/27ad3b7d-98f2-4e3c-b551-7f8b63b68018">

Since it was possible (before this change) to set it to an invalid value for mobile apps, we had to point this out in Quickstarts. Now that this setting is no longer available for mobile apps, this PR removes the respective messaging from the Swift and Flutter mobile Quickstarts.