### PR TITLE
Adding ruby-auth0 in list of supported auth0 SDKs

### DIFF
--- a/articles/_includes/_libraries_support_sdks.html
+++ b/articles/_includes/_libraries_support_sdks.html
@@ -57,5 +57,10 @@
       <td>v7.3</td>
       <td><div class="label label-primary">Supported</div></td>
     </tr>
+    <tr>
+      <td><a href="https://github.com/auth0/ruby-auth0">Auth0 Ruby</a></td>
+      <td>v5</td>
+      <td><div class="label label-primary">Supported</div></td>
+    </tr>
   </tbody>
 </table>


### PR DESCRIPTION
### Description:
Ruby SDK to be added as part of list of [supported SDKs](https://auth0.com/docs/troubleshoot/customer-support/product-support-matrix#auth0-sdks).

### Supported links:
- Ruby SDK: https://github.com/auth0/ruby-auth0
- Auth0 SDKs: https://auth0.com/docs/troubleshoot/customer-support/product-support-matrix#auth0-sdks
