### PR TITLE
Add Universal Links recommendation to Android and Flutter QS

### DIFF
--- a/articles/quickstart/native/android/00-login.md
+++ b/articles/quickstart/native/android/00-login.md
@@ -65,7 +65,7 @@ Remember to synchronize using the Android Studio prompt or run `./gradlew clean 
 Add manifest placeholders required by the SDK. The placeholders are used internally to define an `intent-filter` that captures the authentication callback URL. For this, the Auth0 tenant domain and the scheme that take part in the callback URL must be set.
 
 ::: note
-We've used a value of `demo` for `auth0Scheme` here, so that a custom URL scheme can be used for the URL that Auth0 redirects to after login. The alternative is `https` if you want to use <a href="https://auth0.com/docs/applications/enable-android-app-links" target="_blank" rel="noreferrer">Android App Links</a>. You can read more about setting this value in the <a href="https://github.com/auth0/Auth0.Android#a-note-about-app-deep-linking" target="_blank" rel="noreferrer">Auth0.Android SDK readme</a>.
+We've used a value of `demo` for `auth0Scheme` here, so that a custom URL scheme can be used for the URL that Auth0 redirects to after login.  Whenever possible, Auth0 recommends using <a href="https://auth0.com/docs/applications/enable-android-app-links"> Android App Links</a> with <code> https </code> as a secure way to link directly to content within your app. Custom URL schemes can be subject to <a href="https://datatracker.ietf.org/doc/html/rfc8252#section-8.6">client impersonation attacks</a>. You can read more about setting this value in the <a href="https://github.com/auth0/Auth0.Android#a-note-about-app-deep-linking" target="_blank" rel="noreferrer">Auth0.Android SDK readme</a>.
 :::
 
 To add the manifest placeholders, add the next line:

--- a/articles/quickstart/native/android/interactive.md
+++ b/articles/quickstart/native/android/interactive.md
@@ -24,7 +24,7 @@ locale: en-US
 ## Install the Auth0 Android SDK {{{ data-action="code" data-code="build.gradle#18:18" }}}
 
 
-<p>Add the <a href="https://github.com/auth0/Auth0.Android">Auth0 Android</a> SDK into your project. The library will make requests to the Auth0&#39;s Authentication and Management APIs.</p><p>In your app&#39;s <code>build.gradle</code> dependencies section, add the following:</p><p><pre><code class="language-javascript">implementation 'com.auth0.android:auth0:2. '
+<p>Add the <a href="https://github.com/auth0/Auth0.Android">Auth0 Android</a> SDK into your project. The library will make requests to the Auth0&#39;s Authentication and Management APIs.</p><p>In your app&#39;s <code>build.gradle</code> dependencies section, add the following:</p><p><pre><code class="language-javascript">implementation 'com.auth0.android:auth0:2.+'
 
 </code></pre>
 
@@ -33,7 +33,7 @@ locale: en-US
 ## Add manifest placeholders {{{ data-action="code" data-code="build.gradle#10:12" }}}
 
 
-<p>The SDK requires manifest placeholders. Auth0 uses placeholders internally to define an <code>intent-filter</code>, which captures the authentication callback URL. You must set Auth0 tenant domain and the callback URL scheme.</p><p>You do not need to declare a specific <code>intent-filter</code> for your activity, because you have defined the manifest placeholders with your Auth0 <b>Domain</b> and <b>Scheme</b> values and the library will handle the redirection for you.</p><p><div class="alert-container" severity="default"><p>We&#39;ve used a value of <code>demo</code> for <code>auth0Scheme</code> here, so that a custom URL scheme can be used for the URL that Auth0 redirects to after login. The alternative is <code>https</code> if you want to use <a href="https://auth0.com/docs/applications/enable-android-app-links">Android App Links</a>. You can read more about setting this value in the <a href="https://github.com/auth0/Auth0.Android#a-note-about-app-deep-linking">Auth0.Android SDK README</a>.</p></div></p>
+<p>The SDK requires manifest placeholders. Auth0 uses placeholders internally to define an <code>intent-filter</code>, which captures the authentication callback URL. You must set Auth0 tenant domain and the callback URL scheme.</p><p>You do not need to declare a specific <code>intent-filter</code> for your activity, because you have defined the manifest placeholders with your Auth0 <b>Domain</b> and <b>Scheme</b> values and the library will handle the redirection for you.</p><p><div class="alert-container" severity="default"><p>We&#39;ve used a value of <code>demo</code> for <code>auth0Scheme</code> here, so that a custom URL scheme can be used for the URL that Auth0 redirects to after login. Whenever possible, Auth0 recommends using <a href="https://auth0.com/docs/applications/enable-android-app-links"> Android App Links</a> with <code> https </code> as a secure way to link directly to content within your app. Custom URL schemes can be subject to <a href="https://datatracker.ietf.org/doc/html/rfc8252#section-8.6">client impersonation attacks</a>. You can read more about setting this value in the <a href="https://github.com/auth0/Auth0.Android#a-note-about-app-deep-linking" target="_blank" rel="noreferrer">Auth0.Android SDK readme</a>.</p></div></p>
 
 ## Configure your application {{{ data-action="code" data-code="strings.xml#2:3" }}}
 

--- a/articles/quickstart/native/flutter/01-login.md
+++ b/articles/quickstart/native/flutter/01-login.md
@@ -46,7 +46,7 @@ If the callback and logout URLs are not set, users will be unable to log in and 
 Go to the <a href="${manage_url}/#/applications/${account.clientId}/settings" target="_blank" rel="noreferrer">settings page</a> of your Auth0 application and add the following URLs to **Allowed Callback URLs** and **Allowed Logout URLs**, depending on the platform of your app. If you have a <a href="/customize/custom-domains" target="_blank" rel="noreferrer">custom domain</a>, use this instead of the Auth0 domain from the settings page.
 
 ::: note
-On Android, the value of the `SCHEME` placeholder can be `https` or some other custom scheme. `https` schemes require enabling <a href="https://auth0.com/docs/get-started/applications/enable-android-app-links-support" target="_blank" rel="noreferrer">Android App Links</a>.
+On Android, the value of the `SCHEME` placeholder can be `https` or some other custom scheme. Whenever possible, Auth0 recommends using <a href="https://auth0.com/docs/applications/enable-android-app-links"> Android App Links</a> with `https` as a secure way to link directly to content within your app. Custom URL schemes can be subject to <a href="https://datatracker.ietf.org/doc/html/rfc8252#section-8.6">client impersonation attacks</a>.
 
 On iOS 17.4+ and macOS 14.4+ it is possible to use Universal Links (`https` scheme) as callback and logout URLs. When enabled, the SDK will fall back to using a custom URL scheme on older iOS / macOS versions –your app's <a href="https://developer.apple.com/documentation/appstoreconnectapi/bundle_ids" target="_blank" rel="noreferrer">bundle identifier</a>.
 

--- a/articles/quickstart/native/flutter/_configure_urls_interactive.md
+++ b/articles/quickstart/native/flutter/_configure_urls_interactive.md
@@ -17,7 +17,7 @@ The callback and logout URLs are the URLs that Auth0 invokes to redirect back to
 Set the callback and logout URLs to the following values, depending on your platform.
 
 ::: note
-On Android, the value of the `SCHEME` placeholder can be `https` or some other custom scheme. `https` schemes require enabling <a href="https://auth0.com/docs/get-started/applications/enable-android-app-links-support" target="_blank" rel="noreferrer">Android App Links</a>.
+On Android, the value of the `SCHEME` placeholder can be `https` or some other custom scheme. Whenever possible, Auth0 recommends using <a href="https://auth0.com/docs/applications/enable-android-app-links"> Android App Links</a> with `https` as a secure way to link directly to content within your app. Custom URL schemes can be subject to <a href="https://datatracker.ietf.org/doc/html/rfc8252#section-8.6">client impersonation attacks</a>.
 
 On iOS 17.4+ and macOS 14.4+ it is possible to use Universal Links (`https` scheme) as callback and logout URLs. When enabled, the SDK will fall back to using a custom URL scheme on older iOS / macOS versions –your app's <a href="https://developer.apple.com/documentation/appstoreconnectapi/bundle_ids" target="_blank" rel="noreferrer">bundle identifier</a>.
 


### PR DESCRIPTION
### Changes

This PR adds the following snippet to the Android and Flutter Quickstarts:

> Whenever possible, Auth0 recommends using Android App Links as a secure way to link directly to content within your app. Custom URL schemes can be subject to [client impersonation attacks](https://datatracker.ietf.org/doc/html/rfc8252#section-8.6).