### PR TITLE
Add note on context type

### DIFF
--- a/articles/quickstart/native/android/00-login.md
+++ b/articles/quickstart/native/android/00-login.md
@@ -165,6 +165,9 @@ private fun loginWithBrowser() {
 After you call the `WebAuthProvider#start` function, the browser launches and shows the login page. Once the user authenticates, the callback URL is called. The callback URL contains the final result of the authentication process.
 
 :::note
+To make Auth0 able to open login page you should always use `context` of Activity (not Application). 
+
+:::note
 There are many options to customize the authentication with the `WebAuthProvider` builder. You can read about them in the [Auth0 SDK for Android documentation](/libraries/auth0-android).
 
 <div class="phone-mockup">


### PR DESCRIPTION
<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->

Added note for developers to use activity context instead of application context
