### PR TITLE
fix: nav section title typo

### DIFF
--- a/config/sections.yml
+++ b/config/sections.yml
@@ -26,6 +26,6 @@
   folder: 'libraries'
 
 - id: 'events'
-  title: 'Events Catelog'
-  url: '/events'
+  title: 'Events Catalog'
+  url: '/events/'
   folder: ''


### PR DESCRIPTION
<!---
Pull Requests for Quickstart Guides can still be submitted here, but most other documentation content is no longer hosted on GitHub and therefore no longer open-sourced. If you are an Auth0 employee trying to make a change, please [submit a ticket](https://auth0team.atlassian.net/servicedesk/customer/portal/9). Thank you!
--->

Fix a typo in the _Events Catalog_ nav item title