### PR TITLE
Update the Flutter QS to feature HTTPS redirect URLs on iOS/macOS [SDK-4756]

### DIFF
--- a/articles/quickstart/native/flutter/_configure_urls_interactive.md
+++ b/articles/quickstart/native/flutter/_configure_urls_interactive.md
@@ -12,11 +12,9 @@ If you would rather explore a complete configuration, you can view a sample app 
 
 ### Configure the callback and logout URLs
 
-The callback and logout URLs are the URLs that Auth0 invokes to redirect back to your app. Auth0 invokes the callback URL after authenticating the user, and the logout URL after removing the session cookie.
+The callback and logout URLs are the URLs that Auth0 invokes to redirect back to your app. Auth0 invokes the callback URL after authenticating the user, and the logout URL after removing the session cookie. If the callback and logout URLs are not set, users will be unable to log in and out of the app and will get an error.
 
-If the callback and logout URLs are not set, users will be unable to log in and out of the app and will get an error.
-
-Set the callback and logout URLs to the following value, depending on your platform.
+Set the callback and logout URLs to the following values, depending on your platform.
 
 ::: note
 On Android, the value of the `SCHEME` placeholder can be `https` or some other custom scheme. `https` schemes require enabling [Android App Links](https://auth0.com/docs/get-started/applications/enable-android-app-links-support).

--- a/articles/quickstart/native/flutter/_configure_urls_interactive.md
+++ b/articles/quickstart/native/flutter/_configure_urls_interactive.md
@@ -2,44 +2,52 @@
 
 To use Auth0 services, you need to have an application set up in the Auth0 Dashboard. The Auth0 application is where you will configure how you want authentication to work for your project.
 
-:::note
-The URLs below make use of a `SCHEME` placeholder, and this value varies depending on what platform you're working with. On Android, this can be `https` or some other custom scheme. On iOS/macOS, this is your app's [bundle identifier](https://developer.apple.com/documentation/appstoreconnectapi/bundle_ids).
-:::
-
 ### Configure an Auth0 application
 
-Use the interactive selector to create a new "Native Application", or select an existing application that represents the project you want to integrate with. Every application in Auth0 is assigned an alphanumeric, unique client ID that your application code will use to call Auth0 APIs through the SDK.
+Use the interactive selector to create a new Auth0 application or select an existing **Native** Auth0 application. Every application in Auth0 is assigned an alphanumeric, unique client ID that your application code will use to call Auth0 APIs through the SDK.
 
 Any settings you configure using this quickstart will automatically update for your application in the <a href="${manage_url}/#/">Dashboard</a>, which is where you can manage your applications in the future.
 
 If you would rather explore a complete configuration, you can view a sample app instead.
 
-### Configure Callback URLs
+### Configure the callback and logout URLs
 
-A callback URL is a URL in your app that you would like Auth0 to redirect users to after they have authenticated. If not set, users will not be returned to your app after they log in.
+The callback and logout URLs are the URLs that Auth0 invokes to redirect back to your app. Auth0 invokes the callback URL after authenticating the user, and the logout URL after removing the session cookie.
 
-::: note
-If you are following along with our sample project, set this to one of the following URLs, depending on your platform:
+If the callback and logout URLs are not set, users will be unable to log in and out of the app and will get an error.
 
-**Android**: `SCHEME://${account.namespace}/android/YOUR_PACKAGE_NAME/callback`
-
-**iOS**: `YOUR_BUNDLE_ID://${account.namespace}/ios/YOUR_BUNDLE_ID/callback`
-
-**macOS**: `YOUR_BUNDLE_ID://${account.namespace}/macos/YOUR_BUNDLE_ID/callback`
-:::
-
-### Configure Logout URLs
-
-A logout URL is a URL in your app that you would like Auth0 to redirect users to after they have logged out. If not set, users will not be able to log out from your app and will receive an error.
+Set the callback and logout URLs to the following value, depending on your platform.
 
 ::: note
-If you are following along with our sample project, set this to one of the following URLs, depending on your platform:
+On Android, the value of the `SCHEME` placeholder can be `https` or some other custom scheme. `https` schemes require enabling [Android App Links](https://auth0.com/docs/get-started/applications/enable-android-app-links-support).
 
-**Android**: `SCHEME://${account.namespace}/android/YOUR_PACKAGE_NAME/callback`
-
-**iOS**: `YOUR_BUNDLE_ID://${account.namespace}/ios/YOUR_BUNDLE_ID/callback`
-
-**macOS**: `YOUR_BUNDLE_ID://${account.namespace}/macos/YOUR_BUNDLE_ID/callback`
+On iOS 17.4+ and macOS 14.4+ it is possible to use Universal Links (`https` scheme) as callback and logout URLs. When enabled, the SDK will fall back to using a custom URL scheme on older iOS / macOS versions –your app's [bundle identifier](https://developer.apple.com/documentation/appstoreconnectapi/bundle_ids).
+**This feature requires Xcode 15.3+ and a paid Apple Developer account**.
 :::
 
-Lastly, be sure that the **Application Type** for your application is set to **Native** in the [Application Settings](${manage_url}/#/applications/${account.clientId}/settings).
+#### Android
+
+```text
+SCHEME://${account.namespace}/android/YOUR_PACKAGE_NAME/callback
+```
+
+#### iOS
+
+```text
+https://${account.namespace}/ios/YOUR_BUNDLE_IDENTIFIER/callback,
+YOUR_BUNDLE_IDENTIFIER://${account.namespace}/ios/YOUR_BUNDLE_IDENTIFIER/callback
+```
+
+#### macOS
+
+```text
+https://${account.namespace}/macos/YOUR_BUNDLE_IDENTIFIER/callback,
+YOUR_BUNDLE_IDENTIFIER://${account.namespace}/macos/YOUR_BUNDLE_IDENTIFIER/callback
+```
+
+For example, if your iOS bundle identifier were `com.example.MyApp` and your Auth0 domain were `example.us.auth0.com`, then this value would be:
+
+```text
+https://example.us.auth0.com/ios/com.example.MyApp/callback,
+com.example.MyApp://example.us.auth0.com/ios/com.example.MyApp/callback
+```

--- a/articles/quickstart/native/flutter/download.md
+++ b/articles/quickstart/native/flutter/download.md
@@ -4,7 +4,7 @@
 
 ## 1. Configure the Auth0 application
 
-Open the settings page of your Auth0 application and add the corresponding URLs to **Allowed Callback URLs** and **Allowed Logout URLs**, depending on the platform.
+Open the settings page of your Auth0 application and add the following URLs to **Allowed Callback URLs** and **Allowed Logout URLs**, depending on the platform.
 
 - Android: `com.auth0.sample://YOUR_AUTH0_DOMAIN/android/com.auth0.sample/callback`
 - iOS: `https://YOUR_AUTH0_DOMAIN/ios/YOUR_BUNDLE_IDENTIFIER/callback,YOUR_BUNDLE_IDENTIFIER://YOUR_AUTH0_DOMAIN/ios/YOUR_BUNDLE_IDENTIFIER/callback`

--- a/articles/quickstart/native/flutter/download.md
+++ b/articles/quickstart/native/flutter/download.md
@@ -1,31 +1,25 @@
-To run the sample follow these steps:
+<!-- markdownlint-disable MD041 -->
 
-1) Set the **Allowed Callback URLs** and **Allowed Logout URLs** in the [Application Settings](${manage_url}/#/applications/${account.clientId}/settings) to the following value so it works for Android, iOS, and macOS apps:
+> On all steps, if you have a [custom domain](https://auth0.com/docs/customize/custom-domains), replace `YOUR_AUTH0_DOMAIN` with your custom domain instead of the value from the settings page.
 
-```text
-com.auth0.samples.FlutterSample://${account.namespace}/ios/com.auth0.samples.FlutterSample/callback,com.auth0.sample://${account.namespace}/android/com.auth0.sample/callback,com.auth0.sample://${account.namespace}/macos/com.auth0.sample/callback
-```
+## 1. Configure the Auth0 application
 
-2) Rename the file `.env.example` to `.env` and fill in the following values:
+Open the settings page of your Auth0 application and add the corresponding URLs to **Allowed Callback URLs** and **Allowed Logout URLs**, depending on the platform.
 
-```sh
-AUTH0_DOMAIN=${account.namespace}
-AUTH0_CLIENT_ID=${account.clientId}
-AUTH0_CUSTOM_SCHEME=com.auth0.sample
-```
+- Android: `com.auth0.sample://YOUR_AUTH0_DOMAIN/android/com.auth0.sample/callback`
+- iOS: `https://YOUR_AUTH0_DOMAIN/ios/YOUR_BUNDLE_IDENTIFIER/callback,YOUR_BUNDLE_IDENTIFIER://YOUR_AUTH0_DOMAIN/ios/YOUR_BUNDLE_IDENTIFIER/callback`
+- macOS: `https://YOUR_AUTH0_DOMAIN/macos/YOUR_BUNDLE_IDENTIFIER/callback,YOUR_BUNDLE_IDENTIFIER://YOUR_AUTH0_DOMAIN/macos/YOUR_BUNDLE_IDENTIFIER/callback`
 
-3) Rename the file `strings.xml.example` in `android/app/src/main/res/values` to `strings.xml` and fill in the following values:
+## 2. Configure the associated domain (iOS/macOS only)
 
-```xml
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="com_auth0_domain">${account.namespace}</string>
-    <string name="com_auth0_scheme">com.auth0.sample</string>
-</resources>
-```
+> **This following requires Xcode 15.3+ and a paid Apple Developer account**. If you do not have a paid Apple Developer account, skip this step, and set the `useHTTPS` parameter to `false` in the `login()` and `logout()` calls at `lib/example_app.dart`.
 
-4) Use the [Flutter CLI's](https://docs.flutter.dev/reference/flutter-cli) `run` command to run the app:
+Open `ios/Runner.xcodeproj` (or `macos/Runner.xcodeproj`, for macOS) in Xcode and go to the settings of the **Runner** app target. In the **Signing & Capabilities** tab, change the bundle identifier from the default `com.auth0.samples.FlutterSample` to another value of your choosing. Then, make sure the **Automatically manage signing** box is checked, and that your Apple Team is selected.
 
-```sh
-flutter run
-```
+Next, find the `webcredentials:YOUR_AUTH0_DOMAIN` entry under **Associated Domains**, and replace the `YOUR_AUTH0_DOMAIN` placeholder with the domain of your Auth0 application.
+
+Finally, open the settings page of your Auth0 application, scroll to the end, and open **Advanced Settings > Device Settings**. In the **iOS** section, set **Team ID** to your [Apple Team ID](https://developer.apple.com/help/account/manage-your-team/locate-your-team-id/), and **App ID** to the app's bundle identifier.
+
+## 3. Run the app
+
+Use the [Flutter CLI](https://docs.flutter.dev/reference/flutter-cli) to run the app: `flutter run`.

--- a/articles/quickstart/native/flutter/download.md
+++ b/articles/quickstart/native/flutter/download.md
@@ -1,6 +1,6 @@
 <!-- markdownlint-disable MD041 -->
 
-> On all steps, if you have a [custom domain](https://auth0.com/docs/customize/custom-domains), replace `YOUR_AUTH0_DOMAIN` with your custom domain instead of the value from the settings page.
+> On every step, if you have a [custom domain](https://auth0.com/docs/customize/custom-domains), replace the `YOUR_AUTH0_DOMAIN` placeholder with your custom domain instead of the value from the settings page.
 
 ## 1. Configure the Auth0 application
 

--- a/articles/quickstart/native/flutter/download.md
+++ b/articles/quickstart/native/flutter/download.md
@@ -4,7 +4,7 @@
 
 ## 1. Configure the Auth0 application
 
-Open the settings page of your Auth0 application and add the following URLs to **Allowed Callback URLs** and **Allowed Logout URLs**, depending on the platform.
+Open the settings page of your Auth0 application and add the following URLs to **Allowed Callback URLs** and **Allowed Logout URLs**, depending on the platform you want to use.
 
 - Android: `com.auth0.sample://YOUR_AUTH0_DOMAIN/android/com.auth0.sample/callback`
 - iOS: `https://YOUR_AUTH0_DOMAIN/ios/YOUR_BUNDLE_IDENTIFIER/callback,YOUR_BUNDLE_IDENTIFIER://YOUR_AUTH0_DOMAIN/ios/YOUR_BUNDLE_IDENTIFIER/callback`

--- a/articles/quickstart/native/flutter/files/main.md
+++ b/articles/quickstart/native/flutter/files/main.md
@@ -34,8 +34,10 @@ class _MainViewState extends State<MainView> {
         if (_credentials == null)
           ElevatedButton(
               onPressed: () async {
+                // Use a Universal Link callback URL on iOS 17.4+ / macOS 14.4+
+                // useHTTPS is ignored on Android
                 final credentials =
-                    await auth0.webAuthentication().login();
+                    await auth0.webAuthentication().login(useHTTPS: true);
 
                 setState(() {
                   _credentials = credentials;
@@ -48,7 +50,9 @@ class _MainViewState extends State<MainView> {
               ProfileView(user: _credentials!.user),
               ElevatedButton(
                   onPressed: () async {
-                    await auth0.webAuthentication().logout();
+                    // Use a Universal Link logout URL on iOS 17.4+ / macOS 14.4+
+                    // useHTTPS is ignored on Android
+                    await auth0.webAuthentication().logout(useHTTPS: true);
 
                     setState(() {
                       _credentials = null;

--- a/articles/quickstart/native/flutter/interactive.md
+++ b/articles/quickstart/native/flutter/interactive.md
@@ -27,7 +27,7 @@ github:
 Auth0 allows you to quickly add authentication and access user profile information in your app. This guide demonstrates how to integrate Auth0 with a Flutter app using the [Auth0 Flutter SDK](https://github.com/auth0/auth0-flutter).
 
 :::note
-The Flutter SDK currently only supports Flutter apps running on Android, iOS, and macOS platforms.
+The Flutter SDK currently only supports Flutter apps for Android, iOS, and macOS.
 :::
 
 This quickstart assumes you already have a [Flutter](https://flutter.dev/) app up and running. If not, check out the [Flutter "getting started" guides](https://docs.flutter.dev/get-started/install) to get started with a simple app.
@@ -63,15 +63,39 @@ Run **Sync Project with Gradle Files** inside Android Studio to apply your chang
 
 ## Configure iOS/macOS
 
-If you are not developing for the iOS or macOS platform, skip this step.
+If you are not developing for the iOS or macOS platforms, skip this step.
 
-You need to register your bundle identifier as a custom URL scheme so the callback and logout URLs can reach your app.
+::: warning
+This step requires a paid Apple Developer account. It is needed to use Universal Links as callback and logout URLs. Skip this step to use a custom URL scheme instead.
+:::
 
-In Xcode, go to the **Info** tab of your app target settings. In the **URL Types** section, select the **＋** button to add a new entry. Then enter `auth0` into the **Identifier** field and `$(PRODUCT_BUNDLE_IDENTIFIER)` into the **URL Schemes** field.
+### Configure the Team ID and bundle identifier
 
-<p><img src="/media/articles/native-platforms/ios-swift/url-scheme.png" alt="Custom URL Scheme"></p>
+Go to the [settings page](${manage_url}/#/applications/${account.clientId}/settings) of your Auth0 application, scroll to the end, and open **Advanced Settings > Device Settings**. In the **iOS** section, set **Team ID** to your [Apple Team ID](https://developer.apple.com/help/account/manage-your-team/locate-your-team-id/), and **App ID** to your app's bundle identifier.
 
-## Add login to your application {{{ data-action="code" data-code="main_view.dart#29:38" }}}
+<p><img src="/media/articles/native-platforms/ios-swift/ios-device-settings.png" alt="Screenshot of the iOS section inside the Auth0 application settings page"></p>
+
+This will add your app to your Auth0 tenant's `apple-app-site-association` file.
+
+### Add the associated domain capability
+
+Open your app in Xcode by running `open ios/Runner.xcworkspace` (or `open macos/Runner.xcworkspace` for macOS). Go to the **Signing and Capabilities** [tab](https://developer.apple.com/documentation/xcode/adding-capabilities-to-your-app#Add-a-capability) of the **Runner** target settings, and press the **+ Capability** button. Then select **Associated Domains**.
+
+<p><img src="/media/articles/native-platforms/ios-swift/ios-xcode-capabilities.png" alt="Screenshot of the capabilities library inside Xcode"></p>
+
+Next, add the following [entry](https://developer.apple.com/documentation/xcode/configuring-an-associated-domain#Define-a-service-and-its-associated-domain) under **Associated Domains**:
+
+```text
+webcredentials:${account.namespace}
+```
+
+If you have a [custom domain](/customize/custom-domains), use this instead of the Auth0 domain from the settings page.
+
+::: note
+For the associated domain to work, your app must be signed with your team certificate **even when building for the iOS simulator**. Make sure you are using the Apple Team whose Team ID is configured in the settings page of your Auth0 application.
+:::
+
+## Add login to your application {{{ data-action="code" data-code="main_view.dart#29:40" }}}
 
 [Universal Login](https://auth0.com/docs/authenticate/login/auth0-universal-login) is the easiest way to set up authentication in your app. We recommend using it for the best experience, best security, and the fullest array of features.
 
@@ -104,7 +128,7 @@ Still having issues? Check out our [documentation](https://auth0.com/docs) or vi
 :::
 ::::
 
-## Add logout to your application {{{ data-action=code data-code="main_view.dart#43:51"}}}
+## Add logout to your application {{{ data-action=code data-code="main_view.dart#45:55"}}}
 
 To log users out, redirect them to the Auth0 logout endpoint to clear their login session by calling the Auth0 Flutter SDK `webAuthentication().logout()`. [Read more about logging out of Auth0](https://auth0.com/docs/authenticate/login/logout).
 

--- a/articles/quickstart/native/ios-swift/01-login.md
+++ b/articles/quickstart/native/ios-swift/01-login.md
@@ -19,6 +19,8 @@ useCase: quickstart
 
 ## Configure Auth0
 
+You will need a **Native** Auth0 application. If you don’t have a Native Auth0 application already, [create one](/get-started/auth0-overview/create-applications/native-apps) before continuing. Avoid using other application types, as they have different configurations and may cause errors.
+
 ### Configure the callback and logout URLs
 
 The callback and logout URLs are the URLs that Auth0 invokes to redirect back to your app. Auth0 invokes the callback URL after authenticating the user, and the logout URL after removing the session cookie.
@@ -31,11 +33,7 @@ On iOS 17.4+ and macOS 14.4+ it is possible to use Universal Links as callback a
 **This feature requires Xcode 15.3+ and a paid Apple Developer account**.
 :::
 
-Go to the settings page of your [Auth0 application](${manage_url}/#/applications/${account.clientId}/settings) and add the corresponding URLs to **Allowed Callback URLs** and **Allowed Logout URLs**, according to the platform of your app. If you have a [custom domain](/customize/custom-domains), use this instead of the Auth0 domain from the settings page.
-
-::: warning
-Make sure that the [application type](/get-started/applications) of the Auth0 application is **Native**. If you don’t have a Native Auth0 application already, [create one](/get-started/auth0-overview/create-applications/native-apps) before continuing.
-:::
+Go to the [settings page](${manage_url}/#/applications/${account.clientId}/settings) of your Auth0 application and add the corresponding URLs to **Allowed Callback URLs** and **Allowed Logout URLs**, according to the platform of your app. If you have a [custom domain](/customize/custom-domains), use this instead of the Auth0 domain from the settings page.
 
 #### iOS
 

--- a/articles/quickstart/native/ios-swift/01-login.md
+++ b/articles/quickstart/native/ios-swift/01-login.md
@@ -33,7 +33,7 @@ On iOS 17.4+ and macOS 14.4+ it is possible to use Universal Links as callback a
 **This feature requires Xcode 15.3+ and a paid Apple Developer account**.
 :::
 
-Go to the [settings page](${manage_url}/#/applications/${account.clientId}/settings) of your Auth0 application and add the corresponding URLs to **Allowed Callback URLs** and **Allowed Logout URLs**, according to the platform of your app. If you have a [custom domain](/customize/custom-domains), use this instead of the Auth0 domain from the settings page.
+Go to the [settings page](${manage_url}/#/applications/${account.clientId}/settings) of your Auth0 application and add the following URLs to **Allowed Callback URLs** and **Allowed Logout URLs**, depending on the platform of your app. If you have a [custom domain](/customize/custom-domains), use this instead of the value from the settings page.
 
 #### iOS
 

--- a/articles/quickstart/native/ios-swift/download.md
+++ b/articles/quickstart/native/ios-swift/download.md
@@ -8,7 +8,7 @@
 
 Open `SwiftSample.xcodeproj` in Xcode and go to the settings of the application target you want to run. There are two application targets available: **SwiftSample (iOS)** and **SwiftSample (macOS)**. Change the bundle identifier from the default `com.auth0.samples.SwiftSample` to another value of your choosing. Then, make sure the **Automatically manage signing** box is checked, and that your Apple Team is selected.
 
-Next, go to the **Signing and Capabilities** tab of the app's target settings. Find the `webcredentials:YOUR_AUTH0_DOMAIN` entry under **Associated Domains**, and replace the `YOUR_AUTH0_DOMAIN` placeholder with the domain of your Auth0 application.
+Next, go to the **Signing & Capabilities** tab of the app's target settings. Find the `webcredentials:YOUR_AUTH0_DOMAIN` entry under **Associated Domains**, and replace the `YOUR_AUTH0_DOMAIN` placeholder with the domain of your Auth0 application.
 
 Finally, open the settings page of your Auth0 application, scroll to the end, and open **Advanced Settings > Device Settings**. In the **iOS** section, set **Team ID** to your [Apple Team ID](https://developer.apple.com/help/account/manage-your-team/locate-your-team-id/), and **App ID** to the app's bundle identifier.
 

--- a/articles/quickstart/native/ios-swift/download.md
+++ b/articles/quickstart/native/ios-swift/download.md
@@ -1,32 +1,20 @@
 <!-- markdownlint-disable MD041 -->
 
-## 1. Configure code signing
+> On all steps, if you have a [custom domain](https://auth0.com/docs/customize/custom-domains), replace `YOUR_AUTH0_DOMAIN` with your custom domain instead of the value from the settings page.
 
-To run the sample application, first open `SwiftSample.xcodeproj` in Xcode and go to the settings of the application target you want to run. There are two application targets available: **SwiftSample (iOS)** and **SwiftSample (macOS)**. Change the bundle identifier from the default `com.auth0.samples.SwiftSample` to another value of your choosing.
-Then, make sure the **Automatically manage signing** box is checked, and that your Apple Team is selected.
-
-## 2. Configure the associated domain
+## 1. Configure the associated domain
 
 > **This requires Xcode 15.3+ and a paid Apple Developer account**. If you do not have a paid Apple Developer account, skip this step, and comment out the two `useHTTPS()` calls in `MainView.swift`.
 
-Go to the **Signing and Capabilities** tab of the app's target settings. Find the `webcredentials:{YOUR_AUTH0_DOMAIN}` entry under **Associated Domains**, and replace the placeholder `{YOUR_AUTH0_DOMAIN}` value with the domain of your Auth0 application. If have a [custom domain](https://auth0.com/docs/customize/custom-domains), replace `{YOUR_AUTH0_DOMAIN}` with your custom domain instead of the value from the settings page.
+Open `SwiftSample.xcodeproj` in Xcode and go to the settings of the application target you want to run. There are two application targets available: **SwiftSample (iOS)** and **SwiftSample (macOS)**. Change the bundle identifier from the default `com.auth0.samples.SwiftSample` to another value of your choosing. Then, make sure the **Automatically manage signing** box is checked, and that your Apple Team is selected.
 
-## 3. Configure the Auth0 application
+Next, go to the **Signing and Capabilities** tab of the app's target settings. Find the `webcredentials:YOUR_AUTH0_DOMAIN` entry under **Associated Domains**, and replace the `YOUR_AUTH0_DOMAIN` placeholder with the domain of your Auth0 application.
 
-Open the [settings page](${manage_url}/#/applications/${account.clientId}/settings) of your Auth0 application and add the corresponding URLs to **Allowed Callback URLs** and **Allowed Logout URLs**. If you have a [custom domain](https://auth0.com/docs/customize/custom-domains), replace `YOUR_AUTH0_DOMAIN` with your custom domain instead of the value from the settings page.
+Finally, open the settings page of your Auth0 application, scroll to the end, and open **Advanced Settings > Device Settings**. In the **iOS** section, set **Team ID** to your [Apple Team ID](https://developer.apple.com/help/account/manage-your-team/locate-your-team-id/), and **App ID** to the app's bundle identifier.
 
-For **SwiftSample (iOS)**:
+## 2. Configure the Auth0 application
 
-```text
-https://YOUR_AUTH0_DOMAIN/ios/YOUR_BUNDLE_IDENTIFIER/callback,
-YOUR_BUNDLE_IDENTIFIER://YOUR_AUTH0_DOMAIN/ios/YOUR_BUNDLE_IDENTIFIER/callback
-```
+Open the settings page of your Auth0 application and add the corresponding URLs to **Allowed Callback URLs** and **Allowed Logout URLs**.
 
-For **SwiftSample (macOS)**:
-
-```text
-https://YOUR_AUTH0_DOMAIN/macos/YOUR_BUNDLE_IDENTIFIER/callback,
-YOUR_BUNDLE_IDENTIFIER://YOUR_AUTH0_DOMAIN/macos/YOUR_BUNDLE_IDENTIFIER/callback
-```
-
-Then, scroll to the end of the settings page and open **Advanced Settings > Device Settings**. In the **iOS** section, set **Team ID** to your [Apple Team ID](https://developer.apple.com/help/account/manage-your-team/locate-your-team-id/), and **App ID** to the app's bundle identifier.
+- **SwiftSample (iOS)**: `https://YOUR_AUTH0_DOMAIN/ios/YOUR_BUNDLE_IDENTIFIER/callback,YOUR_BUNDLE_IDENTIFIER://YOUR_AUTH0_DOMAIN/ios/YOUR_BUNDLE_IDENTIFIER/callback`
+- **SwiftSample (macOS)**: `https://YOUR_AUTH0_DOMAIN/macos/YOUR_BUNDLE_IDENTIFIER/callback,YOUR_BUNDLE_IDENTIFIER://YOUR_AUTH0_DOMAIN/macos/YOUR_BUNDLE_IDENTIFIER/callback`

--- a/articles/quickstart/native/ios-swift/download.md
+++ b/articles/quickstart/native/ios-swift/download.md
@@ -1,6 +1,6 @@
 <!-- markdownlint-disable MD041 -->
 
-> On all steps, if you have a [custom domain](https://auth0.com/docs/customize/custom-domains), replace `YOUR_AUTH0_DOMAIN` with your custom domain instead of the value from the settings page.
+> On every step, if you have a [custom domain](https://auth0.com/docs/customize/custom-domains), replace the `YOUR_AUTH0_DOMAIN` placeholder with your custom domain instead of the value from the settings page.
 
 ## 1. Configure the associated domain
 

--- a/articles/quickstart/native/ios-swift/download.md
+++ b/articles/quickstart/native/ios-swift/download.md
@@ -6,7 +6,7 @@
 
 > **This requires Xcode 15.3+ and a paid Apple Developer account**. If you do not have a paid Apple Developer account, skip this step, and comment out the two `useHTTPS()` calls in `MainView.swift`.
 
-Open `SwiftSample.xcodeproj` in Xcode and go to the settings of the application target you want to run. There are two application targets available: **SwiftSample (iOS)** and **SwiftSample (macOS)**. Change the bundle identifier from the default `com.auth0.samples.SwiftSample` to another value of your choosing. Then, make sure the **Automatically manage signing** box is checked, and that your Apple Team is selected.
+Open `SwiftSample.xcodeproj` in Xcode and go to the settings of the app target you want to run. There are two app targets available: **SwiftSample (iOS)** and **SwiftSample (macOS)**. Change the bundle identifier from the default `com.auth0.samples.SwiftSample` to another value of your choosing. Then, make sure the **Automatically manage signing** box is checked, and that your Apple Team is selected.
 
 Next, go to the **Signing & Capabilities** tab of the app's target settings. Find the `webcredentials:YOUR_AUTH0_DOMAIN` entry under **Associated Domains**, and replace the `YOUR_AUTH0_DOMAIN` placeholder with the domain of your Auth0 application.
 
@@ -14,7 +14,7 @@ Finally, open the settings page of your Auth0 application, scroll to the end, an
 
 ## 2. Configure the Auth0 application
 
-Open the settings page of your Auth0 application and add the corresponding URLs to **Allowed Callback URLs** and **Allowed Logout URLs**.
+Open the settings page of your Auth0 application and add the following URLs to **Allowed Callback URLs** and **Allowed Logout URLs**, depending on the app target you want to run.
 
 - **SwiftSample (iOS)**: `https://YOUR_AUTH0_DOMAIN/ios/YOUR_BUNDLE_IDENTIFIER/callback,YOUR_BUNDLE_IDENTIFIER://YOUR_AUTH0_DOMAIN/ios/YOUR_BUNDLE_IDENTIFIER/callback`
 - **SwiftSample (macOS)**: `https://YOUR_AUTH0_DOMAIN/macos/YOUR_BUNDLE_IDENTIFIER/callback,YOUR_BUNDLE_IDENTIFIER://YOUR_AUTH0_DOMAIN/macos/YOUR_BUNDLE_IDENTIFIER/callback`

--- a/articles/quickstart/native/ios-swift/download.md
+++ b/articles/quickstart/native/ios-swift/download.md
@@ -13,7 +13,7 @@ Go to the **Signing and Capabilities** tab of the app's target settings. Find th
 
 ## 3. Configure the Auth0 application
 
-Open the settings page of your [Auth0 application](${manage_url}/#/applications/${account.clientId}/settings) and add the corresponding URLs to **Allowed Callback URLs** and **Allowed Logout URLs**. If you have a [custom domain](https://auth0.com/docs/customize/custom-domains), replace `YOUR_AUTH0_DOMAIN` with your custom domain instead of the value from the settings page.
+Open the [settings page](${manage_url}/#/applications/${account.clientId}/settings) of your Auth0 application and add the corresponding URLs to **Allowed Callback URLs** and **Allowed Logout URLs**. If you have a [custom domain](https://auth0.com/docs/customize/custom-domains), replace `YOUR_AUTH0_DOMAIN` with your custom domain instead of the value from the settings page.
 
 For **SwiftSample (iOS)**:
 

--- a/articles/quickstart/native/ios-swift/interactive.md
+++ b/articles/quickstart/native/ios-swift/interactive.md
@@ -51,7 +51,7 @@ On iOS 17.4+ and macOS 14.4+ it is possible to use Universal Links as callback a
 **This feature requires Xcode 15.3+ and a paid Apple Developer account**.
 :::
 
-Add the corresponding URLs to **Callback URLs** and **Logout URLs**, according to the platform of your app. If you have a [custom domain](/customize/custom-domains), use this instead of your Auth0 tenant’s domain.
+Add the following URLs to **Callback URLs** and **Logout URLs**, depending on the platform of your app. If you have a [custom domain](/customize/custom-domains), use this instead of your Auth0 tenant’s domain.
 
 #### iOS
 

--- a/articles/quickstart/native/ios-swift/interactive.md
+++ b/articles/quickstart/native/ios-swift/interactive.md
@@ -82,7 +82,7 @@ This step requires a paid Apple Developer account. It is needed to use Universal
 
 #### Configure the Team ID and bundle identifier
 
-Go to the settings page of your [Auth0 application](${manage_url}/#/applications/${account.clientId}/settings), scroll to the end, and open **Advanced Settings > Device Settings**. In the **iOS** section, set **Team ID** to your [Apple Team ID](https://developer.apple.com/help/account/manage-your-team/locate-your-team-id/), and **App ID** to your app's bundle identifier.
+Go to the [settings page](${manage_url}/#/applications/${account.clientId}/settings) of your Auth0 application, scroll to the end, and open **Advanced Settings > Device Settings**. In the **iOS** section, set **Team ID** to your [Apple Team ID](https://developer.apple.com/help/account/manage-your-team/locate-your-team-id/), and **App ID** to your app's bundle identifier.
 
 <p><img src="/media/articles/native-platforms/ios-swift/ios-device-settings.png" alt="Screenshot of the iOS section inside the Auth0 application settings page"></p>
 


### PR DESCRIPTION
### Changes

This PR updates the Flutter Quickstarts (interactive and non-interactive) to feature the newly-introduced support for HTTPS redirect URL on iOS and macOS: https://github.com/auth0/auth0-flutter/pull/417