### PR TITLE
Changed groupId according to Maven Central

### DIFF
--- a/articles/quickstart/webapp/java-spring-boot/01-login.md
+++ b/articles/quickstart/webapp/java-spring-boot/01-login.md
@@ -59,7 +59,7 @@ If you are using Maven:
 
 <dependencies>
     <dependency>
-        <groupId>com.okta</groupId>
+        <groupId>com.okta.spring</groupId>
         <artifactId>okta-spring-boot-starter</artifactId>
         <version>3.0.5</version>
     </dependency>


### PR DESCRIPTION
Docs pointed to wrong groupId, in this PR - I set up correct groupId

<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->
