### PR TITLE
docs-4381-remove-query-redir

### DIFF
--- a/config/redirects.js
+++ b/config/redirects.js
@@ -8863,7 +8863,6 @@ const redirects = [
     from: [
       '/users/search/v3/query-syntax',
       '/users/user-search/user-search-query-syntax',
-      '/manage-users/user-search/user-search-query-syntax',
     ],
     to: '/manage-users/user-search',
   },


### PR DESCRIPTION
Erroneous redirect removed.

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
