### PR TITLE
Update 00-login.md

### DIFF
--- a/articles/quickstart/native/react-native/00-login.md
+++ b/articles/quickstart/native/react-native/00-login.md
@@ -85,6 +85,25 @@ At runtime, the `applicationId` value will automatically update with your applic
 
 ### Configure iOS
 
+**For react-native 0.77+**
+
+In the file `ios/<YOUR PROJECT>/AppDelegate.swift` add the following:
+
+```swift
+// …
+
+@main
+class AppDelegate: RCTAppDelegate {
+  // …
+
+  override func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+    return RCTLinkingManager.application(app, open: url, options: options)
+  }
+}
+```
+
+**For react-native < 0.77**
+
 In the file `ios/<YOUR PROJECT>/AppDelegate.mm` add the following:
 
 ```objc


### PR DESCRIPTION
docs: update iOS deep linking guide for React Native 0.77+

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
