### PR TITLE
Chore: Fix typo in multiple files in docs-auth0

### DIFF
--- a/articles/anomaly-detection/guides/use-tenant-data-for-anomaly-detection.md
+++ b/articles/anomaly-detection/guides/use-tenant-data-for-anomaly-detection.md
@@ -31,7 +31,7 @@ The following example shows a credential stuffing attack on 11/20, with a large 
 
 ![Traffic Failure Trends](/media/articles/anomaly-detection/traffic-failure-trends.png)
 
-## Authenticaton failure events from distinct IPs 
+## Authentication failure events from distinct IPs 
 
 You can use the `ip` event to see the number of distinct IPs that your failure traffic is coming from, in this case, the number of distinct IPs that correspond to your `fu` event traffic.
 

--- a/articles/api/authentication/legacy/_userinfo.md
+++ b/articles/api/authentication/legacy/_userinfo.md
@@ -91,6 +91,6 @@ This endpoint validates a <dfn data-key="json-web-token">JSON Web Token (JWT)</d
 
 ### More Information
 
-- [User Profile Struture](/users/references/user-profile-structure)
+- [User Profile Structure](/users/references/user-profile-structure)
 
 - [Auth0 API Rate Limit Policy](/policies/rate-limits)

--- a/articles/connections/database/custom-db/index.md
+++ b/articles/connections/database/custom-db/index.md
@@ -17,7 +17,7 @@ useCase:
   <div data-name="example" class="topic-page-badge"></div>
   <h1>Custom Database Connections</h1>
   <p>
-  Use a custom database connection when you want to provide Auth0 with access to your own independent (legacy) identity data store primarily for authenticaton (filling the role of an identity provider) and for migrating user data to Auth0's data store. 
+  Use a custom database connection when you want to provide Auth0 with access to your own independent (legacy) identity data store primarily for authentication (filling the role of an identity provider) and for migrating user data to Auth0's data store. 
   </p>
 </div>
 

--- a/articles/connections/enterprise/adfs.md
+++ b/articles/connections/enterprise/adfs.md
@@ -113,7 +113,7 @@ Set-ADFSRelyingPartyTrust –TargetName $realm –IssuanceAuthorizationRules $rS
 
 ## Manual setup part 2: Add a claim issuance policy rule
 
-1. If you're using Windows Server 2019, the Edit Claim Issuance Polcy dialog box automatically opens when you finish the Add Relying Party Trust wizard. If you're using Windows 2012 or 2016, follow these steps:
+1. If you're using Windows Server 2019, the Edit Claim Issuance Policy dialog box automatically opens when you finish the Add Relying Party Trust wizard. If you're using Windows 2012 or 2016, follow these steps:
     |  In Windows Server 2012  | In Windows Server 2016 |
     | --- | --- |
     | In the Actions panel on the right side of the console, find the Relying Party Trust you just created. Beneath it, click **Edit Claim Issuance Policy**. | In the console tree, under ADFS, click **Relying Party Trusts**. On the right side of the console, find the Relying Party Trust you just created. Right-click it and click **Edit Claim Issuance Policy**. |

