### PR TITLE
Fix Maven dependency group ID

### DIFF
--- a/articles/quickstart/webapp/java-spring-boot/interactive.md
+++ b/articles/quickstart/webapp/java-spring-boot/interactive.md
@@ -61,7 +61,7 @@ If you are using Maven:
 
 <dependencies>
     <dependency>
-        <groupId>com.okta</groupId>
+        <groupId>com.okta.spring</groupId>
         <artifactId>okta-spring-boot-starter</artifactId>
         <version>3.0.5</version>
     </dependency>


### PR DESCRIPTION
Updated the group ID for the Okta Spring Boot Starter dependency in the Maven POM file from 'com.okta' to 'com.okta.spring'.

This change corrects the group ID to ensure the dependency is resolved correctly.

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
