### PR TITLE
Updated _sign-up.md, removed "active authentication" from description

### DIFF
--- a/articles/api/authentication/_sign-up.md
+++ b/articles/api/authentication/_sign-up.md
@@ -76,7 +76,7 @@ curl --request POST \
   "link": "#signup"
 }) %>
 
-Given a user's credentials, and a `connection`, this endpoint will create a new user using active authentication.
+Given a user's credentials and a `connection`, this endpoint creates a new user.
 
 This endpoint only works for database connections. 
 


### PR DESCRIPTION
<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->

Source: https://auth0team.atlassian.net/browse/DR-2189?atlOrigin=eyJpIjoiZTcwYmM4NWIxMDRiNDU5NjkxZTE5MGEyMDcxMmZmM2EiLCJwIjoiaiJ9