### PR TITLE
feat: add events catalog header section

### DIFF
--- a/config/sections.yml
+++ b/config/sections.yml
@@ -4,23 +4,28 @@
 ##
 ## ------------------------------------------------------------
 
-- id: "articles"
-  title: "Articles"
-  url: "/articles"
-  folder: ""
+- id: 'articles'
+  title: 'Articles'
+  url: '/articles'
+  folder: ''
   default: true
 
-- id: "quickstarts"
-  title: "Quickstarts"
-  url: "/quickstarts"
-  folder: "quickstart"
+- id: 'quickstarts'
+  title: 'Quickstarts'
+  url: '/quickstarts'
+  folder: 'quickstart'
 
-- id: "apis"
-  title: "Auth0 APIs"
-  url: "/api"
-  folder: "api"
+- id: 'apis'
+  title: 'Auth0 APIs'
+  url: '/api'
+  folder: 'api'
 
-- id: "libraries"
-  title: "SDKs"
-  url: "/libraries"
-  folder: "libraries"
+- id: 'libraries'
+  title: 'SDKs'
+  url: '/libraries'
+  folder: 'libraries'
+
+- id: 'events'
+  title: 'Events Catelog'
+  url: '/events'
+  folder: ''


### PR DESCRIPTION
<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->

- This pull-request adds the "Events Catalog" nav link to the header section of the core docs application