### PR TITLE
feat: add MyAccount API Explorer nav link to sidebar

### DIFF
--- a/config/sidebar.yml
+++ b/config/sidebar.yml
@@ -1492,6 +1492,10 @@ apis:
     url: /api/management/v2/
     forceFullReload: true
     external: true
+  - title: myAccountApiExplorer
+    url: /api/myaccount
+    forceFullReload: true
+    external: true
 libraries:
   - title: Overview
     url: /libraries


### PR DESCRIPTION
<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->

- Adding a new navigation item to the sidebar for the new `MyAccount` API Explorer