### PR TITLE
Clarify port for spring boot login quickstart

### DIFF
--- a/articles/quickstart/webapp/java-spring-boot/01-login.md
+++ b/articles/quickstart/webapp/java-spring-boot/01-login.md
@@ -98,6 +98,12 @@ okta:
     issuer: https://${account.namespace}/
     client-id: ${account.clientId}
     client-secret: YOUR_CLIENT_SECRET
+
+# The sample and instructions above for the callback and logout URL configuration use port 3000.
+# If you wish to use a different port, change this and be sure your callback and logout URLs are
+# configured with the correct port.
+server:
+  port: 3000
 ```
 
 ## Add Login to Your Application

--- a/articles/quickstart/webapp/java-spring-boot/interactive.md
+++ b/articles/quickstart/webapp/java-spring-boot/interactive.md
@@ -100,6 +100,12 @@ okta:
     issuer: https://${account.namespace}/
     client-id: ${account.clientId}
     client-secret: YOUR_CLIENT_SECRET
+
+# The sample and instructions above for the callback and logout URL configuration use port 3000.
+# If you wish to use a different port, change this and be sure your callback and logout URLs are
+# configured with the correct port.
+server:
+  port: 3000
 ```
 
 ## Add login to your application {{{ data-action=code data-code="SecurityConfig.java" }}}


### PR DESCRIPTION
Clarifies that the Spring Boot quickstart/sample uses port 3000 instead of the standard java port 8080.