--- a/articles/connections/social/oauth2.md
+++ b/articles/connections/social/oauth2.md
@@ -79,7 +79,7 @@ function fetchUserProfile(accessToken, context, callback) {
 }
 ```
 
-The `user_id` property in the returned profile is required, and the `email` property is optional but highly recommended. To learn more about what attributes can be returend, see [User Profile Root Attributes](/users/updating-user-profile-root-attributes).
+The `user_id` property in the returned profile is required, and the `email` property is optional but highly recommended. To learn more about what attributes can be returned, see [User Profile Root Attributes](/users/updating-user-profile-root-attributes).
 
 You can filter, add, or remove anything from the profile returned from the provider. However, it is recommended that you keep this script as simple as possible. More sophisticated manipulation of user information can be achieved through the use of [Rules](/rules). One advantage of using Rules is that they apply to any connection.
 

--- a/articles/dashboard/manage-dashboard-admins.md
+++ b/articles/dashboard/manage-dashboard-admins.md
@@ -85,4 +85,4 @@ If you want to allow employees of your organization to have access to our [Suppo
 
 We've occasionally found that Dashboard administrations inadvertently create multiple Auth0 accounts. For example, they might sign up with a social provider (e.g., Google, GitHub), then sign up again using the email address. If you have a Dashboard administrator that reports that they cannot see all of their tenants after logging in, check to see if they have multiple Auth0 accounts.
 
-You can confirm the signup method used by the Dashboard adminsitrator by going to **Tenant Settings** > [**Dashboard Admins**](${manage_url}/#/tenant/admins). 
+You can confirm the signup method used by the Dashboard administrator by going to **Tenant Settings** > [**Dashboard Admins**](${manage_url}/#/tenant/admins). 

--- a/articles/extensions/logentries.md
+++ b/articles/extensions/logentries.md
@@ -20,7 +20,7 @@ To install and configure this extension, click on the _Auth0 Logs to Logentries_
 
 At this point you should set the following configuration variables:
 - **Schedule**: The frequency with which logs should be exported. The schedule can be customized even further after creation.
-- **BATCH_SIZE**: The amount of logs to be read on each execution. Maximun is 100.
+- **BATCH_SIZE**: The amount of logs to be read on each execution. Maximum is 100.
 - **LOGENTRIES_TOKEN**: The Logentries Token for your log set to which the Auth0 logs will be exported.
 - **LOG_LEVEL**: The minimal log level of events that you would like sent to Logentries.
 - **LOG_TYPES**: The events for which logs should be exported.  If you want you can send only events with a specific type (for example, failed logins).

--- a/articles/extensions/logstash.md
+++ b/articles/extensions/logstash.md
@@ -23,7 +23,7 @@ At this point you should set the following configuration variables:
 | Parameter        | Description |
 |:-----------------|:------------|
 | **Schedule** | The frequency with which logs should be exported. The schedule can be customized even further after creation. |
-| **BATCH_SIZE** | The amount of logs to be read on each execution. Maximun, and default, is `100`. |
+| **BATCH_SIZE** | The amount of logs to be read on each execution. Maximum, and default, is `100`. |
 | **LOGSTASH_URL** <br/><span class="label label-danger">Required</span> | Your Logstash URL as defined for use with `logstash-input-http` plugin. |
 | **LOGSTASH_INDEX** <br/><span class="label label-danger">Required</span> | Your Logstash Index to which the logs will be routed. |
 | **LOGSTASH_TOKEN** | The token required for your Logstash deployments that will be included in the querystring. |

--- a/articles/extensions/segment.md
+++ b/articles/extensions/segment.md
@@ -20,7 +20,7 @@ At this point you should set the following configuration variables:
 | Parameter        | Description |
 |:-----------------|:------------|
 | **Schedule** | The frequency with which logs should be exported. The schedule can be customized even further after creation. |
-| **BATCH_SIZE** | The amount of logs to be read on each execution. Maximun, and default, is `100`. |
+| **BATCH_SIZE** | The amount of logs to be read on each execution. Maximum, and default, is `100`. |
 | **START_FROM** | The checkpoint ID of the log from where you want to start. |
 | **SLACK_INCOMING_WEBHOOK** | The Slack incoming webhook URL used to send relevant updates. |
 | **SLACK_SEND_SUCCESS** | Toggle for sending verbose notifications to Slack. |

--- a/articles/hooks/extensibility-points/index.md
+++ b/articles/hooks/extensibility-points/index.md
@@ -14,7 +14,7 @@ Extensibility points are places in the Auth0 platform where [Hooks](/hooks) can 
 
 Whether Hooks can be used with connections varies according to extensibility point. Hooks that can be used with connections only work with [Database Connections](/connections/database) and [Passwordless Connections](/connections/passwordless).
 
-Extensibility points may also block processes from executing. Synchronous extensibility points are blocking, which means they execute the Hook as part of the trigger's process and will prevent that process from executing until the Hook is complete. Aynchronous extensibility points will not wait for the Hook to finish its execution before proceeding.
+Extensibility points may also block processes from executing. Synchronous extensibility points are blocking, which means they execute the Hook as part of the trigger's process and will prevent that process from executing until the Hook is complete. Asynchronous extensibility points will not wait for the Hook to finish its execution before proceeding.
 
 The following extensibility points are available:
 

--- a/articles/monitoring/guides/track-leads-salesforce.md
+++ b/articles/monitoring/guides/track-leads-salesforce.md
@@ -168,7 +168,7 @@ function (user, context, callback) {
         client_secret: client_secret,
         username: username,
         password: password
-      }}, (err, respose, body) => {
+      }}, (err, response, body) => {
         return callback(JSON.parse(body));
       });
   }

--- a/articles/monitoring/guides/track-signups-salesforce.md
+++ b/articles/monitoring/guides/track-signups-salesforce.md
@@ -220,7 +220,7 @@ function (user, context, callback) {
         client_secret: client_secret,
         username: username,
         password: password
-      }}, (err, respose, body) => {
+      }}, (err, response, body) => {
         return callback(JSON.parse(body));
       });
   }

--- a/articles/product-lifecycle/migrations.md
+++ b/articles/product-lifecycle/migrations.md
@@ -24,7 +24,7 @@ We are actively migrating customers to new behaviors for all <dfn data-key="depr
   </thead>
   <tbody>
     <tr>
-      <td><a href="/migrations/guides/unpaginated-requests">Unpaginated Managment API v2 Request deprecation</a></td>
+      <td><a href="/migrations/guides/unpaginated-requests">Unpaginated Management API v2 Request deprecation</a></td>
       <td>21 July 2020 (Public Cloud)</td>
       <td>26 January 2021</td>
       <td>

--- a/articles/quickstart/backend/php/interactive.md
+++ b/articles/quickstart/backend/php/interactive.md
@@ -96,7 +96,7 @@ composer require steampixel/simple-php-router
 
 Create a new file in your application called `router.php` to define the routes. Copy in the code from the interactive panel to the right under the <b>router.php</b> tab.
 
-## Configue endpoint authorization {{{ data-action=code data-code="router.php#21:31" }}}
+## Configure endpoint authorization {{{ data-action=code data-code="router.php#21:31" }}}
 
 Now that you have configured your Auth0 application, the Auth0 PHP SDK, and you application retrieves bearer tokens from requests, the next step is to set up endpoint authorization for your project. The `getBearerToken()` method you implemented above returns a `Token` class that includes details on the request's access.
 

--- a/articles/quickstart/backend/rails/01-authorization.md
+++ b/articles/quickstart/backend/rails/01-authorization.md
@@ -256,7 +256,7 @@ class ApplicationController < ActionController::API
 end
 ```
 
