### PR TITLE
microsite removal

### DIFF
--- a/articles/microsites/call-api/call-api-m2m-app.md
+++ b/articles/microsites/call-api/call-api-m2m-app.md
@@ -3,6 +3,7 @@ title: Call Your API from a Machine-to-Machine App
 description: Everything you need to know to call your API from your machine-to-machine (M2M) app
 ctaText: Go to Quickstart
 ctaLink: /docs/quickstart/backend
+public: false
 template: microsite
 topics:
   - authentication

--- a/config/redirects.js
+++ b/config/redirects.js
@@ -959,13 +959,11 @@ const redirects = [
   },
 
   /* MICROSITES */
-  [
-    from: [
-      '/microsites/call-api/call-api-m2m-app',
-    ],
+  {
+    from: ['/microsites/call-api/call-api-m2m-app'],
     to: '/get-started/authentication-and-authorization-flow/client-credentials-flow',
 
-  ],
+  },
 
   /* ARCHITECTURE SCENARIOS */
 

--- a/config/redirects.js
+++ b/config/redirects.js
@@ -963,7 +963,7 @@ const redirects = [
     from: [
       '/microsites/call-api/call-api-m2m-app',
     ],
-    to: '/get-started/authentication-and-authorization-flow/client-credentials-flow'
+    to: '/get-started/authentication-and-authorization-flow/client-credentials-flow',
 
   ],
 

--- a/config/redirects.js
+++ b/config/redirects.js
@@ -959,6 +959,13 @@ const redirects = [
   },
 
   /* MICROSITES */
+  [
+    from: [
+      '/microsites/call-api/call-api-m2m-app',
+    ],
+    to: '/get-started/authentication-and-authorization-flow/client-credentials-flow'
+
+  ],
 
   /* ARCHITECTURE SCENARIOS */
 


### PR DESCRIPTION
added public false and redirect for this microsite since it is still in the sitemap

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
