### PR TITLE
Fix scrolling issue in Flutter QS

### DIFF
--- a/articles/quickstart/native/flutter/interactive.md
+++ b/articles/quickstart/native/flutter/interactive.md
@@ -29,8 +29,6 @@ Auth0 allows you to quickly add authentication and access user profile informati
 The Flutter SDK currently only supports Flutter applications running on Android or iOS platforms.
 :::
 
-## Getting started
-
 This quickstart assumes you already have a [Flutter](https://flutter.dev/) application up and running. If not, check out the [Flutter "getting started" guides](https://docs.flutter.dev/get-started/install) to get started with a simple app.
 
 You should also be familiar with the [Flutter command line tool](https://docs.flutter.dev/reference/flutter-cli).

--- a/articles/quickstart/spa/flutter/interactive.md
+++ b/articles/quickstart/spa/flutter/interactive.md
@@ -30,8 +30,6 @@ Auth0 allows you to quickly add authentication and access user profile informati
 The Flutter SDK currently only supports Flutter applications running on Android, iOS, or Web platforms.
 :::
 
-## Getting started
-
 This quickstart assumes you already have a [Flutter](https://flutter.dev/) application up and running. If not, check out the [Flutter "getting started" guides](https://docs.flutter.dev/get-started/install) to get started with a simple app.
 
 You should also be familiar with the [Flutter command line tool](https://docs.flutter.dev/reference/flutter-cli).


### PR DESCRIPTION
### Changes

Currently, the Flutter interactive QuickStarts for mobile and web have an issue when scrolling past the first "Getting Started" step, whereas the content of the following step remains dimmed:

https://github.com/auth0/docs/assets/5055789/e7afba33-17f6-45e4-84ee-1e3fe87dc5db

Turns out that the step whose content remains dimmed is added through an include. This include contains a level 2 heading with the name of the step ("Configure Auth0"), and is being included after another level 2 heading ("Getting Started"). While this should result (and does result) in a new level 2 heading being appended, it trips up the scroll behavior of the docs app.

This PR simply removes the "Getting Started" heading so that the includes follow after a level 1 heading, which does not cause any issues when scrolling. This is intended as a stop-gap measure until the underlying issue is fixed on the docs app.