-You only ned to protect the `PrivateController` as follows:
+You only need to protect the `PrivateController` as follows:
 
 ```ruby
 class PrivateController < ApplicationController

--- a/articles/tokens/concepts/refresh-tokens.md
+++ b/articles/tokens/concepts/refresh-tokens.md
@@ -45,7 +45,7 @@ Providing secure authentication in SPAs has a number of challenges based on your
 
 Auth0 recommends using [Refresh Token Rotation](/tokens/concepts/refresh-token-rotation) which provides a secure method for using Refresh Tokens in SPAs while providing end-users with seamless access to resources without the disruption in UX caused by browser privacy technology like ITP.
 
-Auth0’s former guidance was to use the [Authorization Code Flow with Proof Key for Code Exchange (PKCE)](/flows/concepts/auth-code-pkce) in conjuntion with [Silent Authentication](/api-auth/tutorials/silent-authentication) in SPAs. This is more secure solution than the Implicit Flow but not as secure as the [Authorization Code Flow with Proof Key for Code Exchange (PKCE)](/flows/concepts/auth-code-pkce) with Refresh Token Rotation. 
+Auth0’s former guidance was to use the [Authorization Code Flow with Proof Key for Code Exchange (PKCE)](/flows/concepts/auth-code-pkce) in conjuction with [Silent Authentication](/api-auth/tutorials/silent-authentication) in SPAs. This is more secure solution than the Implicit Flow but not as secure as the [Authorization Code Flow with Proof Key for Code Exchange (PKCE)](/flows/concepts/auth-code-pkce) with Refresh Token Rotation. 
 
 ### Native/Mobile apps
 

--- a/articles/tokens/guides/use-refresh-tokens.md
+++ b/articles/tokens/guides/use-refresh-tokens.md
@@ -43,7 +43,7 @@ To exchange the Refresh Token you received during authorization for a new Access
 }
 ```
 
