### PR TITLE
QUICKSTART: Fixed Allowed Callback URLs in spring boot download instruction, the existing URL provided is incorrect.

### DIFF
--- a/articles/quickstart/webapp/java-spring-boot/download.md
+++ b/articles/quickstart/webapp/java-spring-boot/download.md
@@ -3,11 +3,13 @@
 To run the sample follow these steps:
 
 1) Set the **Allowed Callback URLs** in the [Application Settings](${manage_url}/#/applications/${account.clientId}/settings) to:
+
 ```text
-http://localhost:3000/login/oauth2/code/auth0
+http://localhost:3000/login/oauth2/code/okta
 ```
 
 2) Set the **Allowed Logout URLs** in the [Application Settings](${manage_url}/#/applications/${account.clientId}/settings) to:
+
 ```text
 http://localhost:3000/
 ```


### PR DESCRIPTION
Before, with http://localhost:3000/login/oauth2/code/auth0:
![Screenshot 2024-10-24 at 12 59 01 PM](https://github.com/user-attachments/assets/9aea1e19-6554-409b-aa6b-736df2d530ae)

After, with http://localhost:3000/login/oauth2/code/okta:
![Screenshot 2024-10-24 at 1 00 40 PM](https://github.com/user-attachments/assets/a311a0c4-5965-44d9-a3f3-978300e94874)

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
