### PR TITLE
Update download.md

### DIFF
--- a/articles/quickstart/webapp/aspnet-core-blazor-server/download.md
+++ b/articles/quickstart/webapp/aspnet-core-blazor-server/download.md
@@ -5,7 +5,7 @@ To run the sample follow these steps:
 1) Set the **Allowed Callback URLs** in the [Application Settings](${manage_url}/#/applications/${account.clientId}/settings) to:
 
 ```text
-http://localhost:3000/callback,http://localhost:7113/callback
+http://localhost:3000/callback,https://localhost:7113/callback
 ```
 
 2) Set the **Allowed Logout URLs** in the [Application Settings](${manage_url}/#/applications/${account.clientId}/settings) to:

--- a/articles/quickstart/webapp/aspnet-core-blazor-server/download.md
+++ b/articles/quickstart/webapp/aspnet-core-blazor-server/download.md
@@ -5,13 +5,13 @@ To run the sample follow these steps:
 1) Set the **Allowed Callback URLs** in the [Application Settings](${manage_url}/#/applications/${account.clientId}/settings) to:
 
 ```text
-http://localhost:3000/callback
+http://localhost:3000/callback,http://localhost:7113/callback
 ```
 
 2) Set the **Allowed Logout URLs** in the [Application Settings](${manage_url}/#/applications/${account.clientId}/settings) to:
 
 ```text
-http://localhost:3000
+http://localhost:3000,https://localhost:7113
 ```
 
 3) Make sure [.NET Core](https://www.microsoft.com/net/download) is installed, and run the following commands:


### PR DESCRIPTION
The quick start guide asks the user to configure port 3000 in the callback and logout URIs. 
However, in case of Blazor, the app by defaults runs in 7113. 

There are cases where the users try running the app directly from Visual Studio (where it runs the app directly on 7113 port)
and when they try to login, they get an error since the URL is white-listed in the application.