-| Attriburte | Description |
+| Attribute | Description |
 | - | - |
 | `grant_type` | The type of grant to execute (the `/token` endpoint is used for various grants, for more information refer to the [Authentication API](/api/authentication#get-token)). To refresh a token, use `refresh_token` |
 | `client_id` | Your application's Client ID |

--- a/articles/troubleshoot/guides/check-error-messages.md
+++ b/articles/troubleshoot/guides/check-error-messages.md
@@ -1,6 +1,6 @@
 ---
 title: Check Error Messages
-description: Learn how to check for error message to troublshoot issues. 
+description: Learn how to check for error message to troubleshoot issues. 
 topics:
   - error-messages
 contentType: how-to

--- a/config/glossary.json
+++ b/config/glossary.json
@@ -216,7 +216,7 @@
   },
   "management-api": {
     "title": "Management API",
-    "definition": "Auth0's API to manage Auth0 services and perform administrative tasks programatically.",
+    "definition": "Auth0's API to manage Auth0 services and perform administrative tasks programmatically.",
     "short": "A product to allow customers to perform administrative tasks. "
   },
   "metadata": {
@@ -342,7 +342,7 @@
   "single-sign-on": {
     "title": "Single Sign-On (SSO)",
     "definition": "A service that, after a user logs into one application, automatically logs that user in to other applications, regardless of the platform, technology, or domain the user is using. The user signs in only one time (hence the name of the feature). Similarly, Single Logout (SLO) occurs when, after a user logs out from one application, they are logged out of each application or service where they were logged in. SSO and SLO are possible through the use of sessions. See <a href='/docs/sso'>Single Sign-On and Single Logout</a>.",
-    "short": "A service that, after a user logs into one applicaton, automatically logs that user in to other applications."
+    "short": "A service that, after a user logs into one application, automatically logs that user in to other applications."
   },
   "subscription": {
     "title": "Subscription",

--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -1436,7 +1436,7 @@ articles:
           - title: Rate Limits
             url: /policies/rate-limit-policy
             children:
-              - title: Managment API Endpoint Rate Limits
+              - title: Management API Endpoint Rate Limits
                 url: /policies/rate-limit-policy/management-api-endpoint-rate-limits
                 hidden: true
               - title: Authentication API Endpoint Rate Limits

--- a/updates/2016-03-30.yml
+++ b/updates/2016-03-30.yml
@@ -5,4 +5,4 @@ added:
       - oauth
       - api-auth
     description: |
-      A new section of documentation was added for [API Authentication and Authorization](/api-auth). These documents are for a preview feature so the content and implimentations are subject to change.
+      A new section of documentation was added for [API Authentication and Authorization](/api-auth). These documents are for a preview feature so the content and implementations are subject to change.

--- a/updates/2016-06-21.yml
+++ b/updates/2016-06-21.yml
@@ -21,7 +21,7 @@ changed:
       - spring security
       - mvc
     description: |
-      - Added Gradle dependecies for java-servlet, java-spring-security-mvc and java-spring-mvc.
+      - Added Gradle dependencies for java-servlet, java-spring-security-mvc and java-spring-mvc.
       - Updated auth0.properties for java-spring-security, java-servlet, java-spring-security-mvc and java-spring-mvc.
       - Updated [overview doc](/java-overview) with new section on Auth0 Resource Server Sample using Spring Boot and Spring Security sample.
       - Updated java-spring-security-mvc doc with section on endpoint security configuration and add note on the [sso sample](https://github.com/auth0-samples/auth0-spring-security-mvc-sso-sample).


### PR DESCRIPTION
<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
This PR solve the typo seen in various files

```pseudo
Authenticaton > Authentication
Struture > Structure
Polcy > Policy
returend > returned
Maximun > Maximum
```