### PR TITLE
Added redirect to Manage Support Center Users page

### DIFF
--- a/config/redirects.js
+++ b/config/redirects.js
@@ -8082,8 +8082,8 @@ const redirects = [
     to: '/troubleshoot/customer-support/operational-policies/entity-limit-policy',
   },
   {
-    from: ['/support/support-center-users', '/dashboard-access/support-center-users'],
-    to: '/get-started/manage-dashboard-access/support-center-users',
+    from: ['/support/support-center-users', '/dashboard-access/support-center-users', '/get-started/manage-dashboard-access/support-center-users'],
+    to: '/get-started/manage-dashboard-access/feature-access-by-role',
   },
 
   /* Troubleshoot */


### PR DESCRIPTION
<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->

Removed Manage Support Center Users page and added a redirect to Dashboard Access By Role. See https://auth0team.atlassian.net/browse/DOCS-3853. 