### PR TITLE
Update WPF and WinForms quickstart to .NET6

### DIFF
--- a/articles/quickstart/native/wpf-winforms/01-login.md
+++ b/articles/quickstart/native/wpf-winforms/01-login.md
@@ -1,7 +1,7 @@
 ---
 title: Login
 default: true
-description: This tutorial demonstrates how to add user login to a Windows Forms C# application using Auth0.
+description: This tutorial demonstrates how to add user login to a WPF and Windows Forms C# application using Auth0.
 budicon: 448
 topics:
   - quickstarts
@@ -41,10 +41,6 @@ To integrate Auth0 login into your application, simply instantiate an instance o
 
 ${snippet(meta.snippets.setup)}
 
-::: note
-By default, the SDK uses WebView (non-chromium Edge) as a Browser. If you wish to use Chromium Edge, you can implement [WebView2](https://docs.microsoft.com/en-us/microsoft-edge/webview2/) as explained on [this Auth0 Community post](https://community.auth0.com/t/howto-use-the-auth0-oidcclient-winforms-sdk-with-edge-chromium-webview2/57746).
-:::
-
 You can then call the `LoginAsync` method to log the user in:
 
 ${snippet(meta.snippets.use)}
@@ -62,8 +58,6 @@ The returned login result will indicate whether authentication was successful, a
 You can check the `IsError` property of the result to see whether the login has failed. The `ErrorMessage` will contain more information regarding the error which occurred.
 
 ```csharp
-// Form1.cs
-
 var loginResult = await client.LoginAsync();
 
 if (loginResult.IsError)
@@ -77,8 +71,6 @@ if (loginResult.IsError)
 On successful login, the login result will contain the ID Token and Access Token in the `IdentityToken` and `AccessToken` properties respectively.
 
 ```csharp
-// Form1.cs
-
 var loginResult = await client.LoginAsync();
 
 if (!loginResult.IsError)
@@ -95,8 +87,6 @@ On successful login, the login result will contain the user information in the `
 To obtain information about the user, you can query the claims. You can for example obtain the user's name and email address from the `name` and `email` claims:
 
 ```csharp
-// Form1.cs
-
 if (!loginResult.IsError)
 {
     Debug.WriteLine($"name: {loginResult.User.FindFirst(c => c.Type == "name")?.Value}");
@@ -111,8 +101,6 @@ The exact claims returned will depend on the scopes that were requested. For mor
 You can obtain a list of all the claims contained in the ID Token by iterating through the `Claims` collection:
 
 ```csharp
-// Form1.cs
-
 if (!loginResult.IsError)
 {
     foreach (var claim in loginResult.User.Claims)
@@ -127,6 +115,5 @@ if (!loginResult.IsError)
 To log the user out call the `LogoutAsync` method.
 
 ```csharp
-// Form1.cs
 await client.LogoutAsync();
 ```

--- a/articles/quickstart/native/wpf-winforms/index.yml
+++ b/articles/quickstart/native/wpf-winforms/index.yml
@@ -40,6 +40,7 @@ sdk:
   logo: windows
 requirements:
   - Microsoft Visual Studio 2022
+  - .NET Framework 4.6.2
   - .NET Framework 4.8.1
   - .NET 6
 next_steps:

--- a/articles/quickstart/native/wpf-winforms/index.yml
+++ b/articles/quickstart/native/wpf-winforms/index.yml
@@ -39,8 +39,8 @@ sdk:
   url: https://github.com/auth0/auth0-oidc-client-net
   logo: windows
 requirements:
-  - Microsoft Visual Studio 2017
-  - .NET Framework 4.6.2
+  - Microsoft Visual Studio 2022
+  - .NET 6
 next_steps:
   - path: 01-login
     list:

--- a/articles/quickstart/native/wpf-winforms/index.yml
+++ b/articles/quickstart/native/wpf-winforms/index.yml
@@ -40,6 +40,7 @@ sdk:
   logo: windows
 requirements:
   - Microsoft Visual Studio 2022
+  - .NET Framework 4.8.1
   - .NET 6
 next_steps:
   - path: 01-login

--- a/articles/quickstart/native/wpf-winforms/index.yml
+++ b/articles/quickstart/native/wpf-winforms/index.yml
@@ -41,7 +41,6 @@ sdk:
 requirements:
   - Microsoft Visual Studio 2022
   - .NET Framework 4.6.2
-  - .NET Framework 4.8.1
   - .NET 6
 next_steps:
   - path: 01-login


### PR DESCRIPTION
Update the WPF and WinForms quickstart for .NET6.

This does not need any content changes, as it just works since the latest version of the SDK.

As the latest version also uses WebView2 automatically, I removed the callout on how to use WebView2 manually, as that is no longer needed.

Also got rid of Form1.cs references, as that only works for WinForms, while the quickstart is also for WPF.