### PR TITLE
DOCS-3574-Edick

### DIFF
--- a/config/redirects.js
+++ b/config/redirects.js
@@ -6810,8 +6810,11 @@ const redirects = [
     to: '/troubleshoot/product-lifecycle/past-migrations/migrate-tenant-member-roles',
   },
   {
-    from: ['/product-lifecycle/deprecations-and-migrations/tenant-hostname-migration'],
-    to: '/troubleshoot/product-lifecycle/deprecations-and-migrations/tenant-hostname-migration',
+    from: [
+        '/product-lifecycle/deprecations-and-migrations/tenant-hostname-migration',
+        '/troubleshoot/product-lifecycle/deprecations-and-migrations/tenant-hostname-migration',
+    ],
+    to: '/troubleshoot/product-lifecycle/past-migrations/tenant-hostname-migration',
   },
   {
     from: [
@@ -6982,6 +6985,35 @@ const redirects = [
       '/product-lifecycle/past-migrations/migrate-from-legacy-auth-flows',
     ],
     to: '/troubleshoot/product-lifecycle/past-migrations/migrate-from-legacy-auth-flows',
+  },
+  {
+    from: ['/troubleshoot/product-lifecycle/deprecations-and-migrations/migrate-from-edge-js-extensibility-features'],
+    to: '/troubleshoot/product-lifecycle/past-migrations/migrate-from-edge-js-extensibility-features',
+  },
+  
+  {
+    from: ['/troubleshoot/product-lifecycle/deprecations-and-migrations/migrate-from-oracledb-extensibility-features'],
+    to: '/troubleshoot/product-lifecycle/past-migrations/migrate-from-oracledb-extensibility-features',
+  },
+  
+  {
+    from: ['/troubleshoot/product-lifecycle/deprecations-and-migrations/custom-claims-migration'],
+    to: '/troubleshoot/product-lifecycle/past-migrations/custom-claims-migration',
+  },
+  
+  {
+    from: ['/troubleshoot/product-lifecycle/deprecations-and-migrations/migrate-actions-nodejs-16-to-nodejs-18'],
+    to: '/troubleshoot/product-lifecycle/past-migrations/migrate-actions-nodejs-16-to-nodejs-18',
+  },
+  
+   {
+    from: ['/troubleshoot/product-lifecycle/deprecations-and-migrations/migrate-to-nodejs-16'],
+    to: '/troubleshoot/product-lifecycle/past-migrations/migrate-to-nodejs-16',
+  },
+  
+  {
+    from: ['/troubleshoot/product-lifecycle/deprecations-and-migrations/migrate-from-log-extensions'],
+    to: '/troubleshoot/product-lifecycle/past-migrations/migrate-from-log-extensions',
   },
 
   /* Professional Services */


### PR DESCRIPTION
- Updated existing redirect for Tenant Hostname Migration
- Added 6 new Past Migration redirects

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
