### PR TITLE
Locked @auth0/nextjs-auth0@3 for non-interactive nextjs quickstart

### DIFF
--- a/articles/quickstart/webapp/nextjs/01-login.md
+++ b/articles/quickstart/webapp/nextjs/01-login.md
@@ -50,7 +50,7 @@ The SDK will read these values from the Node.js process environment and automati
 
 ### Add the dynamic API route handler
 
-Create a file at `app/api/auth/<a href="https://nextjs.org/docs/app/building-your-application/routing/route-handlers#dynamic-route-segments" target="_blank" rel="noreferrer">auth0/route.js`. This is your Route Handler file with a Dynamic Route Segment</a>.
+Create a file at `app/api/auth/[auth0]/route.js`. This is your Route Handler file with a <a href="https://nextjs.org/docs/app/building-your-application/routing/route-handlers#dynamic-route-segments" target="_blank" rel="noreferrer">Dynamic Route Segment</a>.
 
 Then, import the `handleAuth` method from the SDK and call it from the `GET` export.
 

--- a/articles/quickstart/webapp/nextjs/01-login.md
+++ b/articles/quickstart/webapp/nextjs/01-login.md
@@ -23,7 +23,7 @@ useCase: quickstart
 Run the following command within your project directory to install the Auth0 Next.js SDK:
 
 ```sh
-npm install @auth0/nextjs-auth0
+npm install @auth0/nextjs-auth0@3
 ```
 
 The SDK exposes methods and variables that help you integrate Auth0 with your Next.js application using <a href="https://nextjs.org/docs/app/building-your-application/routing/route-handlers" target="_blank" rel="noreferrer">Route Handlers</a> on the backend and <a href="https://reactjs.org/docs/context.html" target="_blank" rel="noreferrer">React Context</a> with <a href="https://reactjs.org/docs/hooks-overview.html" target="_blank" rel="noreferrer">React Hooks</a> on the frontend.


### PR DESCRIPTION
<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
Locking the version to 3 until we can update the steps to work with 4
![Screenshot 2025-02-28 at 4 08 38 PM](https://github.com/user-attachments/assets/9d1909ab-e8d6-4101-b276-5e1644a7745b)

Fixed a broken link
![Screenshot 2025-02-28 at 4 08 49 PM](https://github.com/user-attachments/assets/e72ab069-b547-4e5f-95e8-bce279ff9ac8)
