### PR TITLE
fix/docs: add missing comma to json example

### DIFF
--- a/articles/api/authentication/_sign-up.md
+++ b/articles/api/authentication/_sign-up.md
@@ -13,7 +13,7 @@ Content-Type: application/json
   "family_name": "Doe",
   "name": "John Doe",
   "nickname": "johnny",
-  "picture": "http://example.org/jdoe.png"
+  "picture": "http://example.org/jdoe.png",
   "user_metadata": { plan: 'silver', team_id: 'a111' }
 }
 ```


### PR DESCRIPTION
Fixes the json provided in https://auth0.com/docs/api/authentication#signup.