### PR TITLE
DOCS-3671

### DIFF
--- a/config/redirects.js
+++ b/config/redirects.js
@@ -6810,10 +6810,6 @@ const redirects = [
     to: '/troubleshoot/product-lifecycle/past-migrations/migrate-tenant-member-roles',
   },
   {
-    from: ['/product-lifecycle/deprecations-and-migrations/tenant-hostname-migration'],
-    to: '/troubleshoot/product-lifecycle/deprecations-and-migrations/tenant-hostname-migration',
-  },
-  {
     from: [
       '/guides/login/migration-embedded-universal',
       '/guides/login/migration-embedded-centralized',


### PR DESCRIPTION
- Removing redirect that is causing Contentful publish to fail
- Updated redirect will be added in separate PR after publication is successful

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
